### PR TITLE
Pipeline to device

### DIFF
--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -17,8 +17,9 @@
 import importlib
 import inspect
 import os
-import torch
 from typing import Optional, Union
+
+import torch
 
 from huggingface_hub import snapshot_download
 from PIL import Image
@@ -114,7 +115,6 @@ class DiffusionPipeline(ConfigMixin):
             save_method = getattr(sub_model, save_method_name)
             save_method(os.path.join(save_directory, pipeline_component_name))
 
-
     def to(self, torch_device: Optional[Union[str, torch.device]] = None):
         if torch_device is None:
             return self
@@ -126,7 +126,6 @@ class DiffusionPipeline(ConfigMixin):
                 module.to(torch_device)
         return self
 
-
     @property
     def device(self) -> torch.device:
         module_names, _ = self.extract_init_dict(dict(self.config))
@@ -134,8 +133,7 @@ class DiffusionPipeline(ConfigMixin):
             module = getattr(self, name)
             if isinstance(module, torch.nn.Module):
                 return module.device
-        return torch.device("cpu")        
-
+        return torch.device("cpu")
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: Optional[Union[str, os.PathLike]], **kwargs):

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -115,23 +115,21 @@ class DiffusionPipeline(ConfigMixin):
 
 
     def to(self, torch_device: Optional[Union[str, torch.device]] = None):
-        modules, _ = self.extract_init_dict(dict(self.config))
-        for name in modules.keys():
+        if torch_device is None:
+            return self
+
+        module_names, _ = self.extract_init_dict(dict(self.config))
+        for name in module_names.keys():
             module = getattr(self, name)
             if isinstance(module, torch.nn.Module):
-                if torch_device is None:
-                    if module.device.type == "cpu":
-                        torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-                    else:
-                        torch_device = module.device
                 module.to(torch_device)
         return self
 
 
     @property
     def device(self) -> torch.device:
-        modules, _ = self.extract_init_dict(dict(self.config))
-        for name in modules.keys():
+        module_names, _ = self.extract_init_dict(dict(self.config))
+        for name in module_names.keys():
             module = getattr(self, name)
             if isinstance(module, torch.nn.Module):
                 return module.device

--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 
-import torch
 import warnings
+
+import torch
 
 from tqdm.auto import tqdm
 
@@ -29,10 +30,8 @@ class DDIMPipeline(DiffusionPipeline):
         self.register_modules(unet=unet, scheduler=scheduler)
 
     @torch.no_grad()
-    def __call__(
-        self, batch_size=1, generator=None, eta=0.0, num_inference_steps=50, output_type="pil", **kwargs
-        ):
-        
+    def __call__(self, batch_size=1, generator=None, eta=0.0, num_inference_steps=50, output_type="pil", **kwargs):
+
         if "torch_device" in kwargs:
             device = kwargs.pop("torch_device")
             warnings.warn(

--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -29,7 +29,16 @@ class DDIMPipeline(DiffusionPipeline):
 
     @torch.no_grad()
     def __call__(
-        self, batch_size=1, generator=None, eta=0.0, num_inference_steps=50, output_type="pil"
+        self, batch_size=1, generator=None, eta=0.0, num_inference_steps=50, output_type="pil", **kwargs
+        ):
+        
+        if "torch_device" in kwargs:
+            device = kwargs.pop("torch_device")
+            warnings.warn(
+                "`torch_device` is deprecated as an input argument to `__call__` and will be removed in v0.3.0.
+                Consider using `pipe.to(torch_device)` instead."
+           )
+        # ...set device as previously 
     ):
         # eta corresponds to η in paper and should be between [0, 1]
 

--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -15,6 +15,7 @@
 
 
 import torch
+import warnings
 
 from tqdm.auto import tqdm
 
@@ -35,11 +36,15 @@ class DDIMPipeline(DiffusionPipeline):
         if "torch_device" in kwargs:
             device = kwargs.pop("torch_device")
             warnings.warn(
-                "`torch_device` is deprecated as an input argument to `__call__` and will be removed in v0.3.0.
-                Consider using `pipe.to(torch_device)` instead."
-           )
-        # ...set device as previously 
-    ):
+                "`torch_device` is deprecated as an input argument to `__call__` and will be removed in v0.3.0."
+                " Consider using `pipe.to(torch_device)` instead."
+            )
+
+            # Set device as before (to be removed in 0.3.0)
+            if device is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            self.to(device)
+
         # eta corresponds to η in paper and should be between [0, 1]
 
         # Sample gaussian noise to begin loop

