### PR TITLE
package `version` on main should have `.dev0` suffix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ install_requires = [
 
 setup(
     name="diffusers",
-    version="0.2.4",
+    version="0.2.4.dev0", # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
     description="Diffusers",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ install_requires = [
 
 setup(
     name="diffusers",
-    version="0.2.4.dev0", # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
+    version="0.3.0.dev0", # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
     description="Diffusers",
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",

--- a/src/diffusers/__init__.py
+++ b/src/diffusers/__init__.py
@@ -1,7 +1,7 @@
 from .utils import is_inflect_available, is_scipy_available, is_transformers_available, is_unidecode_available
 
 
-__version__ = "0.2.4"
+__version__ = "0.3.0.dev0"
 
 from .modeling_utils import ModelMixin
 from .models import AutoencoderKL, UNet2DConditionModel, UNet2DModel, VQModel


### PR DESCRIPTION
package `version` on main should have `.dev0` suffix, which is the convention followed in transformers [here](https://github.com/huggingface/transformers/blob/main/setup.py#L403)

Currently, there [are no docs](https://github.com/huggingface/doc-build/tree/main/diffusers) for the `main` version of diffusers because of this convention. This PR should fix the issue