### PR TITLE
Custom pipeline for Stable Diffusion that returns generation seeds

### DIFF
--- a/examples/inference/pipeline_stable_diffusion_seeds.py
+++ b/examples/inference/pipeline_stable_diffusion_seeds.py
@@ -1,0 +1,153 @@
+import inspect
+import warnings
+from itertools import zip_longest
+from typing import List, Optional, Union
+
+import torch
+from tqdm.auto import tqdm
+
+from diffusers import LMSDiscreteScheduler, StableDiffusionPipeline
+from diffusers.pipelines.stable_diffusion import StableDiffusionSafetyChecker
+from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
+
+class StableDiffusionWithSeedsPipeline(StableDiffusionPipeline):
+    @torch.no_grad()
+    def __call__(
+        self,
+        prompt: Union[str, List[str]],
+        height: Optional[int] = 512,
+        width: Optional[int] = 512,
+        seeds: Optional[List[int]] = [],
+        num_inference_steps: Optional[int] = 50,
+        guidance_scale: Optional[float] = 7.5,
+        eta: Optional[float] = 0.0,
+        generator: Optional[torch.Generator] = None,
+        output_type: Optional[str] = "pil",
+        **kwargs,
+    ):
+        if "torch_device" in kwargs:
+            device = kwargs.pop("torch_device")
+            warnings.warn(
+                "`torch_device` is deprecated as an input argument to `__call__` and will be removed in v0.3.0."
+                " Consider using `pipe.to(torch_device)` instead."
+            )
+
+            # Set device as before (to be removed in 0.3.0)
+            if device is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            self.to(device)
+
+        if isinstance(prompt, str):
+            batch_size = 1
+        elif isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            raise ValueError(f"`prompt` has to be of type `str` or `list` but is {type(prompt)}")
+
+        if height % 8 != 0 or width % 8 != 0:
+            raise ValueError(f"`height` and `width` have to be divisible by 8 but are {height} and {width}.")
+
+        # get prompt text embeddings
+        text_input = self.tokenizer(
+            prompt,
+            padding="max_length",
+            max_length=self.tokenizer.model_max_length,
+            truncation=True,
+            return_tensors="pt",
+        )
+        text_embeddings = self.text_encoder(text_input.input_ids.to(self.device))[0]
+
+        # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
+        # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
+        # corresponds to doing no classifier free guidance.
+        do_classifier_free_guidance = guidance_scale > 1.0
+        # get unconditional embeddings for classifier free guidance
+        if do_classifier_free_guidance:
+            max_length = text_input.input_ids.shape[-1]
+            uncond_input = self.tokenizer(
+                [""] * batch_size, padding="max_length", max_length=max_length, return_tensors="pt"
+            )
+            uncond_embeddings = self.text_encoder(uncond_input.input_ids.to(self.device))[0]
+
+            # For classifier free guidance, we need to do two forward passes.
+            # Here we concatenate the unconditional and text embeddings into a single batch
+            # to avoid doing two forward passes
+            text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
+
+        if generator is None:
+            generator = torch.Generator(device=self.device)
+        
+        latents = None
+        new_seeds = []
+        for _, seed in zip_longest(range(batch_size), seeds, fillvalue=None):
+            seed = generator.seed() if seed is None else seed
+            new_seeds.append(seed)
+            generator = generator.manual_seed(seed)
+            cur_latents = torch.randn(
+                (1, self.unet.in_channels, height // 8, width // 8),
+                generator=generator,
+                device=self.device,
+            )
+            latents = cur_latents if latents is None else torch.cat((latents, cur_latents))
+
+        # set timesteps
+        accepts_offset = "offset" in set(inspect.signature(self.scheduler.set_timesteps).parameters.keys())
+        extra_set_kwargs = {}
+        if accepts_offset:
+            extra_set_kwargs["offset"] = 1
+
+        self.scheduler.set_timesteps(num_inference_steps, **extra_set_kwargs)
+
+        # if we use LMSDiscreteScheduler, let's make sure latents are mulitplied by sigmas
+        if isinstance(self.scheduler, LMSDiscreteScheduler):
+            latents = latents * self.scheduler.sigmas[0]
+
+        # prepare extra kwargs for the scheduler step, since not all schedulers have the same signature
+        # eta (η) is only used with the DDIMScheduler, it will be ignored for other schedulers.
+        # eta corresponds to η in DDIM paper: https://arxiv.org/abs/2010.02502
+        # and should be between [0, 1]
+        accepts_eta = "eta" in set(inspect.signature(self.scheduler.step).parameters.keys())
+        extra_step_kwargs = {}
+        if accepts_eta:
+            extra_step_kwargs["eta"] = eta
+
+        for i, t in tqdm(enumerate(self.scheduler.timesteps)):
+            # expand the latents if we are doing classifier free guidance
+            latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+            if isinstance(self.scheduler, LMSDiscreteScheduler):
+                sigma = self.scheduler.sigmas[i]
+                latent_model_input = latent_model_input / ((sigma**2 + 1) ** 0.5)
+
+            # predict the noise residual
+            noise_pred = self.unet(latent_model_input, t, encoder_hidden_states=text_embeddings)["sample"]
+
+            # perform guidance
+            if do_classifier_free_guidance:
+                noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+
+            # compute the previous noisy sample x_t -> x_t-1
+            if isinstance(self.scheduler, LMSDiscreteScheduler):
+                latents = self.scheduler.step(noise_pred, i, latents, **extra_step_kwargs)["prev_sample"]
+            else:
+                latents = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs)["prev_sample"]
+
+        # scale and decode the image latents with vae
+        latents = 1 / 0.18215 * latents
+        image = self.vae.decode(latents)
+
+        image = (image / 2 + 0.5).clamp(0, 1)
+        image = image.cpu().permute(0, 2, 3, 1).numpy()
+
+        # run safety checker
+        safety_cheker_input = self.feature_extractor(self.numpy_to_pil(image), return_tensors="pt").to(self.device)
+        image, has_nsfw_concept = self.safety_checker(images=image, clip_input=safety_cheker_input.pixel_values)
+
+        if output_type == "pil":
+            image = self.numpy_to_pil(image)
+
+        return {
+            "sample": image,
+            "nsfw_content_detected": has_nsfw_concept,
+            "seed": new_seeds,
+        }


