### PR TITLE
missing '=' in modelcards dep spec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ _deps = [
     "requests",
     "torch>=1.4",
     "tensorboard",
-    "modelcards=0.1.4"
+    "modelcards==0.1.4"
 ]
 
 # this is a lookup table with items like:


### PR DESCRIPTION
local install wouldn't run