### PR TITLE
Flax: ignore dtype for configuration

### DIFF
--- a/src/diffusers/modeling_flax_utils.py
+++ b/src/diffusers/modeling_flax_utils.py
@@ -45,7 +45,7 @@ class FlaxModelMixin:
     """
     config_name = CONFIG_NAME
     _automatically_saved_args = ["_diffusers_version", "_class_name", "_name_or_path"]
-    _flax_internal_args = ["name", "parent"]
+    _flax_internal_args = ["name", "parent", "dtype"]
 
     @classmethod
     def _from_config(cls, config, **kwargs):


### PR DESCRIPTION
This makes it possible to save weights and configuration files.