### PR TITLE
Documentation cross-reference

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,7 @@
 ## Training examples
 
+Creating a training image set is [described in a different document](https://huggingface.co/docs/datasets/image_process#image-datasets).
+
 ### Installing the dependencies
 
 Before running the scipts, make sure to install the library's training dependencies:


### PR DESCRIPTION
In https://github.com/huggingface/diffusers/issues/124 I incorrectly suggested that the image set creation process was undocumented.  In reality, I just hadn't located it.  @patrickvonplaten did so for me.

This PR places a hotlink so that people like me can be shoehorned over where they needed to be.