### PR TITLE
Efficient Attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ pipe = StableDiffusionPipeline.from_pretrained(
 pipe = pipe.to("cuda")
 
 prompt = "a photo of an astronaut riding a horse on mars"
-pipe.set_attention_chunk()
+pipe.set_attention_slice()
 with autocast("cuda"):
     image = pipe(prompt).images[0]  
 ```

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ with autocast("cuda"):
     image = pipe(prompt).images[0]  
 ```
 
-If you are limited by GPU memory, you might want to consider using the model in `fp16`.
+If you are limited by GPU memory, you might want to consider using the model in `fp16` as 
+well as chunking the attention computation.
+The following snippet should result in less than 4GB VRAM.
 
 ```python
 pipe = StableDiffusionPipeline.from_pretrained(
@@ -116,6 +118,7 @@ pipe = StableDiffusionPipeline.from_pretrained(
 pipe = pipe.to("cuda")
 
 prompt = "a photo of an astronaut riding a horse on mars"
+pipe.set_attention_chunk()
 with autocast("cuda"):
     image = pipe(prompt).images[0]  
 ```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ pipe = StableDiffusionPipeline.from_pretrained(
 pipe = pipe.to("cuda")
 
 prompt = "a photo of an astronaut riding a horse on mars"
-pipe.set_attention_slice()
+pipe.enable_attention_slicing()
 with autocast("cuda"):
     image = pipe(prompt).images[0]  
 ```

--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -108,9 +108,9 @@ class SpatialTransformer(nn.Module):
 
         self.proj_out = nn.Conv2d(inner_dim, in_channels, kernel_size=1, stride=1, padding=0)
 
-    def _set_attention_chunk_size(self, chunk_size):
+    def _set_attention_chunk(self, chunk_size):
         for block in self.transformer_blocks:
-            block._set_attention_chunk_size(chunk_size)
+            block._set_attention_chunk(chunk_size)
 
     def forward(self, x, context=None):
         # note: if no context is given, cross-attention defaults to self-attention
@@ -141,7 +141,7 @@ class BasicTransformerBlock(nn.Module):
         self.norm3 = nn.LayerNorm(dim)
         self.checkpoint = checkpoint
 
-    def _set_attention_chunk_size(self, chunk_size):
+    def _set_attention_chunk(self, chunk_size):
         self.attn1._chunk_size = chunk_size
         self.attn2._chunk_size = chunk_size
 
@@ -162,7 +162,7 @@ class CrossAttention(nn.Module):
         self.heads = heads
         # for chunk_size > 0 the attention score computation
         # is split across the batch axis to save memory
-        # You can set chunk_size with `set_attention_chunk_size`
+        # You can set chunk_size with `set_attention_chunk`
         self._chunk_size = None
 
         self.to_q = nn.Linear(query_dim, inner_dim, bias=False)

--- a/src/diffusers/models/unet_2d_condition.py
+++ b/src/diffusers/models/unet_2d_condition.py
@@ -133,27 +133,27 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin):
         self.conv_act = nn.SiLU()
         self.conv_out = nn.Conv2d(block_out_channels[0], out_channels, 3, padding=1)
 
-    def set_attention_chunk(self, chunk_size):
-        if chunk_size is not None and self.config.attention_head_dim % chunk_size != 0:
+    def set_attention_slice(self, slice_size):
+        if slice_size is not None and self.config.attention_head_dim % slice_size != 0:
             raise ValueError(
-                f"Make sure chunk_size {chunk_size} is a divisor of "
+                f"Make sure slice_size {slice_size} is a divisor of "
                 f"the number of heads used in cross_attention {self.config.attention_head_dim}"
             )
-        if chunk_size is not None and chunk_size > self.config.attention_head_dim:
+        if slice_size is not None and slice_size > self.config.attention_head_dim:
             raise ValueError(
-                f"Chunk_size {chunk_size} has to be smaller or equal to "
+                f"Chunk_size {slice_size} has to be smaller or equal to "
                 f"the number of heads used in cross_attention {self.config.attention_head_dim}"
             )
 
         for block in self.down_blocks:
             if hasattr(block, "attentions") and block.attentions is not None:
-                block.set_attention_chunk(chunk_size)
+                block.set_attention_slice(slice_size)
 
-        self.mid_block.set_attention_chunk(chunk_size)
+        self.mid_block.set_attention_slice(slice_size)
 
         for block in self.up_blocks:
             if hasattr(block, "attentions") and block.attentions is not None:
-                block.set_attention_chunk(chunk_size)
+                block.set_attention_slice(slice_size)
 
     def forward(
         self,

--- a/src/diffusers/models/unet_2d_condition.py
+++ b/src/diffusers/models/unet_2d_condition.py
@@ -133,7 +133,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin):
         self.conv_act = nn.SiLU()
         self.conv_out = nn.Conv2d(block_out_channels[0], out_channels, 3, padding=1)
 
-    def set_attention_chunk_size(self, chunk_size):
+    def set_attention_chunk(self, chunk_size):
         if chunk_size is not None and self.config.attention_head_dim % chunk_size != 0:
             raise ValueError(
                 f"Make sure chunk_size {chunk_size} is a divisor of "
@@ -147,13 +147,13 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin):
 
         for block in self.down_blocks:
             if hasattr(block, "attentions") and block.attentions is not None:
-                block.set_attention_chunk_size(chunk_size)
+                block.set_attention_chunk(chunk_size)
 
-        self.mid_block.set_attention_chunk_size(chunk_size)
+        self.mid_block.set_attention_chunk(chunk_size)
 
         for block in self.up_blocks:
             if hasattr(block, "attentions") and block.attentions is not None:
-                block.set_attention_chunk_size(chunk_size)
+                block.set_attention_chunk(chunk_size)
 
     def forward(
         self,

--- a/src/diffusers/models/unet_blocks.py
+++ b/src/diffusers/models/unet_blocks.py
@@ -343,20 +343,20 @@ class UNetMidBlock2DCrossAttn(nn.Module):
         self.attentions = nn.ModuleList(attentions)
         self.resnets = nn.ModuleList(resnets)
 
-    def set_attention_chunk(self, chunk_size):
-        if chunk_size is not None and self.attn_num_head_channels % chunk_size != 0:
+    def set_attention_slice(self, slice_size):
+        if slice_size is not None and self.attn_num_head_channels % slice_size != 0:
             raise ValueError(
-                f"Make sure chunk_size {chunk_size} is a divisor of "
+                f"Make sure slice_size {slice_size} is a divisor of "
                 f"the number of heads used in cross_attention {self.attn_num_head_channels}"
             )
-        if chunk_size is not None and chunk_size > self.attn_num_head_channels:
+        if slice_size is not None and slice_size > self.attn_num_head_channels:
             raise ValueError(
-                f"Chunk_size {chunk_size} has to be smaller or equal to "
+                f"Chunk_size {slice_size} has to be smaller or equal to "
                 f"the number of heads used in cross_attention {self.attn_num_head_channels}"
             )
 
         for attn in self.attentions:
-            attn._set_attention_chunk(chunk_size)
+            attn._set_attention_slice(slice_size)
 
     def forward(self, hidden_states, temb=None, encoder_hidden_states=None):
         hidden_states = self.resnets[0](hidden_states, temb)
@@ -514,20 +514,20 @@ class CrossAttnDownBlock2D(nn.Module):
         else:
             self.downsamplers = None
 
-    def set_attention_chunk(self, chunk_size):
-        if chunk_size is not None and self.attn_num_head_channels % chunk_size != 0:
+    def set_attention_slice(self, slice_size):
+        if slice_size is not None and self.attn_num_head_channels % slice_size != 0:
             raise ValueError(
-                f"Make sure chunk_size {chunk_size} is a divisor of "
+                f"Make sure slice_size {slice_size} is a divisor of "
                 f"the number of heads used in cross_attention {self.attn_num_head_channels}"
             )
-        if chunk_size is not None and chunk_size > self.attn_num_head_channels:
+        if slice_size is not None and slice_size > self.attn_num_head_channels:
             raise ValueError(
-                f"Chunk_size {chunk_size} has to be smaller or equal to "
+                f"Chunk_size {slice_size} has to be smaller or equal to "
                 f"the number of heads used in cross_attention {self.attn_num_head_channels}"
             )
 
         for attn in self.attentions:
-            attn._set_attention_chunk(chunk_size)
+            attn._set_attention_slice(slice_size)
 
     def forward(self, hidden_states, temb=None, encoder_hidden_states=None):
         output_states = ()
@@ -1058,20 +1058,20 @@ class CrossAttnUpBlock2D(nn.Module):
         else:
             self.upsamplers = None
 
-    def set_attention_chunk(self, chunk_size):
-        if chunk_size is not None and self.attn_num_head_channels % chunk_size != 0:
+    def set_attention_slice(self, slice_size):
+        if slice_size is not None and self.attn_num_head_channels % slice_size != 0:
             raise ValueError(
-                f"Make sure chunk_size {chunk_size} is a divisor of "
+                f"Make sure slice_size {slice_size} is a divisor of "
                 f"the number of heads used in cross_attention {self.attn_num_head_channels}"
             )
-        if chunk_size is not None and chunk_size > self.attn_num_head_channels:
+        if slice_size is not None and slice_size > self.attn_num_head_channels:
             raise ValueError(
-                f"Chunk_size {chunk_size} has to be smaller or equal to "
+                f"Chunk_size {slice_size} has to be smaller or equal to "
                 f"the number of heads used in cross_attention {self.attn_num_head_channels}"
             )
 
         for attn in self.attentions:
-            attn._set_attention_chunk(chunk_size)
+            attn._set_attention_slice(slice_size)
 
     def forward(self, hidden_states, res_hidden_states_tuple, temb=None, encoder_hidden_states=None):
         for resnet, attn in zip(self.resnets, self.attentions):

--- a/src/diffusers/models/unet_blocks.py
+++ b/src/diffusers/models/unet_blocks.py
@@ -295,6 +295,7 @@ class UNetMidBlock2DCrossAttn(nn.Module):
         super().__init__()
 
         self.attention_type = attention_type
+        self.attn_num_head_channels = attn_num_head_channels
         resnet_groups = resnet_groups if resnet_groups is not None else min(in_channels // 4, 32)
 
         # there is always at least one resnet
@@ -341,6 +342,21 @@ class UNetMidBlock2DCrossAttn(nn.Module):
 
         self.attentions = nn.ModuleList(attentions)
         self.resnets = nn.ModuleList(resnets)
+
+    def set_attention_chunk_size(self, chunk_size):
+        if chunk_size is not None and self.attn_num_head_channels % chunk_size != 0:
+            raise ValueError(
+                f"Make sure chunk_size {chunk_size} is a divisor of "
+                f"the number of heads used in cross_attention {self.attn_num_head_channels}"
+            )
+        if chunk_size is not None and chunk_size > self.attn_num_head_channels:
+            raise ValueError(
+                f"Chunk_size {chunk_size} has to be smaller or equal to "
+                f"the number of heads used in cross_attention {self.attn_num_head_channels}"
+            )
+
+        for attn in self.attentions:
+            attn._set_attention_chunk_size(chunk_size)
 
     def forward(self, hidden_states, temb=None, encoder_hidden_states=None):
         hidden_states = self.resnets[0](hidden_states, temb)
@@ -457,6 +473,7 @@ class CrossAttnDownBlock2D(nn.Module):
         attentions = []
 
         self.attention_type = attention_type
+        self.attn_num_head_channels = attn_num_head_channels
 
         for i in range(num_layers):
             in_channels = in_channels if i == 0 else out_channels
@@ -496,6 +513,21 @@ class CrossAttnDownBlock2D(nn.Module):
             )
         else:
             self.downsamplers = None
+
+    def set_attention_chunk_size(self, chunk_size):
+        if chunk_size is not None and self.attn_num_head_channels % chunk_size != 0:
+            raise ValueError(
+                f"Make sure chunk_size {chunk_size} is a divisor of "
+                f"the number of heads used in cross_attention {self.attn_num_head_channels}"
+            )
+        if chunk_size is not None and chunk_size > self.attn_num_head_channels:
+            raise ValueError(
+                f"Chunk_size {chunk_size} has to be smaller or equal to "
+                f"the number of heads used in cross_attention {self.attn_num_head_channels}"
+            )
+
+        for attn in self.attentions:
+            attn._set_attention_chunk_size(chunk_size)
 
     def forward(self, hidden_states, temb=None, encoder_hidden_states=None):
         output_states = ()
@@ -989,6 +1021,7 @@ class CrossAttnUpBlock2D(nn.Module):
         attentions = []
 
         self.attention_type = attention_type
+        self.attn_num_head_channels = attn_num_head_channels
 
         for i in range(num_layers):
             res_skip_channels = in_channels if (i == num_layers - 1) else out_channels
@@ -1024,6 +1057,21 @@ class CrossAttnUpBlock2D(nn.Module):
             self.upsamplers = nn.ModuleList([Upsample2D(out_channels, use_conv=True, out_channels=out_channels)])
         else:
             self.upsamplers = None
+
+    def set_attention_chunk_size(self, chunk_size):
+        if chunk_size is not None and self.attn_num_head_channels % chunk_size != 0:
+            raise ValueError(
+                f"Make sure chunk_size {chunk_size} is a divisor of "
+                f"the number of heads used in cross_attention {self.attn_num_head_channels}"
+            )
+        if chunk_size is not None and chunk_size > self.attn_num_head_channels:
+            raise ValueError(
+                f"Chunk_size {chunk_size} has to be smaller or equal to "
+                f"the number of heads used in cross_attention {self.attn_num_head_channels}"
+            )
+
+        for attn in self.attentions:
+            attn._set_attention_chunk_size(chunk_size)
 
     def forward(self, hidden_states, res_hidden_states_tuple, temb=None, encoder_hidden_states=None):
         for resnet, attn in zip(self.resnets, self.attentions):

--- a/src/diffusers/models/unet_blocks.py
+++ b/src/diffusers/models/unet_blocks.py
@@ -343,7 +343,7 @@ class UNetMidBlock2DCrossAttn(nn.Module):
         self.attentions = nn.ModuleList(attentions)
         self.resnets = nn.ModuleList(resnets)
 
-    def set_attention_chunk_size(self, chunk_size):
+    def set_attention_chunk(self, chunk_size):
         if chunk_size is not None and self.attn_num_head_channels % chunk_size != 0:
             raise ValueError(
                 f"Make sure chunk_size {chunk_size} is a divisor of "
@@ -356,7 +356,7 @@ class UNetMidBlock2DCrossAttn(nn.Module):
             )
 
         for attn in self.attentions:
-            attn._set_attention_chunk_size(chunk_size)
+            attn._set_attention_chunk(chunk_size)
 
     def forward(self, hidden_states, temb=None, encoder_hidden_states=None):
         hidden_states = self.resnets[0](hidden_states, temb)
@@ -514,7 +514,7 @@ class CrossAttnDownBlock2D(nn.Module):
         else:
             self.downsamplers = None
 
-    def set_attention_chunk_size(self, chunk_size):
+    def set_attention_chunk(self, chunk_size):
         if chunk_size is not None and self.attn_num_head_channels % chunk_size != 0:
             raise ValueError(
                 f"Make sure chunk_size {chunk_size} is a divisor of "
@@ -527,7 +527,7 @@ class CrossAttnDownBlock2D(nn.Module):
             )
 
         for attn in self.attentions:
-            attn._set_attention_chunk_size(chunk_size)
+            attn._set_attention_chunk(chunk_size)
 
     def forward(self, hidden_states, temb=None, encoder_hidden_states=None):
         output_states = ()
@@ -1058,7 +1058,7 @@ class CrossAttnUpBlock2D(nn.Module):
         else:
             self.upsamplers = None
 
-    def set_attention_chunk_size(self, chunk_size):
+    def set_attention_chunk(self, chunk_size):
         if chunk_size is not None and self.attn_num_head_channels % chunk_size != 0:
             raise ValueError(
                 f"Make sure chunk_size {chunk_size} is a divisor of "
@@ -1071,7 +1071,7 @@ class CrossAttnUpBlock2D(nn.Module):
             )
 
         for attn in self.attentions:
-            attn._set_attention_chunk_size(chunk_size)
+            attn._set_attention_chunk(chunk_size)
 
     def forward(self, hidden_states, res_hidden_states_tuple, temb=None, encoder_hidden_states=None):
         for resnet, attn in zip(self.resnets, self.attentions):

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -36,13 +36,13 @@ class StableDiffusionPipeline(DiffusionPipeline):
             feature_extractor=feature_extractor,
         )
 
-    def set_attention_chunk_size(self, chunk_size: Optional[Union[str, int]] = "auto"):
-        # set chunk_size = `None` to disable `set_attention_chunk_size`
+    def set_attention_chunk(self, chunk_size: Optional[Union[str, int]] = "auto"):
+        # set chunk_size = `None` to disable `set_attention_chunk`
         if chunk_size == "auto":
             # half the attention head size is usually a good trade-off between
             # speed and memory
             chunk_size = self.unet.config.attention_head_dim // 2
-        self.unet.set_attention_chunk_size(chunk_size)
+        self.unet.set_attention_chunk(chunk_size)
 
     @torch.no_grad()
     def __call__(

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -36,6 +36,14 @@ class StableDiffusionPipeline(DiffusionPipeline):
             feature_extractor=feature_extractor,
         )
 
+    def set_attention_chunk_size(self, chunk_size: Optional[Union[str, int]] = "auto"):
+        # set chunk_size = `None` to disable `set_attention_chunk_size`
+        if chunk_size == "auto":
+            # half the attention head size is usually a good trade-off between
+            # speed and memory
+            chunk_size = self.unet.config.attention_head_dim // 2
+        self.unet.set_attention_chunk_size(chunk_size)
+
     @torch.no_grad()
     def __call__(
         self,

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -36,13 +36,16 @@ class StableDiffusionPipeline(DiffusionPipeline):
             feature_extractor=feature_extractor,
         )
 
-    def set_attention_chunk(self, chunk_size: Optional[Union[str, int]] = "auto"):
-        # set chunk_size = `None` to disable `set_attention_chunk`
-        if chunk_size == "auto":
+    def enable_attention_slicing(self, slice_size: Optional[Union[str, int]] = "auto"):
+        if slice_size == "auto":
             # half the attention head size is usually a good trade-off between
             # speed and memory
-            chunk_size = self.unet.config.attention_head_dim // 2
-        self.unet.set_attention_chunk(chunk_size)
+            slice_size = self.unet.config.attention_head_dim // 2
+        self.unet.set_attention_slice(slice_size)
+
+    def disable_attention_slicing(self):
+        # set slice_size = `None` to disable `set_attention_slice`
+        self.enable_attention_slice(None)
 
     @torch.no_grad()
     def __call__(

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -47,14 +47,16 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
             feature_extractor=feature_extractor,
         )
 
-    def set_attention_chunk(self, chunk_size: Optional[Union[str, int]] = "auto"):
-        # set chunk_size = `None` to disable `set_attention_chunk`
-        if chunk_size == "auto":
+    def enable_attention_slicing(self, slice_size: Optional[Union[str, int]] = "auto"):
+        if slice_size == "auto":
             # half the attention head size is usually a good trade-off between
             # speed and memory
-            chunk_size = self.unet.config.attention_head_dim // 2
+            slice_size = self.unet.config.attention_head_dim // 2
+        self.unet.set_attention_slice(slice_size)
 
-        self.unet.set_attention_chunk(chunk_size)
+    def disable_attention_slicing(self):
+        # set slice_size = `None` to disable `set_attention_slice`
+        self.enable_attention_slice(None)
 
     @torch.no_grad()
     def __call__(

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -47,6 +47,15 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
             feature_extractor=feature_extractor,
         )
 
+    def set_attention_chunk(self, chunk_size: Optional[Union[str, int]] = "auto"):
+        # set chunk_size = `None` to disable `set_attention_chunk`
+        if chunk_size == "auto":
+            # half the attention head size is usually a good trade-off between
+            # speed and memory
+            chunk_size = self.unet.config.attention_head_dim // 2
+
+        self.unet.set_attention_chunk(chunk_size)
+
     @torch.no_grad()
     def __call__(
         self,

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -61,14 +61,16 @@ class StableDiffusionInpaintPipeline(DiffusionPipeline):
             feature_extractor=feature_extractor,
         )
 
-    def set_attention_chunk(self, chunk_size: Optional[Union[str, int]] = "auto"):
-        # set chunk_size = `None` to disable `set_attention_chunk`
-        if chunk_size == "auto":
+    def enable_attention_slicing(self, slice_size: Optional[Union[str, int]] = "auto"):
+        if slice_size == "auto":
             # half the attention head size is usually a good trade-off between
             # speed and memory
-            chunk_size = self.unet.config.attention_head_dim // 2
+            slice_size = self.unet.config.attention_head_dim // 2
+        self.unet.set_attention_slice(slice_size)
 
-        self.unet.set_attention_chunk(chunk_size)
+    def disable_attention_slicing(self):
+        # set slice_size = `None` to disable `set_attention_slice`
+        self.enable_attention_slice(None)
 
     @torch.no_grad()
     def __call__(

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -61,6 +61,15 @@ class StableDiffusionInpaintPipeline(DiffusionPipeline):
             feature_extractor=feature_extractor,
         )
 
+    def set_attention_chunk(self, chunk_size: Optional[Union[str, int]] = "auto"):
+        # set chunk_size = `None` to disable `set_attention_chunk`
+        if chunk_size == "auto":
+            # half the attention head size is usually a good trade-off between
+            # speed and memory
+            chunk_size = self.unet.config.attention_head_dim // 2
+
+        self.unet.set_attention_chunk(chunk_size)
+
     @torch.no_grad()
     def __call__(
         self,

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -436,7 +436,7 @@ class PipelineFastTests(unittest.TestCase):
         output_1 = sd_pipe([prompt], generator=generator, guidance_scale=6.0, num_inference_steps=2, output_type="np")
 
         # make sure chunking the attention yields the same result
-        sd_pipe.set_attention_chunk_size(chunk_size=1)
+        sd_pipe.set_attention_chunk(chunk_size=1)
         generator = torch.Generator(device=device).manual_seed(0)
         output_2 = sd_pipe([prompt], generator=generator, guidance_scale=6.0, num_inference_steps=2, output_type="np")
 
@@ -1090,7 +1090,7 @@ class PipelineTesterMixin(unittest.TestCase):
         prompt = "a photograph of an astronaut riding a horse"
 
         # make attention efficient
-        pipe.set_attention_chunk_size()
+        pipe.set_attention_chunk()
         generator = torch.Generator(device=torch_device).manual_seed(0)
         with torch.autocast(torch_device):
             output_chunked = pipe(
@@ -1104,7 +1104,7 @@ class PipelineTesterMixin(unittest.TestCase):
         assert mem_bytes < 3.75 * 10**9
 
         # disable chunking
-        pipe.set_attention_chunk_size(chunk_size=None)
+        pipe.set_attention_chunk(chunk_size=None)
         generator = torch.Generator(device=torch_device).manual_seed(0)
         with torch.autocast(torch_device):
             output = pipe(

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -410,6 +410,38 @@ class PipelineFastTests(unittest.TestCase):
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
         assert np.abs(image_from_tuple_slice.flatten() - expected_slice).max() < 1e-2
 
+    def test_stable_diffusion_attention_chunk(self):
+        device = "cpu"  # ensure determinism for the device-dependent torch.Generator
+        unet = self.dummy_cond_unet
+        scheduler = LMSDiscreteScheduler(beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear")
+        vae = self.dummy_vae
+        bert = self.dummy_text_encoder
+        tokenizer = CLIPTokenizer.from_pretrained("hf-internal-testing/tiny-random-clip")
+
+        # make sure here that pndm scheduler skips prk
+        sd_pipe = StableDiffusionPipeline(
+            unet=unet,
+            scheduler=scheduler,
+            vae=vae,
+            text_encoder=bert,
+            tokenizer=tokenizer,
+            safety_checker=self.dummy_safety_checker,
+            feature_extractor=self.dummy_extractor,
+        )
+        sd_pipe = sd_pipe.to(device)
+        sd_pipe.set_progress_bar_config(disable=None)
+
+        prompt = "A painting of a squirrel eating a burger"
+        generator = torch.Generator(device=device).manual_seed(0)
+        output_1 = sd_pipe([prompt], generator=generator, guidance_scale=6.0, num_inference_steps=2, output_type="np")
+
+        # make sure chunking the attention yields the same result
+        sd_pipe.set_attention_chunk_size(chunk_size=1)
+        generator = torch.Generator(device=device).manual_seed(0)
+        output_2 = sd_pipe([prompt], generator=generator, guidance_scale=6.0, num_inference_steps=2, output_type="np")
+
+        assert np.abs(output_2.images.flatten() - output_1.images.flatten()).max() < 1e-4
+
     def test_score_sde_ve_pipeline(self):
         unet = self.dummy_uncond_unet
         scheduler = ScoreSdeVeScheduler(tensor_format="pt")
@@ -1044,6 +1076,44 @@ class PipelineTesterMixin(unittest.TestCase):
         assert image.shape == (1, 512, 512, 3)
         expected_slice = np.array([0.9077, 0.9254, 0.9181, 0.9227, 0.9213, 0.9367, 0.9399, 0.9406, 0.9024])
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
+
+    @slow
+    @unittest.skipIf(torch_device == "cpu", "Stable diffusion is supposed to run on GPU")
+    def test_stable_diffusion_memory_chunking(self):
+        torch.cuda.reset_peak_memory_stats()
+        model_id = "CompVis/stable-diffusion-v1-4"
+        pipe = StableDiffusionPipeline.from_pretrained(
+            model_id, revision="fp16", torch_dtype=torch.float16, use_auth_token=True
+        ).to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
+
+        prompt = "a photograph of an astronaut riding a horse"
+
+        # make attention efficient
+        pipe.set_attention_chunk_size()
+        generator = torch.Generator(device=torch_device).manual_seed(0)
+        with torch.autocast(torch_device):
+            image_chunked = pipe(
+                [prompt], generator=generator, guidance_scale=7.5, num_inference_steps=10, output_type="numpy"
+            )["sample"]
+
+        mem_bytes = torch.cuda.max_memory_allocated()
+        torch.cuda.reset_peak_memory_stats()
+        # make sure that less than 3.75 GB is allocated
+        assert mem_bytes < 3.75 * 10**9
+
+        # disable chunking
+        pipe.set_attention_chunk_size(chunk_size=None)
+        generator = torch.Generator(device=torch_device).manual_seed(0)
+        with torch.autocast(torch_device):
+            image = pipe(
+                [prompt], generator=generator, guidance_scale=7.5, num_inference_steps=10, output_type="numpy"
+            )["sample"]
+
+        # make sure that more than 3.75 GB is allocated
+        mem_bytes = torch.cuda.max_memory_allocated()
+        assert mem_bytes > 3.75 * 10**9
+        assert np.abs(image_chunked.flatten() - image.flatten()).max() < 1e-3
 
     @slow
     @unittest.skipIf(torch_device == "cpu", "Stable diffusion is supposed to run on GPU")

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -153,7 +153,6 @@ class PipelineFastTests(unittest.TestCase):
         torch.manual_seed(0)
         config = CLIPTextConfig(
             bos_token_id=0,
-            chunk_size_feed_forward=0,
             eos_token_id=2,
             hidden_size=32,
             intermediate_size=37,
@@ -436,7 +435,7 @@ class PipelineFastTests(unittest.TestCase):
         output_1 = sd_pipe([prompt], generator=generator, guidance_scale=6.0, num_inference_steps=2, output_type="np")
 
         # make sure chunking the attention yields the same result
-        sd_pipe.set_attention_chunk(chunk_size=1)
+        sd_pipe.enable_attention_slicing(slice_size=1)
         generator = torch.Generator(device=device).manual_seed(0)
         output_2 = sd_pipe([prompt], generator=generator, guidance_scale=6.0, num_inference_steps=2, output_type="np")
 
@@ -1090,7 +1089,7 @@ class PipelineTesterMixin(unittest.TestCase):
         prompt = "a photograph of an astronaut riding a horse"
 
         # make attention efficient
-        pipe.set_attention_chunk()
+        pipe.enable_attention_slicing()
         generator = torch.Generator(device=torch_device).manual_seed(0)
         with torch.autocast(torch_device):
             output_chunked = pipe(
@@ -1104,7 +1103,7 @@ class PipelineTesterMixin(unittest.TestCase):
         assert mem_bytes < 3.75 * 10**9
 
         # disable chunking
-        pipe.set_attention_chunk(chunk_size=None)
+        pipe.disable_attention_slicing()
         generator = torch.Generator(device=torch_device).manual_seed(0)
         with torch.autocast(torch_device):
             output = pipe(

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1093,9 +1093,10 @@ class PipelineTesterMixin(unittest.TestCase):
         pipe.set_attention_chunk_size()
         generator = torch.Generator(device=torch_device).manual_seed(0)
         with torch.autocast(torch_device):
-            image_chunked = pipe(
+            output_chunked = pipe(
                 [prompt], generator=generator, guidance_scale=7.5, num_inference_steps=10, output_type="numpy"
-            )["sample"]
+            )
+            image_chunked = output_chunked.images
 
         mem_bytes = torch.cuda.max_memory_allocated()
         torch.cuda.reset_peak_memory_stats()
@@ -1106,9 +1107,10 @@ class PipelineTesterMixin(unittest.TestCase):
         pipe.set_attention_chunk_size(chunk_size=None)
         generator = torch.Generator(device=torch_device).manual_seed(0)
         with torch.autocast(torch_device):
-            image = pipe(
+            output = pipe(
                 [prompt], generator=generator, guidance_scale=7.5, num_inference_steps=10, output_type="numpy"
-            )["sample"]
+            )
+            image = output.images
 
         # make sure that more than 3.75 GB is allocated
         mem_bytes = torch.cuda.max_memory_allocated()


### PR DESCRIPTION
100% of the credit goes to the amazing thread here: https://github.com/basujindal/stable-diffusion/pull/117

By doing:

```py
pip.set_attention_chunk()
```

VRAM can be reduced from 4.6GB to 3.4GB at only 10% slower inference. Try it out:

```python
import torch
from torch import autocast
from diffusers import StableDiffusionPipeline

pipe = StableDiffusionPipeline.from_pretrained(
    "CompVis/stable-diffusion-v1-4", 
    revision="fp16", 
    torch_dtype=torch.float16,
    use_auth_token=True
)
pipe = pipe.to("cuda")

prompt = "a photo of an astronaut riding a horse on mars"
pipe.set_attention_chunk()
with autocast("cuda"):
    image = pipe(prompt).images[0] 
```