### PR TITLE
[CI] try to fix GPU OOMs between tests and excessive tqdm logging

### DIFF
--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -53,8 +53,6 @@ from tqdm.auto import tqdm
 from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
 
-# don't pollute logs with tqdm progress bars on new lines
-tqdm.__init__ = partialmethod(tqdm.__init__, disable=None)
 torch.backends.cuda.matmul.allow_tf32 = False
 
 
@@ -197,6 +195,7 @@ class PipelineFastTests(unittest.TestCase):
 
         ddpm = DDIMPipeline(unet=unet, scheduler=scheduler)
         ddpm.to(torch_device)
+        ddpm.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
         image = ddpm(generator=generator, num_inference_steps=2, output_type="numpy")["sample"]
@@ -215,6 +214,7 @@ class PipelineFastTests(unittest.TestCase):
 
         pndm = PNDMPipeline(unet=unet, scheduler=scheduler)
         pndm.to(torch_device)
+        pndm.set_progress_bar_config(disable=None)
         generator = torch.manual_seed(0)
         image = pndm(generator=generator, num_inference_steps=20, output_type="numpy")["sample"]
 
@@ -233,6 +233,7 @@ class PipelineFastTests(unittest.TestCase):
 
         ldm = LDMTextToImagePipeline(vqvae=vae, bert=bert, tokenizer=tokenizer, unet=unet, scheduler=scheduler)
         ldm.to(torch_device)
+        ldm.set_progress_bar_config(disable=None)
 
         prompt = "A painting of a squirrel eating a burger"
         generator = torch.manual_seed(0)
@@ -271,6 +272,7 @@ class PipelineFastTests(unittest.TestCase):
             feature_extractor=self.dummy_extractor,
         )
         sd_pipe = sd_pipe.to(torch_device)
+        sd_pipe.set_progress_bar_config(disable=None)
 
         prompt = "A painting of a squirrel eating a burger"
         generator = torch.Generator(device=torch_device).manual_seed(0)
@@ -305,6 +307,7 @@ class PipelineFastTests(unittest.TestCase):
             feature_extractor=self.dummy_extractor,
         )
         sd_pipe = sd_pipe.to(torch_device)
+        sd_pipe.set_progress_bar_config(disable=None)
 
         prompt = "A painting of a squirrel eating a burger"
         generator = torch.Generator(device=torch_device).manual_seed(0)
@@ -340,6 +343,7 @@ class PipelineFastTests(unittest.TestCase):
             feature_extractor=self.dummy_extractor,
         )
         sd_pipe = sd_pipe.to(torch_device)
+        sd_pipe.set_progress_bar_config(disable=None)
 
         prompt = "A painting of a squirrel eating a burger"
         generator = torch.Generator(device=torch_device).manual_seed(0)
@@ -362,6 +366,7 @@ class PipelineFastTests(unittest.TestCase):
 
         sde_ve = ScoreSdeVePipeline(unet=unet, scheduler=scheduler)
         sde_ve.to(torch_device)
+        sde_ve.set_progress_bar_config(disable=None)
 
         torch.manual_seed(0)
         image = sde_ve(num_inference_steps=2, output_type="numpy")["sample"]
@@ -380,6 +385,7 @@ class PipelineFastTests(unittest.TestCase):
 
         ldm = LDMPipeline(unet=unet, vqvae=vae, scheduler=scheduler)
         ldm.to(torch_device)
+        ldm.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
         image = ldm(generator=generator, num_inference_steps=2, output_type="numpy")["sample"]
@@ -396,6 +402,7 @@ class PipelineFastTests(unittest.TestCase):
 
         pipe = KarrasVePipeline(unet=unet, scheduler=scheduler)
         pipe.to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
         image = pipe(num_inference_steps=2, generator=generator, output_type="numpy")["sample"]
@@ -425,6 +432,7 @@ class PipelineFastTests(unittest.TestCase):
             feature_extractor=self.dummy_extractor,
         )
         sd_pipe = sd_pipe.to(torch_device)
+        sd_pipe.set_progress_bar_config(disable=None)
 
         prompt = "A painting of a squirrel eating a burger"
         generator = torch.Generator(device=torch_device).manual_seed(0)
@@ -468,6 +476,7 @@ class PipelineFastTests(unittest.TestCase):
             feature_extractor=self.dummy_extractor,
         )
         sd_pipe = sd_pipe.to(torch_device)
+        sd_pipe.set_progress_bar_config(disable=None)
 
         prompt = "A painting of a squirrel eating a burger"
         generator = torch.Generator(device=torch_device).manual_seed(0)