--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -29,11 +29,9 @@ class DDIMPipeline(DiffusionPipeline):
 
     @torch.no_grad()
     def __call__(
-        self, batch_size=1, generator=None, torch_device=None, eta=0.0, num_inference_steps=50, output_type="pil"
+        self, batch_size=1, generator=None, eta=0.0, num_inference_steps=50, output_type="pil"
     ):
         # eta corresponds to η in paper and should be between [0, 1]
-
-        self.to(torch_device)
 
         # Sample gaussian noise to begin loop
         image = torch.randn(

--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -32,10 +32,14 @@ class DDIMPipeline(DiffusionPipeline):
         self, batch_size=1, generator=None, torch_device=None, eta=0.0, num_inference_steps=50, output_type="pil"
     ):
         # eta corresponds to η in paper and should be between [0, 1]
-        if torch_device is None:
-            torch_device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        self.unet.to(torch_device)
+        if torch_device is None:
+            if self.unet.device.type == "cpu":
+                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            else:
+                torch_device = self.unet.device
+
+        self.to(torch_device)
 
         # Sample gaussian noise to begin loop
         image = torch.randn(

--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -33,12 +33,6 @@ class DDIMPipeline(DiffusionPipeline):
     ):
         # eta corresponds to η in paper and should be between [0, 1]
 
-        if torch_device is None:
-            if self.unet.device.type == "cpu":
-                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-            else:
-                torch_device = self.unet.device
-
         self.to(torch_device)
 
         # Sample gaussian noise to begin loop
@@ -46,7 +40,7 @@ class DDIMPipeline(DiffusionPipeline):
             (batch_size, self.unet.in_channels, self.unet.sample_size, self.unet.sample_size),
             generator=generator,
         )
-        image = image.to(torch_device)
+        image = image.to(self.device)
 
         # set step values
         self.scheduler.set_timesteps(num_inference_steps)

--- a/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
+++ b/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 
-import torch
 import warnings
+
+import torch
 
 from tqdm.auto import tqdm
 

--- a/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
+++ b/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
@@ -30,9 +30,12 @@ class DDPMPipeline(DiffusionPipeline):
     @torch.no_grad()
     def __call__(self, batch_size=1, generator=None, torch_device=None, output_type="pil"):
         if torch_device is None:
-            torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            if self.unet.device.type == "cpu":
+                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            else:
+                torch_device = self.unet.device
 
-        self.unet.to(torch_device)
+        self.to(torch_device)
 
         # Sample gaussian noise to begin loop
         image = torch.randn(

--- a/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
+++ b/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
@@ -28,9 +28,7 @@ class DDPMPipeline(DiffusionPipeline):
         self.register_modules(unet=unet, scheduler=scheduler)
 
     @torch.no_grad()
-    def __call__(self, batch_size=1, generator=None, torch_device=None, output_type="pil"):
-        self.to(torch_device)
-
+    def __call__(self, batch_size=1, generator=None, output_type="pil"):
         # Sample gaussian noise to begin loop
         image = torch.randn(
             (batch_size, self.unet.in_channels, self.unet.sample_size, self.unet.sample_size),

--- a/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
+++ b/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
@@ -29,12 +29,6 @@ class DDPMPipeline(DiffusionPipeline):
 
     @torch.no_grad()
     def __call__(self, batch_size=1, generator=None, torch_device=None, output_type="pil"):
-        if torch_device is None:
-            if self.unet.device.type == "cpu":
-                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-            else:
-                torch_device = self.unet.device
-
         self.to(torch_device)
 
         # Sample gaussian noise to begin loop
@@ -42,7 +36,7 @@ class DDPMPipeline(DiffusionPipeline):
             (batch_size, self.unet.in_channels, self.unet.sample_size, self.unet.sample_size),
             generator=generator,
         )
-        image = image.to(torch_device)
+        image = image.to(self.device)
 
         # set step values
         self.scheduler.set_timesteps(1000)

--- a/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
+++ b/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
@@ -1,10 +1,10 @@
 import inspect
+import warnings
 from typing import List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint
-import warnings
 
 from tqdm.auto import tqdm
 from transformers.activations import ACT2FN
@@ -33,7 +33,7 @@ class LDMTextToImagePipeline(DiffusionPipeline):
         eta: Optional[float] = 0.0,
         generator: Optional[torch.Generator] = None,
         output_type: Optional[str] = "pil",
-        **kwargs
+        **kwargs,
     ):
         # eta corresponds to η in paper and should be between [0, 1]
 
