### PR TITLE
Fix mutable proj_out weight in the Attention layer

### DIFF
--- a/examples/train_unconditional.py
+++ b/examples/train_unconditional.py
@@ -4,7 +4,7 @@ import os
 import torch
 import torch.nn.functional as F
 
-from accelerate import Accelerator
+from accelerate import Accelerator, DistributedDataParallelKwargs
 from accelerate.logging import get_logger
 from datasets import load_dataset
 from diffusers import DDIMPipeline, DDIMScheduler, UNetModel
@@ -27,8 +27,14 @@ logger = get_logger(__name__)
 
 
 def main(args):
+    ddp_unused_params = DistributedDataParallelKwargs(find_unused_parameters=True)
     logging_dir = os.path.join(args.output_dir, args.logging_dir)
-    accelerator = Accelerator(mixed_precision=args.mixed_precision, log_with="tensorboard", logging_dir=logging_dir)
+    accelerator = Accelerator(
+        mixed_precision=args.mixed_precision,
+        log_with="tensorboard",
+        logging_dir=logging_dir,
+        kwargs_handlers=[ddp_unused_params]
+    )
 
     model = UNetModel(
         attn_resolutions=(16,),

--- a/examples/train_unconditional.py
+++ b/examples/train_unconditional.py
@@ -33,7 +33,7 @@ def main(args):
         mixed_precision=args.mixed_precision,
         log_with="tensorboard",
         logging_dir=logging_dir,
-        kwargs_handlers=[ddp_unused_params]
+        kwargs_handlers=[ddp_unused_params],
     )
 
     model = UNetModel(

--- a/src/diffusers/training_utils.py
+++ b/src/diffusers/training_utils.py
@@ -30,7 +30,7 @@ class EMAModel:
             min_value (float): The minimum EMA decay rate. Default: 0.
         """
 
-        self.averaged_model = copy.deepcopy(model)
+        self.averaged_model = copy.deepcopy(model).eval()
         self.averaged_model.requires_grad_(False)
 
         self.update_after_step = update_after_step


### PR DESCRIPTION
This fixes a shape mismatch in `proj_out.weight` during an EMA step, and adds an EMA test to catch it in the future.

To reproduce the bug:
```python
import torch
from diffusers import UNetModel
from diffusers.training_utils import EMAModel

# 1. init EMAModel with a copy.deepcopy(unet)
unet = UNetModel(resolution=32)
ema = EMAModel(unet)

# 2. mock a "forward pass"
outputs = unet(torch.randn((1, 3, 32, 32)), torch.ones(1))

# 3. try to average the updated model with the one saved at the start
ema.step(unet, 1)
```

```python
Traceback (most recent call last):
  File "/diffusers/src/diffusers/training_utils.py", line 81, in step
    ema_param.add_(param.data.to(dtype=ema_param.dtype), alpha=1 - self.decay)
RuntimeError: output with shape [128, 128, 1, 1] doesn't match the broadcast shape [128, 128, 128, 1]
```