### PR TITLE
fix alphas_cumprod

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddpm.py
+++ b/src/diffusers/schedulers/scheduling_ddpm.py
@@ -137,8 +137,8 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
         return pred_prev_sample
 
     def forward_step(self, original_sample, noise, t):
-        sqrt_alpha_prod = self.alpha_prod_t[t] ** 0.5
-        sqrt_one_minus_alpha_prod = (1 - self.alpha_prod_t[t]) ** 0.5
+        sqrt_alpha_prod = self.alphas_cumprod[t] ** 0.5
+        sqrt_one_minus_alpha_prod = (1 - self.alphas_cumprod[t]) ** 0.5
         noisy_sample = sqrt_alpha_prod * original_sample + sqrt_one_minus_alpha_prod * noise
         return noisy_sample
 


### PR DESCRIPTION
Changed from alpha_prod_t to alphas_cumprod

If I'm not mistaken it's a type from [this commit](https://github.com/huggingface/diffusers/commit/2b8bc91cf8f4d33a1b62fc7010a1a598e03c8e63#diff-5014bf116e54d20c980d805dc58ac83ac75b2976a2d785978632f14d8fb53ea9) when 
get_alpha_prod method was removed 

