### PR TITLE
[Don't merge] SDE_VE integration test

### DIFF
--- a/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
+++ b/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
@@ -50,9 +50,4 @@ class ScoreSdeVePipeline(DiffusionPipeline):
 
             sample, sample_mean = output["prev_sample"], output["prev_sample_mean"]
 
-        sample = sample_mean.clamp(0, 1)
-        sample = sample.cpu().permute(0, 2, 3, 1).numpy()
-        if output_type == "pil":
-            sample = self.numpy_to_pil(sample)
-
-        return {"sample": sample}
+        return sample_mean

--- a/src/diffusers/schedulers/scheduling_sde_ve.py
+++ b/src/diffusers/schedulers/scheduling_sde_ve.py
@@ -135,7 +135,8 @@ class ScoreSdeVeScheduler(SchedulerMixin, ConfigMixin):
         drift = drift - diffusion[:, None, None, None] ** 2 * model_output
 
         #  equation 6: sample noise for the diffusion term of
-        noise = self.randn_like(sample)
+#        noise = self.randn_like(sample)
+        noise = torch.randn_like(sample)
         prev_sample_mean = sample - drift  # subtract because `dt` is a small negative timestep
         # TODO is the variable diffusion the correct scaling term for the noise?
         prev_sample = prev_sample_mean + diffusion[:, None, None, None] * noise  # add impact of diffusion field g
@@ -157,7 +158,8 @@ class ScoreSdeVeScheduler(SchedulerMixin, ConfigMixin):
 
         # For small batch sizes, the paper "suggest replacing norm(z) with sqrt(d), where d is the dim. of z"
         # sample noise for correction
-        noise = self.randn_like(sample)
+#        noise = self.randn_like(sample)
+        noise = torch.randn_like(sample)
 
         # compute step size from the model_output, the noise, and the snr
         grad_norm = self.norm(model_output)

--- a/src/diffusers/schedulers/scheduling_utils.py
+++ b/src/diffusers/schedulers/scheduling_utils.py
@@ -90,7 +90,6 @@ class SchedulerMixin:
         if tensor_format == "np":
             return np.random.randn(*np.shape(tensor))
         elif tensor_format == "pt":
-            # return torch.randn_like(tensor)
             return torch.randn(tensor.shape, layout=tensor.layout, generator=generator).to(tensor.device)
 
         raise ValueError(f"`self.tensor_format`: {self.tensor_format} is not valid.")


### PR DESCRIPTION
Just want to leave this PR up here for anybody that wants to double check the SDE_VE integration.
If you run the following code from this branch:

```python
from diffusers import DiffusionPipeline
import torch


score_sde_sv = DiffusionPipeline.from_pretrained("google/ncsnpp-church-256")
score_sde_sv.to("cuda")

# Note this might take up to 3 minutes on a GPU
# for i in range(12):
i = 0
torch.manual_seed(i)
#image = score_sde_sv(num_inference_steps=1, output_type="np")["sample"][0]
image = score_sde_sv(num_inference_steps=10, output_type="np")

print("Out mean", image.abs().mean())
print("Out sum", image.abs().sum())
```

You get the exact same numbers that when doing the following:

1. git clone https://github.com/yang-song/score_sde_pytorch
2. Download `[ve/church_ncsnpp_continuous](https://drive.google.com/drive/folders/1zVChA0HrnJU66Jkt4P6KOnlREhBMc4Yh?usp=sharing)`
3. Run the following script from the root of the cloned repo:
<details>
  <summary>Click me</summary>
  
 ```python
#!/usr/bin/env python3
import numpy as np
import PIL
import functools

import models
from models import utils as mutils
from models import ncsnv2
from models import ncsnpp
from models import ddpm as ddpm_model
from models import layerspp
from models import layers
from models import normalization
from models.ema import ExponentialMovingAverage
from losses import get_optimizer

from utils import restore_checkpoint

import sampling
from sde_lib import VESDE, VPSDE, subVPSDE
from sampling import (NoneCorrector, 
                      ReverseDiffusionPredictor, 
                      LangevinCorrector,
                      EulerMaruyamaPredictor, 
                      AncestralSamplingPredictor, 
                      NonePredictor,
                      AnnealedLangevinDynamics)
import datasets
import torch


torch.backends.cuda.matmul.allow_tf32 = False


sde = 'VESDE' #@param ['VESDE', 'VPSDE', 'subVPSDE'] {"type": "string"}
#sde = 'VPSDE' #@param ['VESDE', 'VPSDE', 'subVPSDE'] {"type": "string"}
if sde.lower() == 'vesde':
#  from configs.ve import cifar10_ncsnpp_continuous as configs
#  ckpt_filename = "exp/ve/cifar10_ncsnpp_continuous/checkpoint_24.pth"
#  from configs.ve import cifar10_ncsnpp_deep_continuous as configs
#  ckpt_filename = "exp/ve/cifar10_ncsnpp_deep_continuous/checkpoint_12.pth"
  from configs.ve import church_ncsnpp_continuous as configs
  ckpt_filename = "exp/ve/church_ncsnpp_continuous/checkpoint_126.pth"
#  from configs.ve import ffhq_ncsnpp_continuous as configs
#  ckpt_filename = "exp/ve/ffhq_1024_ncsnpp_continuous/checkpoint_60.pth"
#  config.model.num_scales = 5
#  from configs.ve import ffhq_256_ncsnpp_continuous as configs
#  ckpt_filename = "exp/ve/ffhq_256_ncsnpp_continuous/checkpoint_48.pth"
#  from configs.ve import celebahq_256_ncsnpp_continuous as configs
#  ckpt_filename = "exp/ve/celebahq_256_ncsnpp_continuous/checkpoint_48.pth"
  config = configs.get_config()  
  config.model.num_scales = 10
  sde = VESDE(sigma_min=config.model.sigma_min, sigma_max=config.model.sigma_max, N=config.model.num_scales)
  sigma_min, sigma_max = config.model.sigma_min, config.model.sigma_max
  sampling_eps = 1e-5
elif sde.lower() == 'vpsde':
  from configs.vp import cifar10_ddpmpp_deep_continuous as configs  
  ckpt_filename = "exp/vp/cifar10_ddpmpp_continuous/checkpoint_8.pth"
  ckpt_filename = "exp/vp/cifar10_ddpmpp_deep_continuous/checkpoint_19.pth"
  config = configs.get_config()
  config.model.num_scales = 10
  sde = VPSDE(beta_min=config.model.beta_min, beta_max=config.model.beta_max, N=config.model.num_scales)
  sampling_eps = 1e-3
elif sde.lower() == 'subvpsde':
  from configs.subvp import cifar10_ddpmpp_continuous as configs
  ckpt_filename = "exp/subvp/cifar10_ddpmpp_continuous/checkpoint_26.pth"
  config = configs.get_config()
  sde = subVPSDE(beta_min=config.model.beta_min, beta_max=config.model.beta_max, N=config.model.num_scales)
  sampling_eps = 1e-3

batch_size = 1 #@param {"type":"integer"}
config.training.batch_size = batch_size
config.eval.batch_size = batch_size

random_seed = 0 #@param {"type": "integer"}

sigmas = mutils.get_sigmas(config)
scaler = datasets.get_data_scaler(config)
inverse_scaler = datasets.get_data_inverse_scaler(config)
score_model = mutils.create_model(config)

optimizer = get_optimizer(config, score_model.parameters())
ema = ExponentialMovingAverage(score_model.parameters(),
                               decay=config.model.ema_rate)
state = dict(step=0, optimizer=optimizer,
             model=score_model, ema=ema)

state = restore_checkpoint(ckpt_filename, state, config.device)
ema.copy_to(score_model.parameters())

#from diffusers import NCSNpp
#score_model = NCSNpp.from_pretrained("/home/patrick/cifar10-ddpmpp-vp")
#score_model = torch.nn.DataParallel(score_model)
#score_model.to(config.device)

#@title PC sampling
img_size = config.data.image_size
channels = config.data.num_channels
shape = (batch_size, channels, img_size, img_size)
predictor = ReverseDiffusionPredictor #@param ["EulerMaruyamaPredictor", "AncestralSamplingPredictor", "ReverseDiffusionPredictor", "None"] {"type": "raw"}
#predictor = EulerMaruyamaPredictor #@param ["EulerMaruyamaPredictor", "AncestralSamplingPredictor", "ReverseDiffusionPredictor", "None"] {"type": "raw"}
corrector = LangevinCorrector #@param ["LangevinCorrector", "AnnealedLangevinDynamics", "None"] {"type": "raw"}
#corrector = None #@param ["LangevinCorrector", "AnnealedLangevinDynamics", "None"] {"type": "raw"}
snr = 0.075 #@param {"type": "number"}
n_steps = 1 #@param {"type": "integer"}
probability_flow = False #@param {"type": "boolean"}
sampling_fn = sampling.get_pc_sampler(sde, shape, predictor, corrector,
                                      inverse_scaler, snr, n_steps=n_steps,
                                      probability_flow=probability_flow,
                                      continuous=config.training.continuous,
                                      eps=sampling_eps, device=config.device)


def save_image(x, i):
    image_processed = np.clip(x.permute(0, 2, 3, 1).cpu().numpy() * 255, 0, 255).astype(np.uint8)
    image_pil = PIL.Image.fromarray(image_processed[0])
    image_pil.save(f"../images/original_sde_ve_church_{i}.png")

torch.manual_seed(0)
x, n = sampling_fn(score_model)

print(20 * "=")
print("Out mean", x.abs().mean())
print("Out sum", x.abs().sum())


#i = 0
#import ipdb; ipdb.set_trace()
#save_image(x, i)
 ```
</details>