### PR TITLE
Downsample / Upsample - clean to 1D and 2D

### DIFF
--- a/src/diffusers/modeling_utils.py
+++ b/src/diffusers/modeling_utils.py
@@ -324,6 +324,9 @@ class ModelMixin(torch.nn.Module):
 
         user_agent = {"file_type": "model", "framework": "pytorch", "from_auto_class": from_auto_class}
 
+        # TODO(Patrick remove if have internet)
+        local_files_only = True
+
         # Load config if we don't provide a configuration
         config_path = pretrained_model_name_or_path
         model, unused_kwargs = cls.from_config(

--- a/src/diffusers/modeling_utils.py
+++ b/src/diffusers/modeling_utils.py
@@ -324,9 +324,6 @@ class ModelMixin(torch.nn.Module):
 
         user_agent = {"file_type": "model", "framework": "pytorch", "from_auto_class": from_auto_class}
 
-        # TODO(Patrick remove if have internet)
-        local_files_only = True
-
         # Load config if we don't provide a configuration
         config_path = pretrained_model_name_or_path
         model, unused_kwargs = cls.from_config(

--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -204,6 +204,136 @@ class Downsample1D(nn.Module):
         return self.conv(x)
 
 
+class FirUpsample2D(nn.Module):
+    def __init__(self, channels=None, out_channels=None, use_conv=False, fir_kernel=(1, 3, 3, 1)):
+        super().__init__()
+        out_channels = out_channels if out_channels else channels
+        if use_conv:
+            self.Conv2d_0 = nn.Conv2d(channels, out_channels, kernel_size=3, stride=1, padding=1)
+        self.use_conv = use_conv
+        self.fir_kernel = fir_kernel
+        self.out_channels = out_channels
+
+    def forward(self, x):
+        if self.use_conv:
+            h = _upsample_conv_2d(x, self.Conv2d_0.weight, k=self.fir_kernel)
+            h = h + self.Conv2d_0.bias.reshape(1, -1, 1, 1)
+        else:
+            h = upsample_2d(x, self.fir_kernel, factor=2)
+
+        return h
+
+
+class FirDownsample2D(nn.Module):
+    def __init__(self, channels=None, out_channels=None, use_conv=False, fir_kernel=(1, 3, 3, 1)):
+        super().__init__()
+        out_channels = out_channels if out_channels else channels
+        if use_conv:
+            self.Conv2d_0 = self.Conv2d_0 = nn.Conv2d(channels, out_channels, kernel_size=3, stride=1, padding=1)
+        self.fir_kernel = fir_kernel
+        self.use_conv = use_conv
+        self.out_channels = out_channels
+
+    def forward(self, x):
+        if self.use_conv:
+            x = _conv_downsample_2d(x, self.Conv2d_0.weight, k=self.fir_kernel)
+            x = x + self.Conv2d_0.bias.reshape(1, -1, 1, 1)
+        else:
+            x = downsample_2d(x, self.fir_kernel, factor=2)
+
+        return x
+
+
+def _conv_downsample_2d(x, w, k=None, factor=2, gain=1):
+    """Fused `Conv2d()` followed by `downsample_2d()`.
+
+    Args:
+    Padding is performed only once at the beginning, not between the operations. The fused op is considerably more
+    efficient than performing the same calculation using standard TensorFlow ops. It supports gradients of arbitrary
+    order.
+        x: Input tensor of the shape `[N, C, H, W]` or `[N, H, W,
+          C]`.
+        w: Weight tensor of the shape `[filterH, filterW, inChannels,
+          outChannels]`. Grouped convolution can be performed by `inChannels = x.shape[0] // numGroups`.
+        k: FIR filter of the shape `[firH, firW]` or `[firN]`
+          (separable). The default is `[1] * factor`, which corresponds to average pooling.
+        factor: Integer downsampling factor (default: 2). gain: Scaling factor for signal magnitude (default: 1.0).
+
+    Returns:
+        Tensor of the shape `[N, C, H // factor, W // factor]` or `[N, H // factor, W // factor, C]`, and same datatype
+        as `x`.
+    """
+
+    assert isinstance(factor, int) and factor >= 1
+    _outC, _inC, convH, convW = w.shape
+    assert convW == convH
+    if k is None:
+        k = [1] * factor
+    k = _setup_kernel(k) * gain
+    p = (k.shape[0] - factor) + (convW - 1)
+    s = [factor, factor]
+    x = upfirdn2d(x, torch.tensor(k, device=x.device), pad=((p + 1) // 2, p // 2))
+    return F.conv2d(x, w, stride=s, padding=0)
+
+
+def _upsample_conv_2d(x, w, k=None, factor=2, gain=1):
+    """Fused `upsample_2d()` followed by `Conv2d()`.
+
+    Args:
+    Padding is performed only once at the beginning, not between the operations. The fused op is considerably more
+    efficient than performing the same calculation using standard TensorFlow ops. It supports gradients of arbitrary
+    order.
+      x: Input tensor of the shape `[N, C, H, W]` or `[N, H, W,
+        C]`.
+      w: Weight tensor of the shape `[filterH, filterW, inChannels,
+        outChannels]`. Grouped convolution can be performed by `inChannels = x.shape[0] // numGroups`.
+      k: FIR filter of the shape `[firH, firW]` or `[firN]`
+        (separable). The default is `[1] * factor`, which corresponds to nearest-neighbor upsampling.
+      factor: Integer upsampling factor (default: 2). gain: Scaling factor for signal magnitude (default: 1.0).
+
+    Returns:
+      Tensor of the shape `[N, C, H * factor, W * factor]` or `[N, H * factor, W * factor, C]`, and same datatype as
+      `x`.
+    """
+
+    assert isinstance(factor, int) and factor >= 1
+
+    # Check weight shape.
+    assert len(w.shape) == 4
+    convH = w.shape[2]
+    convW = w.shape[3]
+    inC = w.shape[1]
+
+    assert convW == convH
+
+    # Setup filter kernel.
+    if k is None:
+        k = [1] * factor
+    k = _setup_kernel(k) * (gain * (factor**2))
+    p = (k.shape[0] - factor) - (convW - 1)
+
+    stride = (factor, factor)
+
+    # Determine data dimensions.
+    stride = [1, 1, factor, factor]
+    output_shape = ((x.shape[2] - 1) * factor + convH, (x.shape[3] - 1) * factor + convW)
+    output_padding = (
+        output_shape[0] - (x.shape[2] - 1) * stride[0] - convH,
+        output_shape[1] - (x.shape[3] - 1) * stride[1] - convW,
+    )
+    assert output_padding[0] >= 0 and output_padding[1] >= 0
+    num_groups = x.shape[1] // inC
+
+    # Transpose weights.
+    w = torch.reshape(w, (num_groups, -1, inC, convH, convW))
+    w = w[..., ::-1, ::-1].permute(0, 2, 1, 3, 4)
+    w = torch.reshape(w, (num_groups * inC, -1, convH, convW))
+
+    x = F.conv_transpose2d(x, w, stride=stride, output_padding=output_padding, padding=0)
+
+    return upfirdn2d(x, torch.tensor(k, device=x.device), pad=((p + 1) // 2 + factor - 1, p // 2 + 1))
+
+
 # TODO (patil-suraj): needs test
 # class Upsample2D1d(nn.Module):
 #    def __init__(self, dim):

--- a/src/diffusers/models/unet.py
+++ b/src/diffusers/models/unet.py
@@ -22,7 +22,7 @@ from ..configuration_utils import ConfigMixin
 from ..modeling_utils import ModelMixin
 from .attention import AttentionBlock
 from .embeddings import get_timestep_embedding
-from .resnet import Downsample, ResnetBlock2D, Upsample
+from .resnet import Downsample2D, ResnetBlock2D, Upsample2D
 
 
 def nonlinearity(x):
@@ -100,7 +100,7 @@ class UNetModel(ModelMixin, ConfigMixin):
             down.block = block
             down.attn = attn
             if i_level != self.num_resolutions - 1:
-                down.downsample = Downsample(block_in, use_conv=resamp_with_conv, padding=0)
+                down.downsample = Downsample2D(block_in, use_conv=resamp_with_conv, padding=0)
                 curr_res = curr_res // 2
             self.down.append(down)
 
@@ -139,7 +139,7 @@ class UNetModel(ModelMixin, ConfigMixin):
             up.block = block
             up.attn = attn
             if i_level != 0:
-                up.upsample = Upsample(block_in, use_conv=resamp_with_conv)
+                up.upsample = Upsample2D(block_in, use_conv=resamp_with_conv)
                 curr_res = curr_res * 2
             self.up.insert(0, up)  # prepend to get consistent order
 

--- a/src/diffusers/models/unet_glide.py
+++ b/src/diffusers/models/unet_glide.py
@@ -6,7 +6,7 @@ from ..configuration_utils import ConfigMixin
 from ..modeling_utils import ModelMixin
 from .attention import AttentionBlock
 from .embeddings import get_timestep_embedding
-from .resnet import Downsample, ResnetBlock2D, Upsample
+from .resnet import Downsample2D, ResnetBlock2D, Upsample2D
 
 
 def convert_module_to_f16(l):
@@ -218,7 +218,7 @@ class GlideUNetModel(ModelMixin, ConfigMixin):
                             down=True,
                         )
                         if resblock_updown
-                        else Downsample(
+                        else Downsample2D(
                             ch, use_conv=conv_resample, dims=dims, out_channels=out_ch, padding=1, name="op"
                         )
                     )
@@ -299,7 +299,7 @@ class GlideUNetModel(ModelMixin, ConfigMixin):
                             up=True,
                         )
                         if resblock_updown
-                        else Upsample(ch, use_conv=conv_resample, dims=dims, out_channels=out_ch)
+                        else Upsample2D(ch, use_conv=conv_resample, dims=dims, out_channels=out_ch)
                     )
                     ds //= 2
                 self.output_blocks.append(TimestepEmbedSequential(*layers))

--- a/src/diffusers/models/unet_glide.py
+++ b/src/diffusers/models/unet_glide.py
@@ -218,9 +218,7 @@ class GlideUNetModel(ModelMixin, ConfigMixin):
                             down=True,
                         )
                         if resblock_updown
-                        else Downsample2D(
-                            ch, use_conv=conv_resample, dims=dims, out_channels=out_ch, padding=1, name="op"
-                        )
+                        else Downsample2D(ch, use_conv=conv_resample, out_channels=out_ch, padding=1, name="op")
                     )
                 )
                 ch = out_ch
