### PR TITLE
Return Flax scheduler state

### DIFF
--- a/src/diffusers/configuration_utils.py
+++ b/src/diffusers/configuration_utils.py
@@ -161,8 +161,8 @@ class ConfigMixin:
         model = cls(**init_dict)
         return_tuple = (model,)
 
-        # Some components (Flax schedulers) have a state.
-        if getattr(cls, "has_state", False):       # Check for "create_state" in model instead?
+        # Flax schedulers have a state, so return it.
+        if cls.__name__.startswith("Flax") and hasattr(model, "create_state") and getattr(model, "has_state", False):
             state = model.create_state()
             return_tuple += (state,)
 

--- a/src/diffusers/configuration_utils.py
+++ b/src/diffusers/configuration_utils.py
@@ -157,12 +157,19 @@ class ConfigMixin:
 
         init_dict, unused_kwargs = cls.extract_init_dict(config_dict, **kwargs)
 
+        # Return model and optionally state and/or unused_kwargs
         model = cls(**init_dict)
+        return_tuple = (model,)
+
+        # Some components (Flax schedulers) have a state.
+        if getattr(cls, "has_state", False):       # Check for "create_state" in model instead?
+            state = model.create_state()
+            return_tuple += (state,)
 
         if return_unused_kwargs:
-            return model, unused_kwargs
+            return return_tuple + (unused_kwargs,)
         else:
-            return model
+            return return_tuple if len(return_tuple) > 1 else model
 
     @classmethod
     def get_config_dict(

--- a/src/diffusers/pipeline_flax_utils.py
+++ b/src/diffusers/pipeline_flax_utils.py
@@ -437,8 +437,8 @@ class FlaxDiffusionPipeline(ConfigMixin):
                         loaded_sub_model, loaded_params = load_method(loadable_folder, _do_init=False)
                     params[name] = loaded_params
                 elif issubclass(class_obj, SchedulerMixin):
-                    loaded_sub_model = load_method(loadable_folder)
-                    params[name] = loaded_sub_model.create_state()
+                    loaded_sub_model, scheduler_state = load_method(loadable_folder)
+                    params[name] = scheduler_state
                 else:
                     loaded_sub_model = load_method(loadable_folder)
 

--- a/src/diffusers/schedulers/scheduling_ddim_flax.py
+++ b/src/diffusers/schedulers/scheduling_ddim_flax.py
@@ -104,6 +104,7 @@ class FlaxDDIMScheduler(SchedulerMixin, ConfigMixin):
             `set_alpha_to_one=False`, to make the last step use step 0 for the previous alpha product, as done in
             stable diffusion.
     """
+
     @property
     def has_state(self):
         return True

--- a/src/diffusers/schedulers/scheduling_ddim_flax.py
+++ b/src/diffusers/schedulers/scheduling_ddim_flax.py
@@ -104,7 +104,9 @@ class FlaxDDIMScheduler(SchedulerMixin, ConfigMixin):
             `set_alpha_to_one=False`, to make the last step use step 0 for the previous alpha product, as done in
             stable diffusion.
     """
-    has_state = True
+    @property
+    def has_state(self):
+        return True
 
     @register_to_config
     def __init__(

--- a/src/diffusers/schedulers/scheduling_ddim_flax.py
+++ b/src/diffusers/schedulers/scheduling_ddim_flax.py
@@ -104,6 +104,7 @@ class FlaxDDIMScheduler(SchedulerMixin, ConfigMixin):
             `set_alpha_to_one=False`, to make the last step use step 0 for the previous alpha product, as done in
             stable diffusion.
     """
+    has_state = True
 
     @register_to_config
     def __init__(

--- a/src/diffusers/schedulers/scheduling_pndm_flax.py
+++ b/src/diffusers/schedulers/scheduling_pndm_flax.py
@@ -112,7 +112,9 @@ class FlaxPNDMScheduler(SchedulerMixin, ConfigMixin):
             `set_alpha_to_one=False`, to make the last step use step 0 for the previous alpha product, as done in
             stable diffusion.
     """
-    has_state = True
+    @property
+    def has_state(self):
+        return True
     
     @register_to_config
     def __init__(

--- a/src/diffusers/schedulers/scheduling_pndm_flax.py
+++ b/src/diffusers/schedulers/scheduling_pndm_flax.py
@@ -112,7 +112,8 @@ class FlaxPNDMScheduler(SchedulerMixin, ConfigMixin):
             `set_alpha_to_one=False`, to make the last step use step 0 for the previous alpha product, as done in
             stable diffusion.
     """
-
+    has_state = True
+    
     @register_to_config
     def __init__(
         self,

--- a/src/diffusers/schedulers/scheduling_pndm_flax.py
+++ b/src/diffusers/schedulers/scheduling_pndm_flax.py
@@ -112,10 +112,11 @@ class FlaxPNDMScheduler(SchedulerMixin, ConfigMixin):
             `set_alpha_to_one=False`, to make the last step use step 0 for the previous alpha product, as done in
             stable diffusion.
     """
+
     @property
     def has_state(self):
         return True
-    
+
     @register_to_config
     def __init__(
         self,


### PR DESCRIPTION
This was initially done as part of #583.

The way to set up a custom scheduler, as discussed offline, is:

```Python
scheduler, scheduler_state = FlaxPNDMScheduler.from_config(...)
pipeline, params = FlaxStableDiffusionPipeline.from_pretrained(
    model_id,
    scheduler=scheduler,
)
params["scheduler"] = scheduler_state
```