@@ -513,6 +522,7 @@ class PipelineTesterMixin(unittest.TestCase):
 
         ddpm = DDPMPipeline(model, schedular)
         ddpm.to(torch_device)
+        ddpm.set_progress_bar_config(disable=None)
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             ddpm.save_pretrained(tmpdirname)
@@ -535,8 +545,10 @@ class PipelineTesterMixin(unittest.TestCase):
 
         ddpm = DDPMPipeline.from_pretrained(model_path, scheduler=scheduler)
         ddpm.to(torch_device)
+        ddpm.set_progress_bar_config(disable=None)
         ddpm_from_hub = DiffusionPipeline.from_pretrained(model_path, scheduler=scheduler)
         ddpm_from_hub.to(torch_device)
+        ddpm_from_hub.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
 
@@ -556,9 +568,11 @@ class PipelineTesterMixin(unittest.TestCase):
         unet = UNet2DModel.from_pretrained(model_path)
         ddpm_from_hub_custom_model = DiffusionPipeline.from_pretrained(model_path, unet=unet, scheduler=scheduler)
         ddpm_from_hub_custom_model.to(torch_device)
+        ddpm_from_hub_custom_model.set_progress_bar_config(disable=None)
 
         ddpm_from_hub = DiffusionPipeline.from_pretrained(model_path, scheduler=scheduler)
         ddpm_from_hub.to(torch_device)
+        ddpm_from_hub_custom_model.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
 
@@ -574,6 +588,7 @@ class PipelineTesterMixin(unittest.TestCase):
 
         pipe = DDIMPipeline.from_pretrained(model_path)
         pipe.to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
         images = pipe(generator=generator, output_type="numpy")["sample"]
@@ -600,6 +615,7 @@ class PipelineTesterMixin(unittest.TestCase):
 
         ddpm = DDPMPipeline(unet=unet, scheduler=scheduler)
         ddpm.to(torch_device)
+        ddpm.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
         image = ddpm(generator=generator, output_type="numpy")["sample"]
@@ -619,6 +635,7 @@ class PipelineTesterMixin(unittest.TestCase):
 
         ddpm = DDIMPipeline(unet=unet, scheduler=scheduler)
         ddpm.to(torch_device)
+        ddpm.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
         image = ddpm(generator=generator, output_type="numpy")["sample"]
@@ -638,6 +655,7 @@ class PipelineTesterMixin(unittest.TestCase):
 
         ddim = DDIMPipeline(unet=unet, scheduler=scheduler)
         ddim.to(torch_device)
+        ddim.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
         image = ddim(generator=generator, eta=0.0, output_type="numpy")["sample"]
@@ -657,6 +675,7 @@ class PipelineTesterMixin(unittest.TestCase):
 
         pndm = PNDMPipeline(unet=unet, scheduler=scheduler)
         pndm.to(torch_device)
+        pndm.set_progress_bar_config(disable=None)
         generator = torch.manual_seed(0)
         image = pndm(generator=generator, output_type="numpy")["sample"]
 
@@ -670,6 +689,7 @@ class PipelineTesterMixin(unittest.TestCase):
     def test_ldm_text2img(self):
         ldm = LDMTextToImagePipeline.from_pretrained("CompVis/ldm-text2im-large-256")
         ldm.to(torch_device)
+        ldm.set_progress_bar_config(disable=None)
 
         prompt = "A painting of a squirrel eating a burger"
         generator = torch.manual_seed(0)
@@ -687,6 +707,7 @@ class PipelineTesterMixin(unittest.TestCase):
     def test_ldm_text2img_fast(self):
         ldm = LDMTextToImagePipeline.from_pretrained("CompVis/ldm-text2im-large-256")
         ldm.to(torch_device)
+        ldm.set_progress_bar_config(disable=None)
 
         prompt = "A painting of a squirrel eating a burger"
         generator = torch.manual_seed(0)
@@ -704,6 +725,7 @@ class PipelineTesterMixin(unittest.TestCase):
         # make sure here that pndm scheduler skips prk
         sd_pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-1", use_auth_token=True)
         sd_pipe = sd_pipe.to(torch_device)
+        sd_pipe.set_progress_bar_config(disable=None)
 
         prompt = "A painting of a squirrel eating a burger"
         generator = torch.Generator(device=torch_device).manual_seed(0)
@@ -725,6 +747,7 @@ class PipelineTesterMixin(unittest.TestCase):
     def test_stable_diffusion_fast_ddim(self):
         sd_pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-1", use_auth_token=True)
         sd_pipe = sd_pipe.to(torch_device)
