### PR TITLE
Up to 2x speedup on GPUs using memory efficient attention

### DIFF
--- a/docs/source/optimization/fp16.mdx
+++ b/docs/source/optimization/fp16.mdx
@@ -295,7 +295,8 @@ with torch.inference_mode():
 
 ## Memory Efficient Attention
 Recent work on optimizing the bandwitdh in the attention block have generated huge speed ups and gains in GPU memory usage. The most recent being Flash Attention (from @tridao, [code](https://github.com/HazyResearch/flash-attention), [paper](https://arxiv.org/pdf/2205.14135.pdf)) .
-Here are the speedups we obtain on a few Nvidia GPUs: 
+Here are the speedups we obtain on a few Nvidia GPUs when running the inference at 512x512 with a batch size of 1 (one prompt):
+ 
 | GPU              	| Base Attention FP16 	| Memory Efficient Attention FP16 	|
 |------------------	|---------------------	|---------------------------------	|
 | NVIDIA Tesla T4  	| 3.5it/s             	| 5.5it/s                         	|
@@ -325,6 +326,6 @@ pipe.enable_xformers_memory_efficient_attention()
 with torch.inference_mode(), torch.autocast("cuda", dtype=torch.float16):
     sample = pipe("a small cat")
 
-# optional: You can disable it via 
+# optional: You can disable it via
 # pipe.disable_xformers_memory_efficient_attention()
 ```

--- a/docs/source/optimization/fp16.mdx
+++ b/docs/source/optimization/fp16.mdx
@@ -22,6 +22,7 @@ We present some techniques and ideas to optimize 🤗 Diffusers _inference_ for 
 | fp16             | 3.61s   | x2.63   |
 | channels last    | 3.30s   | x2.88   |
 | traced UNet      | 3.21s   | x2.96   |
+| memory efficient attention  | 2.63s  | x3.61   |
 
 <em>
   obtained on NVIDIA TITAN RTX by generating a single image of size 512x512 from
@@ -301,6 +302,7 @@ Here are the speedups we obtain on a few Nvidia GPUs:
 | NVIDIA 3060 RTX  	| 4.6it/s             	| 7.8it/s                         	|
 | NVIDIA A10G      	| 8.88it/s            	| 15.6it/s                        	|
 | NVIDIA RTX A6000 	| 11.7it/s            	| 21.09it/s                       	|
+| NVIDIA TITAN RTX  | 12.51it/s         	| 18.22it/s                       	|
 | A100-SXM4-40GB    	| 18.6it/s            	| 29.it/s                        	|
 | A100-SXM-80GB    	| 18.7it/s            	| 29.5it/s                        	|
 
@@ -323,6 +325,6 @@ pipe.enable_xformers_memory_efficient_attention()
 with torch.inference_mode(), torch.autocast("cuda", dtype=torch.float16):
     sample = pipe("a small cat")
 
-# You can disable it via 
-pipe.disable_xformers_memory_efficient_attention()
+# optional: You can disable it via 
+# pipe.disable_xformers_memory_efficient_attention()
 ```

--- a/docs/source/optimization/fp16.mdx
+++ b/docs/source/optimization/fp16.mdx
@@ -296,7 +296,7 @@ with torch.inference_mode():
 ## Memory Efficient Attention
 Recent work on optimizing the bandwitdh in the attention block have generated huge speed ups and gains in GPU memory usage. The most recent being Flash Attention (from @tridao, [code](https://github.com/HazyResearch/flash-attention), [paper](https://arxiv.org/pdf/2205.14135.pdf)) .
 Here are the speedups we obtain on a few Nvidia GPUs when running the inference at 512x512 with a batch size of 1 (one prompt):
- 
+
 | GPU              	| Base Attention FP16 	| Memory Efficient Attention FP16 	|
 |------------------	|---------------------	|---------------------------------	|
 | NVIDIA Tesla T4  	| 3.5it/s             	| 5.5it/s                         	|
@@ -323,7 +323,7 @@ pipe = StableDiffusionPipeline.from_pretrained(
 
 pipe.enable_xformers_memory_efficient_attention()
 
-with torch.inference_mode(), torch.autocast("cuda", dtype=torch.float16):
+with torch.inference_mode():
     sample = pipe("a small cat")
 
 # optional: You can disable it via

--- a/docs/source/optimization/fp16.mdx
+++ b/docs/source/optimization/fp16.mdx
@@ -290,3 +290,39 @@ pipe.unet = TracedUNet()
 with torch.inference_mode():
     image = pipe([prompt] * 1, num_inference_steps=50).images[0]
 ```
+
+
+## Memory Efficient Attention
+Recent work on optimizing the bandwitdh in the attention block have generated huge speed ups and gains in GPU memory usage. The most recent being Flash Attention (from @tridao, [code](https://github.com/HazyResearch/flash-attention), [paper](https://arxiv.org/pdf/2205.14135.pdf)) .
+Here are the speedups we obtain on a few Nvidia GPUs: 
+| GPU              	| Base Attention FP16 	| Memory Efficient Attention FP16 	|
+|------------------	|---------------------	|---------------------------------	|
+| NVIDIA Tesla T4  	| 3.5it/s             	| 5.5it/s                         	|
+| NVIDIA 3060 RTX  	| 4.6it/s             	| 7.8it/s                         	|
+| NVIDIA A10G      	| 8.88it/s            	| 15.6it/s                        	|
+| NVIDIA RTX A6000 	| 11.7it/s            	| 21.09it/s                       	|
+| A100-SXM4-40GB    	| 18.6it/s            	| 29.it/s                        	|
+| A100-SXM-80GB    	| 18.7it/s            	| 29.5it/s                        	|
+
+To leverage it just make sure you have: 
+ - PyTorch > 1.12
+ - Cuda available
+ - Installed the [xformers](https://github.com/facebookresearch/xformers) library
+```python
+from diffusers import StableDiffusionPipeline
+import torch
+
+pipe = StableDiffusionPipeline.from_pretrained(
+    "runwayml/stable-diffusion-v1-5",
+    revision="fp16",
+    torch_dtype=torch.float16,
+).to("cuda")
+
+pipe.enable_xformers_memory_efficient_attention()
+
+with torch.inference_mode(), torch.autocast("cuda", dtype=torch.float16):
+    sample = pipe("a small cat")
+
+# You can disable it via 
+pipe.disable_xformers_memory_efficient_attention()
+```

--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -238,7 +238,6 @@ class MemoryEfficientCrossAttention(nn.Module):
         inner_dim = dim_head * heads
         context_dim = default(context_dim, query_dim)
 
-        self.scale = dim_head**-0.5
         self.heads = heads
         self.dim_head = dim_head
 
@@ -248,29 +247,6 @@ class MemoryEfficientCrossAttention(nn.Module):
 
         self.to_out = nn.Sequential(nn.Linear(inner_dim, query_dim), nn.Dropout(dropout))
         self.attention_op: Optional[Any] = None
-
-    def _maybe_init(self, x):
-        """
-        Initialize the attention operator, if required We expect the head dimension to be exposed here, meaning that x
-        : B, Head, Length
-        """
-        if self.attention_op is not None:
-            return
-
-        _, M, K = x.shape
-        try:
-            self.attention_op = xformers.ops.AttentionOpDispatch(
-                dtype=x.dtype,
-                device=x.device,
-                k=K,
-                attn_bias_type=type(None),
-                has_dropout=False,
-                kv_len=M,
-                q_len=M,
-            ).op
-
-        except NotImplementedError as err:
-            raise NotImplementedError(f"Please install xformers with the flash attention / cutlass components.\n{err}")
 
     def forward(self, x, context=None, mask=None):
         q = self.to_q(x)
@@ -287,9 +263,6 @@ class MemoryEfficientCrossAttention(nn.Module):
             .contiguous(),
             (q, k, v),
         )
-
-        # init the attention op, if required, using the proper dimensions
-        self._maybe_init(q)
 
         # actually compute the attention, what we cannot get enough of
         out = xformers.ops.memory_efficient_attention(q, k, v, attn_bias=None, op=self.attention_op)

--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -257,7 +257,7 @@ class MemoryEfficientCrossAttention(nn.Module):
         if self.attention_op is not None:
             return
 
-        _, K, M = x.shape
+        _, M, K = x.shape
         try:
             self.attention_op = xformers.ops.AttentionOpDispatch(
                 dtype=x.dtype,

--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -20,11 +20,17 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-import xformers
-import xformers.ops
+from diffusers.utils.import_utils import is_xformers_available
 
 
-_USE_MEMORY_EFFICIENT_ATTENTION = int(os.environ.get("USE_MEMORY_EFFICIENT_ATTENTION", 0)) == 1
+if is_xformers_available():
+    import xformers
+    import xformers.ops
+
+    _USE_MEMORY_EFFICIENT_ATTENTION = int(os.environ.get("USE_MEMORY_EFFICIENT_ATTENTION", 0)) == 1
+else:
+    xformers = None
+    _USE_MEMORY_EFFICIENT_ATTENTION = False
 
 
 def exists(val):

--- a/src/diffusers/models/unet_2d_blocks.py
+++ b/src/diffusers/models/unet_2d_blocks.py
@@ -367,6 +367,10 @@ class UNetMidBlock2DCrossAttn(nn.Module):
         for attn in self.attentions:
             attn._set_attention_slice(slice_size)
 
+    def set_use_memory_efficient_attention_xformers(self, use_memory_efficient_attention_xformers: bool):
+        for attn in self.attentions:
+            attn._set_use_memory_efficient_attention_xformers(use_memory_efficient_attention_xformers)
+
     def forward(self, hidden_states, temb=None, encoder_hidden_states=None):
         hidden_states = self.resnets[0](hidden_states, temb)
         for attn, resnet in zip(self.attentions, self.resnets[1:]):
@@ -541,6 +545,10 @@ class CrossAttnDownBlock2D(nn.Module):
 
         for attn in self.attentions:
             attn._set_attention_slice(slice_size)
+
+    def set_use_memory_efficient_attention_xformers(self, use_memory_efficient_attention_xformers: bool):
+        for attn in self.attentions:
+            attn._set_use_memory_efficient_attention_xformers(use_memory_efficient_attention_xformers)
 
     def forward(self, hidden_states, temb=None, encoder_hidden_states=None):
         output_states = ()
@@ -1116,6 +1124,10 @@ class CrossAttnUpBlock2D(nn.Module):
             attn._set_attention_slice(slice_size)
 
         self.gradient_checkpointing = False
+
+    def set_use_memory_efficient_attention_xformers(self, use_memory_efficient_attention_xformers: bool):
+        for attn in self.attentions:
+            attn._set_use_memory_efficient_attention_xformers(use_memory_efficient_attention_xformers)
 
     def forward(
         self,

--- a/src/diffusers/models/unet_2d_condition.py
+++ b/src/diffusers/models/unet_2d_condition.py
@@ -225,6 +225,17 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin):
             if hasattr(block, "attentions") and block.attentions is not None:
                 block.set_attention_slice(slice_size)
 
+    def set_use_memory_efficient_attention_xformers(self, use_memory_efficient_attention_xformers: bool):
+        for block in self.down_blocks:
+            if hasattr(block, "attentions") and block.attentions is not None:
+                block.set_use_memory_efficient_attention_xformers(use_memory_efficient_attention_xformers)
+
+        self.mid_block.set_use_memory_efficient_attention_xformers(use_memory_efficient_attention_xformers)
+
+        for block in self.up_blocks:
+            if hasattr(block, "attentions") and block.attentions is not None:
+                block.set_use_memory_efficient_attention_xformers(use_memory_efficient_attention_xformers)
+
     def _set_gradient_checkpointing(self, module, value=False):
         if isinstance(module, (CrossAttnDownBlock2D, DownBlock2D, CrossAttnUpBlock2D, UpBlock2D)):
             module.gradient_checkpointing = value

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -113,6 +113,24 @@ class StableDiffusionPipeline(DiffusionPipeline):
             feature_extractor=feature_extractor,
         )
 
+    def enable_xformers_memory_efficient_attention(self):
+        r"""
+        Enable memory efficient attention as implemented in xformers.
+
+        When this option is enabled, you should observe lower GPU memory usage and a potential speed up at inference
+        time. Speed up at training time is not guaranteed.
+
+        Warning: When Memory Efficient Attention and Sliced attention are both enabled, the Memory Efficient Attention
+        is used.
+        """
+        self.unet.set_use_memory_efficient_attention_xformers(True)
+
+    def disable_xformers_memory_efficient_attention(self):
+        r"""
+        Disable memory efficient attention as implemented in xformers.
+        """
+        self.unet.set_use_memory_efficient_attention_xformers(False)
+
     def enable_attention_slicing(self, slice_size: Optional[Union[str, int]] = "auto"):
         r"""
         Enable sliced attention computation.

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -151,6 +151,24 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
         # set slice_size = `None` to disable `set_attention_slice`
         self.enable_attention_slicing(None)
 
+    def enable_xformers_memory_efficient_attention(self):
+        r"""
+        Enable memory efficient attention as implemented in xformers.
+
+        When this option is enabled, you should observe lower GPU memory usage and a potential speed up at inference
+        time. Speed up at training time is not guaranteed.
+
+        Warning: When Memory Efficient Attention and Sliced attention are both enabled, the Memory Efficient Attention
+        is used.
+        """
+        self.unet.set_use_memory_efficient_attention_xformers(True)
+
+    def disable_xformers_memory_efficient_attention(self):
+        r"""
+        Disable memory efficient attention as implemented in xformers.
+        """
+        self.unet.set_use_memory_efficient_attention_xformers(False)
+
     @torch.no_grad()
     def __call__(
         self,

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -151,6 +151,24 @@ class StableDiffusionInpaintPipeline(DiffusionPipeline):
         # set slice_size = `None` to disable `attention slicing`
         self.enable_attention_slicing(None)
 
+    def enable_xformers_memory_efficient_attention(self):
+        r"""
+        Enable memory efficient attention as implemented in xformers.
+
+        When this option is enabled, you should observe lower GPU memory usage and a potential speed up at inference
+        time. Speed up at training time is not guaranteed.
+
+        Warning: When Memory Efficient Attention and Sliced attention are both enabled, the Memory Efficient Attention
+        is used.
+        """
+        self.unet.set_use_memory_efficient_attention_xformers(True)
+
+    def disable_xformers_memory_efficient_attention(self):
+        r"""
+        Disable memory efficient attention as implemented in xformers.
+        """
+        self.unet.set_use_memory_efficient_attention_xformers(False)
+
     @torch.no_grad()
     def __call__(
         self,

--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -19,8 +19,6 @@ import os
 import sys
 from collections import OrderedDict
 
-import torch
-
 from packaging import version
 
 from . import logging
@@ -173,8 +171,11 @@ except importlib_metadata.PackageNotFoundError:
 _xformers_available = importlib.util.find_spec("xformers") is not None
 try:
     _xformers_version = importlib_metadata.version("xformers")
-    if torch.__version__ < version.Version("1.12"):
-        raise ValueError("PyTorch should be >= 1.12")
+    if _torch_available:
+        import torch
+
+        if torch.__version__ < version.Version("1.12"):
+            raise ValueError("PyTorch should be >= 1.12")
     logger.debug(f"Successfully imported xformers version {_xformers_version}")
 except importlib_metadata.PackageNotFoundError:
     _xformers_available = False

--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -19,6 +19,8 @@ import os
 import sys
 from collections import OrderedDict
 
+import torch
+
 from packaging import version
 
 from . import logging
@@ -171,6 +173,8 @@ except importlib_metadata.PackageNotFoundError:
 _xformers_available = importlib.util.find_spec("xformers") is not None
 try:
     _xformers_version = importlib_metadata.version("xformers")
+    if torch.__version__ < version.Version("1.12"):
+        raise ValueError("PyTorch should be >= 1.12")
     logger.debug(f"Successfully imported xformers version {_xformers_version}")
 except importlib_metadata.PackageNotFoundError:
     _xformers_available = False

--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -168,6 +168,13 @@ try:
 except importlib_metadata.PackageNotFoundError:
     _accelerate_available = False
 
+_xformers_available = importlib.util.find_spec("xformers") is not None
+try:
+    _xformers_version = importlib_metadata.version("xformers")
+    logger.debug(f"Successfully imported xformers version {_xformers_version}")
+except importlib_metadata.PackageNotFoundError:
+    _xformers_available = False
+
 
 def is_torch_available():
     return _torch_available
@@ -203,6 +210,10 @@ def is_onnx_available():
 
 def is_scipy_available():
     return _scipy_available
+
+
+def is_xformers_available():
+    return _xformers_available
 
 
 def is_accelerate_available():


### PR DESCRIPTION
# Why ? 
While stable diffusion democratized the access to text to image generative models, it can still be relatively long to generate an image on consumer GPUs. The GPU memory requirements are also hindering the use of diffusion on small GPUs. 


# How ?
Recent work on optimizing the bandwitdh in the attention block have generated huge speed ups and gains in GPU memory usage. The most recent being Flash Attention (from @tridao, [code](https://github.com/HazyResearch/flash-attention), [paper](https://arxiv.org/pdf/2205.14135.pdf)) . 

In this PR we use the MemoryEfficientAttention implementation from [xformers](https://github.com/facebookresearch/xformers) (cc. @fmassa, @danthe3rd, @blefaudeux) to both speedup the cross-attention speed and decrease its GPU memory requirements. 

The memory efficient attention can be activated by setting the environment variable `USE_MEMORY_EFFICIENT_ATTENTION=1`
and installing the `xformers` library: 

```
pip install git+https://github.com/facebookresearch/xformers@51dd119#egg=xformers
```

This installation is a known pain point, there are two ways to improve that: 
  - xformers ships wheels
  - this dependency could be made optional in this repository

Thank you @tridao, @fmassa, @danthe3rd for the work on Flash Attention and its integration in xformers. 
Would it be possible to add a more optimised kernel for head-dim=40 which is the parameter used in stable diffusion. @blefaudeux and I would be happy to contribute :) 

Note: 
 - Masked cross-attention is not supported yet with this implementation but could be added in future work. 
 - This PR does not solve the xformers dependency just yet, any help appreciated

### Speedups on various GPUs with a 512x512 shape and running FP16: 
| GPU              	| Base Attention FP16 	| Memory Efficient Attention FP16 	|
|------------------	|---------------------	|---------------------------------	|
| NVIDIA Tesla T4  	| 3.5it/s             	| 5.5it/s                         	|
| NVIDIA 3060 RTX  	| 4.6it/s             	| 7.8it/s                         	|
| NVIDIA A10G      	| 8.88it/s            	| 15.6it/s                        	|
| NVIDIA RTX A6000 	| 11.7it/s            	| 21.09it/s                       	|
| A100-SXM-80GB    	| 18.7it/s            	| 29.5it/s                        	|
 
 
 ### How to test: 
I use the following setup: 
```
sudo docker run -it --gpus=all --ipc=host -v /home:/home nvcr.io/nvidia/pytorch:22.08-py3 bash

# Then 
pip install git+https://github.com/facebookresearch/xformers@51dd119#egg=xformers
pip install transformers ftfy scipy

# Followed by
cd PATH_TO_DIFFUSER_FOLDER
git checkout memory_efficient_attention
pip install -e . 
``` 
 
 Then create a python file, mine is named `test.py`, with the following code:
 ```
import torch
from diffusers import StableDiffusionPipeline


pipe = StableDiffusionPipeline.from_pretrained(
    "CompVis/stable-diffusion-v1-4", revision="fp16", torch_dtype=torch.float16, use_auth_token=True
).to("cuda")

with torch.inference_mode(), torch.autocast("cuda"):
    image = pipe("a small cat")
 ```
 
 Then run in the aforementioned docker container
 ```
 # Test without Memory Efficient Attention: 
 python test.py
 
 # Test with Memory Efficient Attention: 
 USE_MEMORY_EFFICIENT_ATTENTION=1 python test.py
 ```