### PR TITLE
changes comments and env vars in `utils/logging.py`

### DIFF
--- a/src/diffusers/utils/logging.py
+++ b/src/diffusers/utils/logging.py
@@ -49,16 +49,16 @@ _tqdm_active = True
 
 def _get_default_logging_level():
     """
-    If TRANSFORMERS_VERBOSITY env var is set to one of the valid choices return that as the new default level. If it is
+    If DIFFUSERS_VERBOSITY env var is set to one of the valid choices return that as the new default level. If it is
     not - fall back to `_default_log_level`
     """
-    env_level_str = os.getenv("TRANSFORMERS_VERBOSITY", None)
+    env_level_str = os.getenv("DIFFUSERS_VERBOSITY", None)
     if env_level_str:
         if env_level_str in log_levels:
             return log_levels[env_level_str]
         else:
             logging.getLogger().warning(
-                f"Unknown option TRANSFORMERS_VERBOSITY={env_level_str}, "
+                f"Unknown option DIFFUSERS_VERBOSITY={env_level_str}, "
                 f"has to be one of: { ', '.join(log_levels.keys()) }"
             )
     return _default_log_level
@@ -126,14 +126,14 @@ def get_logger(name: Optional[str] = None) -> logging.Logger:
 
 def get_verbosity() -> int:
     """
-    Return the current level for the 🤗 Transformers's root logger as an int.
+    Return the current level for the 🤗 Diffusers' root logger as an int.
 
     Returns:
         `int`: The logging level.
 
     <Tip>
 
-    🤗 Transformers has following logging levels:
+    🤗 Diffusers has following logging levels:
 
     - 50: `diffusers.logging.CRITICAL` or `diffusers.logging.FATAL`
     - 40: `diffusers.logging.ERROR`
@@ -149,7 +149,7 @@ def get_verbosity() -> int:
 
 def set_verbosity(verbosity: int) -> None:
     """
-    Set the verbosity level for the 🤗 Transformers's root logger.
+    Set the verbosity level for the 🤗 Diffusers' root logger.
 
     Args:
         verbosity (`int`):
@@ -187,7 +187,7 @@ def set_verbosity_error():
 
 
 def disable_default_handler() -> None:
-    """Disable the default handler of the HuggingFace Transformers's root logger."""
+    """Disable the default handler of the HuggingFace Diffusers' root logger."""
 
     _configure_library_root_logger()
 
@@ -196,7 +196,7 @@ def disable_default_handler() -> None:
 
 
 def enable_default_handler() -> None:
-    """Enable the default handler of the HuggingFace Transformers's root logger."""
+    """Enable the default handler of the HuggingFace Diffusers' root logger."""
 
     _configure_library_root_logger()
 
@@ -205,7 +205,7 @@ def enable_default_handler() -> None:
 
 
 def add_handler(handler: logging.Handler) -> None:
-    """adds a handler to the HuggingFace Transformers's root logger."""
+    """adds a handler to the HuggingFace Diffusers' root logger."""
 
     _configure_library_root_logger()
 
@@ -214,7 +214,7 @@ def add_handler(handler: logging.Handler) -> None:
 
 
 def remove_handler(handler: logging.Handler) -> None:
-    """removes given handler from the HuggingFace Transformers's root logger."""
+    """removes given handler from the HuggingFace Diffusers' root logger."""
 
     _configure_library_root_logger()
 
@@ -233,7 +233,7 @@ def disable_propagation() -> None:
 
 def enable_propagation() -> None:
     """
-    Enable propagation of the library log outputs. Please disable the HuggingFace Transformers's default handler to
+    Enable propagation of the library log outputs. Please disable the HuggingFace Diffusers' default handler to
     prevent double logging if the root logger has been configured.
     """
 
@@ -243,7 +243,7 @@ def enable_propagation() -> None:
 
 def enable_explicit_format() -> None:
     """
-    Enable explicit formatting for every HuggingFace Transformers's logger. The explicit formatter is as follows:
+    Enable explicit formatting for every HuggingFace Diffusers' logger. The explicit formatter is as follows:
     ```
         [LEVELNAME|FILENAME|LINE NUMBER] TIME >> MESSAGE
     ```
@@ -258,7 +258,7 @@ def enable_explicit_format() -> None:
 
 def reset_format() -> None:
     """
-    Resets the formatting for HuggingFace Transformers's loggers.
+    Resets the formatting for HuggingFace Diffusers' loggers.
 
     All handlers currently bound to the root logger are affected by this method.
     """
@@ -270,10 +270,10 @@ def reset_format() -> None:
 
 def warning_advice(self, *args, **kwargs):
     """
-    This method is identical to `logger.warninging()`, but if env var TRANSFORMERS_NO_ADVISORY_WARNINGS=1 is set, this
+    This method is identical to `logger.warninging()`, but if env var DIFFUSERS_NO_ADVISORY_WARNINGS=1 is set, this
     warning will not be printed
     """
-    no_advisory_warnings = os.getenv("TRANSFORMERS_NO_ADVISORY_WARNINGS", False)
+    no_advisory_warnings = os.getenv("DIFFUSERS_NO_ADVISORY_WARNINGS", False)
     if no_advisory_warnings:
         return
     self.warning(*args, **kwargs)


### PR DESCRIPTION
Removes mentions of 🤗Transformers with 🤗Diffusers equivalent in `utils/logging.py`.
This includes comments and environmental variables.
This was mentioned in issue #12 