### PR TITLE
Fix GPU tests (token + single-process)

### DIFF
--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -46,5 +46,7 @@ jobs:
         python utils/print_env.py
 
     - name: Run all (incl. slow) tests on GPU
+      env:
+        HF_API_TOKEN: ${{ secrets.HF_API_TOKEN }}
       run: |
-        python -m pytest -n 2 --max-worker-restart=0 --dist=loadfile -s tests/
+        python -m pytest -n 1 --max-worker-restart=0 --dist=loadfile -s tests/


### PR DESCRIPTION
Setting `pytest -n 1` should help with GPU OOMs, but if it doesn't then we can do something like this in another PR for each large test suite:
```python
    def tearDown(self):
        super().tearDown()
        gc.collect()
        torch.cuda.empty_cache()
```