@@ -299,7 +297,7 @@ class GlideUNetModel(ModelMixin, ConfigMixin):
                             up=True,
                         )
                         if resblock_updown
-                        else Upsample2D(ch, use_conv=conv_resample, dims=dims, out_channels=out_ch)
+                        else Upsample2D(ch, use_conv=conv_resample, out_channels=out_ch)
                     )
                     ds //= 2
                 self.output_blocks.append(TimestepEmbedSequential(*layers))

--- a/src/diffusers/models/unet_grad_tts.py
+++ b/src/diffusers/models/unet_grad_tts.py
@@ -4,7 +4,7 @@ from ..configuration_utils import ConfigMixin
 from ..modeling_utils import ModelMixin
 from .attention import LinearAttention
 from .embeddings import get_timestep_embedding
-from .resnet import Downsample, ResnetBlock2D, Upsample
+from .resnet import Downsample2D, ResnetBlock2D, Upsample2D
 
 
 class Mish(torch.nn.Module):
@@ -105,7 +105,7 @@ class UNetGradTTSModel(ModelMixin, ConfigMixin):
                             overwrite_for_grad_tts=True,
                         ),
                         Residual(Rezero(LinearAttention(dim_out))),
-                        Downsample(dim_out, use_conv=True, padding=1) if not is_last else torch.nn.Identity(),
+                        Downsample2D(dim_out, use_conv=True, padding=1) if not is_last else torch.nn.Identity(),
                     ]
                 )
             )
