### PR TITLE
Add safety module

### DIFF
--- a/src/diffusers/__init__.py
+++ b/src/diffusers/__init__.py
@@ -39,6 +39,5 @@ from .training_utils import EMAModel
 
 if is_transformers_available():
     from .pipelines import LDMTextToImagePipeline, StableDiffusionPipeline
-    from .pipelines.stable_diffusion import StableDiffusionSafetyChecker
 else:
     from .utils.dummy_transformers_objects import *

--- a/src/diffusers/__init__.py
+++ b/src/diffusers/__init__.py
@@ -39,5 +39,6 @@ from .training_utils import EMAModel
 
 if is_transformers_available():
     from .pipelines import LDMTextToImagePipeline, StableDiffusionPipeline
+    from .pipelines.stable_diffusion import StableDiffusionSafetyChecker
 else:
     from .utils.dummy_transformers_objects import *

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -64,9 +64,7 @@ class DiffusionPipeline(ConfigMixin):
             library = module.__module__.split(".")[0]
 
             # check if the module is a pipeline module
-            pipeline_file = module.__module__.split(".")[-1]
             pipeline_dir = module.__module__.split(".")[-2]
-            # is_pipeline_module = pipeline_file == "pipeline_" + pipeline_dir and hasattr(pipelines, pipeline_dir)
             path = module.__module__.split(".")
             is_pipeline_module = pipeline_dir in path and hasattr(pipelines, pipeline_dir)
 

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -42,6 +42,7 @@ LOADABLE_CLASSES = {
         "PreTrainedTokenizer": ["save_pretrained", "from_pretrained"],
         "PreTrainedTokenizerFast": ["save_pretrained", "from_pretrained"],
         "PreTrainedModel": ["save_pretrained", "from_pretrained"],
+        "FeatureExtractionMixin": ["save_pretrained", "from_pretrained"],
     },
 }
 

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -66,7 +66,9 @@ class DiffusionPipeline(ConfigMixin):
             # check if the module is a pipeline module
             pipeline_file = module.__module__.split(".")[-1]
             pipeline_dir = module.__module__.split(".")[-2]
-            is_pipeline_module = pipeline_file == "pipeline_" + pipeline_dir and hasattr(pipelines, pipeline_dir)
+            # is_pipeline_module = pipeline_file == "pipeline_" + pipeline_dir and hasattr(pipelines, pipeline_dir)
+            path = module.__module__.split(".")
+            is_pipeline_module = pipeline_dir in path and hasattr(pipelines, pipeline_dir)
 
             # if library is not in LOADABLE_CLASSES, then it is a custom module.
             # Or if it's a pipeline module, then the module is inside the pipeline

--- a/src/diffusers/pipelines/stable_diffusion/__init__.py
+++ b/src/diffusers/pipelines/stable_diffusion/__init__.py
@@ -3,4 +3,4 @@ from ...utils import is_transformers_available
 
 
 if is_transformers_available():
-    from .pipeline_stable_diffusion import StableDiffusionSafetyChecker, StableDiffusionPipeline
+    from .pipeline_stable_diffusion import StableDiffusionPipeline, StableDiffusionSafetyChecker

--- a/src/diffusers/pipelines/stable_diffusion/__init__.py
+++ b/src/diffusers/pipelines/stable_diffusion/__init__.py
@@ -3,4 +3,4 @@ from ...utils import is_transformers_available
 
 
 if is_transformers_available():
-    from .pipeline_stable_diffusion import SafetyChecker, StableDiffusionPipeline
+    from .pipeline_stable_diffusion import StableDiffusionSafetyChecker, StableDiffusionPipeline

--- a/src/diffusers/pipelines/stable_diffusion/__init__.py
+++ b/src/diffusers/pipelines/stable_diffusion/__init__.py
@@ -3,4 +3,4 @@ from ...utils import is_transformers_available
 
 
 if is_transformers_available():
-    from .pipeline_stable_diffusion import StableDiffusionPipeline
+    from .pipeline_stable_diffusion import SafetyChecker, StableDiffusionPipeline

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -156,4 +156,4 @@ class StableDiffusionPipeline(DiffusionPipeline):
         if output_type == "pil":
             image = self.numpy_to_pil(image)
 
-        return {"sample": image, "nsfw": has_nsfw_concept}
+        return {"sample": image, "nsfw_content_detected": has_nsfw_concept}

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -9,7 +9,7 @@ from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...pipeline_utils import DiffusionPipeline
 from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