@@ -48,7 +48,6 @@ class LDMTextToImagePipeline(DiffusionPipeline):
             if device is None:
                 device = "cuda" if torch.cuda.is_available() else "cpu"
             self.to(device)
-
 
         if isinstance(prompt, str):
             batch_size = 1

--- a/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
+++ b/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
@@ -27,7 +27,6 @@ class LDMTextToImagePipeline(DiffusionPipeline):
         prompt,
         batch_size=1,
         generator=None,
-        torch_device=None,
         eta=0.0,
         guidance_scale=1.0,
         num_inference_steps=50,
@@ -35,25 +34,22 @@ class LDMTextToImagePipeline(DiffusionPipeline):
     ):
         # eta corresponds to η in paper and should be between [0, 1]
 
-        self.to(torch_device)
-        torch_device = self.device
-
         batch_size = len(prompt)
 
         # get unconditional embeddings for classifier free guidance
         if guidance_scale != 1.0:
             uncond_input = self.tokenizer([""] * batch_size, padding="max_length", max_length=77, return_tensors="pt")
-            uncond_embeddings = self.bert(uncond_input.input_ids.to(torch_device))[0]
+            uncond_embeddings = self.bert(uncond_input.input_ids.to(self.device))[0]
 
         # get prompt text embeddings
         text_input = self.tokenizer(prompt, padding="max_length", max_length=77, return_tensors="pt")
-        text_embeddings = self.bert(text_input.input_ids.to(torch_device))[0]
+        text_embeddings = self.bert(text_input.input_ids.to(self.device))[0]
 
         latents = torch.randn(
             (batch_size, self.unet.in_channels, self.unet.sample_size, self.unet.sample_size),
             generator=generator,
         )
-        latents = latents.to(torch_device)
+        latents = latents.to(self.device)
 
         self.scheduler.set_timesteps(num_inference_steps)
 

--- a/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
+++ b/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
@@ -36,12 +36,14 @@ class LDMTextToImagePipeline(DiffusionPipeline):
         # eta corresponds to η in paper and should be between [0, 1]
 
         if torch_device is None:
-            torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-        batch_size = len(prompt)
+            if self.unet.device.type == "cpu":
+                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            else:
+                torch_device = self.unet.device
+                
+        self.to(torch_device)
 
-        self.unet.to(torch_device)
-        self.vqvae.to(torch_device)
-        self.bert.to(torch_device)
+        batch_size = len(prompt)
 
         # get unconditional embeddings for classifier free guidance
         if guidance_scale != 1.0:

--- a/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
+++ b/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple, Union
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint
+import warnings
 
 from tqdm.auto import tqdm
 from transformers.activations import ACT2FN
@@ -31,8 +32,21 @@ class LDMTextToImagePipeline(DiffusionPipeline):
         guidance_scale=1.0,
         num_inference_steps=50,
         output_type="pil",
+        **kwargs
     ):
         # eta corresponds to η in paper and should be between [0, 1]
+
+        if "torch_device" in kwargs:
+            device = kwargs.pop("torch_device")
+            warnings.warn(
+                "`torch_device` is deprecated as an input argument to `__call__` and will be removed in v0.3.0."
+                " Consider using `pipe.to(torch_device)` instead."
+            )
+
+            # Set device as before (to be removed in 0.3.0)
+            if device is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            self.to(device)
 
         batch_size = len(prompt)
 

--- a/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
+++ b/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
@@ -35,13 +35,8 @@ class LDMTextToImagePipeline(DiffusionPipeline):
     ):
         # eta corresponds to η in paper and should be between [0, 1]
 
