### PR TITLE
[Flax] Fix unet and ddim scheduler

### DIFF
--- a/src/diffusers/models/embeddings_flax.py
+++ b/src/diffusers/models/embeddings_flax.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 
 # This is like models.embeddings.get_timestep_embedding (PyTorch) but
 # less general (only handles the case we currently need).
-def get_sinusoidal_embeddings(timesteps, embedding_dim):
+def get_sinusoidal_embeddings(timesteps, embedding_dim, freq_shift: float = 1):
     """
     This matches the implementation in Denoising Diffusion Probabilistic Models: Create sinusoidal timestep embeddings.
 
@@ -29,7 +29,7 @@ def get_sinusoidal_embeddings(timesteps, embedding_dim):
     embeddings. :return: an [N x dim] tensor of positional embeddings.
     """
     half_dim = embedding_dim // 2
-    emb = math.log(10000) / (half_dim - 1)
+    emb = math.log(10000) / (half_dim - freq_shift)
     emb = jnp.exp(jnp.arange(half_dim) * -emb)
     emb = timesteps[:, None] * emb[None, :]
     emb = jnp.concatenate([jnp.cos(emb), jnp.sin(emb)], -1)
@@ -50,7 +50,8 @@ class FlaxTimestepEmbedding(nn.Module):
 
 class FlaxTimesteps(nn.Module):
     dim: int = 32
+    freq_shift: float = 1
 
     @nn.compact
     def __call__(self, timesteps):
-        return get_sinusoidal_embeddings(timesteps, self.dim)
+        return get_sinusoidal_embeddings(timesteps, self.dim, freq_shift=self.freq_shift)

--- a/src/diffusers/models/unet_2d_condition_flax.py
+++ b/src/diffusers/models/unet_2d_condition_flax.py
@@ -73,6 +73,7 @@ class FlaxUNet2DConditionModel(nn.Module, FlaxModelMixin, ConfigMixin):
     cross_attention_dim: int = 1280
     dropout: float = 0.0
     dtype: jnp.dtype = jnp.float32
+    freq_shift: int = 0
 
     def init_weights(self, rng: jax.random.PRNGKey) -> FrozenDict:
         # init input tensors
@@ -100,7 +101,7 @@ class FlaxUNet2DConditionModel(nn.Module, FlaxModelMixin, ConfigMixin):
         )
 
         # time
-        self.time_proj = FlaxTimesteps(block_out_channels[0])
+        self.time_proj = FlaxTimesteps(block_out_channels[0], freq_shift=self.config.freq_shift)
         self.time_embedding = FlaxTimestepEmbedding(time_embed_dim, dtype=self.dtype)
 
         # down

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -393,12 +393,7 @@ class DiffusionPipeline(ConfigMixin):
                     if issubclass(class_obj, class_candidate):
                         load_method_name = importable_classes[class_name][1]
 
-                try:
-                    load_method = getattr(class_obj, load_method_name)
-                except:
-                    import ipdb
-
-                    ipdb.set_trace()
+                load_method = getattr(class_obj, load_method_name)
 
                 loading_kwargs = {}
                 if issubclass(class_obj, torch.nn.Module):

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -341,6 +341,10 @@ class DiffusionPipeline(ConfigMixin):
 
         # 3. Load each module in the pipeline
         for name, (library_name, class_name) in init_dict.items():
+            # 3.1 - now that JAX/Flax is an official framework of the library, we might load from Flax names
+            if class_name.startswith("Flax"):
+                class_name = class_name[4:]
+
             is_pipeline_module = hasattr(pipelines, library_name)
             loaded_sub_model = None
 
@@ -389,7 +393,12 @@ class DiffusionPipeline(ConfigMixin):
                     if issubclass(class_obj, class_candidate):
                         load_method_name = importable_classes[class_name][1]
 
-                load_method = getattr(class_obj, load_method_name)
+                try:
+                    load_method = getattr(class_obj, load_method_name)
+                except:
+                    import ipdb
+
+                    ipdb.set_trace()
 
                 loading_kwargs = {}
                 if issubclass(class_obj, torch.nn.Module):

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_flax_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_flax_stable_diffusion.py
@@ -178,7 +178,6 @@ class FlaxStableDiffusionPipeline(FlaxDiffusionPipeline):
                 jnp.array(latents_input),
                 jnp.array(timestep, dtype=jnp.int32),
                 encoder_hidden_states=context,
-                rngs={},
             ).sample
             # perform guidance
             noise_pred_uncond, noise_prediction_text = jnp.split(noise_pred, 2, axis=0)

--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -222,6 +222,7 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
         # 2. compute alphas, betas
         alpha_prod_t = self.alphas_cumprod[timestep]
         alpha_prod_t_prev = self.alphas_cumprod[prev_timestep] if prev_timestep >= 0 else self.final_alpha_cumprod
+
         beta_prod_t = 1 - alpha_prod_t
 
         # 3. compute predicted original sample from predicted noise also called


### PR DESCRIPTION
```python
from diffusers import FlaxStableDiffusionPipeline
from diffusers import StableDiffusionPipeline
from jax import pmap
import numpy as np
import jax
import jax.numpy as jnp
import torch
from flax.jax_utils import replicate
from flax.training.common_utils import shard


def safety_checker(images=None, clip_input=None):
    return images, False


prng_seed = jax.random.PRNGKey(0)
num_inference_steps = 2

pipeline_torch = StableDiffusionPipeline.from_pretrained("hf-internal-testing/tiny-stable-diffusion-pipe")
pipeline_torch.safety_checker = safety_checker
pipeline, params = FlaxStableDiffusionPipeline.from_pretrained("hf-internal-testing/tiny-stable-diffusion-pipe")

latents_torch = torch.rand(1, 4, pipeline_torch.unet.config.sample_size, pipeline_torch.unet.config.sample_size)
latents = jnp.array(latents_torch.cpu())

prompt = "A cinematic film still of Morgan Freeman starring as Jimi Hendrix, portrait, 40mm lens, shallow depth of field, close up, split lighting, cinematic"

num_samples = 1

prompt_ids = pipeline.prepare_inputs(prompt)
images_np = pipeline(prompt_ids, params, prng_seed, num_inference_steps, latents=latents, debug=True).images
images = pipeline.numpy_to_pil(np.asarray(images_np.reshape((num_samples,) + images_np.shape[-3:])))
print(100 * "-")
images_torch_np = pipeline_torch(prompt, latents=latents_torch, height=256, width=256, num_inference_steps=num_inference_steps, output_type="np").images
images_torch = pipeline_torch.numpy_to_pil(images_torch_np)

print(f"Diff Sum: {np.abs(images_torch_np - images_np).sum()}")
print(f"Diff Max: {np.abs(images_torch_np - images_np).max()}")
import ipdb; ipdb.set_trace()
print("works!")
```

Now gives:
```
Diff Sum: 0.19847372174263                                                                                             │
Diff Max: 0.00012359023094177246 
```