### PR TITLE
LDM conversion script

### DIFF
--- a/scripts/convert_ldm_original_checkpoint_to_diffusers.py
+++ b/scripts/convert_ldm_original_checkpoint_to_diffusers.py
@@ -1,0 +1,309 @@
+# coding=utf-8
+# Copyright 2022 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Conversion script for the LDM checkpoints. """
+
+import argparse
+import json
+import torch
+
+
+def shave_segments(path, n_shave_prefix_segments=1):
+    """
+    Removes segments. Positive values shave the first segments, negative shave the last segments.
+    """
+    if n_shave_prefix_segments >= 0:
+        return '.'.join(path.split('.')[n_shave_prefix_segments:])
+    else:
+        return '.'.join(path.split('.')[:n_shave_prefix_segments])
+
+
+def renew_resnet_paths(old_list, n_shave_prefix_segments=0):
+    """
+    Updates paths inside resnets to the new naming scheme (local renaming)
+    """
+    mapping = []
+    for old_item in old_list:
+        new_item = old_item.replace('in_layers.0', 'norm1')
+        new_item = new_item.replace('in_layers.2', 'conv1')
+
+        new_item = new_item.replace('out_layers.0', 'norm2')
+        new_item = new_item.replace('out_layers.3', 'conv2')
+
+        new_item = new_item.replace('emb_layers.1', 'time_emb_proj')
+        new_item = new_item.replace('skip_connection', 'conv_shortcut')
+
+        new_item = shave_segments(new_item, n_shave_prefix_segments=n_shave_prefix_segments)
+
+        mapping.append({'old': old_item, 'new': new_item})
+
+    return mapping
+
+
+def renew_attention_paths(old_list, n_shave_prefix_segments=0):
+    """
+    Updates paths inside attentions to the new naming scheme (local renaming)
+    """
+    mapping = []
+    for old_item in old_list:
+        new_item = old_item
+
+        new_item = new_item.replace('norm.weight', 'group_norm.weight')
+        new_item = new_item.replace('norm.bias', 'group_norm.bias')
+
+        new_item = new_item.replace('proj_out.weight', 'proj_attn.weight')
+        new_item = new_item.replace('proj_out.bias', 'proj_attn.bias')
+
+        new_item = shave_segments(new_item, n_shave_prefix_segments=n_shave_prefix_segments)
+
+        mapping.append({'old': old_item, 'new': new_item})
+
+    return mapping
+
+
+def assign_to_checkpoint(paths, checkpoint, old_checkpoint, attention_paths_to_split=None, additional_replacements=None):
+    """
+    This does the final conversion step: take locally converted weights and apply a global renaming
+    to them. It splits attention layers, and takes into account additional replacements
+    that may arise.
+
+    Assigns the weights to the new checkpoint.
+    """
+    assert isinstance(paths, list), "Paths should be a list of dicts containing 'old' and 'new' keys."
+
+    # Splits the attention layers into three variables.
+    if attention_paths_to_split is not None:
+        for path, path_map in attention_paths_to_split.items():
+            query, key, value = torch.split(old_checkpoint[path], int(old_checkpoint[path].shape[0] / 3))
+
+            checkpoint[path_map['query']] = query
+            checkpoint[path_map['key']] = key
+            checkpoint[path_map['value']] = value
+
+    for path in paths:
+        new_path = path['new']
+
+        # These have already been assigned
+        if attention_paths_to_split is not None and new_path in attention_paths_to_split:
+            continue
+
+        # Global renaming happens here
+        new_path = new_path.replace('middle_block.0', 'mid.resnets.0')
+        new_path = new_path.replace('middle_block.1', 'mid.attentions.0')
+        new_path = new_path.replace('middle_block.2', 'mid.resnets.1')
+
+        if additional_replacements is not None:
+            for replacement in additional_replacements:
+                new_path = new_path.replace(replacement['old'], replacement['new'])
+
+        checkpoint[new_path] = old_checkpoint[path['old']]
+
+
+def convert_ldm_checkpoint(checkpoint, config):
+    """
+    Takes a state dict and the path to
+    """
+    new_checkpoint = {}
+
+    new_checkpoint['time_embedding.linear_1.weight'] = checkpoint['time_embed.0.weight']
+    new_checkpoint['time_embedding.linear_1.bias'] = checkpoint['time_embed.0.bias']
+    new_checkpoint['time_embedding.linear_2.weight'] = checkpoint['time_embed.2.weight']
+    new_checkpoint['time_embedding.linear_2.bias'] = checkpoint['time_embed.2.bias']
+
+    new_checkpoint['conv_in.weight'] = checkpoint['input_blocks.0.0.weight']
+    new_checkpoint['conv_in.bias'] = checkpoint['input_blocks.0.0.bias']
+
+    new_checkpoint['conv_norm_out.weight'] = checkpoint['out.0.weight']
+    new_checkpoint['conv_norm_out.bias'] = checkpoint['out.0.bias']
+    new_checkpoint['conv_out.weight'] = checkpoint['out.2.weight']
+    new_checkpoint['conv_out.bias'] = checkpoint['out.2.bias']
+
+    # Retrieves the keys for the input blocks only
+    num_input_blocks = len({shave_segments(layer, -2) for layer in checkpoint if 'input_blocks' in layer})
+    input_blocks = {layer_id: [key for key in checkpoint if f'input_blocks.{layer_id}' in key] for layer_id in range(num_input_blocks)}
+
+    # Retrieves the keys for the middle blocks only
+    num_middle_blocks = len({shave_segments(layer, -2) for layer in checkpoint if 'middle_block' in layer})
+    middle_blocks = {layer_id: [key for key in checkpoint if f'middle_block.{layer_id}' in key] for layer_id in range(num_middle_blocks)}
+
+    # Retrieves the keys for the output blocks only
+    num_output_blocks = len({shave_segments(layer, -2) for layer in checkpoint if 'output_blocks' in layer})
+    output_blocks = {layer_id: [key for key in checkpoint if f'output_blocks.{layer_id}' in key] for layer_id in range(num_output_blocks)}
+
+    for i in range(1, num_input_blocks):
+        block_id = (i - 1) // (config['num_res_blocks'] + 1)
+        layer_in_block_id = (i - 1) % (config['num_res_blocks'] + 1)
+
+        resnets = [key for key in input_blocks[i] if f'input_blocks.{i}.0' in key]
+        attentions = [key for key in input_blocks[i] if f'input_blocks.{i}.1' in key]
+
+        if f'input_blocks.{i}.0.op.weight' in checkpoint:
+            new_checkpoint[f'downsample_blocks.{block_id}.downsamplers.0.conv.weight'] = checkpoint[f'input_blocks.{i}.0.op.weight']
+            new_checkpoint[f'downsample_blocks.{block_id}.downsamplers.0.conv.bias'] = checkpoint[f'input_blocks.{i}.0.op.bias']
+
+        paths = renew_resnet_paths(resnets)
+        meta_path = {'old': f'input_blocks.{i}.0', 'new': f'downsample_blocks.{block_id}.resnets.{layer_in_block_id}'}
+        resnet_op = {'old': 'resnets.2.op', 'new': 'downsamplers.0.op'}
+        assign_to_checkpoint(paths, new_checkpoint, checkpoint, additional_replacements=[meta_path, resnet_op])
+
+        if len(attentions):
+            paths = renew_attention_paths(attentions)
+            meta_path = {'old': f'input_blocks.{i}.1', 'new': f'downsample_blocks.{block_id}.attentions.{layer_in_block_id}'}
+            to_split = {
+                f'input_blocks.{i}.1.qkv.bias': {
+                    'key': f'downsample_blocks.{block_id}.attentions.{layer_in_block_id}.key.bias',
+                    'query': f'downsample_blocks.{block_id}.attentions.{layer_in_block_id}.query.bias',
+                    'value': f'downsample_blocks.{block_id}.attentions.{layer_in_block_id}.value.bias',
+                },
+                f'input_blocks.{i}.1.qkv.weight': {
+                    'key': f'downsample_blocks.{block_id}.attentions.{layer_in_block_id}.key.weight',
+                    'query': f'downsample_blocks.{block_id}.attentions.{layer_in_block_id}.query.weight',
+                    'value': f'downsample_blocks.{block_id}.attentions.{layer_in_block_id}.value.weight',
+                },
+            }
+            assign_to_checkpoint(
+                paths,
+                new_checkpoint,
+                checkpoint,
+                additional_replacements=[meta_path],
+                attention_paths_to_split=to_split
+            )
+
+
+    resnet_0 = middle_blocks[0]
+    attentions = middle_blocks[1]
+    resnet_1 = middle_blocks[2]
+
+    resnet_0_paths = renew_resnet_paths(resnet_0)
+    assign_to_checkpoint(resnet_0_paths, new_checkpoint, checkpoint)
+
+    resnet_1_paths = renew_resnet_paths(resnet_1)
+    assign_to_checkpoint(resnet_1_paths, new_checkpoint, checkpoint)
+
+    attentions_paths = renew_attention_paths(attentions)
+    to_split = {
+        'middle_block.1.qkv.bias': {
+            'key': 'mid.attentions.0.key.bias',
+            'query': 'mid.attentions.0.query.bias',
+            'value': 'mid.attentions.0.value.bias',
+        },
+        'middle_block.1.qkv.weight': {
+            'key': 'mid.attentions.0.key.weight',
+            'query': 'mid.attentions.0.query.weight',
+            'value': 'mid.attentions.0.value.weight',
+        },
+    }
+    assign_to_checkpoint(attentions_paths, new_checkpoint, checkpoint, attention_paths_to_split=to_split)
+
+    for i in range(num_output_blocks):
+        block_id = i // (config['num_res_blocks'] + 1)
+        layer_in_block_id = i % (config['num_res_blocks'] + 1)
+        output_block_layers = [shave_segments(name, 2) for name in output_blocks[i]]
+        output_block_list = {}
+
+        for layer in output_block_layers:
+            layer_id, layer_name = layer.split('.')[0], shave_segments(layer, 1)
+            if layer_id in output_block_list:
+                output_block_list[layer_id].append(layer_name)
+            else:
+                output_block_list[layer_id] = [layer_name]
+
+        if len(output_block_list) > 1:
+            resnets = [key for key in output_blocks[i] if f'output_blocks.{i}.0' in key]
+            attentions = [key for key in output_blocks[i] if f'output_blocks.{i}.1' in key]
+
+            resnet_0_paths = renew_resnet_paths(resnets)
+            paths = renew_resnet_paths(resnets)
+
+            meta_path = {'old': f'output_blocks.{i}.0', 'new': f'upsample_blocks.{block_id}.resnets.{layer_in_block_id}'}
+            assign_to_checkpoint(paths, new_checkpoint, checkpoint, additional_replacements=[meta_path])
+
+            if ['conv.weight', 'conv.bias'] in output_block_list.values():
+                index = list(output_block_list.values()).index(['conv.weight', 'conv.bias'])
+                new_checkpoint[f'upsample_blocks.{block_id}.upsamplers.0.conv.weight'] = checkpoint[f'output_blocks.{i}.{index}.conv.weight']
+                new_checkpoint[f'upsample_blocks.{block_id}.upsamplers.0.conv.bias'] = checkpoint[f'output_blocks.{i}.{index}.conv.bias']
+
+                # Clear attentions as they have been attributed above.
+                if len(attentions) == 2:
+                    attentions = []
+
+
+            if len(attentions):
+                paths = renew_attention_paths(attentions)
+                meta_path = {
+                    'old': f'output_blocks.{i}.1',
+                    'new': f'upsample_blocks.{block_id}.attentions.{layer_in_block_id}'
+                }
+                to_split = {
+                    f'output_blocks.{i}.1.qkv.bias': {
+                        'key': f'upsample_blocks.{block_id}.attentions.{layer_in_block_id}.key.bias',
+                        'query': f'upsample_blocks.{block_id}.attentions.{layer_in_block_id}.query.bias',
+                        'value': f'upsample_blocks.{block_id}.attentions.{layer_in_block_id}.value.bias',
+                    },
+                    f'output_blocks.{i}.1.qkv.weight': {
+                        'key': f'upsample_blocks.{block_id}.attentions.{layer_in_block_id}.key.weight',
+                        'query': f'upsample_blocks.{block_id}.attentions.{layer_in_block_id}.query.weight',
+                        'value': f'upsample_blocks.{block_id}.attentions.{layer_in_block_id}.value.weight',
+                    },
+                }
+                assign_to_checkpoint(
+                    paths,
+                    new_checkpoint,
+                    checkpoint,
+                    additional_replacements=[meta_path],
+                    attention_paths_to_split=to_split if any('qkv' in key for key in attentions) else None
+                )
+        else:
+            resnet_0_paths = renew_resnet_paths(output_block_layers, n_shave_prefix_segments=1)
+            for path in resnet_0_paths:
+                old_path = '.'.join(['output_blocks', str(i), path['old']])
+                new_path = '.'.join(['upsample_blocks', str(block_id), 'resnets', str(layer_in_block_id), path['new']])
+
+                new_checkpoint[new_path] = checkpoint[old_path]
+
+    return new_checkpoint
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--checkpoint_path", default=None, type=str, required=True, help="Path to the checkpoint to convert."
+    )
+
+    parser.add_argument(
+        "--config_file",
+        default=None,
+        type=str,
+        required=True,
+        help="The config json file corresponding to the architecture.",
+    )
+
+    parser.add_argument(
+        "--dump_path", default=None, type=str, required=True, help="Path to the output model."
+    )
+
+    args = parser.parse_args()
+
+
+    checkpoint = torch.load(args.checkpoint_path)
+
+    with open(args.config_file) as f:
+        config = json.loads(f.read())
+
+    converted_checkpoint = convert_ldm_checkpoint(checkpoint, config)
+    torch.save(checkpoint, args.dump_path)
+
+
+