+        sd_pipe.set_progress_bar_config(disable=None)
 
         scheduler = DDIMScheduler(
             beta_start=0.00085,
@@ -757,6 +780,7 @@ class PipelineTesterMixin(unittest.TestCase):
 
         sde_ve = ScoreSdeVePipeline(unet=model, scheduler=scheduler)
         sde_ve.to(torch_device)
+        sde_ve.set_progress_bar_config(disable=None)
 
         torch.manual_seed(0)
         image = sde_ve(num_inference_steps=300, output_type="numpy")["sample"]
@@ -772,6 +796,7 @@ class PipelineTesterMixin(unittest.TestCase):
     def test_ldm_uncond(self):
         ldm = LDMPipeline.from_pretrained("CompVis/ldm-celebahq-256")
         ldm.to(torch_device)
+        ldm.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
         image = ldm(generator=generator, num_inference_steps=5, output_type="numpy")["sample"]
@@ -792,8 +817,10 @@ class PipelineTesterMixin(unittest.TestCase):
 
         ddpm = DDPMPipeline(unet=unet, scheduler=ddpm_scheduler)
         ddpm.to(torch_device)
+        ddpm.set_progress_bar_config(disable=None)
         ddim = DDIMPipeline(unet=unet, scheduler=ddim_scheduler)
         ddim.to(torch_device)
+        ddim.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
         ddpm_image = ddpm(generator=generator, output_type="numpy")["sample"]
@@ -814,9 +841,11 @@ class PipelineTesterMixin(unittest.TestCase):
 
         ddpm = DDPMPipeline(unet=unet, scheduler=ddpm_scheduler)
         ddpm.to(torch_device)
+        ddpm.set_progress_bar_config(disable=None)
 
         ddim = DDIMPipeline(unet=unet, scheduler=ddim_scheduler)
         ddim.to(torch_device)
+        ddim.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
         ddpm_images = ddpm(batch_size=4, generator=generator, output_type="numpy")["sample"]
@@ -837,6 +866,7 @@ class PipelineTesterMixin(unittest.TestCase):
 
         pipe = KarrasVePipeline(unet=model, scheduler=scheduler)
         pipe.to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
 
         generator = torch.manual_seed(0)
         image = pipe(num_inference_steps=20, generator=generator, output_type="numpy")["sample"]
@@ -851,6 +881,7 @@ class PipelineTesterMixin(unittest.TestCase):
     def test_lms_stable_diffusion_pipeline(self):
         model_id = "CompVis/stable-diffusion-v1-1"
         pipe = StableDiffusionPipeline.from_pretrained(model_id, use_auth_token=True).to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
         scheduler = LMSDiscreteScheduler.from_config(model_id, subfolder="scheduler", use_auth_token=True)
         pipe.scheduler = scheduler
 
@@ -876,6 +907,7 @@ class PipelineTesterMixin(unittest.TestCase):
         model_id = "CompVis/stable-diffusion-v1-4"
         pipe = StableDiffusionImg2ImgPipeline.from_pretrained(model_id, use_auth_token=True)
         pipe.to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
 
         prompt = "A fantasy landscape, trending on artstation"
 
@@ -902,6 +934,7 @@ class PipelineTesterMixin(unittest.TestCase):
         model_id = "CompVis/stable-diffusion-v1-4"
         pipe = StableDiffusionInpaintPipeline.from_pretrained(model_id, use_auth_token=True)
         pipe.to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
 
         prompt = "A red cat sitting on a parking bench"
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -49,7 +49,7 @@ from diffusers import (
 from diffusers.pipeline_utils import DiffusionPipeline
 from diffusers.testing_utils import floats_tensor, slow, torch_device
 from PIL import Image
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -17,7 +17,6 @@ import gc
 import random
 import tempfile
 import unittest
-from functools import partialmethod
 
 import numpy as np
 import torch
@@ -49,7 +48,6 @@ from diffusers import (
 from diffusers.pipeline_utils import DiffusionPipeline
 from diffusers.testing_utils import floats_tensor, slow, torch_device
 from PIL import Image
-from tqdm.auto import tqdm
 from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -54,7 +54,7 @@ from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
 
 # don't pollute logs with tqdm progress bars on new lines
-tqdm.__init__ = partialmethod(tqdm.__init__, position=0, leave=True)
+tqdm.__init__ = partialmethod(tqdm.__init__, disable=None)
 torch.backends.cuda.matmul.allow_tf32 = False
 
 


### PR DESCRIPTION
Adding a bunch of `set_progress_bar_config(disable=None)` to disable tqdm in non-interactive console outputs (i.e. in our CI logs)

*Sorry for merging that with GPU tearDowns, happy to branch out into a different PR if necessary :)