### PR TITLE
Make flax from_pretrained work with local subfolder

### DIFF
--- a/src/diffusers/modeling_flax_utils.py
+++ b/src/diffusers/modeling_flax_utils.py
@@ -310,26 +310,31 @@ class FlaxModelMixin:
         )
 
         # Load model
-        if os.path.isdir(pretrained_model_name_or_path):
+        pretrained_path_with_subfolder = (
+            pretrained_model_name_or_path
+            if subfolder is None
+            else os.path.join(pretrained_model_name_or_path, subfolder)
+        )
+        if os.path.isdir(pretrained_path_with_subfolder):
             if from_pt:
-                if not os.path.isfile(os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME)):
+                if not os.path.isfile(os.path.join(pretrained_path_with_subfolder, WEIGHTS_NAME)):
                     raise EnvironmentError(
-                        f"Error no file named {WEIGHTS_NAME} found in directory {pretrained_model_name_or_path} "
+                        f"Error no file named {WEIGHTS_NAME} found in directory {pretrained_path_with_subfolder} "
                     )
-                model_file = os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME)
-            elif os.path.isfile(os.path.join(pretrained_model_name_or_path, FLAX_WEIGHTS_NAME)):
+                model_file = os.path.join(pretrained_path_with_subfolder, WEIGHTS_NAME)
+            elif os.path.isfile(os.path.join(pretrained_path_with_subfolder, FLAX_WEIGHTS_NAME)):
                 # Load from a Flax checkpoint
-                model_file = os.path.join(pretrained_model_name_or_path, FLAX_WEIGHTS_NAME)
+                model_file = os.path.join(pretrained_path_with_subfolder, FLAX_WEIGHTS_NAME)
             # Check if pytorch weights exist instead
-            elif os.path.isfile(os.path.join(pretrained_model_name_or_path, WEIGHTS_NAME)):
+            elif os.path.isfile(os.path.join(pretrained_path_with_subfolder, WEIGHTS_NAME)):
                 raise EnvironmentError(
-                    f"{WEIGHTS_NAME} file found in directory {pretrained_model_name_or_path}. Please load the model"
+                    f"{WEIGHTS_NAME} file found in directory {pretrained_path_with_subfolder}. Please load the model"
                     " using  `from_pt=True`."
                 )
             else:
                 raise EnvironmentError(
                     f"Error no file named {FLAX_WEIGHTS_NAME} or {WEIGHTS_NAME} found in directory "
-                    f"{pretrained_model_name_or_path}."
+                    f"{pretrained_path_with_subfolder}."
                 )
         else:
             try:


### PR DESCRIPTION
```py
from diffusers import FlaxUNet2DConditionModel

model, params = FlaxUNet2DConditionModel.from_pretrained("/home/mishig/sd-v1-4-flax", subfolder="unet")
```

on `main`, this would raise an error saying that `/home/mishig/sd-v1-4-flax/{FLAX_MODEL} does not exist` because it was not respecting argument `subfolder` when checking locally


Pytorch version already handled it correctly:
https://github.com/huggingface/diffusers/blob/8685699392cfaa79c9c9ab0e16fca49b0f0574f3/src/diffusers/modeling_utils.py#L297-L300