### PR TITLE
[CI] Fix onnxruntime installation order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,6 @@ _deps = [
     "jaxlib>=0.1.65,<=0.3.6",
     "modelcards>=0.1.4",
     "numpy",
-    "onnxruntime",
     "onnxruntime-gpu",
     "pytest",
     "pytest-timeout",
@@ -179,7 +178,6 @@ extras["docs"] = deps_list("hf-doc-builder")
 extras["training"] = deps_list("accelerate", "datasets", "tensorboard", "modelcards")
 extras["test"] = deps_list(
     "datasets",
-    "onnxruntime",
     "onnxruntime-gpu",
     "pytest",
     "pytest-timeout",


### PR DESCRIPTION
Currently `onnxruntime` can get installed after `onnxruntime-gpu` resulting in a timeout bug for onnx tests 