-from .safety_checker import SafetyChecker
+from .safety_checker import StableDiffusionSafetyChecker
 
 
 class StableDiffusionPipeline(DiffusionPipeline):
@@ -20,7 +20,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
         tokenizer: CLIPTokenizer,
         unet: UNet2DConditionModel,
         scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler],
-        safety_checker: SafetyChecker,
+        safety_checker: StableDiffusionSafetyChecker,
         feature_extractor: CLIPFeatureExtractor,
     ):
         super().__init__()
@@ -149,8 +149,8 @@ class StableDiffusionPipeline(DiffusionPipeline):
         image = (image / 2 + 0.5).clamp(0, 1)
         image = image.cpu().permute(0, 2, 3, 1).numpy()
 
-        safety_cheker_input = self.feature_extractor(self.numpy_to_pil(image)).pixel_values
-        has_bad_concepts = self.safety_checker(safety_cheker_input)
+        safety_cheker_input = self.feature_extractor(self.numpy_to_pil(image), return_tensors="pt").pixel_values
+        has_bad_concepts = self.safety_checker(safety_cheker_input.to(torch_device))
 
         if has_bad_concepts:
             raise ValueError("The generated image contains concepts that are not allowed.")

--- a/src/diffusers/pipelines/stable_diffusion/safety_checker.py
+++ b/src/diffusers/pipelines/stable_diffusion/safety_checker.py
@@ -2,7 +2,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from PIL import ImageDraw
 from transformers import CLIPConfig, CLIPVisionModel, PreTrainedModel
 
 
@@ -29,7 +28,6 @@ class StableDiffusionSafetyChecker(PreTrainedModel):
 
     @torch.no_grad()
     def forward(self, clip_input, images):
-        """Get embeddings for images and output nsfw and concept scores"""
         pooled_output = self.vision_model(clip_input)[1]  # pooled_output
         image_embeds = self.visual_projection(pooled_output)
 

--- a/src/diffusers/pipelines/stable_diffusion/safety_checker.py
+++ b/src/diffusers/pipelines/stable_diffusion/safety_checker.py
@@ -10,7 +10,7 @@ def cosine_distance(image_embeds, text_embeds):
     return torch.mm(normalized_image_embeds, normalized_text_embeds.T)
 
 
-class SafetyChecker(PreTrainedModel):
+class StableDiffusionSafetyChecker(PreTrainedModel):
     config_class = CLIPConfig
 
     def __init__(self, config: CLIPConfig):
@@ -28,7 +28,7 @@ class SafetyChecker(PreTrainedModel):
     @torch.no_grad()
     def forward(self, images):
         """Get embeddings for images and output nsfw and concept scores"""
-        pooled_output = self.vision_model(**images)[1]  # pooled_output
+        pooled_output = self.vision_model(images)[1]  # pooled_output
         image_embeds = self.visual_projection(pooled_output)
 
         special_cos_dist = cosine_distance(image_embeds, self.special_care_embeds).cpu().numpy()

--- a/src/diffusers/pipelines/stable_diffusion/safety_checker.py
+++ b/src/diffusers/pipelines/stable_diffusion/safety_checker.py
@@ -57,7 +57,9 @@ class StableDiffusionSafetyChecker(PreTrainedModel):
 
             result.append(result_img)
 
-        has_nsfw_concept = [len(result[i]["bad_concepts"]) > 0 for i in range(len(result))]
+        has_nsfw_concept = [
+            len(result[i]["bad_concepts"]) > 0 or len(result[i]["special_care"]) > 0 for i in range(len(result))
+        ]
 
         for idx, has_nsfw_concept in enumerate(has_nsfw_concept):
             if has_nsfw_concept:

--- a/src/diffusers/pipelines/stable_diffusion/safety_checker.py
+++ b/src/diffusers/pipelines/stable_diffusion/safety_checker.py
@@ -63,9 +63,6 @@ class StableDiffusionSafetyChecker(PreTrainedModel):
 
         for idx, has_nsfw_concept in enumerate(has_nsfw_concept):
             if has_nsfw_concept:
-                black_image = np.zeros(images[idx].shape)  # black image
-                draw = ImageDraw.Draw(black_image)
-                draw.text((10, 10), "Too NSFW for diffusers")  # TODO: better text
-                images[idx] = black_image
+                images[idx] = np.zeros(images[idx].shape)  # black image
 
         return images, has_nsfw_concept