@@ -158,7 +158,7 @@ class UNetGradTTSModel(ModelMixin, ConfigMixin):
                             overwrite_for_grad_tts=True,
                         ),
                         Residual(Rezero(LinearAttention(dim_in))),
-                        Upsample(dim_in, use_conv_transpose=True),
+                        Upsample2D(dim_in, use_conv_transpose=True),
                     ]
                 )
             )

--- a/src/diffusers/models/unet_ldm.py
+++ b/src/diffusers/models/unet_ldm.py
@@ -10,7 +10,7 @@ from ..configuration_utils import ConfigMixin
 from ..modeling_utils import ModelMixin
 from .attention import AttentionBlock
 from .embeddings import get_timestep_embedding
-from .resnet import Downsample, ResnetBlock2D, Upsample
+from .resnet import Downsample2D, ResnetBlock2D, Upsample2D
 
 
 # from .resnet import ResBlock
@@ -350,7 +350,7 @@ class UNetLDMModel(ModelMixin, ConfigMixin):
                 out_ch = ch
                 self.input_blocks.append(
                     TimestepEmbedSequential(
-                        Downsample(ch, use_conv=conv_resample, dims=dims, out_channels=out_ch, padding=1, name="op")
+                        Downsample2D(ch, use_conv=conv_resample, dims=dims, out_channels=out_ch, padding=1, name="op")
                     )
                 )
                 ch = out_ch
@@ -437,7 +437,7 @@ class UNetLDMModel(ModelMixin, ConfigMixin):
                     )
                 if level and i == num_res_blocks:
                     out_ch = ch
-                    layers.append(Upsample(ch, use_conv=conv_resample, dims=dims, out_channels=out_ch))
+                    layers.append(Upsample2D(ch, use_conv=conv_resample, dims=dims, out_channels=out_ch))
                     ds //= 2
                 self.output_blocks.append(TimestepEmbedSequential(*layers))
                 self._feature_size += ch

--- a/src/diffusers/models/unet_ldm.py
+++ b/src/diffusers/models/unet_ldm.py
@@ -350,7 +350,7 @@ class UNetLDMModel(ModelMixin, ConfigMixin):
                 out_ch = ch
                 self.input_blocks.append(
                     TimestepEmbedSequential(
-                        Downsample2D(ch, use_conv=conv_resample, dims=dims, out_channels=out_ch, padding=1, name="op")
+                        Downsample2D(ch, use_conv=conv_resample, out_channels=out_ch, padding=1, name="op")
                     )
                 )
                 ch = out_ch
@@ -437,7 +437,7 @@ class UNetLDMModel(ModelMixin, ConfigMixin):
                     )
                 if level and i == num_res_blocks:
                     out_ch = ch
-                    layers.append(Upsample2D(ch, use_conv=conv_resample, dims=dims, out_channels=out_ch))
+                    layers.append(Upsample2D(ch, use_conv=conv_resample, out_channels=out_ch))
                     ds //= 2
                 self.output_blocks.append(TimestepEmbedSequential(*layers))
                 self._feature_size += ch

--- a/src/diffusers/models/unet_rl.py
+++ b/src/diffusers/models/unet_rl.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 from ..configuration_utils import ConfigMixin
 from ..modeling_utils import ModelMixin
 from .embeddings import get_timestep_embedding
-from .resnet import Downsample, ResidualTemporalBlock, Upsample
+from .resnet import Downsample1D, ResidualTemporalBlock, Upsample1D
 
 
 class SinusoidalPosEmb(nn.Module):
@@ -96,7 +96,7 @@ class TemporalUNet(ModelMixin, ConfigMixin):  # (nn.Module):
                     [
                         ResidualTemporalBlock(dim_in, dim_out, embed_dim=time_dim, horizon=training_horizon),
                         ResidualTemporalBlock(dim_out, dim_out, embed_dim=time_dim, horizon=training_horizon),
-                        Downsample(dim_out, use_conv=True, dims=1) if not is_last else nn.Identity(),
+                        Downsample1D(dim_out, use_conv=True, dims=1) if not is_last else nn.Identity(),
                     ]
                 )
             )
@@ -116,7 +116,7 @@ class TemporalUNet(ModelMixin, ConfigMixin):  # (nn.Module):
                     [
                         ResidualTemporalBlock(dim_out * 2, dim_in, embed_dim=time_dim, horizon=training_horizon),
                         ResidualTemporalBlock(dim_in, dim_in, embed_dim=time_dim, horizon=training_horizon),
-                        Upsample(dim_in, use_conv_transpose=True, dims=1) if not is_last else nn.Identity(),
+                        Upsample1D(dim_in, use_conv_transpose=True, dims=1) if not is_last else nn.Identity(),
                     ]
                 )
             )

