### PR TITLE
Adds missing torch imports to inpainting and image_to_image example

### DIFF
--- a/examples/inference/readme.md
+++ b/examples/inference/readme.md
@@ -16,6 +16,7 @@ The `image_to_image.py` script implements `StableDiffusionImg2ImgPipeline`. It l
 
 
 ```python
+import torch
 from torch import autocast
 import requests
 from PIL import Image
@@ -61,6 +62,7 @@ The `inpainting.py` script implements `StableDiffusionInpaintingPipeline`. This 
 ### How to use it
 
 ```python
+import torch
 from io import BytesIO
 
 from torch import autocast


### PR DESCRIPTION
thanks for the work on diffusers. Here's a minor fix to the code in readme