### PR DESCRIPTION
This adds a conversion script for the LDM models.

Tested on `fusing/unet-ldm-dummy` and `fusing/latent-diffusion-celeba-256`.

*There is still an issue with the QKV layer, see below for reproducer*.

<details>
  <summary>Running with <code>fusing/unet-ldm-dummy</code></summary>
  
```python
import json
from diffusers import UNetUnconditionalModel
from scripts.convert_ldm_original_checkpoint_to_diffusers import convert_ldm_checkpoint
from huggingface_hub import hf_hub_download
import torch

original_checkpoint = torch.load(hf_hub_download('fusing/unet-ldm-dummy', 'diffusion_model.pt'))
config_path = hf_hub_download('fusing/unet-ldm-dummy', 'config.json')

with open(config_path) as f:
    config = json.load(f)

checkpoint = convert_ldm_checkpoint(original_checkpoint, config)


def current_codebase_conversion():
    model = UNetUnconditionalModel.from_pretrained("fusing/unet-ldm-dummy", ldm=True)
    model.eval()

    torch.manual_seed(0)
    if torch.cuda.is_available():
        torch.cuda.manual_seed_all(0)

    noise = torch.randn(1, model.config.in_channels, model.config.image_size, model.config.image_size)
    time_step = torch.tensor([10] * noise.shape[0])

    with torch.no_grad():
        output = model(noise, time_step)

    return model.state_dict()


currently_converted_checkpoint = current_codebase_conversion()
torch.save(currently_converted_checkpoint, 'currently_converted_checkpoint.pt')



def diff_between_checkpoints(ch_0, ch_1):
    all_layers_included = False

    if not set(ch_0.keys()) == set(ch_1.keys()):
        print(f"Contained in ch_0 and not in ch_1 (Total: {len((set(ch_0.keys()) - set(ch_1.keys())))})")
        for key in sorted(list((set(ch_0.keys()) - set(ch_1.keys())))):
            print(f"\t{key}")

        print(f"Contained in ch_1 and not in ch_0 (Total: {len((set(ch_1.keys()) - set(ch_0.keys())))})")
        for key in sorted(list((set(ch_1.keys()) - set(ch_0.keys())))):
            print(f"\t{key}")
    else:
        print("Keys are the same between the two checkpoints")
        all_layers_included = True

    keys = ch_0.keys()
    non_equal_keys = []

    if all_layers_included:
        for key in keys:
            try:
                if not torch.allclose(ch_0[key].cpu(), ch_1[key].cpu()):
                    non_equal_keys.append(f'{key}. Diff: {torch.max(torch.abs(ch_0[key].cpu() - ch_1[key].cpu()))}')

            except RuntimeError as e:
                print(e)
                non_equal_keys.append(f'{key}. Diff in shape: {ch_0[key].size()} vs {ch_1[key].size()}')

        if len(non_equal_keys):
            non_equal_keys = '\n\t'.join(non_equal_keys)
            print(f"These keys do not satisfy equivalence requirement:\n\t{non_equal_keys}")
        else:
            print("All keys are equal across checkpoints.")


diff_between_checkpoints(currently_converted_checkpoint, checkpoint)
```

