### PR TITLE
refactor(scripts): `params` and `conv_shortcut`

### DIFF
--- a/scripts/convert_ddpm_original_checkpoint_to_diffusers.py
+++ b/scripts/convert_ddpm_original_checkpoint_to_diffusers.py
@@ -21,7 +21,7 @@ def renew_resnet_paths(old_list, n_shave_prefix_segments=0):
     for old_item in old_list:
         new_item = old_item
         new_item = new_item.replace("block.", "resnets.")
-        new_item = new_item.replace("conv_shorcut", "conv1")
+        new_item = new_item.replace("conv_shortcut", "conv1")
         new_item = new_item.replace("in_shortcut", "conv_shortcut")
         new_item = new_item.replace("temb_proj", "time_emb_proj")
 

--- a/scripts/convert_original_stable_diffusion_to_diffusers.py
+++ b/scripts/convert_original_stable_diffusion_to_diffusers.py
@@ -276,7 +276,7 @@ def create_diffusers_schedular(original_config):
 
 
 def create_ldm_bert_config(original_config):
-    bert_params = original_config.model.parms.cond_stage_config.params
+    bert_params = original_config.model.params.cond_stage_config.params
     config = LDMBertConfig(
         d_model=bert_params.n_embed,
         encoder_layers=bert_params.n_layer,


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

This one has functional implications.

@pcuenca -- I don't believe either of these `scripts` were doing what they were intended to do. 
- `create_ldm_bert_config()` -- Was calling a bad object path...
- Please let me know if the replace was intentionally mis-spelled and I'm missing context.

Best,
Ryan