-        if torch_device is None:
-            if self.unet.device.type == "cpu":
-                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-            else:
-                torch_device = self.unet.device
-                
         self.to(torch_device)
+        torch_device = self.device
 
         batch_size = len(prompt)
 

--- a/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
+++ b/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
@@ -1,7 +1,7 @@
 import inspect
+import warnings
 
 import torch
-import warnings
 
 from tqdm.auto import tqdm
 
@@ -15,9 +15,7 @@ class LDMPipeline(DiffusionPipeline):
         self.register_modules(vqvae=vqvae, unet=unet, scheduler=scheduler)
 
     @torch.no_grad()
-    def __call__(
-        self, batch_size=1, generator=None, eta=0.0, num_inference_steps=50, output_type="pil", **kwargs
-    ):
+    def __call__(self, batch_size=1, generator=None, eta=0.0, num_inference_steps=50, output_type="pil", **kwargs):
         # eta corresponds to η in paper and should be between [0, 1]
 
         if "torch_device" in kwargs:

--- a/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
+++ b/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
@@ -15,11 +15,9 @@ class LDMPipeline(DiffusionPipeline):
 
     @torch.no_grad()
     def __call__(
-        self, batch_size=1, generator=None, torch_device=None, eta=0.0, num_inference_steps=50, output_type="pil"
+        self, batch_size=1, generator=None, eta=0.0, num_inference_steps=50, output_type="pil"
     ):
         # eta corresponds to η in paper and should be between [0, 1]
-
-        self.to(torch_device)
 
         latents = torch.randn(
             (batch_size, self.unet.in_channels, self.unet.sample_size, self.unet.sample_size),

--- a/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
+++ b/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
@@ -19,19 +19,13 @@ class LDMPipeline(DiffusionPipeline):
     ):
         # eta corresponds to η in paper and should be between [0, 1]
 
-        if torch_device is None:
-            if self.unet.device.type == "cpu":
-                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-            else:
-                torch_device = self.unet.device
-
         self.to(torch_device)
 
         latents = torch.randn(
             (batch_size, self.unet.in_channels, self.unet.sample_size, self.unet.sample_size),
             generator=generator,
         )
-        latents = latents.to(torch_device)
+        latents = latents.to(self.device)
 
         self.scheduler.set_timesteps(num_inference_steps)
 

--- a/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
+++ b/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
@@ -20,10 +20,12 @@ class LDMPipeline(DiffusionPipeline):
         # eta corresponds to η in paper and should be between [0, 1]
 
         if torch_device is None:
-            torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            if self.unet.device.type == "cpu":
+                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            else:
+                torch_device = self.unet.device
 
