### PR TITLE
Restore `is_modelcards_available` in `.utils`

### DIFF
--- a/src/diffusers/utils/__init__.py
+++ b/src/diffusers/utils/__init__.py
@@ -33,6 +33,7 @@ from .import_utils import (
     is_torch_available,
     is_transformers_available,
     is_unidecode_available,
+    is_modelcards_available,
     requires_backends,
 )
 from .logging import get_logger


### PR DESCRIPTION
Otherwise attempting to import `hub_utils` (in training scripts, for example), fails.

This was removed during the refactor in df90f0c.