### PR TITLE
Add `init_weights` method to `FlaxMixin`

### DIFF
--- a/src/diffusers/modeling_flax_utils.py
+++ b/src/diffusers/modeling_flax_utils.py
@@ -403,7 +403,7 @@ class FlaxModelMixin:
         params_shape_tree = jax.eval_shape(model.init_weights, prng_key)
         required_params = set(flatten_dict(unfreeze(params_shape_tree)).keys())
 
-        random_state = flatten_dict(unfreeze(params_shape_tree))
+        shape_state = flatten_dict(unfreeze(params_shape_tree))
 
         missing_keys = required_params - set(state.keys())
         unexpected_keys = set(state.keys()) - required_params
@@ -419,14 +419,14 @@ class FlaxModelMixin:
         # matching the weights in the model.
         mismatched_keys = []
         for key in state.keys():
-            if key in random_state and state[key].shape != random_state[key].shape:
+            if key in shape_state and state[key].shape != shape_state[key].shape:
                 if ignore_mismatched_sizes:
-                    mismatched_keys.append((key, state[key].shape, random_state[key].shape))
-                    state[key] = random_state[key]
+                    mismatched_keys.append((key, state[key].shape, shape_state[key].shape))
+                    state[key] = shape_state[key]
                 else:
                     raise ValueError(
                         f"Trying to load the pretrained weight for {key} failed: checkpoint has shape "
-                        f"{state[key].shape} which is incompatible with the model shape {random_state[key].shape}. "
+                        f"{state[key].shape} which is incompatible with the model shape {shape_state[key].shape}. "
                         "Using `ignore_mismatched_sizes=True` if you really want to load this checkpoint inside this "
                         "model."
                     )

--- a/src/diffusers/modeling_flax_utils.py
+++ b/src/diffusers/modeling_flax_utils.py
@@ -284,7 +284,6 @@ class FlaxModelMixin:
         revision = kwargs.pop("revision", None)
         from_auto_class = kwargs.pop("_from_auto", False)
         subfolder = kwargs.pop("subfolder", None)
-        prng_key = kwargs.pop("prng_key", None)
 
         user_agent = {"file_type": "model", "framework": "flax", "from_auto_class": from_auto_class}
 
@@ -399,7 +398,7 @@ class FlaxModelMixin:
         # flatten dicts
         state = flatten_dict(state)
 
-        prng_key = prng_key if prng_key is not None else jax.random.PRNGKey(0)
+        prng_key = jax.random.PRNGKey(0)
         params_shape_tree = jax.eval_shape(model.init_weights, prng_key)
         required_params = set(flatten_dict(unfreeze(params_shape_tree)).keys())
 

--- a/src/diffusers/modeling_flax_utils.py
+++ b/src/diffusers/modeling_flax_utils.py
@@ -427,10 +427,7 @@ class FlaxModelMixin:
                 f"Some weights of the model checkpoint at {pretrained_model_name_or_path} were not used when"
                 f" initializing {model.__class__.__name__}: {unexpected_keys}\n- This IS expected if you are"
                 f" initializing {model.__class__.__name__} from the checkpoint of a model trained on another task or"
-                " with another architecture (e.g. initializing a BertForSequenceClassification model from a"
-                " BertForPreTraining model).\n- This IS NOT expected if you are initializing"
-                f" {model.__class__.__name__} from the checkpoint of a model that you expect to be exactly identical"
-                " (initializing a BertForSequenceClassification model from a BertForSequenceClassification model)."
+                " with another architecture."
             )
         else:
             logger.info(f"All model checkpoint weights were used when initializing {model.__class__.__name__}.\n")

--- a/src/diffusers/modeling_flax_utils.py
+++ b/src/diffusers/modeling_flax_utils.py
@@ -184,7 +184,7 @@ class FlaxModelMixin:
         return self._cast_floating_to(params, jnp.float16, mask)
 
     def init_weights(self, rng: jax.random.PRNGKey) -> Dict:
-        raise NotImplementedError(f"init method has to be implemented for {self}")
+        raise NotImplementedError(f"init_weights method has to be implemented for {self}")
 
     @classmethod
     def from_pretrained(

--- a/src/diffusers/modeling_flax_utils.py
+++ b/src/diffusers/modeling_flax_utils.py
@@ -393,8 +393,7 @@ class FlaxModelMixin:
         # flatten dicts
         state = flatten_dict(state)
 
-        prng_key = jax.random.PRNGKey(0)
-        params_shape_tree = jax.eval_shape(model.init_weights, prng_key)
+        params_shape_tree = jax.eval_shape(model.init_weights, rng=jax.random.PRNGKey(0))
         required_params = set(flatten_dict(unfreeze(params_shape_tree)).keys())
 
         shape_state = flatten_dict(unfreeze(params_shape_tree))

--- a/src/diffusers/modeling_flax_utils.py
+++ b/src/diffusers/modeling_flax_utils.py
@@ -230,10 +230,6 @@ class FlaxModelMixin:
             cache_dir (`Union[str, os.PathLike]`, *optional*):
                 Path to a directory in which a downloaded pretrained model configuration should be cached if the
                 standard cache should not be used.
-            ignore_mismatched_sizes (`bool`, *optional*, defaults to `False`):
-                Whether or not to raise an error if some of the weights from the checkpoint do not have the same size
-                as the weights of the model (if for instance, you are instantiating a model with 10 labels from a
-                checkpoint with 3 labels).
             force_download (`bool`, *optional*, defaults to `False`):
                 Whether or not to force the (re-)download of the model weights and configuration files, overriding the
                 cached versions if they exist.
@@ -275,7 +271,6 @@ class FlaxModelMixin:
         ```"""
         config = kwargs.pop("config", None)
         cache_dir = kwargs.pop("cache_dir", DIFFUSERS_CACHE)
-        ignore_mismatched_sizes = kwargs.pop("ignore_mismatched_sizes", False)
         force_download = kwargs.pop("force_download", False)
         resume_download = kwargs.pop("resume_download", False)
         proxies = kwargs.pop("proxies", None)
@@ -419,16 +414,10 @@ class FlaxModelMixin:
         mismatched_keys = []
         for key in state.keys():
             if key in shape_state and state[key].shape != shape_state[key].shape:
-                if ignore_mismatched_sizes:
-                    mismatched_keys.append((key, state[key].shape, shape_state[key].shape))
-                    state[key] = shape_state[key]
-                else:
-                    raise ValueError(
-                        f"Trying to load the pretrained weight for {key} failed: checkpoint has shape "
-                        f"{state[key].shape} which is incompatible with the model shape {shape_state[key].shape}. "
-                        "Using `ignore_mismatched_sizes=True` if you really want to load this checkpoint inside this "
-                        "model."
-                    )
+                raise ValueError(
+                    f"Trying to load the pretrained weight for {key} failed: checkpoint has shape "
+                    f"{state[key].shape} which is incompatible with the model shape {shape_state[key].shape}. "
+                )
 
         # remove unexpected keys to not be saved again
         for unexpected_key in unexpected_keys:


### PR DESCRIPTION
### Implementation of `init_weights` method is required for any class that is inheriting from [FlaxModelMixin](https://github.com/huggingface/diffusers/blob/32c2be514bb4d3bd76b23a5ceed7865bc34f821d/src/diffusers/modeling_flax_utils.py#L39).

[Here](https://github.com/mishig25/stable-diffusion-jax/blob/70f384f1dcd6f7ea11a10cd5e48e69722fb38990/stable_diffusion_jax/modeling_unet2d.py#L689-L699) is an example:
```py
class UNet2D(nn.Module, FlaxModelMixin, ConfigMixin):
    def init_weights(self, rng: jax.random.PRNGKey) -> FrozenDict:
        # init input tensors
        sample_shape = (1, self.config.sample_size, self.config.sample_size, self.config.in_channels)
        sample = jnp.zeros(sample_shape, dtype=jnp.float32)
        timestpes = jnp.ones((1,), dtype=jnp.int32)
        encoder_hidden_states = jnp.zeros((1, 1, self.config.cross_attention_dim), dtype=jnp.float32)

        params_rng, dropout_rng = jax.random.split(rng)
        rngs = {"params": params_rng, "dropout": dropout_rng}

        return self.init(rngs, sample, timestpes, encoder_hidden_states)["params"]
```

Unlike [transformers.FlaxPretrainedModel.init_weights](https://github.com/huggingface/transformers/blob/bce36ee065f7749c997be4c30a3f9279df7d5dba/src/transformers/modeling_flax_utils.py#L229), [diffusers.FlaxModelMixin.init_weights](https://github.com/huggingface/transformers/blob/bce36ee065f7749c997be4c30a3f9279df7d5dba/src/transformers/modeling_flax_utils.py#L229) signature does not have parameter `input_shape`. Read more [here](https://github.com/huggingface/diffusers/pull/513#discussion_r971271647) & [here](https://github.com/huggingface/diffusers/pull/493#issuecomment-1246550570) on why the decision was made


Users will have 2 option to init weights:
```py
class FlaxModel(nn.Module, FlaxModelMixin, ConfigMixin):
   ...

my_model = FlaxModel()
# option1 (FlaxModelMixin)
params = my_model.init_weights(key)
# option2 (linen.Module)
x = random.normal(key1, (...)) # Dummy input
params = FlaxModel.init(key, x)

# option1 is more convenient since the random input is automatically handled inside `init_weights`, but they will still have an option2 if they want to use it as a normal linen.Module
```