### PR TITLE
[textual-inversion] fix saving embeds

### DIFF
--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -564,7 +564,7 @@ def main():
         pipeline.save_pretrained(args.output_dir)
         # Also save the newly trained embeddings
         learned_embeds = accelerator.unwrap_model(text_encoder).get_input_embeddings().weight[placeholder_token_id]
-        learned_embeds_dict = {args.placeholder_token: learned_embeds}
+        learned_embeds_dict = {args.placeholder_token: learned_embeds.detach().cpu()}
         torch.save(learned_embeds_dict, os.path.join(args.output_dir, "learned_embeds.bin"))
 
         if args.push_to_hub:


### PR DESCRIPTION
This PR fixes saving the `learned_embeds`, the embeds are detached and put on CPU before saving, this brings down the size to 3.7KB