### PR TITLE
allow pndm scheduler to be used with ldm pipeline

### DIFF
--- a/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
+++ b/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
@@ -79,7 +79,7 @@ class LDMTextToImagePipeline(DiffusionPipeline):
                 noise_pred = noise_pred_uncond + guidance_scale * (noise_prediction_text - noise_pred_uncond)
 
             # compute the previous noisy sample x_t -> x_t-1
-            latents = self.scheduler.step(noise_pred, t, latents, eta)["prev_sample"]
+            latents = self.scheduler.step(noise_pred, t, latents, eta=eta)["prev_sample"]
 
         # scale and decode the image latents with vae
         latents = 1 / 0.18215 * latents

--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -113,6 +113,7 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         model_output: Union[torch.FloatTensor, np.ndarray],
         timestep: int,
         sample: Union[torch.FloatTensor, np.ndarray],
+        **kwargs,
     ):
         if self.counter < len(self.prk_timesteps):
             return self.step_prk(model_output=model_output, timestep=timestep, sample=sample)


### PR DESCRIPTION
The Stable diffusion model uses PNDM as the main scheduler. Right now it's not possible to use PNDM scheduler in `LDMText2ImagePipeline` as the `eta` for DDIM is always passed to `step` method. The `PNDMScheduler` does not have this argument.

This PR adds `**kwargs` in `PNDMScheduler.step` and passes `eta` as kwarg in `LDMText2ImagePipeline`, so that the pipeline can be used with both schedulers. Since both LDM and stable diffusion model can be used with both these schedulers it's important to allow this interoperability.