### PR TITLE
[Tests] Test attention.py

### DIFF
--- a/src/diffusers/models/__init__.py
+++ b/src/diffusers/models/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .attention import AttentionBlock, SpatialTransformer
 from .unet_2d import UNet2DModel
 from .unet_2d_condition import UNet2DConditionModel
 from .vae import AutoencoderKL, VQModel

--- a/src/diffusers/models/__init__.py
+++ b/src/diffusers/models/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .attention import AttentionBlock, SpatialTransformer
 from .unet_2d import UNet2DModel
 from .unet_2d_condition import UNet2DConditionModel
 from .vae import AutoencoderKL, VQModel

--- a/tests/test_layers_utils.py
+++ b/tests/test_layers_utils.py
@@ -289,25 +289,3 @@ class SpatialTransformerTests(unittest.TestCase):
 
         expected_slice = torch.tensor([-0.0278, -0.7288, -2.2825, -2.0128, 1.4513, 0.2600, -0.2489, -1.4279, 0.1277])
         assert torch.allclose(output_slice.flatten(), expected_slice, atol=1e-3)
-
-    def test_spatial_transformer_dropout(self):
-        torch.manual_seed(0)
-        if torch.cuda.is_available():
-            torch.cuda.manual_seed_all(0)
-
-        sample = torch.randn(1, 32, 64, 64).to(torch_device)
-        spatialTransformerBlock = SpatialTransformer(
-            in_channels=32,
-            n_heads=2,
-            d_head=16,
-            dropout=0.3,
-            context_dim=None,
-        ).to(torch_device)
-        with torch.no_grad():
-            attention_scores = spatialTransformerBlock(sample)
-
-        assert attention_scores.shape == (1, 32, 64, 64)
-        output_slice = attention_scores[0, -1, -3:, -3:]
-
-        expected_slice = torch.tensor([-1.4387, 0.0335, -0.9627, -1.4815, 0.6288, -1.0577, -2.1272, 0.8841, -1.0216])
-        assert torch.allclose(output_slice.flatten(), expected_slice, atol=1e-3)

--- a/tests/test_layers_utils.py
+++ b/tests/test_layers_utils.py
@@ -19,6 +19,7 @@ import unittest
 import numpy as np
 import torch
 
+from diffusers.models.attention import AttentionBlock, SpatialTransformer
 from diffusers.models.embeddings import get_timestep_embedding
 from diffusers.models.resnet import Downsample2D, Upsample2D
 
@@ -216,3 +217,45 @@ class Downsample2DBlockTests(unittest.TestCase):
         output_slice = downsampled[0, -1, -3:, -3:]
         expected_slice = torch.tensor([-0.6586, 0.5985, 0.0721, 0.1256, -0.1492, 0.4436, -0.2544, 0.5021, 1.1522])
         assert torch.allclose(output_slice.flatten(), expected_slice, atol=1e-3)
+
+
+class AttentionBlockTests(unittest.TestCase):
+    def test_attention_block_default(self):
+        torch.manual_seed(0)
+        sample = torch.randn(1, 32, 64, 64)
+        attentionBlock = AttentionBlock(
+            channels=32,
+            num_head_channels=1,
+            rescale_output_factor=1.0,
+            eps=1e-6,
+            num_groups=32,
+        )
+        with torch.no_grad():
+            attention_scores = attentionBlock(sample)
+
+        assert attention_scores.shape == (1, 32, 64, 64)
+        output_slice = attention_scores[0, -1, -3:, -3:]
+
+        expected_slice = torch.tensor([-1.4975, -0.0038, -0.7847, -1.4567, 1.1220, -0.8962, -1.7394, 1.1319, -0.5427])
+        assert torch.allclose(output_slice.flatten(), expected_slice, atol=1e-1)
+
+
+class SpatialTransformerTests(unittest.TestCase):
+    def test_spatial_transformer_default(self):
+        torch.manual_seed(0)
+        sample = torch.randn(1, 32, 64, 64)
+        spatialTransformerBlock = SpatialTransformer(
+            in_channels=32,
+            n_heads=1,
+            d_head=32,
+            dropout=0.0,
+            context_dim=None,
+        )
+        with torch.no_grad():
+            attention_scores = spatialTransformerBlock(sample)
+
+        assert attention_scores.shape == (1, 32, 64, 64)
+        output_slice = attention_scores[0, -1, -3:, -3:]
+
+        expected_slice = torch.tensor([-1.2447, -0.0137, -0.9559, -1.5223, 0.6991, -1.0126, -2.0974, 0.8921, -1.0201])
+        assert torch.allclose(output_slice.flatten(), expected_slice, atol=1e-1)


### PR DESCRIPTION
Added blackbox tests for AttentionBlock and SpatialTransformer - #201. A question - since BasicTransformerBlock, CrossAttention and FeedForward classes are all used within SpatialTransformerBlock, is it required to test them separately? Or testing SpatialTransformer is enough, since any change in them would cause the SpatialTransformerBlockTests to fail.