### PR TITLE
fixing tests for numpy and make deterministic (ddpm)

### DIFF
--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -28,7 +28,9 @@ class DDIMPipeline(DiffusionPipeline):
         self.register_modules(unet=unet, scheduler=scheduler)
 
     @torch.no_grad()
-    def __call__(self, batch_size=1, generator=None, torch_device=None, eta=0.0, num_inference_steps=50, output_type="pil"):
+    def __call__(
+        self, batch_size=1, generator=None, torch_device=None, eta=0.0, num_inference_steps=50, output_type="pil"
+    ):
         # eta corresponds to η in paper and should be between [0, 1]
         if torch_device is None:
             torch_device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -59,7 +59,7 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
         trained_betas=None,
         timestep_values=None,
         clip_sample=True,
-        tensor_format="np",
+        tensor_format="pt",
     ):
 
         if beta_schedule == "linear":

--- a/src/diffusers/schedulers/scheduling_ddpm.py
+++ b/src/diffusers/schedulers/scheduling_ddpm.py
@@ -59,7 +59,7 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
         timestep_values=None,
         variance_type="fixed_small",
         clip_sample=True,
-        tensor_format="np",
+        tensor_format="pt",
     ):
 
         if trained_betas is not None:
@@ -155,7 +155,6 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
         # 6. Add noise
         variance = 0
         if t > 0:
-            # noise = torch.randn(model_output.shape, generator=generator).to(model_output.device)
             noise = self.randn_like(model_output, generator=generator)
             variance = (self._get_variance(t) ** 0.5) * noise
 

--- a/src/diffusers/schedulers/scheduling_ddpm.py
+++ b/src/diffusers/schedulers/scheduling_ddpm.py
@@ -165,8 +165,9 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
         # 6. Add noise
         variance = 0
         if t > 0:
-            noise = torch.randn(model_output.shape, generator=generator).to(model_output.device)
-            variance = self._get_variance(t).sqrt() * noise
+            # noise = torch.randn(model_output.shape, generator=generator).to(model_output.device)
+            noise = self.randn_like(model_output, generator=generator)
+            variance = (self._get_variance(t) ** 0.5) * noise
 
         pred_prev_sample = pred_prev_sample + variance
 

--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -56,7 +56,7 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         beta_start=0.0001,
         beta_end=0.02,
         beta_schedule="linear",
-        tensor_format="np",
+        tensor_format="pt",
     ):
 
         if beta_schedule == "linear":

--- a/src/diffusers/schedulers/scheduling_utils.py
+++ b/src/diffusers/schedulers/scheduling_utils.py
@@ -84,12 +84,13 @@ class SchedulerMixin:
 
         raise ValueError(f"`self.tensor_format`: {self.tensor_format} is not valid.")
 
-    def randn_like(self, tensor):
+    def randn_like(self, tensor, generator=None):
         tensor_format = getattr(self, "tensor_format", "pt")
         if tensor_format == "np":
             return np.random.randn(*np.shape(tensor))
         elif tensor_format == "pt":
-            return torch.randn_like(tensor)
+            # return torch.randn_like(tensor)
+            return torch.randn(tensor.shape, layout=tensor.layout, generator=generator).to(tensor.device)
 
         raise ValueError(f"`self.tensor_format`: {self.tensor_format} is not valid.")
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -213,6 +213,7 @@ class DDPMSchedulerTest(SchedulerCommonTest):
             "beta_schedule": "linear",
             "variance_type": "fixed_small",
             "clip_sample": True,
+            "tensor_format": "np",
         }
 
         config.update(**kwargs)
@@ -247,9 +248,9 @@ class DDPMSchedulerTest(SchedulerCommonTest):
         scheduler_config = self.get_scheduler_config()
         scheduler = scheduler_class(**scheduler_config)
 
-        assert np.sum(np.abs(scheduler.get_variance(0) - 0.0)) < 1e-5
-        assert np.sum(np.abs(scheduler.get_variance(487) - 0.00979)) < 1e-5
-        assert np.sum(np.abs(scheduler.get_variance(999) - 0.02)) < 1e-5
+        assert np.sum(np.abs(scheduler._get_variance(0) - 0.0)) < 1e-5
+        assert np.sum(np.abs(scheduler._get_variance(487) - 0.00979)) < 1e-5
+        assert np.sum(np.abs(scheduler._get_variance(999) - 0.02)) < 1e-5
 
     def test_full_loop_no_noise(self):
         scheduler_class = self.scheduler_classes[0]
@@ -268,11 +269,12 @@ class DDPMSchedulerTest(SchedulerCommonTest):
             # 2. predict previous mean of sample x_t-1
             pred_prev_sample = scheduler.step(residual, t, sample)["prev_sample"]
 
-            if t > 0:
-                noise = self.dummy_sample_deter
-                variance = scheduler.get_variance(t) ** (0.5) * noise
-
-            sample = pred_prev_sample + variance
+            # if t > 0:
+            #     noise = self.dummy_sample_deter
+            #     variance = scheduler.get_variance(t) ** (0.5) * noise
+            #
+            # sample = pred_prev_sample + variance
+            sample = pred_prev_sample
 
         result_sum = np.sum(np.abs(sample))
         result_mean = np.mean(np.abs(sample))


### PR DESCRIPTION
cc @patrickvonplaten. Will let you know if I fix this before bed today. Numpy not having a generator makes this tricky. 

Some easy fixes are in this, such as `get_variance` in `DDPMTesterClass` needs to be changed to `_get_variance` (what should the common terminology on this be)

Then this change also broke the `ve sde test` for the full loop, which is very sensitive to changes in `randn_like`. This is a common problem for these tests.