### PR TITLE
Revive `make quality`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,6 @@ test:
 test-examples:
 	python -m pytest -n auto --dist=loadfile -s -v ./examples/pytorch/
 
-# Run tests for SageMaker DLC release
-
-test-sagemaker: # install sagemaker dependencies in advance with pip install .[sagemaker]
-	TEST_SAGEMAKER=True python -m pytest -n auto  -s -v ./tests/sagemaker
-
 
 # Release stuff
 

--- a/setup.py
+++ b/setup.py
@@ -77,19 +77,21 @@ from setuptools import find_packages, setup
 # 2. once modified, run: `make deps_table_update` to update src/diffusers/dependency_versions_table.py
 _deps = [
     "Pillow",
+    "accelerate>=0.11.0",
     "black~=22.0,>=22.3",
     "filelock",
     "flake8>=3.8.3",
+    "hf-doc-builder>=0.3.0",
     "huggingface-hub",
     "importlib_metadata",
     "isort>=5.5.4",
+    "modelcards==0.1.4",
     "numpy",
     "pytest",
     "regex!=2019.12.17",
     "requests",
     "torch>=1.4",
     "tensorboard",
-    "modelcards==0.1.4"
 ]
 
 # this is a lookup table with items like:
@@ -161,12 +163,12 @@ extras = {}
 
 extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3"]
-extras["docs"] = []
-extras["training"] = ["tensorboard", "modelcards"]
+extras["docs"] = ["hf-doc-builder"]
+extras["training"] = ["accelerate", "tensorboard", "modelcards"]
 extras["test"] = [
     "pytest",
 ]
-extras["dev"] = extras["quality"] + extras["test"] + extras["training"]
+extras["dev"] = extras["quality"] + extras["test"] + extras["training"] + extras["docs"]
 
 install_requires = [
     deps["importlib_metadata"],

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ _deps = [
     "Pillow",
     "accelerate>=0.11.0",
     "black~=22.0,>=22.3",
+    "datasets",
     "filelock",
     "flake8>=3.8.3",
     "hf-doc-builder>=0.3.0",
@@ -90,8 +91,8 @@ _deps = [
     "pytest",
     "regex!=2019.12.17",
     "requests",
-    "torch>=1.4",
     "tensorboard",
+    "torch>=1.4",
 ]
 
 # this is a lookup table with items like:
@@ -164,10 +165,8 @@ extras = {}
 extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3"]
 extras["docs"] = ["hf-doc-builder"]
-extras["training"] = ["accelerate", "tensorboard", "modelcards"]
-extras["test"] = [
-    "pytest",
-]
+extras["training"] = ["accelerate", "datasets", "tensorboard", "modelcards"]
+extras["test"] = ["pytest"]
 extras["dev"] = extras["quality"] + extras["test"] + extras["training"] + extras["docs"]
 
 install_requires = [

--- a/src/diffusers/dependency_versions_table.py
+++ b/src/diffusers/dependency_versions_table.py
@@ -3,17 +3,19 @@
 # 2. run `make deps_table_update``
 deps = {
     "Pillow": "Pillow",
+    "accelerate": "accelerate>=0.11.0",
     "black": "black~=22.0,>=22.3",
     "filelock": "filelock",
     "flake8": "flake8>=3.8.3",
+    "hf-doc-builder": "hf-doc-builder>=0.3.0",
     "huggingface-hub": "huggingface-hub",
     "importlib_metadata": "importlib_metadata",
     "isort": "isort>=5.5.4",
+    "modelcards": "modelcards==0.1.4",
     "numpy": "numpy",
     "pytest": "pytest",
     "regex": "regex!=2019.12.17",
     "requests": "requests",
     "torch": "torch>=1.4",
     "tensorboard": "tensorboard",
-    "modelcards": "modelcards==0.1.4",
 }

--- a/src/diffusers/optimization.py
+++ b/src/diffusers/optimization.py
@@ -18,7 +18,6 @@ import math
 from enum import Enum
 from typing import Optional, Union
 
-import torch
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LambdaLR
 

--- a/src/diffusers/pipelines/__init__.py
+++ b/src/diffusers/pipelines/__init__.py
@@ -1,4 +1,8 @@
-from ..utils import is_inflect_available, is_transformers_available, is_unidecode_available
+# flake8: noqa
+# There's no way to ignore "F401 '...' imported but unused" warnings in this
+# module, but to preserve other warnings. So, don't check this module at all.
+
+from ..utils import is_transformers_available
 from .ddim import DDIMPipeline
 from .ddpm import DDPMPipeline
 from .latent_diffusion_uncond import LDMPipeline

--- a/src/diffusers/pipelines/ddim/__init__.py
+++ b/src/diffusers/pipelines/ddim/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from .pipeline_ddim import DDIMPipeline

--- a/src/diffusers/pipelines/ddpm/__init__.py
+++ b/src/diffusers/pipelines/ddpm/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from .pipeline_ddpm import DDPMPipeline

--- a/src/diffusers/pipelines/latent_diffusion/__init__.py
+++ b/src/diffusers/pipelines/latent_diffusion/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from ...utils import is_transformers_available
 
 

--- a/src/diffusers/pipelines/latent_diffusion_uncond/__init__.py
+++ b/src/diffusers/pipelines/latent_diffusion_uncond/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from .pipeline_latent_diffusion_uncond import LDMPipeline

--- a/src/diffusers/pipelines/pndm/__init__.py
+++ b/src/diffusers/pipelines/pndm/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from .pipeline_pndm import PNDMPipeline

--- a/src/diffusers/pipelines/score_sde_ve/__init__.py
+++ b/src/diffusers/pipelines/score_sde_ve/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from .pipeline_score_sde_ve import ScoreSdeVePipeline

--- a/src/diffusers/pipelines/stable_diffusion/__init__.py
+++ b/src/diffusers/pipelines/stable_diffusion/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from ...utils import is_transformers_available
 
 

--- a/src/diffusers/pipelines/stochatic_karras_ve/__init__.py
+++ b/src/diffusers/pipelines/stochatic_karras_ve/__init__.py
@@ -1,1 +1,2 @@
+# flake8: noqa
 from .pipeline_stochastic_karras_ve import KarrasVePipeline

--- a/src/diffusers/schedulers/scheduling_lms_discrete.py
+++ b/src/diffusers/schedulers/scheduling_lms_discrete.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Union
+from typing import Union
 
 import numpy as np
 import torch

--- a/src/diffusers/utils/dummy_scipy_objects.py
+++ b/src/diffusers/utils/dummy_scipy_objects.py
@@ -8,17 +8,3 @@ class LMSDiscreteScheduler(metaclass=DummyObject):
 
     def __init__(self, *args, **kwargs):
         requires_backends(self, ["scipy"])
-
-
-class LDMTextToImagePipeline(metaclass=DummyObject):
-    _backends = ["scipy"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["scipy"])
-
-
-class StableDiffusionPipeline(metaclass=DummyObject):
-    _backends = ["scipy"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["scipy"])


### PR DESCRIPTION
This cleans up unused imports and code, and adds flake flags where needed.
As a result, `make quality` will work now, similar to `transformers`.

:warning: Make sure to `pip install -e ".[dev]" ` to install `hf-doc-builder` for the upcoming docs overhaul :) 
cc @patil-suraj @patrickvonplaten @pcuenca @natolambert 