### PR TITLE
Fix scheduler inference steps error with power of 3

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -146,7 +146,7 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
         """
         self.num_inference_steps = num_inference_steps
         step_ratio = self.config.num_train_timesteps // self.num_inference_steps
-        # creates integer timesteps by multipling by ratio
+        # creates integer timesteps by multiplying by ratio
         # casting to int to avoid issues when num_inference_step is power of 3
         self.timesteps = (np.arange(0, num_inference_steps) * step_ratio).astype(int)[::-1].copy()
         self.timesteps += offset

--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -145,9 +145,10 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
             offset (`int`): TODO
         """
         self.num_inference_steps = num_inference_steps
-        self.timesteps = np.arange(
-            0, self.config.num_train_timesteps, self.config.num_train_timesteps // self.num_inference_steps
-        )[::-1].copy()
+        step_ratio = self.config.num_train_timesteps // self.num_inference_steps
+        # creates integer timesteps by multipling by ratio
+        # casting to int to avoid issues when num_inference_step is power of 3
+        self.timesteps = (np.arange(0, num_inference_steps) * step_ratio).astype(int)[::-1].copy()
         self.timesteps += offset
         self.set_format(tensor_format=self.tensor_format)
 

--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -148,7 +148,7 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
         step_ratio = self.config.num_train_timesteps // self.num_inference_steps
         # creates integer timesteps by multiplying by ratio
         # casting to int to avoid issues when num_inference_step is power of 3
-        self.timesteps = (np.arange(0, num_inference_steps) * step_ratio).astype(int)[::-1].copy()
+        self.timesteps = (np.arange(0, num_inference_steps) * step_ratio).round()[::-1].copy()
         self.timesteps += offset
         self.set_format(tensor_format=self.tensor_format)
 

--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -141,9 +141,10 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
             offset (`int`): TODO
         """
         self.num_inference_steps = num_inference_steps
-        self._timesteps = list(
-            range(0, self.config.num_train_timesteps, self.config.num_train_timesteps // num_inference_steps)
-        )
+        step_ratio = self.config.num_train_timesteps // self.num_inference_steps
+        # creates integer timesteps by multiplying by ratio
+        # casting to int to avoid issues when num_inference_step is power of 3
+        self._timesteps = (np.arange(0, num_inference_steps) * step_ratio).astype(int).tolist()
         self._offset = offset
         self._timesteps = np.array([t + self._offset for t in self._timesteps])
 

--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -144,7 +144,7 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         step_ratio = self.config.num_train_timesteps // self.num_inference_steps
         # creates integer timesteps by multiplying by ratio
         # casting to int to avoid issues when num_inference_step is power of 3
-        self._timesteps = (np.arange(0, num_inference_steps) * step_ratio).astype(int).tolist()
+        self._timesteps = (np.arange(0, num_inference_steps) * step_ratio).round().tolist()
         self._offset = offset
         self._timesteps = np.array([t + self._offset for t in self._timesteps])
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -380,21 +380,6 @@ class DDIMSchedulerTest(SchedulerCommonTest):
         for t, num_inference_steps in zip([1, 10, 50], [10, 50, 500]):
             self.check_over_forward(time_step=t, num_inference_steps=num_inference_steps)
 
-    def test_pow_of_3_inference_steps(self):
-        num_inference_steps = 27
-
-        for scheduler_class in self.scheduler_classes:
-            sample = self.dummy_sample
-            residual = 0.1 * sample
-
-            scheduler_config = self.get_scheduler_config()
-            scheduler = scheduler_class(**scheduler_config)
-
-            scheduler.set_timesteps(num_inference_steps)
-
-            for i, t in enumerate(scheduler.timesteps):
-                sample = scheduler.step(residual, i, sample).prev_sample
-
     def test_eta(self):
         for t, eta in zip([1, 10, 49], [0.0, 0.5, 1.0]):
             self.check_over_forward(time_step=t, eta=eta)
@@ -649,7 +634,7 @@ class PNDMSchedulerTest(SchedulerCommonTest):
             scheduler.set_timesteps(num_inference_steps)
 
             for i, t in enumerate(scheduler.prk_timesteps):
-                sample = scheduler.step_prk(residual, i, sample).prev_sample
+                sample = scheduler.step_prk(residual, t, sample).prev_sample
 
     def test_inference_plms_no_past_residuals(self):
         with self.assertRaises(ValueError):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -378,7 +378,22 @@ class DDIMSchedulerTest(SchedulerCommonTest):
 
     def test_inference_steps(self):
         for t, num_inference_steps in zip([1, 10, 50], [10, 50, 500]):
-            self.check_over_forward(num_inference_steps=num_inference_steps)
+            self.check_over_forward(time_step=t, num_inference_steps=num_inference_steps)
+
+    def test_pow_of_3_inference_steps(self):
+        num_inference_steps = 27
+
+        for scheduler_class in self.scheduler_classes:
+            sample = self.dummy_sample
+            residual = 0.1 * sample
+
+            scheduler_config = self.get_scheduler_config()
+            scheduler = scheduler_class(**scheduler_config)
+
+            scheduler.set_timesteps(num_inference_steps)
+
+            for i, t in enumerate(scheduler.timesteps):
+                sample = scheduler.step(residual, i, sample).prev_sample
 
     def test_eta(self):
         for t, eta in zip([1, 10, 49], [0.0, 0.5, 1.0]):
@@ -620,6 +635,21 @@ class PNDMSchedulerTest(SchedulerCommonTest):
     def test_inference_steps(self):
         for t, num_inference_steps in zip([1, 5, 10], [10, 50, 100]):
             self.check_over_forward(time_step=t, num_inference_steps=num_inference_steps)
+
+    def test_pow_of_3_inference_steps(self):
+        num_inference_steps = 27
+
+        for scheduler_class in self.scheduler_classes:
+            sample = self.dummy_sample
+            residual = 0.1 * sample
+
+            scheduler_config = self.get_scheduler_config()
+            scheduler = scheduler_class(**scheduler_config)
+
+            scheduler.set_timesteps(num_inference_steps)
+
+            for i, t in enumerate(scheduler.prk_timesteps):
+                sample = scheduler.step_prk(residual, i, sample).prev_sample
 
     def test_inference_plms_no_past_residuals(self):
         with self.assertRaises(ValueError):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -622,6 +622,7 @@ class PNDMSchedulerTest(SchedulerCommonTest):
             self.check_over_forward(time_step=t, num_inference_steps=num_inference_steps)
 
     def test_pow_of_3_inference_steps(self):
+        # earlier version of set_timesteps() caused an error indexing alpha's with inference steps as power of 3
         num_inference_steps = 27
 
         for scheduler_class in self.scheduler_classes:
@@ -633,7 +634,8 @@ class PNDMSchedulerTest(SchedulerCommonTest):
 
             scheduler.set_timesteps(num_inference_steps)
 
-            for i, t in enumerate(scheduler.prk_timesteps):
+            # before power of 3 fix, would error on first step, so we only need to do two
+            for i, t in enumerate(scheduler.prk_timesteps[:2]):
                 sample = scheduler.step_prk(residual, t, sample).prev_sample
 
     def test_inference_plms_no_past_residuals(self):


### PR DESCRIPTION
Discussing in #444.
More verification to do on the unclear number of iterations vs `num_inference_steps`

Solution inspired by this [discussion](https://github.com/CompVis/stable-diffusion/issues/111) in original SD repo, thanks @ryanirl.