--- a/src/diffusers/models/unet_rl.py
+++ b/src/diffusers/models/unet_rl.py
@@ -96,7 +96,7 @@ class TemporalUNet(ModelMixin, ConfigMixin):  # (nn.Module):
                     [
                         ResidualTemporalBlock(dim_in, dim_out, embed_dim=time_dim, horizon=training_horizon),
                         ResidualTemporalBlock(dim_out, dim_out, embed_dim=time_dim, horizon=training_horizon),
-                        Downsample1D(dim_out, use_conv=True, dims=1) if not is_last else nn.Identity(),
+                        Downsample1D(dim_out, use_conv=True) if not is_last else nn.Identity(),
                     ]
                 )
             )
@@ -116,7 +116,7 @@ class TemporalUNet(ModelMixin, ConfigMixin):  # (nn.Module):
                     [
                         ResidualTemporalBlock(dim_out * 2, dim_in, embed_dim=time_dim, horizon=training_horizon),
                         ResidualTemporalBlock(dim_in, dim_in, embed_dim=time_dim, horizon=training_horizon),
-                        Upsample1D(dim_in, use_conv_transpose=True, dims=1) if not is_last else nn.Identity(),
+                        Upsample1D(dim_in, use_conv_transpose=True) if not is_last else nn.Identity(),
                     ]
                 )
             )

--- a/src/diffusers/models/unet_sde_score_estimation.py
+++ b/src/diffusers/models/unet_sde_score_estimation.py
@@ -27,7 +27,16 @@ from ..configuration_utils import ConfigMixin
 from ..modeling_utils import ModelMixin
 from .attention import AttentionBlock
 from .embeddings import GaussianFourierProjection, get_timestep_embedding
-from .resnet import Downsample2D, ResnetBlock2D, Upsample2D, downsample_2d, upfirdn2d, upsample_2d
+from .resnet import (
+    Downsample2D,
+    FirDownsample2D,
+    FirUpsample2D,
+    ResnetBlock2D,
+    Upsample2D,
+    downsample_2d,
+    upfirdn2d,
+    upsample_2d,
+)
 
 
 def _setup_kernel(k):
@@ -40,94 +49,74 @@ def _setup_kernel(k):
     return k
 
 
