### PR TITLE
Add better compatibility with `diffusers-interpret` (and possibly other use cases!)

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/__init__.py
+++ b/src/diffusers/pipelines/stable_diffusion/__init__.py
@@ -21,7 +21,7 @@ class StableDiffusionPipelineOutput(BaseOutput):
         nsfw_content_detected (`List[bool]`)
             List of flags denoting whether the corresponding generated image likely represents "not-safe-for-work"
             (nsfw) content.
-        latents (`List[torch.Tensor]`, *optional*, returned when `output_latents=True` is passed)
+        latents (`List[torch.Tensor]`, *optional*, returned when `output_latents=True` and `return_dict=True` is passed)
             List (one element for each diffusion step) of `torch.Tensor` of shape `(batch_size, in_channels, height // 8, width // 8)`
     """
 

--- a/src/diffusers/pipelines/stable_diffusion/__init__.py
+++ b/src/diffusers/pipelines/stable_diffusion/__init__.py
@@ -21,10 +21,13 @@ class StableDiffusionPipelineOutput(BaseOutput):
         nsfw_content_detected (`List[bool]`)
             List of flags denoting whether the corresponding generated image likely represents "not-safe-for-work"
             (nsfw) content.
+        latents (`List[torch.Tensor]`, *optional*, returned when `output_latents=True` is passed)
+            List (one element for each diffusion step) of `torch.Tensor` of shape `(batch_size, in_channels, height // 8, width // 8)`
     """
 
     images: Union[List[PIL.Image.Image], np.ndarray]
     nsfw_content_detected: List[bool]
+    latents: Optional[List[torch.Tensor]] = None
 
 
 if is_transformers_available():

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -123,7 +123,6 @@ class StableDiffusionPipeline(DiffusionPipeline):
         output_type: Optional[str] = "pil",
         return_dict: bool = True,
         output_latents: bool = False,
-        run_safety_checker: bool = True,
         enable_grad: bool = False,
         **kwargs,
     ):
@@ -166,8 +165,6 @@ class StableDiffusionPipeline(DiffusionPipeline):
             output_latents (`bool`, *optional*, defaults to `False`):
                 Whether or not to return the latents from all the diffusion steps. See `latents` under returned tensors
                 for more details.
-            run_safety_checker (`bool`, *optional*, defaults to `True`):
-                Whether or not to return run the safety checker in the final generated image.
             enable_grad (`bool`, *optional*, defaults to `False`):
                 Whether or not to enable gradient calculation during diffusion process.
 

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -132,7 +132,8 @@ class StableDiffusionPipeline(DiffusionPipeline):
 
         Args:
             prompt (`str`, `List[str]` or `torch.Tensor`):
-                The prompt or prompts to guide the image generation.
+                The prompt or prompts to guide the image generation. If a `torch.Tensor` is provided, it should
+                have the shape (sequence len, embedding dim) or (batch size, sequence len, embedding dim).
             height (`int`, *optional*, defaults to 512):
                 The height in pixels of the generated image.
             width (`int`, *optional*, defaults to 512):
@@ -327,7 +328,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
             image = self.numpy_to_pil(image)
 
         if not return_dict:
-            return (image, has_nsfw_concept, all_latents)
+            return (image, has_nsfw_concept)
 
         # reset
         torch.set_grad_enabled(was_grad_enabled)

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -327,7 +327,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
             image = self.numpy_to_pil(image)
 
         if not return_dict:
-            return (image, has_nsfw_concept, latents)
+            return (image, has_nsfw_concept, all_latents)
 
         # reset
         torch.set_grad_enabled(was_grad_enabled)

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -327,7 +327,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
             image = self.numpy_to_pil(image)
 
         if not return_dict:
-            return (image, has_nsfw_concept)
+            return (image, has_nsfw_concept, latents)
 
         # reset
         torch.set_grad_enabled(was_grad_enabled)

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -90,26 +90,6 @@ class StableDiffusionPipeline(DiffusionPipeline):
         # set slice_size = `None` to disable `attention slicing`
         self.enable_attention_slicing(None)
 
-    def gradient_checkpointing_enable(self) -> None:
-        """
-        Activates gradient checkpointing for the current model.
-
-        Note that in other frameworks this feature can be referred to as "activation checkpointing" or "checkpoint
-        activations".
-        """
-        self.pipe.text_encoder.gradient_checkpointing_enable()
-        # TODO: activate gradient checkpointing for self.unet and self.vae
-
-    def gradient_checkpointing_disable(self) -> None:
-        """
-        Deactivates gradient checkpointing for the current model.
-
-        Note that in other frameworks this feature can be referred to as "activation checkpointing" or "checkpoint
-        activations".
-        """
-        self.pipe.text_encoder.gradient_checkpointing_disable()
-        # TODO: disable gradient checkpointing for self.unet and self.vae
-
     def __call__(
         self,
         prompt: Union[str, List[str], torch.Tensor],


### PR DESCRIPTION
Hi there!
I love this package ❤️

I'm the author of [diffusers-interpret](https://github.com/JoaoLages/diffusers-interpret) and along my work found these features very useful to add to this main package:
- Having the option to run `DiffusionPipeline.__call__` **while calculating gradients**;
- Having a `output_latents` flag (similar to `output_scores`/`output_attentions`/etc from `transformers`) that adds a `latents` attribute to the output;
- ~Deactivating safety checker;~ removed this option (https://github.com/huggingface/diffusers/pull/506/commits/12ca96990b0e6d7ef34a0c4bbcd9819ffe2752bd)
- Passing `text_embeddings` directly instead of the text string;
- Gradient checkpointing (this was already a feature in `transformers` too).

That's about it 😄 
To start this PR I made the changes only for the `StableDiffusionPipeline` class, but I can port those changes to the other pipelines if you agree with them.