### PR TITLE
Allow downloading of revisions for models.

### DIFF
--- a/src/diffusers/configuration_utils.py
+++ b/src/diffusers/configuration_utils.py
@@ -152,6 +152,7 @@ class ConfigMixin:
                     use_auth_token=use_auth_token,
                     user_agent=user_agent,
                     subfolder=subfolder,
+                    revision=revision,
                 )
 
             except RepositoryNotFoundError:

--- a/src/diffusers/modeling_utils.py
+++ b/src/diffusers/modeling_utils.py
@@ -373,6 +373,7 @@ class ModelMixin(torch.nn.Module):
                     use_auth_token=use_auth_token,
                     user_agent=user_agent,
                     subfolder=subfolder,
+                    revision=revision,
                 )
 
             except RepositoryNotFoundError:


### PR DESCRIPTION
Currently the expression below will download the main branch of the "CompVis/stable-diffusion-v1-4" model repo. The PR fixes so it correctly downloads the fp16 branch.

`UNet2DConditionModel.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="unet", revision="fp16", torch_dtype=torch.float16, use_auth_token=True)`