### PR TITLE
[CI] Make push tests run nightly

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -1,9 +1,9 @@
 name: Run all tests
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
   HF_HOME: /mnt/cache


### PR DESCRIPTION
This is needed to reduce the load on our CI runner, as the push-tests block the queue quite a bit.
The slow tests will stay accessible to maintaines through the `Actions` tab (launch the `Run all tests` workflow manually)

cc @patrickvonplaten @patil-suraj @pcuenca 