### PR TITLE
[CI] Cancel pending jobs for PRs on new commits

### DIFF
--- a/.github/workflows/pr_quality.yml
+++ b/.github/workflows/pr_quality.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check_code_quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   HF_HOME: /mnt/cache
   OMP_NUM_THREADS: 8


### PR DESCRIPTION
This will drop any running or pending jobs for a PR if a new commit is pushed, freeing the queue for a fresh test run.
This won't affect jobs running on the `main` branch like the slow GPU tests.