--- a/src/diffusers/pipelines/stable_diffusion/safety_checker.py
+++ b/src/diffusers/pipelines/stable_diffusion/safety_checker.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
+from PIL import ImageDraw
 from transformers import CLIPConfig, CLIPVisionModel, PreTrainedModel
 
 
@@ -62,6 +63,9 @@ class StableDiffusionSafetyChecker(PreTrainedModel):
 
         for idx, has_nsfw_concept in enumerate(has_nsfw_concept):
             if has_nsfw_concept:
-                images[idx] = np.zeros(images[idx].shape)  # black image
+                black_image = np.zeros(images[idx].shape)  # black image
+                draw = ImageDraw.Draw(black_image)
+                draw.text((10, 10), "Too NSFW for diffusers")  # TODO: better text
+                images[idx] = black_image
 
         return images, has_nsfw_concept

--- a/src/diffusers/pipelines/stable_diffusion/safety_checker.py
+++ b/src/diffusers/pipelines/stable_diffusion/safety_checker.py
@@ -1,0 +1,60 @@
+import torch
+import torch.nn as nn
+
+from transformers import CLIPConfig, CLIPProcessor, CLIPVisionModel, PreTrainedModel
+
+
+def cosine_distance(image_embeds, text_embeds):
+    normalized_image_embeds = nn.functional.normalize(image_embeds)
+    normalized_text_embeds = nn.functional.normalize(text_embeds)
+    return torch.mm(normalized_image_embeds, normalized_text_embeds.T)
+
+
+class SafetyChecker(PreTrainedModel):
+    config_class = CLIPConfig
+
+    def __init__(self, config: CLIPConfig):
+        super().__init__(config)
+
+        self.vision_model = CLIPVisionModel(config.vision_config)
+        self.visual_projection = nn.Linear(config.vision_config.hidden_size, config.projection_dim, bias=False)
+
+        self.concept_embeds = nn.Parameter(torch.ones(17, config.projection_dim), requires_grad=False)
+        self.special_care_embeds = nn.Parameter(torch.ones(3, config.projection_dim), requires_grad=False)
+
+        self.register_buffer("concept_embeds_weights", torch.ones(17))
+        self.register_buffer("special_care_embeds_weights", torch.ones(3))
+
+    @torch.no_grad()
+    def forward(self, images):
+        """Get embeddings for images and output nsfw and concept scores"""
+        pooled_output = self.vision_model(**images)[1]  # pooled_output
+        image_embeds = self.visual_projection(pooled_output)
+
+        special_cos_dist = cosine_distance(image_embeds, self.special_care_embeds).cpu().numpy()
+        cos_dist = cosine_distance(image_embeds, self.concept_embeds).cpu().numpy()
+
+        result = []
+        for i in range(image_embeds.shape[0]):
+            result_img = {"special_scores": {}, "special_care": [], "concept_scores": {}, "bad_concepts": []}
+            adjustment = 0.05
+
+            for concet_idx in range(len(special_cos_dist[0])):
+                concept_cos = special_cos_dist[i][concet_idx]
+                concept_threshold = self.special_care_embeds_weights[concet_idx].item()
+                result_img["special_scores"][concet_idx] = round(concept_cos - concept_threshold + adjustment, 3)
+                if result_img["special_scores"][concet_idx] > 0:
+                    result_img["special_care"].append({concet_idx, result_img["special_scores"][concet_idx]})
+                    adjustment = 0.01
+
+            for concet_idx in range(len(cos_dist[0])):
+                concept_cos = cos_dist[i][concet_idx]
+                concept_threshold = self.concept_embeds_weights[concet_idx].item()
+                result_img["concept_scores"][concet_idx] = round(concept_cos - concept_threshold + adjustment, 3)
+                if result_img["concept_scores"][concet_idx] > 0:
+                    result_img["bad_concepts"].append(concet_idx)
+
+            result.append(result_img)
+
+        has_bad_concepts = [len(result[i]["bad_concepts"]) > 0 for i in range(len(result))]
+        return has_bad_concepts


### PR DESCRIPTION
This PR adds `StableDiffusionSafetyChecker` to filter out NSFW content in `StableDiffusionPipeline`.

The `StableDiffusionSafetyChecker` contains the clip vision model, vision projection. The nsfw concept embeddings are pre-computed and part of the state_dict. The module takes images and replaces nsfew image if detected with a black image.

It's added as a new required attribute in `StableDiffusionPipeline` so it'll always be loaded.