### PR TITLE
use device argument when available

### DIFF
--- a/examples/train_unconditional.py
+++ b/examples/train_unconditional.py
@@ -122,7 +122,7 @@ def main(args):
         for step, batch in enumerate(train_dataloader):
             clean_images = batch["input"]
             # Sample noise that we'll add to the images
-            noise = torch.randn(clean_images.shape).to(clean_images.device)
+            noise = torch.randn(clean_images.shape, device=clean_images.device)
             bsz = clean_images.shape[0]
             # Sample a random timestep for each image
             timesteps = torch.randint(

--- a/src/diffusers/models/vae.py
+++ b/src/diffusers/models/vae.py
@@ -209,7 +209,7 @@ class VectorQuantizer(nn.Module):
         new = match.argmax(-1)
         unknown = match.sum(2) < 1
         if self.unknown_index == "random":
-            new[unknown] = torch.randint(0, self.re_embed, size=new[unknown].shape).to(device=new.device)
+            new[unknown] = torch.randint(0, self.re_embed, size=new[unknown].shape, device=new.device)
         else:
             new[unknown] = self.unknown_index
         return new.reshape(ishape)
@@ -290,10 +290,10 @@ class DiagonalGaussianDistribution(object):
         self.std = torch.exp(0.5 * self.logvar)
         self.var = torch.exp(self.logvar)
         if self.deterministic:
-            self.var = self.std = torch.zeros_like(self.mean).to(device=self.parameters.device)
+            self.var = self.std = torch.zeros_like(self.mean, device=self.parameters.device)
 
     def sample(self):
-        x = self.mean + self.std * torch.randn(self.mean.shape).to(device=self.parameters.device)
+        x = self.mean + self.std * torch.randn(self.mean.shape, device=self.parameters.device)
         return x
 
     def kl(self, other=None):

--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -154,7 +154,7 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
 
         if eta > 0:
             device = model_output.device if torch.is_tensor(model_output) else "cpu"
-            noise = torch.randn(model_output.shape, generator=generator).to(device)
+            noise = torch.randn(model_output.shape, generator=generator, device=device)
             variance = self._get_variance(timestep, prev_timestep) ** (0.5) * eta * noise
 
             if not torch.is_tensor(model_output):

--- a/src/diffusers/schedulers/scheduling_sde_ve.py
+++ b/src/diffusers/schedulers/scheduling_sde_ve.py
@@ -163,7 +163,7 @@ class ScoreSdeVeScheduler(SchedulerMixin, ConfigMixin):
         grad_norm = self.norm(model_output)
         noise_norm = self.norm(noise)
         step_size = (self.config.snr * noise_norm / grad_norm) ** 2 * 2
-        step_size = step_size * torch.ones(sample.shape[0]).to(sample.device)
+        step_size = step_size * torch.ones(sample.shape[0], device=sample.device)
         # self.repeat_scalar(step_size, sample.shape[0])
 
         # compute corrected sample: model_output term and noise term

--- a/src/diffusers/schedulers/scheduling_utils.py
+++ b/src/diffusers/schedulers/scheduling_utils.py
@@ -91,7 +91,7 @@ class SchedulerMixin:
             return np.random.randn(*np.shape(tensor))
         elif tensor_format == "pt":
             # return torch.randn_like(tensor)
-            return torch.randn(tensor.shape, layout=tensor.layout, generator=generator).to(tensor.device)
+            return torch.randn(tensor.shape, layout=tensor.layout, generator=generator, device=tensor.device)
 
         raise ValueError(f"`self.tensor_format`: {self.tensor_format} is not valid.")
 

--- a/src/diffusers/testing_utils.py
+++ b/src/diffusers/testing_utils.py
@@ -29,7 +29,7 @@ def parse_flag_from_env(key, default=False):
 _run_slow_tests = parse_flag_from_env("RUN_SLOW", default=False)
 
 
-def floats_tensor(shape, scale=1.0, rng=None, name=None):
+def floats_tensor(shape, scale=1.0, rng=None, name=None, device=None):
     """Creates a random float32 tensor"""
     if rng is None:
         rng = global_rng
@@ -42,7 +42,7 @@ def floats_tensor(shape, scale=1.0, rng=None, name=None):
     for _ in range(total_dims):
         values.append(rng.random() * scale)
 
-    return torch.tensor(data=values, dtype=torch.float).view(shape).contiguous()
+    return torch.tensor(data=values, dtype=torch.float, device=device).view(shape).contiguous()
 
 
 def slow(test_case):

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -246,7 +246,7 @@ class ModelTesterMixin:
         if isinstance(output, dict):
             output = output["sample"]
 
-        noise = torch.randn((inputs_dict["sample"].shape[0],) + self.output_shape).to(torch_device)
+        noise = torch.randn((inputs_dict["sample"].shape[0],) + self.output_shape, device=torch_device)
         loss = torch.nn.functional.mse_loss(output, noise)
         loss.backward()
 
@@ -263,7 +263,7 @@ class ModelTesterMixin:
         if isinstance(output, dict):
             output = output["sample"]
 
-        noise = torch.randn((inputs_dict["sample"].shape[0],) + self.output_shape).to(torch_device)
+        noise = torch.randn((inputs_dict["sample"].shape[0],) + self.output_shape, device=torch_device)
         loss = torch.nn.functional.mse_loss(output, noise)
         loss.backward()
         ema_model.step(model)
@@ -278,8 +278,8 @@ class UnetModelTests(ModelTesterMixin, unittest.TestCase):
         num_channels = 3
         sizes = (32, 32)
 
-        noise = floats_tensor((batch_size, num_channels) + sizes).to(torch_device)
-        time_step = torch.tensor([10]).to(torch_device)
+        noise = floats_tensor((batch_size, num_channels) + sizes, device=torch_device)
+        time_step = torch.tensor([10], device=torch_device)
 
         return {"sample": noise, "timestep": time_step}
 
@@ -337,8 +337,8 @@ class UNetLDMModelTests(ModelTesterMixin, unittest.TestCase):
         num_channels = 4
         sizes = (32, 32)
 
-        noise = floats_tensor((batch_size, num_channels) + sizes).to(torch_device)
-        time_step = torch.tensor([10]).to(torch_device)
+        noise = floats_tensor((batch_size, num_channels) + sizes, device=torch_device)
+        time_step = torch.tensor([10], device=torch_device)
 
         return {"sample": noise, "timestep": time_step}
 
@@ -430,8 +430,8 @@ class NCSNppModelTests(ModelTesterMixin, unittest.TestCase):
         batch_size = 4
         num_channels = 3
 
-        noise = floats_tensor((batch_size, num_channels) + sizes).to(torch_device)
-        time_step = torch.tensor(batch_size * [10]).to(torch_device)
+        noise = floats_tensor((batch_size, num_channels) + sizes, device=torch_device)
+        time_step = torch.tensor(batch_size * [10], device=torch_device)
 
         return {"sample": noise, "timestep": time_step}
 
@@ -476,7 +476,7 @@ class NCSNppModelTests(ModelTesterMixin, unittest.TestCase):
 
         model.to(torch_device)
         inputs = self.dummy_input
-        noise = floats_tensor((4, 3) + (256, 256)).to(torch_device)
+        noise = floats_tensor((4, 3) + (256, 256), device=torch_device)
         inputs["sample"] = noise
         image = model(**inputs)
 
@@ -494,8 +494,8 @@ class NCSNppModelTests(ModelTesterMixin, unittest.TestCase):
         num_channels = 3
         sizes = (256, 256)
 
-        noise = torch.ones((batch_size, num_channels) + sizes).to(torch_device)
-        time_step = torch.tensor(batch_size * [1e-4]).to(torch_device)
+        noise = torch.ones((batch_size, num_channels) + sizes, device=torch_device)
+        time_step = torch.tensor(batch_size * [1e-4], device=torch_device)
 
         with torch.no_grad():
             output = model(noise, time_step)["sample"]
@@ -519,8 +519,8 @@ class NCSNppModelTests(ModelTesterMixin, unittest.TestCase):
         num_channels = 3
         sizes = (32, 32)
 
-        noise = torch.ones((batch_size, num_channels) + sizes).to(torch_device)
-        time_step = torch.tensor(batch_size * [1e-4]).to(torch_device)
+        noise = torch.ones((batch_size, num_channels) + sizes, device=torch_device)
+        time_step = torch.tensor(batch_size * [1e-4], device=torch_device)
 
         with torch.no_grad():
             output = model(noise, time_step)["sample"]
@@ -541,7 +541,7 @@ class VQModelTests(ModelTesterMixin, unittest.TestCase):
         batch_size = 4
         num_channels = 3
 
-        image = floats_tensor((batch_size, num_channels) + sizes).to(torch_device)
+        image = floats_tensor((batch_size, num_channels) + sizes, device=torch_device)
 
         return {"sample": image}
 
@@ -609,7 +609,7 @@ class AutoencoderKLTests(ModelTesterMixin, unittest.TestCase):
         num_channels = 3
         sizes = (32, 32)
 
-        image = floats_tensor((batch_size, num_channels) + sizes).to(torch_device)
+        image = floats_tensor((batch_size, num_channels) + sizes, device=torch_device)
 
         return {"sample": image}
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -57,9 +57,9 @@ class TrainingTests(unittest.TestCase):
 
         # shared batches for DDPM and DDIM
         set_seed(0)
-        clean_images = [torch.randn((4, 3, 32, 32)).clip(-1, 1).to(torch_device) for _ in range(4)]
-        noise = [torch.randn((4, 3, 32, 32)).to(torch_device) for _ in range(4)]
-        timesteps = [torch.randint(0, 1000, (4,)).long().to(torch_device) for _ in range(4)]
+        clean_images = [torch.randn((4, 3, 32, 32), device=torch_device).clip(-1, 1) for _ in range(4)]
+        noise = [torch.randn((4, 3, 32, 32), device=torch_device) for _ in range(4)]
+        timesteps = [torch.randint(0, 1000, (4,), device=torch_device).long() for _ in range(4)]
 
         # train with a DDPM scheduler
         model, optimizer = self.get_model_optimizer(resolution=32)


### PR DESCRIPTION
instead of using `.to` use the available `device` arguments