-def _upsample_conv_2d(x, w, k=None, factor=2, gain=1):
-    """Fused `upsample_2d()` followed by `Conv2d()`.
-
-    Args:
-    Padding is performed only once at the beginning, not between the operations. The fused op is considerably more
-    efficient than performing the same calculation using standard TensorFlow ops. It supports gradients of arbitrary
-    order.
-      x: Input tensor of the shape `[N, C, H, W]` or `[N, H, W,
-        C]`.
-      w: Weight tensor of the shape `[filterH, filterW, inChannels,
-        outChannels]`. Grouped convolution can be performed by `inChannels = x.shape[0] // numGroups`.
-      k: FIR filter of the shape `[firH, firW]` or `[firN]`
-        (separable). The default is `[1] * factor`, which corresponds to nearest-neighbor upsampling.
-      factor: Integer upsampling factor (default: 2). gain: Scaling factor for signal magnitude (default: 1.0).
-
-    Returns:
-      Tensor of the shape `[N, C, H * factor, W * factor]` or `[N, H * factor, W * factor, C]`, and same datatype as
-      `x`.
-    """
-
-    assert isinstance(factor, int) and factor >= 1
-
-    # Check weight shape.
-    assert len(w.shape) == 4
-    convH = w.shape[2]
-    convW = w.shape[3]
-    inC = w.shape[1]
-
-    assert convW == convH
-
-    # Setup filter kernel.
-    if k is None:
-        k = [1] * factor
-    k = _setup_kernel(k) * (gain * (factor**2))
-    p = (k.shape[0] - factor) - (convW - 1)
-
-    stride = (factor, factor)
-
-    # Determine data dimensions.
-    stride = [1, 1, factor, factor]
-    output_shape = ((x.shape[2] - 1) * factor + convH, (x.shape[3] - 1) * factor + convW)
-    output_padding = (
-        output_shape[0] - (x.shape[2] - 1) * stride[0] - convH,
-        output_shape[1] - (x.shape[3] - 1) * stride[1] - convW,
-    )
-    assert output_padding[0] >= 0 and output_padding[1] >= 0
-    num_groups = x.shape[1] // inC
-
-    # Transpose weights.
-    w = torch.reshape(w, (num_groups, -1, inC, convH, convW))
-    w = w[..., ::-1, ::-1].permute(0, 2, 1, 3, 4)
-    w = torch.reshape(w, (num_groups * inC, -1, convH, convW))
-
-    x = F.conv_transpose2d(x, w, stride=stride, output_padding=output_padding, padding=0)
-
-    return upfirdn2d(x, torch.tensor(k, device=x.device), pad=((p + 1) // 2 + factor - 1, p // 2 + 1))
+# def _upsample_conv_2d(x, w, k=None, factor=2, gain=1):
+#    """Fused `upsample_2d()` followed by `Conv2d()`. # # Args: # Padding is performed only once at the beginning, not between
+the operations. The fused op is considerably more # efficient than performing the same calculation using standard
+TensorFlow ops. It supports gradients of arbitrary # order. # x: Input tensor of the shape `[N, C, H, W]` or `[N, H, W,
+# C]`. # w: Weight tensor of the shape `[filterH, filterW, inChannels, # outChannels]`. Grouped convolution can be
+performed by `inChannels = x.shape[0] // numGroups`. # k: FIR filter of the shape `[firH, firW]` or `[firN]` #
+(separable). The default is `[1] * factor`, which corresponds to nearest-neighbor upsampling. # factor: Integer
+upsampling factor (default: 2). gain: Scaling factor for signal magnitude (default: 1.0). # # Returns: # Tensor of the
+shape `[N, C, H * factor, W * factor]` or `[N, H * factor, W * factor, C]`, and same datatype as # `x`. #"""
+#
+#    assert isinstance(factor, int) and factor >= 1
+#
+# Check weight shape.
+#    assert len(w.shape) == 4
+#    convH = w.shape[2]
+#    convW = w.shape[3]
+#    inC = w.shape[1]
+#
+#    assert convW == convH
+#
+# Setup filter kernel.
+#    if k is None:
+#        k = [1] * factor
+#    k = _setup_kernel(k) * (gain * (factor**2))
+#    p = (k.shape[0] - factor) - (convW - 1)
+#
+#    stride = (factor, factor)
+#
+# Determine data dimensions.
+#    stride = [1, 1, factor, factor]
+#    output_shape = ((x.shape[2] - 1) * factor + convH, (x.shape[3] - 1) * factor + convW)
+#    output_padding = (
+#        output_shape[0] - (x.shape[2] - 1) * stride[0] - convH,
+#        output_shape[1] - (x.shape[3] - 1) * stride[1] - convW,
+#    )
+#    assert output_padding[0] >= 0 and output_padding[1] >= 0
+#    num_groups = x.shape[1] // inC
+#
+# Transpose weights.
+#    w = torch.reshape(w, (num_groups, -1, inC, convH, convW))
+#    w = w[..., ::-1, ::-1].permute(0, 2, 1, 3, 4)
+#    w = torch.reshape(w, (num_groups * inC, -1, convH, convW))
+#
+#    x = F.conv_transpose2d(x, w, stride=stride, output_padding=output_padding, padding=0)
+#
+#    return upfirdn2d(x, torch.tensor(k, device=x.device), pad=((p + 1) // 2 + factor - 1, p // 2 + 1))
 
 
-def _conv_downsample_2d(x, w, k=None, factor=2, gain=1):
-    """Fused `Conv2d()` followed by `downsample_2d()`.
-
-    Args:
-    Padding is performed only once at the beginning, not between the operations. The fused op is considerably more
-    efficient than performing the same calculation using standard TensorFlow ops. It supports gradients of arbitrary
-    order.
-        x: Input tensor of the shape `[N, C, H, W]` or `[N, H, W,
-          C]`.
-        w: Weight tensor of the shape `[filterH, filterW, inChannels,
-          outChannels]`. Grouped convolution can be performed by `inChannels = x.shape[0] // numGroups`.
-        k: FIR filter of the shape `[firH, firW]` or `[firN]`
-          (separable). The default is `[1] * factor`, which corresponds to average pooling.
-        factor: Integer downsampling factor (default: 2). gain: Scaling factor for signal magnitude (default: 1.0).
-
-    Returns:
-        Tensor of the shape `[N, C, H // factor, W // factor]` or `[N, H // factor, W // factor, C]`, and same datatype
-        as `x`.
-    """
-
-    assert isinstance(factor, int) and factor >= 1
-    _outC, _inC, convH, convW = w.shape
-    assert convW == convH
-    if k is None:
-        k = [1] * factor
-    k = _setup_kernel(k) * gain
-    p = (k.shape[0] - factor) + (convW - 1)
-    s = [factor, factor]
-    x = upfirdn2d(x, torch.tensor(k, device=x.device), pad=((p + 1) // 2, p // 2))
-    return F.conv2d(x, w, stride=s, padding=0)
+# def _conv_downsample_2d(x, w, k=None, factor=2, gain=1):
+#    """Fused `Conv2d()` followed by `downsample_2d()`. # # Args: # Padding is performed only once at the beginning, not
+between the operations. The fused op is considerably more # efficient than performing the same calculation using
+standard TensorFlow ops. It supports gradients of arbitrary # order. # x: Input tensor of the shape `[N, C, H, W]` or
+`[N, H, W, # C]`. # w: Weight tensor of the shape `[filterH, filterW, inChannels, # outChannels]`. Grouped convolution
+can be performed by `inChannels = x.shape[0] // numGroups`. # k: FIR filter of the shape `[firH, firW]` or `[firN]` #
+(separable). The default is `[1] * factor`, which corresponds to average pooling. # factor: Integer downsampling factor
+(default: 2). gain: Scaling factor for signal magnitude (default: 1.0). # # Returns: # Tensor of the shape `[N, C, H //
+factor, W // factor]` or `[N, H // factor, W // factor, C]`, and same datatype # as `x`. #"""
+#
+#    assert isinstance(factor, int) and factor >= 1
+#    _outC, _inC, convH, convW = w.shape
+#    assert convW == convH
+#    if k is None:
+#        k = [1] * factor
+#    k = _setup_kernel(k) * gain
+#    p = (k.shape[0] - factor) + (convW - 1)
+#    s = [factor, factor]
+#    x = upfirdn2d(x, torch.tensor(k, device=x.device), pad=((p + 1) // 2, p // 2))
+#    return F.conv2d(x, w, stride=s, padding=0)
 
 
 def _variance_scaling(scale=1.0, in_axis=1, out_axis=0, dtype=torch.float32, device="cpu"):
@@ -181,46 +170,6 @@ class Combine(nn.Module):
             return h + y
         else:
             raise ValueError(f"Method {self.method} not recognized.")
-
-
-class FirUpsample2D(nn.Module):
-    def __init__(self, channels=None, out_channels=None, use_conv=False, fir_kernel=(1, 3, 3, 1)):
-        super().__init__()
-        out_channels = out_channels if out_channels else channels
-        if use_conv:
-            self.Conv2d_0 = Conv2d(channels, out_channels, kernel_size=3, stride=1, padding=1)
-        self.use_conv = use_conv
-        self.fir_kernel = fir_kernel
-        self.out_channels = out_channels
-
-    def forward(self, x):
-        if self.use_conv:
-            h = _upsample_conv_2d(x, self.Conv2d_0.weight, k=self.fir_kernel)
-            h = h + self.Conv2d_0.bias.reshape(1, -1, 1, 1)
-        else:
-            h = upsample_2d(x, self.fir_kernel, factor=2)
-
-        return h
-
-
-class FirDownsample2D(nn.Module):
-    def __init__(self, channels=None, out_channels=None, use_conv=False, fir_kernel=(1, 3, 3, 1)):
-        super().__init__()
-        out_channels = out_channels if out_channels else channels
-        if use_conv:
-            self.Conv2d_0 = self.Conv2d_0 = Conv2d(channels, out_channels, kernel_size=3, stride=1, padding=1)
-        self.fir_kernel = fir_kernel
-        self.use_conv = use_conv
-        self.out_channels = out_channels
-
-    def forward(self, x):
-        if self.use_conv:
-            x = _conv_downsample_2d(x, self.Conv2d_0.weight, k=self.fir_kernel)
-            x = x + self.Conv2d_0.bias.reshape(1, -1, 1, 1)
-        else:
-            x = downsample_2d(x, self.fir_kernel, factor=2)
-
-        return x
 
 
 class NCSNpp(ModelMixin, ConfigMixin):

--- a/src/diffusers/models/unet_sde_score_estimation.py
+++ b/src/diffusers/models/unet_sde_score_estimation.py
@@ -27,7 +27,7 @@ from ..configuration_utils import ConfigMixin
 from ..modeling_utils import ModelMixin
 from .attention import AttentionBlock
 from .embeddings import GaussianFourierProjection, get_timestep_embedding
-from .resnet import Downsample, ResnetBlock2D, Upsample, downsample_2d, upfirdn2d, upsample_2d
+from .resnet import Downsample2D, ResnetBlock2D, Upsample2D, downsample_2d, upfirdn2d, upsample_2d
 
 
 def _setup_kernel(k):
@@ -183,7 +183,7 @@ class Combine(nn.Module):
             raise ValueError(f"Method {self.method} not recognized.")
 
 
-class FirUpsample(nn.Module):
+class FirUpsample2D(nn.Module):
     def __init__(self, channels=None, out_channels=None, use_conv=False, fir_kernel=(1, 3, 3, 1)):
         super().__init__()
         out_channels = out_channels if out_channels else channels
@@ -203,7 +203,7 @@ class FirUpsample(nn.Module):
         return h
 
 
-class FirDownsample(nn.Module):
+class FirDownsample2D(nn.Module):
     def __init__(self, channels=None, out_channels=None, use_conv=False, fir_kernel=(1, 3, 3, 1)):
         super().__init__()
         out_channels = out_channels if out_channels else channels
@@ -313,9 +313,9 @@ class NCSNpp(ModelMixin, ConfigMixin):
         AttnBlock = functools.partial(AttentionBlock, overwrite_linear=True, rescale_output_factor=math.sqrt(2.0))
 
         if self.fir:
-            Up_sample = functools.partial(FirUpsample, fir_kernel=fir_kernel, use_conv=resamp_with_conv)
+            Up_sample = functools.partial(FirUpsample2D, fir_kernel=fir_kernel, use_conv=resamp_with_conv)
         else:
-            Up_sample = functools.partial(Upsample, name="Conv2d_0")
+            Up_sample = functools.partial(Upsample2D, name="Conv2d_0")
 
         if progressive == "output_skip":
             self.pyramid_upsample = Up_sample(channels=None, use_conv=False)
@@ -323,9 +323,9 @@ class NCSNpp(ModelMixin, ConfigMixin):
             pyramid_upsample = functools.partial(Up_sample, use_conv=True)
 
         if self.fir:
-            Down_sample = functools.partial(FirDownsample, fir_kernel=fir_kernel, use_conv=resamp_with_conv)
+            Down_sample = functools.partial(FirDownsample2D, fir_kernel=fir_kernel, use_conv=resamp_with_conv)
         else:
-            Down_sample = functools.partial(Downsample, padding=0, name="Conv2d_0")
+            Down_sample = functools.partial(Downsample2D, padding=0, name="Conv2d_0")
 
         if progressive_input == "input_skip":
             self.pyramid_downsample = Down_sample(channels=None, use_conv=False)

--- a/src/diffusers/models/unet_sde_score_estimation.py
+++ b/src/diffusers/models/unet_sde_score_estimation.py
@@ -21,22 +21,12 @@ import math
 import numpy as np
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 from ..configuration_utils import ConfigMixin
 from ..modeling_utils import ModelMixin
 from .attention import AttentionBlock
 from .embeddings import GaussianFourierProjection, get_timestep_embedding
-from .resnet import (
-    Downsample2D,
-    FirDownsample2D,
-    FirUpsample2D,
-    ResnetBlock2D,
-    Upsample2D,
-    downsample_2d,
-    upfirdn2d,
-    upsample_2d,
-)
+from .resnet import Downsample2D, FirDownsample2D, FirUpsample2D, ResnetBlock2D, Upsample2D
 
 
 def _setup_kernel(k):
@@ -47,76 +37,6 @@ def _setup_kernel(k):
     assert k.ndim == 2
     assert k.shape[0] == k.shape[1]
     return k
-
-
-# def _upsample_conv_2d(x, w, k=None, factor=2, gain=1):
-#    """Fused `upsample_2d()` followed by `Conv2d()`. # # Args: # Padding is performed only once at the beginning, not between
-the operations. The fused op is considerably more # efficient than performing the same calculation using standard
-TensorFlow ops. It supports gradients of arbitrary # order. # x: Input tensor of the shape `[N, C, H, W]` or `[N, H, W,
-# C]`. # w: Weight tensor of the shape `[filterH, filterW, inChannels, # outChannels]`. Grouped convolution can be
-performed by `inChannels = x.shape[0] // numGroups`. # k: FIR filter of the shape `[firH, firW]` or `[firN]` #
-(separable). The default is `[1] * factor`, which corresponds to nearest-neighbor upsampling. # factor: Integer
-upsampling factor (default: 2). gain: Scaling factor for signal magnitude (default: 1.0). # # Returns: # Tensor of the
-shape `[N, C, H * factor, W * factor]` or `[N, H * factor, W * factor, C]`, and same datatype as # `x`. #"""
-#
-#    assert isinstance(factor, int) and factor >= 1
-#
-# Check weight shape.
-#    assert len(w.shape) == 4
-#    convH = w.shape[2]
-#    convW = w.shape[3]
-#    inC = w.shape[1]
-#
-#    assert convW == convH
-#
-# Setup filter kernel.
-#    if k is None:
-#        k = [1] * factor
-#    k = _setup_kernel(k) * (gain * (factor**2))
-#    p = (k.shape[0] - factor) - (convW - 1)
-#
-#    stride = (factor, factor)
-#
-# Determine data dimensions.
-#    stride = [1, 1, factor, factor]
-#    output_shape = ((x.shape[2] - 1) * factor + convH, (x.shape[3] - 1) * factor + convW)
-#    output_padding = (
-#        output_shape[0] - (x.shape[2] - 1) * stride[0] - convH,
-#        output_shape[1] - (x.shape[3] - 1) * stride[1] - convW,
-#    )
-#    assert output_padding[0] >= 0 and output_padding[1] >= 0
-#    num_groups = x.shape[1] // inC
-#
-# Transpose weights.
-#    w = torch.reshape(w, (num_groups, -1, inC, convH, convW))
-#    w = w[..., ::-1, ::-1].permute(0, 2, 1, 3, 4)
-#    w = torch.reshape(w, (num_groups * inC, -1, convH, convW))
-#
-#    x = F.conv_transpose2d(x, w, stride=stride, output_padding=output_padding, padding=0)
-#
-#    return upfirdn2d(x, torch.tensor(k, device=x.device), pad=((p + 1) // 2 + factor - 1, p // 2 + 1))
-
-
-# def _conv_downsample_2d(x, w, k=None, factor=2, gain=1):
-#    """Fused `Conv2d()` followed by `downsample_2d()`. # # Args: # Padding is performed only once at the beginning, not
-between the operations. The fused op is considerably more # efficient than performing the same calculation using
-standard TensorFlow ops. It supports gradients of arbitrary # order. # x: Input tensor of the shape `[N, C, H, W]` or
-`[N, H, W, # C]`. # w: Weight tensor of the shape `[filterH, filterW, inChannels, # outChannels]`. Grouped convolution
-can be performed by `inChannels = x.shape[0] // numGroups`. # k: FIR filter of the shape `[firH, firW]` or `[firN]` #
-(separable). The default is `[1] * factor`, which corresponds to average pooling. # factor: Integer downsampling factor
-(default: 2). gain: Scaling factor for signal magnitude (default: 1.0). # # Returns: # Tensor of the shape `[N, C, H //
-factor, W // factor]` or `[N, H // factor, W // factor, C]`, and same datatype # as `x`. #"""
-#
-#    assert isinstance(factor, int) and factor >= 1
-#    _outC, _inC, convH, convW = w.shape
-#    assert convW == convH
-#    if k is None:
-#        k = [1] * factor
-#    k = _setup_kernel(k) * gain
-#    p = (k.shape[0] - factor) + (convW - 1)
-#    s = [factor, factor]
-#    x = upfirdn2d(x, torch.tensor(k, device=x.device), pad=((p + 1) // 2, p // 2))
-#    return F.conv2d(x, w, stride=s, padding=0)
 
 
 def _variance_scaling(scale=1.0, in_axis=1, out_axis=0, dtype=torch.float32, device="cpu"):

--- a/src/diffusers/models/vae.py
+++ b/src/diffusers/models/vae.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 from ..configuration_utils import ConfigMixin
 from ..modeling_utils import ModelMixin
 from .attention import AttentionBlock
-from .resnet import Downsample, ResnetBlock2D, Upsample
+from .resnet import Downsample2D, ResnetBlock2D, Upsample2D
 
 
 def nonlinearity(x):
@@ -65,7 +65,7 @@ class Encoder(nn.Module):
             down.block = block
             down.attn = attn
             if i_level != self.num_resolutions - 1:
-                down.downsample = Downsample(block_in, use_conv=resamp_with_conv, padding=0)
+                down.downsample = Downsample2D(block_in, use_conv=resamp_with_conv, padding=0)
                 curr_res = curr_res // 2
             self.down.append(down)
 
@@ -179,7 +179,7 @@ class Decoder(nn.Module):
             up.block = block
             up.attn = attn
             if i_level != 0:
-                up.upsample = Upsample(block_in, use_conv=resamp_with_conv)
+                up.upsample = Upsample2D(block_in, use_conv=resamp_with_conv)
                 curr_res = curr_res * 2
             self.up.insert(0, up)  # prepend to get consistent order
 

--- a/src/diffusers/pipelines/bddm/pipeline_bddm.py
+++ b/src/diffusers/pipelines/bddm/pipeline_bddm.py
@@ -137,7 +137,7 @@ class ResidualBlock(nn.Module):
         # Dilated conv layer
         h = self.dilated_conv_layer(h)
 
-        # Upsample spectrogram to size of audio
+        # Upsample2D spectrogram to size of audio
         mel_spec = torch.unsqueeze(mel_spec, dim=1)
         mel_spec = F.leaky_relu(self.upsample_conv2d[0](mel_spec), 0.4, inplace=False)
         mel_spec = F.leaky_relu(self.upsample_conv2d[1](mel_spec), 0.4, inplace=False)

--- a/tests/test_layers_utils.py
+++ b/tests/test_layers_utils.py
@@ -22,7 +22,7 @@ import numpy as np
 import torch
 
 from diffusers.models.embeddings import get_timestep_embedding
-from diffusers.models.resnet import Downsample, Upsample
+from diffusers.models.resnet import Downsample2D, Upsample2D
 from diffusers.testing_utils import floats_tensor, slow, torch_device
 
 
@@ -116,11 +116,11 @@ class EmbeddingsTests(unittest.TestCase):
         )
 
 
-class UpsampleBlockTests(unittest.TestCase):
+class Upsample2DBlockTests(unittest.TestCase):
     def test_upsample_default(self):
         torch.manual_seed(0)
         sample = torch.randn(1, 32, 32, 32)
-        upsample = Upsample(channels=32, use_conv=False)
+        upsample = Upsample2D(channels=32, use_conv=False)
         with torch.no_grad():
             upsampled = upsample(sample)
 
@@ -132,7 +132,7 @@ class UpsampleBlockTests(unittest.TestCase):
     def test_upsample_with_conv(self):
         torch.manual_seed(0)
         sample = torch.randn(1, 32, 32, 32)
-        upsample = Upsample(channels=32, use_conv=True)
+        upsample = Upsample2D(channels=32, use_conv=True)
         with torch.no_grad():
             upsampled = upsample(sample)
 
@@ -144,7 +144,7 @@ class UpsampleBlockTests(unittest.TestCase):
     def test_upsample_with_conv_out_dim(self):
         torch.manual_seed(0)
         sample = torch.randn(1, 32, 32, 32)
-        upsample = Upsample(channels=32, use_conv=True, out_channels=64)
+        upsample = Upsample2D(channels=32, use_conv=True, out_channels=64)
         with torch.no_grad():
             upsampled = upsample(sample)
 
@@ -156,7 +156,7 @@ class UpsampleBlockTests(unittest.TestCase):
     def test_upsample_with_transpose(self):
         torch.manual_seed(0)
         sample = torch.randn(1, 32, 32, 32)
-        upsample = Upsample(channels=32, use_conv=False, use_conv_transpose=True)
+        upsample = Upsample2D(channels=32, use_conv=False, use_conv_transpose=True)
         with torch.no_grad():
             upsampled = upsample(sample)
 
@@ -166,11 +166,11 @@ class UpsampleBlockTests(unittest.TestCase):
         assert torch.allclose(output_slice.flatten(), expected_slice, atol=1e-3)
 
 
-class DownsampleBlockTests(unittest.TestCase):
+class Downsample2DBlockTests(unittest.TestCase):
     def test_downsample_default(self):
         torch.manual_seed(0)
         sample = torch.randn(1, 32, 64, 64)
-        downsample = Downsample(channels=32, use_conv=False)
+        downsample = Downsample2D(channels=32, use_conv=False)
         with torch.no_grad():
             downsampled = downsample(sample)
 
@@ -184,7 +184,7 @@ class DownsampleBlockTests(unittest.TestCase):
     def test_downsample_with_conv(self):
         torch.manual_seed(0)
         sample = torch.randn(1, 32, 64, 64)
-        downsample = Downsample(channels=32, use_conv=True)
+        downsample = Downsample2D(channels=32, use_conv=True)
         with torch.no_grad():
             downsampled = downsample(sample)
 
@@ -199,7 +199,7 @@ class DownsampleBlockTests(unittest.TestCase):
     def test_downsample_with_conv_pad1(self):
         torch.manual_seed(0)
         sample = torch.randn(1, 32, 64, 64)
-        downsample = Downsample(channels=32, use_conv=True, padding=1)
+        downsample = Downsample2D(channels=32, use_conv=True, padding=1)
         with torch.no_grad():
             downsampled = downsample(sample)
 
@@ -211,7 +211,7 @@ class DownsampleBlockTests(unittest.TestCase):
     def test_downsample_with_conv_out_dim(self):
         torch.manual_seed(0)
         sample = torch.randn(1, 32, 64, 64)
-        downsample = Downsample(channels=32, use_conv=True, out_channels=16)
+        downsample = Downsample2D(channels=32, use_conv=True, out_channels=16)
         with torch.no_grad():
             downsampled = downsample(sample)
 


### PR DESCRIPTION
Move `FirUpsample` and `FirDownsample` to `resnet.py` class - should maybe go into a `sampler.py` at some point but not stay in the `unet_...py` files.

Most importantly make upsamplers and downsamplers 1D and 2D specific