### PR DESCRIPTION
TODO:
- [ ] Demo Colab.

The idea here is simply to iterate when generating the latents and take note of the seeds that were used. If the user provides any seeds, use them, otherwise generate new ones. Either way, return them.

I think this is a good opportunity to discuss how we want to incorporate these extensions inside the library, depending on how popular we think it could happen. @patil-suraj wrote image-to-image just yesterday, for example. It feels like the natural way to provide an extension is via the pipeline interface. It was very easy to do it, but most of the code is boilerplate. I only had to do the following:
- Add a new argument to `__call__` (the previous seeds).
- Change the way latents are generated ([~10 lines of code](https://github.com/huggingface/diffusers/pull/240/commits/788d0921e844916522e70d3ebed6861173db4f14#diff-cef54e510e4317808dbcf9a48482ac32b35c9fcbac6de94043c0790cec8226d6R80-R91)).
- Change the return dict.
- Copy everything else.

I wonder if we should design Pipelines in a way that they are meant for subclassing, or if we could use mixins or something else. Having to repeat the same steps everywhere (even the deprecated `torch_device` snippet) feels fragile.

Another limitation I found is that this mechanism could be useful for other diffusion pipelines, not just Stable Diffusion. But if you use `DiffusionPipeline` as a superclass then you are forced to write `__init__` to register the appropriate modules, tying your implementation to some specific combination anyway.

One alternative is to just do nothing and keep this as it is right now. This makes perfect sense if we don't expect many contributions in the form of new pipelines. The code is now easy to read if you focus on a specific pipeline and don't care what others look like. But it might be a problem if we end up having lots of pipelines with similar blocks of code.

Thoughts @patrickvonplaten @anton-l @patil-suraj ?