-        self.unet.to(torch_device)
-        self.vqvae.to(torch_device)
+        self.to(torch_device)
 
         latents = torch.randn(
             (batch_size, self.unet.in_channels, self.unet.sample_size, self.unet.sample_size),

--- a/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
+++ b/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
@@ -1,6 +1,7 @@
 import inspect
 
 import torch
+import warnings
 
 from tqdm.auto import tqdm
 
@@ -15,9 +16,21 @@ class LDMPipeline(DiffusionPipeline):
 
     @torch.no_grad()
     def __call__(
-        self, batch_size=1, generator=None, eta=0.0, num_inference_steps=50, output_type="pil"
+        self, batch_size=1, generator=None, eta=0.0, num_inference_steps=50, output_type="pil", **kwargs
     ):
         # eta corresponds to η in paper and should be between [0, 1]
+
+        if "torch_device" in kwargs:
+            device = kwargs.pop("torch_device")
+            warnings.warn(
+                "`torch_device` is deprecated as an input argument to `__call__` and will be removed in v0.3.0."
+                " Consider using `pipe.to(torch_device)` instead."
+            )
+
+            # Set device as before (to be removed in 0.3.0)
+            if device is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            self.to(device)
 
         latents = torch.randn(
             (batch_size, self.unet.in_channels, self.unet.sample_size, self.unet.sample_size),

--- a/src/diffusers/pipelines/pndm/pipeline_pndm.py
+++ b/src/diffusers/pipelines/pndm/pipeline_pndm.py
@@ -31,10 +31,14 @@ class PNDMPipeline(DiffusionPipeline):
     def __call__(self, batch_size=1, generator=None, torch_device=None, num_inference_steps=50, output_type="pil"):
         # For more information on the sampling method you can take a look at Algorithm 2 of
         # the official paper: https://arxiv.org/pdf/2202.09778.pdf
-        if torch_device is None:
-            torch_device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        self.unet.to(torch_device)
+        if torch_device is None:
+            if self.unet.device.type == "cpu":
+                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            else:
+                torch_device = self.unet.device
+
+        self.to(torch_device)
 
         # Sample gaussian noise to begin loop
         image = torch.randn(

--- a/src/diffusers/pipelines/pndm/pipeline_pndm.py
+++ b/src/diffusers/pipelines/pndm/pipeline_pndm.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 
-import torch
 import warnings
+
+import torch
 
 from tqdm.auto import tqdm
 

--- a/src/diffusers/pipelines/pndm/pipeline_pndm.py
+++ b/src/diffusers/pipelines/pndm/pipeline_pndm.py
@@ -32,12 +32,6 @@ class PNDMPipeline(DiffusionPipeline):
         # For more information on the sampling method you can take a look at Algorithm 2 of
         # the official paper: https://arxiv.org/pdf/2202.09778.pdf
 
-        if torch_device is None:
-            if self.unet.device.type == "cpu":
-                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-            else:
-                torch_device = self.unet.device
-
         self.to(torch_device)
 
         # Sample gaussian noise to begin loop
@@ -45,7 +39,7 @@ class PNDMPipeline(DiffusionPipeline):
             (batch_size, self.unet.in_channels, self.unet.sample_size, self.unet.sample_size),
             generator=generator,
         )
-        image = image.to(torch_device)
+        image = image.to(self.device)
 
         self.scheduler.set_timesteps(num_inference_steps)
         for t in tqdm(self.scheduler.timesteps):

--- a/src/diffusers/pipelines/pndm/pipeline_pndm.py
+++ b/src/diffusers/pipelines/pndm/pipeline_pndm.py
@@ -15,6 +15,7 @@
 
 
 import torch
+import warnings
 
 from tqdm.auto import tqdm
 
@@ -28,9 +29,21 @@ class PNDMPipeline(DiffusionPipeline):
         self.register_modules(unet=unet, scheduler=scheduler)
 
     @torch.no_grad()
-    def __call__(self, batch_size=1, generator=None, num_inference_steps=50, output_type="pil"):
+    def __call__(self, batch_size=1, generator=None, num_inference_steps=50, output_type="pil", **kwargs):
         # For more information on the sampling method you can take a look at Algorithm 2 of
         # the official paper: https://arxiv.org/pdf/2202.09778.pdf
+
+        if "torch_device" in kwargs:
+            device = kwargs.pop("torch_device")
+            warnings.warn(
+                "`torch_device` is deprecated as an input argument to `__call__` and will be removed in v0.3.0."
+                " Consider using `pipe.to(torch_device)` instead."
+            )
+
+            # Set device as before (to be removed in 0.3.0)
+            if device is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            self.to(device)
 
         # Sample gaussian noise to begin loop
         image = torch.randn(

--- a/src/diffusers/pipelines/pndm/pipeline_pndm.py
+++ b/src/diffusers/pipelines/pndm/pipeline_pndm.py
@@ -28,11 +28,9 @@ class PNDMPipeline(DiffusionPipeline):
         self.register_modules(unet=unet, scheduler=scheduler)
 
     @torch.no_grad()
-    def __call__(self, batch_size=1, generator=None, torch_device=None, num_inference_steps=50, output_type="pil"):
+    def __call__(self, batch_size=1, generator=None, num_inference_steps=50, output_type="pil"):
         # For more information on the sampling method you can take a look at Algorithm 2 of
         # the official paper: https://arxiv.org/pdf/2202.09778.pdf
-
-        self.to(torch_device)
 
         # Sample gaussian noise to begin loop
         image = torch.randn(

--- a/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
+++ b/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
@@ -12,16 +12,11 @@ class ScoreSdeVePipeline(DiffusionPipeline):
 
     @torch.no_grad()
     def __call__(self, batch_size=1, num_inference_steps=2000, generator=None, torch_device=None, output_type="pil"):
-        if torch_device is None:
-            if self.unet.device.type == "cpu":
-                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-            else:
-                torch_device = self.unet.device
-
         img_size = self.unet.config.sample_size
         shape = (batch_size, 3, img_size, img_size)
 
         self.to(torch_device)
+        torch_device = self.device
         model = self.unet
 
         sample = torch.randn(*shape) * self.scheduler.config.sigma_max

--- a/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
+++ b/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
@@ -11,22 +11,20 @@ class ScoreSdeVePipeline(DiffusionPipeline):
         self.register_modules(unet=unet, scheduler=scheduler)
 
     @torch.no_grad()
-    def __call__(self, batch_size=1, num_inference_steps=2000, generator=None, torch_device=None, output_type="pil"):
+    def __call__(self, batch_size=1, num_inference_steps=2000, generator=None, output_type="pil"):
         img_size = self.unet.config.sample_size
         shape = (batch_size, 3, img_size, img_size)
 
-        self.to(torch_device)
-        torch_device = self.device
         model = self.unet
 
         sample = torch.randn(*shape) * self.scheduler.config.sigma_max
-        sample = sample.to(torch_device)
+        sample = sample.to(self.device)
 
         self.scheduler.set_timesteps(num_inference_steps)
         self.scheduler.set_sigmas(num_inference_steps)
 
         for i, t in tqdm(enumerate(self.scheduler.timesteps)):
-            sigma_t = self.scheduler.sigmas[i] * torch.ones(shape[0], device=torch_device)
+            sigma_t = self.scheduler.sigmas[i] * torch.ones(shape[0], device=self.device)
 
             # correction step
             for _ in range(self.scheduler.correct_steps):

--- a/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
+++ b/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-import torch
 import warnings
+
+import torch
 
 from diffusers import DiffusionPipeline
 from tqdm.auto import tqdm

--- a/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
+++ b/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
@@ -12,14 +12,17 @@ class ScoreSdeVePipeline(DiffusionPipeline):
 
     @torch.no_grad()
     def __call__(self, batch_size=1, num_inference_steps=2000, generator=None, torch_device=None, output_type="pil"):
-
         if torch_device is None:
-            torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            if self.unet.device.type == "cpu":
+                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            else:
+                torch_device = self.unet.device
 
         img_size = self.unet.config.sample_size
         shape = (batch_size, 3, img_size, img_size)
 
-        model = self.unet.to(torch_device)
+        self.to(torch_device)
+        model = self.unet
 
         sample = torch.randn(*shape) * self.scheduler.config.sigma_max
         sample = sample.to(torch_device)

--- a/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
+++ b/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import torch
+import warnings
 
 from diffusers import DiffusionPipeline
 from tqdm.auto import tqdm
@@ -11,7 +12,19 @@ class ScoreSdeVePipeline(DiffusionPipeline):
         self.register_modules(unet=unet, scheduler=scheduler)
 
     @torch.no_grad()
-    def __call__(self, batch_size=1, num_inference_steps=2000, generator=None, output_type="pil"):
+    def __call__(self, batch_size=1, num_inference_steps=2000, generator=None, output_type="pil", **kwargs):
+        if "torch_device" in kwargs:
+            device = kwargs.pop("torch_device")
+            warnings.warn(
+                "`torch_device` is deprecated as an input argument to `__call__` and will be removed in v0.3.0."
+                " Consider using `pipe.to(torch_device)` instead."
+            )
+
+            # Set device as before (to be removed in 0.3.0)
+            if device is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            self.to(device)
+
         img_size = self.unet.config.sample_size
         shape = (batch_size, 3, img_size, img_size)
 

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -1,8 +1,8 @@
 import inspect
+import warnings
 from typing import List, Optional, Union
 
 import torch
-import warnings
 
 from tqdm.auto import tqdm
 from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
@@ -47,7 +47,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
         eta: Optional[float] = 0.0,
         generator: Optional[torch.Generator] = None,
         output_type: Optional[str] = "pil",
-        **kwargs
+        **kwargs,
     ):
         if "torch_device" in kwargs:
             device = kwargs.pop("torch_device")
@@ -155,7 +155,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
         image = image.cpu().permute(0, 2, 3, 1).numpy()
 
         # run safety checker
-        safety_cheker_input = self.feature_extractor(self.numpy_to_pil(image), return_tensors="pt").to(torch_device)
+        safety_cheker_input = self.feature_extractor(self.numpy_to_pil(image), return_tensors="pt").to(self.device)
         image, has_nsfw_concept = self.safety_checker(images=image, clip_input=safety_cheker_input.pixel_values)
 
         if output_type == "pil":

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -2,6 +2,7 @@ import inspect
 from typing import List, Optional, Union
 
 import torch
+import warnings
 
 from tqdm.auto import tqdm
 from transformers import CLIPTextModel, CLIPTokenizer
@@ -35,7 +36,20 @@ class StableDiffusionPipeline(DiffusionPipeline):
         eta: Optional[float] = 0.0,
         generator: Optional[torch.Generator] = None,
         output_type: Optional[str] = "pil",
-    ):        
+        **kwargs
+    ):
+        if "torch_device" in kwargs:
+            device = kwargs.pop("torch_device")
+            warnings.warn(
+                "`torch_device` is deprecated as an input argument to `__call__` and will be removed in v0.3.0."
+                " Consider using `pipe.to(torch_device)` instead."
+            )
+
+            # Set device as before (to be removed in 0.3.0)
+            if device is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            self.to(device)
+
         if isinstance(prompt, str):
             batch_size = 1
         elif isinstance(prompt, list):

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -38,7 +38,10 @@ class StableDiffusionPipeline(DiffusionPipeline):
         output_type: Optional[str] = "pil",
     ):
         if torch_device is None:
-            torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            if self.unet.device.type == "cpu":
+                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            else:
+                torch_device = self.unet.device
 
         if isinstance(prompt, str):
             batch_size = 1
@@ -50,9 +53,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
         if height % 8 != 0 or width % 8 != 0:
             raise ValueError(f"`height` and `width` have to be divisible by 8 but are {height} and {width}.")
 
-        self.unet.to(torch_device)
-        self.vae.to(torch_device)
-        self.text_encoder.to(torch_device)
+        self.to(torch_device)
 
         # get prompt text embeddings
         text_input = self.tokenizer(

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -37,12 +37,9 @@ class StableDiffusionPipeline(DiffusionPipeline):
         torch_device: Optional[Union[str, torch.device]] = None,
         output_type: Optional[str] = "pil",
     ):
-        if torch_device is None:
-            if self.unet.device.type == "cpu":
-                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-            else:
-                torch_device = self.unet.device
-
+        self.to(torch_device)
+        torch_device = self.device
+        
         if isinstance(prompt, str):
             batch_size = 1
         elif isinstance(prompt, list):

--- a/src/diffusers/pipelines/stochatic_karras_ve/pipeline_stochastic_karras_ve.py
+++ b/src/diffusers/pipelines/stochatic_karras_ve/pipeline_stochastic_karras_ve.py
@@ -27,19 +27,15 @@ class KarrasVePipeline(DiffusionPipeline):
         self.register_modules(unet=unet, scheduler=scheduler)
 
     @torch.no_grad()
