### PR TITLE
[PNDM in LDM pipeline] use inspect in pipeline instead of unused kwargs

### DIFF
--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -116,7 +116,6 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         model_output: Union[torch.FloatTensor, np.ndarray],
         timestep: int,
         sample: Union[torch.FloatTensor, np.ndarray],
-        **kwargs,
     ):
         if self.counter < len(self.prk_timesteps):
             return self.step_prk(model_output=model_output, timestep=timestep, sample=sample)


### PR DESCRIPTION
This PR updates the `LDMTextToImagePipeline` and `LDMPipeline` to determine wether the `scheduler.step` accepts  the `eta` arg using `inspect.signature`. And removes the unused `kwargs` from `PNDMScheduler`