### PR TITLE
FlaxUNet2DConditionOutput @flax.struct.dataclass

### DIFF
--- a/src/diffusers/models/unet_2d_condition_flax.py
+++ b/src/diffusers/models/unet_2d_condition_flax.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass
 from typing import Tuple, Union
 
+import flax
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
@@ -19,7 +19,7 @@ from .unet_blocks_flax import (
 )
 
 
-@dataclass
+@flax.struct.dataclass
 class FlaxUNet2DConditionOutput(BaseOutput):
     """
     Args:


### PR DESCRIPTION
Closes #528

If I'm not mistaken, there is no change requireed to [BaseOutput](https://github.com/huggingface/diffusers/blob/43c585111d9b6841236ea13c9763265849d48991/src/diffusers/utils/outputs.py#L41). Could anyone confirm that?

Thanks!