### PR TITLE
Fix flax from_pretrained pytorch weoghts check

### DIFF
--- a/src/diffusers/modeling_flax_utils.py
+++ b/src/diffusers/modeling_flax_utils.py
@@ -307,7 +307,7 @@ class FlaxModelMixin:
         # Load model
         if os.path.isdir(pretrained_model_name_or_path):
             if from_pt:
-                if not os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME):
+                if not os.path.isfile(os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME)):
                     raise EnvironmentError(
                         f"Error no file named {WEIGHTS_NAME} found in directory {pretrained_model_name_or_path} "
                     )
@@ -315,8 +315,8 @@ class FlaxModelMixin:
             elif os.path.isfile(os.path.join(pretrained_model_name_or_path, FLAX_WEIGHTS_NAME)):
                 # Load from a Flax checkpoint
                 model_file = os.path.join(pretrained_model_name_or_path, FLAX_WEIGHTS_NAME)
-            # At this stage we don't have a weight file so we will raise an error.
-            elif os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME):
+            # Check if pytorch weights exist instead
+            elif os.path.isfile(os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME)):
                 raise EnvironmentError(
                     f"{WEIGHTS_NAME} file found in directory {pretrained_model_name_or_path}. Please load the model"
                     " using  `from_pt=True`."


### PR DESCRIPTION
The implementation was mostly copied from `transformers.FlaxPreTrainedModel` & I think there was an error (made PR https://github.com/huggingface/transformers/pull/19133 as well)

cc: @younesbelkada github is not letting me add you as reviwer


```py
from diffusers import FlaxUNet2DConditionModel

# should tell you to use `from_pt=True`
model, params = FlaxUNet2DConditionModel.from_pretrained("{PT_PATH}")

# works by converting the weights
model, params = FlaxUNet2DConditionModel.from_pretrained("{PT_PATH}", from_pt=True)
```