### PR TITLE
add stable_diffusion_walk notebook to example/community folder

### DIFF
--- a/examples/community/text_and_noise_interpolation/stable_diffusion_walk.ipynb
+++ b/examples/community/text_and_noise_interpolation/stable_diffusion_walk.ipynb
@@ -1,0 +1,438 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "view-in-github"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/danielpatrickhug/karpathy_stablediffusionwalk_notebook_adaption/blob/main/stable_diffusion_walk.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-mvdZ2L2Dd-R"
+      },
+      "source": [
+        "# Stable Diffusion Walk\n",
+        "Notebook Adaption of @karpathy [stablediffusionwalk](https://gist.github.com/karpathy/00103b0037c5aaea32fe1da1af553355) "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bl_vX8EmDsWB"
+      },
+      "source": [
+        "## Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "TLdnTQD_DXXL"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install --upgrade diffusers transformers scipy\n",
+        "!pip install ffmpeg-python\n",
+        "!pip install ftfy"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Ui-SpBSqFBy8"
+      },
+      "source": [
+        "## Nvidia Info\n",
+        "- Check is GPU is initialized\n",
+        "    - If a GPU is not initialized, go to Edit/Notebook settings and set \"Hardware Accelerator\" to GPU"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "4nqY7iwoFFyc"
+      },
+      "outputs": [],
+      "source": [
+        "!nvidia-smi"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "54ktiozlIJQR"
+      },
+      "source": [
+        "#Huggingface Auth"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "-9qhSyohIMh6"
+      },
+      "outputs": [],
+      "source": [
+        "!huggingface-cli login"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rB266BxZEayR"
+      },
+      "source": [
+        "## Imports"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "pYu623NhEb1_"
+      },
+      "outputs": [],
+      "source": [
+        "import torch\n",
+        "from torch import autocast\n",
+        "import os\n",
+        "from diffusers import StableDiffusionPipeline\n",
+        "from diffusers.schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler\n",
+        "from PIL import Image\n",
+        "from IPython import display\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import inspect\n",
+        "from IPython.display import Image as IPImage\n",
+        "from types import SimpleNamespace\n",
+        "\n",
+        "torch.manual_seed(7)\n",
+        "device = \"cuda\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3-3BGFa0JD-q"
+      },
+      "source": [
+        "## Function definition"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "IfsO08ozG2yv"
+      },
+      "outputs": [],
+      "source": [
+        "@torch.no_grad()\n",
+        "def diffuse(\n",
+        "        pipe,\n",
+        "        cond_embeddings, # text conditioning, should be (1, 77, 768)\n",
+        "        cond_latents,    # image conditioning, should be (1, 4, 64, 64)\n",
+        "        num_inference_steps,\n",
+        "        guidance_scale,\n",
+        "        eta,\n",
+        "    ):\n",
+        "    torch_device = cond_latents.get_device()\n",
+        "\n",
+        "    # classifier guidance: add the unconditional embedding\n",
+        "    max_length = cond_embeddings.shape[1] # 77\n",
+        "    uncond_input = pipe.tokenizer([\"\"], padding=\"max_length\", max_length=max_length, return_tensors=\"pt\")\n",
+        "    uncond_embeddings = pipe.text_encoder(uncond_input.input_ids.to(torch_device))[0]\n",
+        "    text_embeddings = torch.cat([uncond_embeddings, cond_embeddings])\n",
+        "\n",
+        "    # if we use LMSDiscreteScheduler, let's make sure latents are mulitplied by sigmas\n",
+        "    if isinstance(pipe.scheduler, LMSDiscreteScheduler):\n",
+        "        cond_latents = cond_latents * pipe.scheduler.sigmas[0]\n",
+        "\n",
+        "    # init the scheduler\n",
+        "    accepts_offset = \"offset\" in set(inspect.signature(pipe.scheduler.set_timesteps).parameters.keys())\n",
+        "    extra_set_kwargs = {}\n",
+        "    if accepts_offset:\n",
+        "        extra_set_kwargs[\"offset\"] = 1\n",
+        "    pipe.scheduler.set_timesteps(num_inference_steps, **extra_set_kwargs)\n",
+        "    # prepare extra kwargs for the scheduler step, since not all schedulers have the same signature\n",
+        "    # eta (η) is only used with the DDIMScheduler, it will be ignored for other schedulers.\n",
+        "    # eta corresponds to η in DDIM paper: https://arxiv.org/abs/2010.02502\n",
+        "    # and should be between [0, 1]\n",
+        "    accepts_eta = \"eta\" in set(inspect.signature(pipe.scheduler.step).parameters.keys())\n",
+        "    extra_step_kwargs = {}\n",
+        "    if accepts_eta:\n",
+        "        extra_step_kwargs[\"eta\"] = eta\n",
+        "\n",
+        "    # diffuse!\n",
+        "    for i, t in enumerate(pipe.scheduler.timesteps):\n",
+        "\n",
+        "        # expand the latents for classifier free guidance\n",
+        "        latent_model_input = torch.cat([cond_latents] * 2)\n",
+        "        if isinstance(pipe.scheduler, LMSDiscreteScheduler):\n",
+        "            sigma = pipe.scheduler.sigmas[i]\n",
+        "            latent_model_input = latent_model_input / ((sigma**2 + 1) ** 0.5)\n",
+        "\n",
+        "        # predict the noise residual\n",
+        "        noise_pred = pipe.unet(latent_model_input, t, encoder_hidden_states=text_embeddings)[\"sample\"]\n",
+        "\n",
+        "        # cfg\n",
+        "        noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)\n",
+        "        noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)\n",
+        "\n",
+        "        # compute the previous noisy sample x_t -> x_t-1\n",
+        "        if isinstance(pipe.scheduler, LMSDiscreteScheduler):\n",
+        "            cond_latents = pipe.scheduler.step(noise_pred, i, cond_latents, **extra_step_kwargs)[\"prev_sample\"]\n",
+        "        else:\n",
+        "            cond_latents = pipe.scheduler.step(noise_pred, t, cond_latents, **extra_step_kwargs)[\"prev_sample\"]\n",
+        "\n",
+        "    # scale and decode the image latents with vae\n",
+        "    cond_latents = 1 / 0.18215 * cond_latents\n",
+        "    image = pipe.vae.decode(cond_latents)\n",
+        "\n",
+        "    # generate output numpy image as uint8\n",
+        "    image = (image[0] / 2 + 0.5).clamp(0, 1)\n",
+        "    image = image.cpu().permute(0, 2, 3, 1).numpy()\n",
+        "    image = (image[0] * 255).astype(np.uint8)\n",
+        "\n",
+        "    return image\n",
+        "\n",
+        "\n",
+        "def slerp(t, v0, v1, DOT_THRESHOLD=0.9995):\n",
+        "    \"\"\" helper function to spherically interpolate two arrays v1 v2 \"\"\"\n",
+        "\n",
+        "    if not isinstance(v0, np.ndarray):\n",
+        "        inputs_are_torch = True\n",
+        "        input_device = v0.device\n",
+        "        v0 = v0.cpu().numpy()\n",
+        "        v1 = v1.cpu().numpy()\n",
+        "\n",
+        "    dot = np.sum(v0 * v1 / (np.linalg.norm(v0) * np.linalg.norm(v1)))\n",
+        "    if np.abs(dot) > DOT_THRESHOLD:\n",
+        "        v2 = (1 - t) * v0 + t * v1\n",
+        "    else:\n",
+        "        theta_0 = np.arccos(dot)\n",
+        "        sin_theta_0 = np.sin(theta_0)\n",
+        "        theta_t = theta_0 * t\n",
+        "        sin_theta_t = np.sin(theta_t)\n",
+        "        s0 = np.sin(theta_0 - theta_t) / sin_theta_0\n",
+        "        s1 = sin_theta_t / sin_theta_0\n",
+        "        v2 = s0 * v0 + s1 * v1\n",
+        "\n",
+        "    if inputs_are_torch:\n",
+        "        v2 = torch.from_numpy(v2).to(input_device)\n",
+        "\n",
+        "    return v2"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "azzIsBymJjEU"
+      },
+      "source": [
+        "## Dreaming"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KzUE4d6RFrwj"
+      },
+      "source": [
+        "### Load Stable Diffusion Model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "rD4uaA2iFuUm"
+      },
+      "outputs": [],
+      "source": [
+        "model_checkpoint = \"CompVis/stable-diffusion-v1-4\"\n",
+        "\n",
+        "\n",
+        "lms = LMSDiscreteScheduler(beta_start=0.00085, beta_end=0.012, beta_schedule=\"scaled_linear\")\n",
+        "pipe = StableDiffusionPipeline.from_pretrained(model_checkpoint, scheduler=lms, use_auth_token=True)\n",
+        "\n",
+        "pipe = pipe.to(device)\n",
+        "pipe.unet.to(device)\n",
+        "pipe.vae.to(device)\n",
+        "pipe.text_encoder.to(device)\n",
+        "\n",
+        "print('w00t')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NSVxXo42J2NI"
+      },
+      "source": [
+        "Paths"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "63axSXKwJlpi"
+      },
+      "outputs": [],
+      "source": [
+        "prompt = \"blueberry spaghetti\" "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "HWcqX37KJ3ln"
+      },
+      "outputs": [],
+      "source": [
+        "root_dir = \"/content/drive/MyDrive/StableDreams\"\n",
+        "dream_name = \"Blueberry\"\n",
+        "outdir = os.path.join(root_dir, dream_name)\n",
+        "os.makedirs(outdir, exist_ok=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "cMDzRguHK9Hk"
+      },
+      "outputs": [],
+      "source": [
+        "def DreamArgs():\n",
+        "    height = 512 #@param {type:\"number\"}\n",
+        "    width = 512 #@param {type:\"number\"}\n",
+        "    max_frames = 10 #@param {type:\"number\"}\n",
+        "    num_steps = 200 #@param {type:\"number\"}\n",
+        "    num_inference_steps = 50 #@param {type:\"number\"}\n",
+        "    guidance_scale = 7.5 #@param {type:\"number\"}\n",
+        "    eta = 0.0 #@param {type:\"number\"}\n",
+        "    quality = 90 #@param {type:\"number\"}\n",
+        "    return locals()\n",
+        "\n",
+        "args = SimpleNamespace(**DreamArgs())"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "FH1aFnRRKTZJ"
+      },
+      "outputs": [],
+      "source": [
+        "# get the conditional text embeddings based on the prompt\n",
+        "text_input = pipe.tokenizer(prompt, padding=\"max_length\", max_length=pipe.tokenizer.model_max_length, truncation=True, return_tensors=\"pt\")\n",
+        "cond_embeddings = pipe.text_encoder(text_input.input_ids.to(device))[0] # shape [1, 77, 768]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "tVXirKNyK2r6"
+      },
+      "outputs": [],
+      "source": [
+        "# sample a source\n",
+        "init1 = torch.randn((1, pipe.unet.in_channels, args.height // 8, args.width // 8), device=device)\n",
+        "\n",
+        "# iterate the loop\n",
+        "frame_index = 0\n",
+        "while frame_index < args.max_frames:\n",
+        "\n",
+        "    # sample the destination\n",
+        "    init2 = torch.randn((1, pipe.unet.in_channels, args.height // 8, args.width // 8), device=device)\n",
+        "\n",
+        "    for i, t in enumerate(np.linspace(0, 1, args.num_steps)):\n",
+        "        init = slerp(float(t), init1, init2)\n",
+        "\n",
+        "        print(\"dreaming... \", frame_index)\n",
+        "        with autocast(\"cuda\"):\n",
+        "            image = diffuse(pipe, cond_embeddings, init, args.num_inference_steps, args.guidance_scale, args.eta)\n",
+        "        im = Image.fromarray(image)\n",
+        "        outpath = os.path.join(outdir, 'frame%06d.jpg' % frame_index)\n",
+        "        im.save(outpath, quality=args.quality)\n",
+        "        frame_index += 1\n",
+        "\n",
+        "    init1 = init2"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ToIEpUQCN5A_"
+      },
+      "source": [
+        "### Dream Seam"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "I7OcXbB5N_TU"
+      },
+      "outputs": [],
+      "source": [
+        "import ffmpeg\n",
+        "mp4_path = f'{outdir}/{dream_name}.mp4'\n",
+        "(\n",
+        "    ffmpeg\n",
+        "    .input(f\"{outdir}/*.jpg\", pattern_type='glob', framerate=10)\n",
+        "    .output(mp4_path)\n",
+        "    .run()\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "4qBrtSe7PIQN"
+      },
+      "outputs": [],
+      "source": [
+        "from base64 import b64encode\n",
+        "mp4 = open(mp4_path,'rb').read()\n",
+        "data_url = \"data:video/mp4;base64,\" + b64encode(mp4).decode()\n",
+        "\n",
+        "display.display( display.HTML(f'<video controls loop><source src=\"{data_url}\" type=\"video/mp4\"></video>') )\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "collapsed_sections": [],
+      "include_colab_link": true,
+      "private_outputs": true,
+      "provenance": []
+    },
+    "gpuClass": "standard",
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
Related issue: [205](https://github.com/huggingface/diffusers/issues/205) 

Hello, this pull request is for adding the notebook stable_diffusion_walk to community examples. this notebook is designed to be run on google colab free version.

this notebook is **self contained** to google colab.
this notebook is relatively **easy to tweak** parameters.
this notebook's inference pipeline has **one purpose only** - to create videos.
running this notebook should be relatively **beginner friendly**, tweaking it may not be. 


@anton-l @patil-suraj @pcuenca or @patrickvonplaten may I please get a review?
Please let me know if there are any other changes that can be made for this pull request.