It outputs the following:

```
Keys are the same between the two checkpoints
These keys do not satisfy equivalence requirement:
	mid.attentions.0.query.weight. Diff: 0.24961645901203156
	mid.attentions.0.query.bias. Diff: 0.2195194512605667
	mid.attentions.0.key.weight. Diff: 0.2491813600063324
	mid.attentions.0.key.bias. Diff: 0.20943328738212585
	mid.attentions.0.value.weight. Diff: 0.24932505190372467
	mid.attentions.0.value.bias. Diff: 0.23784728348255157
	mid.attentions.0.proj_attn.weight. Diff: 0.999199390411377

Process finished with exit code 0
```

So all keys are correctly loaded, and have the correct value. Only the QKV tensors are wrong.

</details>


<details>
  <summary>Running with <code>fusing/latent-diffusion-celeba-256</code></summary>
  
```python
import json
from diffusers import UNetUnconditionalModel
from scripts.convert_ldm_original_checkpoint_to_diffusers import convert_ldm_checkpoint
from huggingface_hub import hf_hub_download
import torch

original_checkpoint = torch.load(hf_hub_download('fusing/latent-diffusion-celeba-256', 'unet/diffusion_model.pt'))
config_path = hf_hub_download('fusing/latent-diffusion-celeba-256', 'unet/config.json')

with open(config_path) as f:
    config = json.load(f)

checkpoint = convert_ldm_checkpoint(original_checkpoint, config)


def current_codebase_conversion():
    model = UNetUnconditionalModel.from_pretrained("fusing/latent-diffusion-celeba-256", subfolder="unet", ldm=True)
    model.eval()

    torch.manual_seed(0)
    if torch.cuda.is_available():
        torch.cuda.manual_seed_all(0)

    noise = torch.randn(1, model.config.in_channels, model.config.image_size, model.config.image_size)
    time_step = torch.tensor([10] * noise.shape[0])

    with torch.no_grad():
        output = model(noise, time_step)

    return model.state_dict()


currently_converted_checkpoint = current_codebase_conversion()
torch.save(currently_converted_checkpoint, 'currently_converted_checkpoint.pt')



def diff_between_checkpoints(ch_0, ch_1):
    all_layers_included = False

    if not set(ch_0.keys()) == set(ch_1.keys()):
        print(f"Contained in ch_0 and not in ch_1 (Total: {len((set(ch_0.keys()) - set(ch_1.keys())))})")
        for key in sorted(list((set(ch_0.keys()) - set(ch_1.keys())))):
            print(f"\t{key}")

        print(f"Contained in ch_1 and not in ch_0 (Total: {len((set(ch_1.keys()) - set(ch_0.keys())))})")
        for key in sorted(list((set(ch_1.keys()) - set(ch_0.keys())))):
            print(f"\t{key}")
    else:
        print("Keys are the same between the two checkpoints")
        all_layers_included = True

    keys = ch_0.keys()
    non_equal_keys = []

    if all_layers_included:
        for key in keys:
            try:
                if not torch.allclose(ch_0[key].cpu(), ch_1[key].cpu()):
                    non_equal_keys.append(f'{key}. Diff: {torch.max(torch.abs(ch_0[key].cpu() - ch_1[key].cpu()))}')

            except RuntimeError as e:
                print(e)
                non_equal_keys.append(f'{key}. Diff in shape: {ch_0[key].size()} vs {ch_1[key].size()}')

        if len(non_equal_keys):
            non_equal_keys = '\n\t'.join(non_equal_keys)
            print(f"These keys do not satisfy equivalence requirement:\n\t{non_equal_keys}")
        else:
            print("All keys are equal across checkpoints.")


diff_between_checkpoints(currently_converted_checkpoint, checkpoint)
```