-    def __call__(self, batch_size=1, num_inference_steps=50, generator=None, torch_device=None, output_type="pil"):
-        self.to(torch_device)
-        torch_device = self.device
-
+    def __call__(self, batch_size=1, num_inference_steps=50, generator=None, output_type="pil"):
         img_size = self.unet.config.sample_size
         shape = (batch_size, 3, img_size, img_size)
 
-        self.to(torch_device)
         model = self.unet
 
         # sample x_0 ~ N(0, sigma_0^2 * I)
         sample = torch.randn(*shape) * self.scheduler.config.sigma_max
-        sample = sample.to(torch_device)
+        sample = sample.to(self.device)
 
         self.scheduler.set_timesteps(num_inference_steps)
 

--- a/src/diffusers/pipelines/stochatic_karras_ve/pipeline_stochastic_karras_ve.py
+++ b/src/diffusers/pipelines/stochatic_karras_ve/pipeline_stochastic_karras_ve.py
@@ -28,11 +28,8 @@ class KarrasVePipeline(DiffusionPipeline):
 
     @torch.no_grad()
     def __call__(self, batch_size=1, num_inference_steps=50, generator=None, torch_device=None, output_type="pil"):
-        if torch_device is None:
-            if self.unet.device.type == "cpu":
-                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
-            else:
-                torch_device = self.unet.device
+        self.to(torch_device)
+        torch_device = self.device
 
         img_size = self.unet.config.sample_size
         shape = (batch_size, 3, img_size, img_size)

