### PR TITLE
Fix `CrossAttention._sliced_attention`

### DIFF
--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -249,12 +249,14 @@ class CrossAttention(nn.Module):
         return tensor
 
     def forward(self, hidden_states, context=None, mask=None):
-        batch_size, sequence_length, dim = hidden_states.shape
+        batch_size, sequence_length, _ = hidden_states.shape
 
         query = self.to_q(hidden_states)
         context = context if context is not None else hidden_states
         key = self.to_k(context)
         value = self.to_v(context)
+
+        dim = query.shape[-1]
 
         query = self.reshape_heads_to_batch_dim(query)
         key = self.reshape_heads_to_batch_dim(key)


### PR DESCRIPTION
Fix `CrossAttention._sliced_attention`. See the review comment.

### To Reproduce without this PR

```python
from diffusers.models.attention import CrossAttention
import numpy as np
import torch

# # This is OK: i.e. if `query_dim` == `inner_dim`
# N, T_query, T_context, query_dim, context_dim, heads, dim_head = (2, 5, 3, 16, 4, 2, 8)

# This fails
N, T_query, T_context, query_dim, context_dim, heads, dim_head = (2, 5, 3, 8, 4, 2, 8)

sample = np.random.default_rng().standard_normal(size=(N, T_query, query_dim), dtype=np.float32)
context = np.random.default_rng().standard_normal(size=(N, T_context, context_dim), dtype=np.float32)
pt_sample = torch.tensor(sample, dtype=torch.float32)
pt_context = torch.tensor(context, dtype=torch.float32)


pt_layer = CrossAttention(query_dim=query_dim, context_dim=context_dim, heads=heads, dim_head=dim_head)
# Use sliced attention
pt_layer._slice_size = 1

with torch.no_grad():
    pt_output = pt_layer(pt_sample, context=pt_context)
```

which gives
```bash
Traceback (most recent call last):
  File "C:\Users\33611\Desktop\Project\diffusers\debug.py", line 18, in <module>
    pt_output = pt_layer(pt_sample, context=pt_context)
  File "C:\Users\33611\miniconda3\envs\py39\lib\site-packages\torch\nn\modules\module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "C:\Users\33611\Desktop\Project\diffusers\src\diffusers\models\attention.py", line 270, in forward
    hidden_states = self._sliced_attention(query, key, value, sequence_length, dim)
  File "C:\Users\33611\Desktop\Project\diffusers\src\diffusers\models\attention.py", line 296, in _sliced_attention
    hidden_states[start_idx:end_idx] = attn_slice
RuntimeError: The expanded size of the tensor (4) must match the existing size (8) at non-singleton dimension 2.  Target sizes: [1, 5, 4].  Tensor sizes: [5, 8]
```