It outputs the following:

```
Keys are the same between the two checkpoints
These keys do not satisfy equivalence requirement:
	downsample_blocks.1.attentions.0.query.weight. Diff: 0.5322743654251099
	downsample_blocks.1.attentions.0.query.bias. Diff: 0.8808112144470215
	downsample_blocks.1.attentions.0.key.weight. Diff: 0.5599208474159241
	downsample_blocks.1.attentions.0.key.bias. Diff: 0.48327890038490295
	downsample_blocks.1.attentions.0.value.weight. Diff: 0.5090557336807251
	downsample_blocks.1.attentions.0.value.bias. Diff: 0.47728630900382996
	downsample_blocks.1.attentions.0.proj_attn.weight. Diff: 0.4575197398662567
	downsample_blocks.1.attentions.1.query.weight. Diff: 0.4770662784576416
	downsample_blocks.1.attentions.1.query.bias. Diff: 0.6338784098625183
	downsample_blocks.1.attentions.1.key.weight. Diff: 0.4851330816745758
	downsample_blocks.1.attentions.1.key.bias. Diff: 0.5410565137863159
	downsample_blocks.1.attentions.1.value.weight. Diff: 0.4469549059867859
	downsample_blocks.1.attentions.1.value.bias. Diff: 0.6092959642410278
	downsample_blocks.1.attentions.1.proj_attn.weight. Diff: 0.4274057149887085
	downsample_blocks.2.attentions.0.query.weight. Diff: 0.44912058115005493
	downsample_blocks.2.attentions.0.query.bias. Diff: 0.5055721998214722
	downsample_blocks.2.attentions.0.key.weight. Diff: 0.4473114013671875
	downsample_blocks.2.attentions.0.key.bias. Diff: 0.4652261734008789
	downsample_blocks.2.attentions.0.value.weight. Diff: 0.4159700274467468
	downsample_blocks.2.attentions.0.value.bias. Diff: 0.4726192057132721
	downsample_blocks.2.attentions.0.proj_attn.weight. Diff: 0.40516728162765503
	downsample_blocks.2.attentions.1.query.weight. Diff: 0.47691595554351807
	downsample_blocks.2.attentions.1.query.bias. Diff: 0.44218048453330994
	downsample_blocks.2.attentions.1.key.weight. Diff: 0.47986364364624023
	downsample_blocks.2.attentions.1.key.bias. Diff: 0.30777376890182495
	downsample_blocks.2.attentions.1.value.weight. Diff: 0.43578052520751953
	downsample_blocks.2.attentions.1.value.bias. Diff: 0.3202424645423889
	downsample_blocks.2.attentions.1.proj_attn.weight. Diff: 0.4038900136947632
	downsample_blocks.3.attentions.0.query.weight. Diff: 0.34657835960388184
	downsample_blocks.3.attentions.0.query.bias. Diff: 0.2610008716583252
	downsample_blocks.3.attentions.0.key.weight. Diff: 0.36991608142852783
	downsample_blocks.3.attentions.0.key.bias. Diff: 0.17349816858768463
	downsample_blocks.3.attentions.0.value.weight. Diff: 0.34488216042518616
	downsample_blocks.3.attentions.0.value.bias. Diff: 0.21758568286895752
	downsample_blocks.3.attentions.0.proj_attn.weight. Diff: 0.3563486337661743
	downsample_blocks.3.attentions.1.query.weight. Diff: 0.33214086294174194
	downsample_blocks.3.attentions.1.query.bias. Diff: 0.23919078707695007
	downsample_blocks.3.attentions.1.key.weight. Diff: 0.3269691467285156
	downsample_blocks.3.attentions.1.key.bias. Diff: 0.16143986582756042
	downsample_blocks.3.attentions.1.value.weight. Diff: 0.32020965218544006
	downsample_blocks.3.attentions.1.value.bias. Diff: 0.1538049429655075
	downsample_blocks.3.attentions.1.proj_attn.weight. Diff: 0.30319327116012573
	upsample_blocks.0.attentions.0.query.weight. Diff: 0.323334276676178
	upsample_blocks.0.attentions.0.query.bias. Diff: 0.15119221806526184
	upsample_blocks.0.attentions.0.key.weight. Diff: 0.3194403052330017
	upsample_blocks.0.attentions.0.key.bias. Diff: 0.10946163535118103
	upsample_blocks.0.attentions.0.value.weight. Diff: 0.2954217195510864
	upsample_blocks.0.attentions.0.value.bias. Diff: 0.10782133787870407
	upsample_blocks.0.attentions.0.proj_attn.weight. Diff: 0.27988484501838684
	upsample_blocks.0.attentions.1.query.weight. Diff: 0.4926428496837616
	upsample_blocks.0.attentions.1.query.bias. Diff: 0.23354901373386383
	upsample_blocks.0.attentions.1.key.weight. Diff: 0.44477805495262146
	upsample_blocks.0.attentions.1.key.bias. Diff: 0.136196106672287
	upsample_blocks.0.attentions.1.value.weight. Diff: 0.4591912627220154
	upsample_blocks.0.attentions.1.value.bias. Diff: 0.20084039866924286
	upsample_blocks.0.attentions.1.proj_attn.weight. Diff: 0.3511205017566681
	upsample_blocks.0.attentions.2.query.weight. Diff: 0.43573683500289917
	upsample_blocks.0.attentions.2.query.bias. Diff: 0.2736799716949463
	upsample_blocks.0.attentions.2.key.weight. Diff: 0.4903469681739807
	upsample_blocks.0.attentions.2.key.bias. Diff: 0.22087500989437103
	upsample_blocks.0.attentions.2.value.weight. Diff: 0.4181097149848938
	upsample_blocks.0.attentions.2.value.bias. Diff: 0.20197127759456635
	upsample_blocks.0.attentions.2.proj_attn.weight. Diff: 0.38062620162963867
	upsample_blocks.1.attentions.0.query.weight. Diff: 0.5398491621017456
	upsample_blocks.1.attentions.0.query.bias. Diff: 0.6305736899375916
	upsample_blocks.1.attentions.0.key.weight. Diff: 0.4547557830810547
	upsample_blocks.1.attentions.0.key.bias. Diff: 0.3777274787425995
	upsample_blocks.1.attentions.0.value.weight. Diff: 0.44644907116889954
	upsample_blocks.1.attentions.0.value.bias. Diff: 0.3492506742477417
	upsample_blocks.1.attentions.0.proj_attn.weight. Diff: 0.5145654678344727
	upsample_blocks.1.attentions.1.query.weight. Diff: 0.4706581234931946
	upsample_blocks.1.attentions.1.query.bias. Diff: 0.4212320148944855
	upsample_blocks.1.attentions.1.key.weight. Diff: 0.4634551703929901
	upsample_blocks.1.attentions.1.key.bias. Diff: 0.31732258200645447
	upsample_blocks.1.attentions.1.value.weight. Diff: 0.5137529373168945
	upsample_blocks.1.attentions.1.value.bias. Diff: 0.35679009556770325
	upsample_blocks.1.attentions.1.proj_attn.weight. Diff: 0.48483580350875854
	upsample_blocks.1.attentions.2.query.weight. Diff: 0.4876726269721985
	upsample_blocks.1.attentions.2.query.bias. Diff: 0.44213277101516724
	upsample_blocks.1.attentions.2.key.weight. Diff: 0.43293285369873047
	upsample_blocks.1.attentions.2.key.bias. Diff: 0.32396024465560913
	upsample_blocks.1.attentions.2.value.weight. Diff: 0.4422367513179779
	upsample_blocks.1.attentions.2.value.bias. Diff: 0.26448380947113037
	upsample_blocks.1.attentions.2.proj_attn.weight. Diff: 0.44627588987350464
	upsample_blocks.2.attentions.0.query.weight. Diff: 0.49386805295944214
	upsample_blocks.2.attentions.0.query.bias. Diff: 0.6003696322441101
	upsample_blocks.2.attentions.0.key.weight. Diff: 0.498620867729187
	upsample_blocks.2.attentions.0.key.bias. Diff: 0.3520910143852234
	upsample_blocks.2.attentions.0.value.weight. Diff: 0.5287502408027649
	upsample_blocks.2.attentions.0.value.bias. Diff: 0.4354410767555237
	upsample_blocks.2.attentions.0.proj_attn.weight. Diff: 0.5489526987075806
	upsample_blocks.2.attentions.1.query.weight. Diff: 0.5196881890296936
	upsample_blocks.2.attentions.1.query.bias. Diff: 0.5461060404777527
	upsample_blocks.2.attentions.1.key.weight. Diff: 0.5029891133308411
	upsample_blocks.2.attentions.1.key.bias. Diff: 0.32834288477897644
	upsample_blocks.2.attentions.1.value.weight. Diff: 0.5868792533874512
	upsample_blocks.2.attentions.1.value.bias. Diff: 0.37310025095939636
	upsample_blocks.2.attentions.1.proj_attn.weight. Diff: 0.5955682396888733
	upsample_blocks.2.attentions.2.query.weight. Diff: 0.50129234790802
	upsample_blocks.2.attentions.2.query.bias. Diff: 0.6187994480133057
	upsample_blocks.2.attentions.2.key.weight. Diff: 0.5791605710983276
	upsample_blocks.2.attentions.2.key.bias. Diff: 0.3670012652873993
	upsample_blocks.2.attentions.2.value.weight. Diff: 0.553672194480896
	upsample_blocks.2.attentions.2.value.bias. Diff: 0.44034507870674133
	upsample_blocks.2.attentions.2.proj_attn.weight. Diff: 0.5612399578094482
	mid.attentions.0.query.weight. Diff: 0.2735501527786255
	mid.attentions.0.query.bias. Diff: 0.2128082811832428
	mid.attentions.0.key.weight. Diff: 0.268943727016449
	mid.attentions.0.key.bias. Diff: 0.09677034616470337
	mid.attentions.0.value.weight. Diff: 0.2759656310081482
	mid.attentions.0.value.bias. Diff: 0.13031360507011414
	mid.attentions.0.proj_attn.weight. Diff: 0.25482624769210815

Process finished with exit code 0
```

So all keys are correctly loaded, and have the correct value. Only the QKV tensors are wrong.

</details>

