### PR TITLE
[StableDiffusionPipeline] use default params in __call__

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pipe = StableDiffusionPipeline.from_pretrained(
 
 prompt = "a photo of an astronaut riding a horse on mars"
 with autocast("cuda"):
-    image = pipe(prompt, width=512, guidance_scale=7.5)["sample"][0]  
+    image = pipe(prompt)["sample"][0]  
     
 image.save("astronaut_rides_horse.png")
 ```

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -31,7 +31,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
         height: Optional[int] = 512,
         width: Optional[int] = 512,
         num_inference_steps: Optional[int] = 50,
-        guidance_scale: Optional[float] = 1.0,
+        guidance_scale: Optional[float] = 7.5,
         eta: Optional[float] = 0.0,
         generator: Optional[torch.Generator] = None,
         torch_device: Optional[Union[str, torch.device]] = None,


### PR DESCRIPTION
This PR sets `guidance_scale` to `7.5` in `StableDiffusionPipeline` as per the official defaults.