### PR TITLE
Removing `.float()` (`autocast` in fp16 will discard this (I think)).

### DIFF
--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -333,7 +333,7 @@ class ResnetBlock2D(nn.Module):
 
         # make sure hidden states is in float32
         # when running in half-precision
-        hidden_states = self.norm1(hidden_states.float()).type(hidden_states.dtype)
+        hidden_states = self.norm1(hidden_states).type(hidden_states.dtype)
         hidden_states = self.nonlinearity(hidden_states)
 
         if self.upsample is not None:
@@ -351,7 +351,7 @@ class ResnetBlock2D(nn.Module):
 
         # make sure hidden states is in float32
         # when running in half-precision
-        hidden_states = self.norm2(hidden_states.float()).type(hidden_states.dtype)
+        hidden_states = self.norm2(hidden_states).type(hidden_states.dtype)
         hidden_states = self.nonlinearity(hidden_states)
 
         hidden_states = self.dropout(hidden_states)


### PR DESCRIPTION
While investigating performance improvements, the main culprit I found was

`autocast` which actually adds a LOT of copies of tensors a bit everywhere
to cast to `float16`. I added a lot of custom made casts for now in an offbranch.

This PR tries to check 1 of the changes which is this `.float()` cast which break
in `fp16` mode (because the model is in fp16, while the tensor is now in `float`.