--- a/src/diffusers/pipelines/stochatic_karras_ve/pipeline_stochastic_karras_ve.py
+++ b/src/diffusers/pipelines/stochatic_karras_ve/pipeline_stochastic_karras_ve.py
@@ -29,12 +29,16 @@ class KarrasVePipeline(DiffusionPipeline):
     @torch.no_grad()
     def __call__(self, batch_size=1, num_inference_steps=50, generator=None, torch_device=None, output_type="pil"):
         if torch_device is None:
-            torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            if self.unet.device.type == "cpu":
+                torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+            else:
+                torch_device = self.unet.device
 
         img_size = self.unet.config.sample_size
         shape = (batch_size, 3, img_size, img_size)
 
-        model = self.unet.to(torch_device)
+        self.to(torch_device)
+        model = self.unet
 
         # sample x_0 ~ N(0, sigma_0^2 * I)
         sample = torch.randn(*shape) * self.scheduler.config.sigma_max

--- a/src/diffusers/pipelines/stochatic_karras_ve/pipeline_stochastic_karras_ve.py
+++ b/src/diffusers/pipelines/stochatic_karras_ve/pipeline_stochastic_karras_ve.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import torch
+import warnings
 
 from tqdm.auto import tqdm
 
@@ -27,7 +28,19 @@ class KarrasVePipeline(DiffusionPipeline):
         self.register_modules(unet=unet, scheduler=scheduler)
 
     @torch.no_grad()
-    def __call__(self, batch_size=1, num_inference_steps=50, generator=None, output_type="pil"):
+    def __call__(self, batch_size=1, num_inference_steps=50, generator=None, output_type="pil", **kwargs):
+        if "torch_device" in kwargs:
+            device = kwargs.pop("torch_device")
+            warnings.warn(
+                "`torch_device` is deprecated as an input argument to `__call__` and will be removed in v0.3.0."
+                " Consider using `pipe.to(torch_device)` instead."
+            )
+
+            # Set device as before (to be removed in 0.3.0)
+            if device is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            self.to(device)
+
         img_size = self.unet.config.sample_size
         shape = (batch_size, 3, img_size, img_size)
 

--- a/src/diffusers/pipelines/stochatic_karras_ve/pipeline_stochastic_karras_ve.py
+++ b/src/diffusers/pipelines/stochatic_karras_ve/pipeline_stochastic_karras_ve.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-import torch
 import warnings
+
+import torch
 
 from tqdm.auto import tqdm
 


### PR DESCRIPTION
The following will run the pipeline in `cuda:1` (not `cuda:0`) as would be expected:

```Python
pipe = StableDiffusionPipeline.from_pretrained(
    "CompVis/stable-diffusion-v1-3-diffusers",
    use_auth_token=True).to("cuda:1")
pipe("Some prompt")
```

However, passing a device to `__call__` will still move the pipeline to that device.

The implementation of `DiffusionPipeline.to()` does nothing if the device is `None`. This is to preserve the same semantics as PyTorch, where AFAIK if you use `to(None)` the object is not moved anywhere.

If we were to forgo that behaviour, we could make `DiffusionPipeline.to(None)` select `cuda` by default (when available). This would make for much simpler code in all pipeline implementations, as they'd just need to invoke `self.to`, but might break the expectations of PyTorch users. The current implementation in all the pipelines `__call__` methods does exactly that: select `cuda` if available, and if no previous device was already set by the user. It is a bit repetitive and maybe a bit fragile.

Is it important to preserve PyTorch semantics in this regard, or is it better to make all `__call__` implementations simpler? What do you think @anton-l @patil-suraj @patrickvonplaten ?

Fixes #195