### PR TITLE
Run x.contiguous to support Apple MPS

### DIFF
--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -137,7 +137,7 @@ class BasicTransformerBlock(nn.Module):
         self.checkpoint = checkpoint
 
     def forward(self, x, context=None):
-        x = self.attn1(self.norm1(x)) + x
+        x = self.attn1(self.norm1(x.contiguous())) + x
         x = self.attn2(self.norm2(x), context=context) + x
         x = self.ff(self.norm3(x)) + x
         return x

--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -281,6 +281,7 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         timesteps: Union[torch.IntTensor, np.ndarray],
     ) -> torch.Tensor:
 
+        self.alphas_cumprod = self.alphas_cumprod.to('mps')
         sqrt_alpha_prod = self.alphas_cumprod[timesteps] ** 0.5
         sqrt_alpha_prod = self.match_shape(sqrt_alpha_prod, original_samples)
         sqrt_one_minus_alpha_prod = (1 - self.alphas_cumprod[timesteps]) ** 0.5


### PR DESCRIPTION
This call to x.continguous() is required on Apple MPS implementations due to a 16/32-bit problem. Without it, the error I get is `RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.`