### PR TITLE
Handle the PIL.Image.Resampling deprecation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ from setuptools import find_packages, setup
 # 1. all dependencies should be listed here with their version requirements if any
 # 2. once modified, run: `make deps_table_update` to update src/diffusers/dependency_versions_table.py
 _deps = [
-    "Pillow",
+    "Pillow<10.0",  # keep the PIL.Image.Resampling deprecation away
     "accelerate>=0.11.0",
     "black==22.8",
     "datasets",

--- a/src/diffusers/dependency_versions_table.py
+++ b/src/diffusers/dependency_versions_table.py
@@ -2,7 +2,7 @@
 # 1. modify the `_deps` dict in setup.py
 # 2. run `make deps_table_update``
 deps = {
-    "Pillow": "Pillow",
+    "Pillow": "Pillow<10.0",
     "accelerate": "accelerate>=0.11.0",
     "black": "black==22.8",
     "datasets": "datasets",


### PR DESCRIPTION
Context: PIL deprecates PIL.Image.BILINEAR etc. in favor of PIL.Image.Resampling.BILINEAR in 10.0 (currently 9.2):
https://github.com/python-pillow/Pillow/blob/488589b4b69ab7729a059b3f1512398d717d2eda/docs/deprecations.rst#constants

As Pillow 10.0 is not yet officially released, and `transformers` still use `PIL.Image.BILINEAR` for our CLIP dependency (https://github.com/huggingface/transformers/blob/cdaed367b005d2a88a70a1e3c2cc5ec151e68fed/src/transformers/models/clip/feature_extraction_clip.py#L67), I'm capping the PIL version at 10.0 until its release. 

Fixes #586 