### PR TITLE
Add leave=False for tqdm steps to allow nesting

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -126,7 +126,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
         if accepts_eta:
             extra_step_kwargs["eta"] = eta
 
-        for i, t in tqdm(enumerate(self.scheduler.timesteps)):
+        for i, t in tqdm(enumerate(self.scheduler.timesteps), leave=False):
             # expand the latents if we are doing classifier free guidance
             latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
             if isinstance(self.scheduler, LMSDiscreteScheduler):


### PR DESCRIPTION
This is a relatively small change that allows nesting of the `pipe(...)` call inside another `tqdm` loop. Without this the output looks like this

![image](https://user-images.githubusercontent.com/123374/185817582-986ee63d-0bcf-4f10-b3d8-16eddbed2722.png)

where each intermediate run produces a progress bar. This pollutes the output the more nested loops of inference are run. With the change the inner-most progress bar disappears after each run, allowing arbitrary number of calls to `pipe(...)`, with just the top bar being shown in the end

![image](https://user-images.githubusercontent.com/123374/185817648-3759bd9c-5baa-4da3-bec6-e3877145ea22.png)

I'm not sure if this should be enabled by default, maybe it should be a flag as part of the kwargs?