### PR TITLE
[Utils] Add deprecate function and move testing_utils under utils

### DIFF
--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -32,13 +32,13 @@ warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
 def pytest_addoption(parser):
-    from diffusers.testing_utils import pytest_addoption_shared
+    from diffusers.utils import pytest_addoption_shared
 
     pytest_addoption_shared(parser)
 
 
 def pytest_terminal_summary(terminalreporter):
-    from diffusers.testing_utils import pytest_terminal_summary_main
+    from diffusers.utils import pytest_terminal_summary_main
 
     make_reports = terminalreporter.config.getoption("--make-reports")
     if make_reports:

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -32,13 +32,13 @@ warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
 def pytest_addoption(parser):
-    from diffusers.utils import pytest_addoption_shared
+    from diffusers.utils.testing_utils import pytest_addoption_shared
 
     pytest_addoption_shared(parser)
 
 
 def pytest_terminal_summary(terminalreporter):
-    from diffusers.utils import pytest_terminal_summary_main
+    from diffusers.utils.testing_utils import pytest_terminal_summary_main
 
     make_reports = terminalreporter.config.getoption("--make-reports")
     if make_reports:

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -24,7 +24,7 @@ import unittest
 from typing import List
 
 from accelerate.utils import write_basic_config
-from diffusers.testing_utils import slow
+from diffusers.utils import slow
 
 
 logging.basicConfig(level=logging.DEBUG)

--- a/src/diffusers/dependency_versions_table.py
+++ b/src/diffusers/dependency_versions_table.py
@@ -17,7 +17,6 @@ deps = {
     "jaxlib": "jaxlib>=0.1.65,<=0.3.6",
     "modelcards": "modelcards>=0.1.4",
     "numpy": "numpy",
-    "onnxruntime": "onnxruntime",
     "onnxruntime-gpu": "onnxruntime-gpu",
     "pytest": "pytest",
     "pytest-timeout": "pytest-timeout",

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -1,5 +1,4 @@
 import inspect
-import warnings
 from typing import List, Optional, Union
 
 import torch
@@ -10,7 +9,7 @@ from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...pipeline_utils import DiffusionPipeline
 from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
-from ...utils import logging
+from ...utils import deprecate, logging
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
 
@@ -59,15 +58,15 @@ class StableDiffusionPipeline(DiffusionPipeline):
         super().__init__()
 
         if hasattr(scheduler.config, "steps_offset") and scheduler.config.steps_offset != 1:
-            warnings.warn(
+            deprecation_message = (
                 f"The configuration file of this scheduler: {scheduler} is outdated. `steps_offset`"
                 f" should be set to 1 instead of {scheduler.config.steps_offset}. Please make sure "
                 "to update the config accordingly as leaving `steps_offset` might led to incorrect results"
                 " in future versions. If you have downloaded this checkpoint from the Hugging Face Hub,"
                 " it would be very nice if you could open a Pull request for the `scheduler/scheduler_config.json`"
-                " file",
-                DeprecationWarning,
+                " file"
             )
+            deprecate("steps_offset!=1", "1.0.0", deprecation_message, standard_warn=False)
             new_config = dict(scheduler.config)
             new_config["steps_offset"] = 1
             scheduler._internal_dict = FrozenDict(new_config)

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -1,5 +1,4 @@
 import inspect
-import warnings
 from typing import Callable, List, Optional, Union
 
 import torch

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -1,5 +1,4 @@
 import inspect
-import warnings
 from typing import List, Optional, Union
 
 import numpy as np
@@ -12,7 +11,7 @@ from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...pipeline_utils import DiffusionPipeline
 from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
-from ...utils import logging
+from ...utils import deprecate, logging
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
 
@@ -71,15 +70,15 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
         super().__init__()
 
         if hasattr(scheduler.config, "steps_offset") and scheduler.config.steps_offset != 1:
-            warnings.warn(
+            deprecation_message = (
                 f"The configuration file of this scheduler: {scheduler} is outdated. `steps_offset`"
                 f" should be set to 1 instead of {scheduler.config.steps_offset}. Please make sure "
                 "to update the config accordingly as leaving `steps_offset` might led to incorrect results"
                 " in future versions. If you have downloaded this checkpoint from the Hugging Face Hub,"
                 " it would be very nice if you could open a Pull request for the `scheduler/scheduler_config.json`"
-                " file",
-                DeprecationWarning,
+                " file"
             )
+            deprecate("steps_offset!=1", "1.0.0", deprecation_message, standard_warn=False)
             new_config = dict(scheduler.config)
             new_config["steps_offset"] = 1
             scheduler._internal_dict = FrozenDict(new_config)

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -1,5 +1,4 @@
 import inspect
-import warnings
 from typing import List, Optional, Union
 
 import numpy as np
@@ -13,7 +12,7 @@ from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...pipeline_utils import DiffusionPipeline
 from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
-from ...utils import logging
+from ...utils import deprecate, logging
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
 
@@ -86,15 +85,15 @@ class StableDiffusionInpaintPipeline(DiffusionPipeline):
         logger.info("`StableDiffusionInpaintPipeline` is experimental and will very likely change in the future.")
 
         if hasattr(scheduler.config, "steps_offset") and scheduler.config.steps_offset != 1:
-            warnings.warn(
+            deprecation_message = (
                 f"The configuration file of this scheduler: {scheduler} is outdated. `steps_offset`"
                 f" should be set to 1 instead of {scheduler.config.steps_offset}. Please make sure "
                 "to update the config accordingly as leaving `steps_offset` might led to incorrect results"
                 " in future versions. If you have downloaded this checkpoint from the Hugging Face Hub,"
                 " it would be very nice if you could open a Pull request for the `scheduler/scheduler_config.json`"
-                " file",
-                DeprecationWarning,
+                " file"
             )
+            deprecate("steps_offset!=1", "1.0.0", deprecation_message, standard_warn=False)
             new_config = dict(scheduler.config)
             new_config["steps_offset"] = 1
             scheduler._internal_dict = FrozenDict(new_config)

--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -125,7 +125,7 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
             "tensor_format",
             "0.5.0",
             "If you're running your code in PyTorch, you can safely remove this argument.",
-            kwargs,
+            take_from=kwargs,
         )
 
         if trained_betas is not None:
@@ -174,7 +174,9 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
             num_inference_steps (`int`):
                 the number of diffusion steps used when generating samples with a pre-trained model.
         """
-        deprecated_offset = deprecate("offset", "0.5.0", "Please pass `steps_offset` to `__init__` instead.", kwargs)
+        deprecated_offset = deprecate(
+            "offset", "0.5.0", "Please pass `steps_offset` to `__init__` instead.", take_from=kwargs
+        )
         offset = deprecated_offset or self.config.steps_offset
 
         self.num_inference_steps = num_inference_steps

--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -16,7 +16,6 @@
 # and https://github.com/hojonathanho/diffusion
 
 import math
-import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
@@ -24,7 +23,7 @@ import numpy as np
 import torch
 
 from ..configuration_utils import ConfigMixin, register_to_config
-from ..utils import BaseOutput
+from ..utils import BaseOutput, deprecate
 from .scheduling_utils import SchedulerMixin
 
 
@@ -122,12 +121,12 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
         steps_offset: int = 0,
         **kwargs,
     ):
-        if "tensor_format" in kwargs:
-            warnings.warn(
-                "`tensor_format` is deprecated as an argument and will be removed in version `0.5.0`."
-                "If you're running your code in PyTorch, you can safely remove this argument.",
-                DeprecationWarning,
-            )
+        deprecate(
+            "tensor_format",
+            "0.5.0",
+            "If you're running your code in PyTorch, you can safely remove this argument.",
+            kwargs,
+        )
 
         if trained_betas is not None:
             self.betas = torch.from_numpy(trained_betas)
@@ -175,17 +174,8 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
             num_inference_steps (`int`):
                 the number of diffusion steps used when generating samples with a pre-trained model.
         """
-
-        offset = self.config.steps_offset
-
-        if "offset" in kwargs:
-            warnings.warn(
-                "`offset` is deprecated as an input argument to `set_timesteps` and will be removed in v0.4.0."
-                " Please pass `steps_offset` to `__init__` instead.",
-                DeprecationWarning,
-            )
-
-            offset = kwargs["offset"]
+        deprecated_offset = deprecate("offset", "0.5.0", "Please pass `steps_offset` to `__init__` instead.", kwargs)
+        offset = deprecated_offset or self.config.steps_offset
 
         self.num_inference_steps = num_inference_steps
         step_ratio = self.config.num_train_timesteps // self.num_inference_steps

--- a/src/diffusers/schedulers/scheduling_ddpm.py
+++ b/src/diffusers/schedulers/scheduling_ddpm.py
@@ -118,7 +118,7 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
             "tensor_format",
             "0.5.0",
             "If you're running your code in PyTorch, you can safely remove this argument.",
-            kwargs,
+            take_from=kwargs,
         )
 
         if trained_betas is not None:

--- a/src/diffusers/schedulers/scheduling_ddpm.py
+++ b/src/diffusers/schedulers/scheduling_ddpm.py
@@ -15,7 +15,6 @@
 # DISCLAIMER: This file is strongly influenced by https://github.com/ermongroup/ddim
 
 import math
-import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
@@ -24,6 +23,7 @@ import torch
 
 from ..configuration_utils import ConfigMixin, register_to_config
 from ..utils import BaseOutput
+from ..testing_utils import deprecate_args
 from .scheduling_utils import SchedulerMixin
 
 
@@ -115,12 +115,7 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
         clip_sample: bool = True,
         **kwargs,
     ):
-        if "tensor_format" in kwargs:
-            warnings.warn(
-                "`tensor_format` is deprecated as an argument and will be removed in version `0.5.0`."
-                "If you're running your code in PyTorch, you can safely remove this argument.",
-                DeprecationWarning,
-            )
+        deprecate_args(kwargs, "tensor_format", "0.5.0", "If you're running your code in PyTorch, you can safely remove this argument.")
 
         if trained_betas is not None:
             self.betas = torch.from_numpy(trained_betas)

--- a/src/diffusers/schedulers/scheduling_ddpm.py
+++ b/src/diffusers/schedulers/scheduling_ddpm.py
@@ -22,8 +22,7 @@ import numpy as np
 import torch
 
 from ..configuration_utils import ConfigMixin, register_to_config
-from ..utils import BaseOutput
-from ..testing_utils import deprecate_args
+from ..utils import BaseOutput, deprecate
 from .scheduling_utils import SchedulerMixin
 
 
@@ -115,7 +114,12 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
         clip_sample: bool = True,
         **kwargs,
     ):
-        deprecate_args(kwargs, "tensor_format", "0.5.0", "If you're running your code in PyTorch, you can safely remove this argument.")
+        deprecate(
+            "tensor_format",
+            "0.5.0",
+            "If you're running your code in PyTorch, you can safely remove this argument.",
+            kwargs,
+        )
 
         if trained_betas is not None:
             self.betas = torch.from_numpy(trained_betas)

--- a/src/diffusers/schedulers/scheduling_karras_ve.py
+++ b/src/diffusers/schedulers/scheduling_karras_ve.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
@@ -21,7 +20,7 @@ import numpy as np
 import torch
 
 from ..configuration_utils import ConfigMixin, register_to_config
-from ..utils import BaseOutput
+from ..utils import BaseOutput, deprecate
 from .scheduling_utils import SchedulerMixin
 
 
@@ -89,12 +88,12 @@ class KarrasVeScheduler(SchedulerMixin, ConfigMixin):
         s_max: float = 50,
         **kwargs,
     ):
-        if "tensor_format" in kwargs:
-            warnings.warn(
-                "`tensor_format` is deprecated as an argument and will be removed in version `0.5.0`."
-                "If you're running your code in PyTorch, you can safely remove this argument.",
-                DeprecationWarning,
-            )
+        deprecate(
+            "tensor_format",
+            "0.5.0",
+            "If you're running your code in PyTorch, you can safely remove this argument.",
+            kwargs,
+        )
 
         # setable values
         self.num_inference_steps: int = None

--- a/src/diffusers/schedulers/scheduling_karras_ve.py
+++ b/src/diffusers/schedulers/scheduling_karras_ve.py
@@ -92,7 +92,7 @@ class KarrasVeScheduler(SchedulerMixin, ConfigMixin):
             "tensor_format",
             "0.5.0",
             "If you're running your code in PyTorch, you can safely remove this argument.",
-            kwargs,
+            take_from=kwargs,
         )
 
         # setable values

--- a/src/diffusers/schedulers/scheduling_lms_discrete.py
+++ b/src/diffusers/schedulers/scheduling_lms_discrete.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
@@ -22,7 +21,7 @@ import torch
 from scipy import integrate
 
 from ..configuration_utils import ConfigMixin, register_to_config
-from ..utils import BaseOutput
+from ..utils import BaseOutput, deprecate
 from .scheduling_utils import SchedulerMixin
 
 
@@ -77,12 +76,12 @@ class LMSDiscreteScheduler(SchedulerMixin, ConfigMixin):
         trained_betas: Optional[np.ndarray] = None,
         **kwargs,
     ):
-        if "tensor_format" in kwargs:
-            warnings.warn(
-                "`tensor_format` is deprecated as an argument and will be removed in version `0.5.0`."
-                "If you're running your code in PyTorch, you can safely remove this argument.",
-                DeprecationWarning,
-            )
+        deprecate(
+            "tensor_format",
+            "0.5.0",
+            "If you're running your code in PyTorch, you can safely remove this argument.",
+            kwargs,
+        )
 
         if trained_betas is not None:
             self.betas = torch.from_numpy(trained_betas)

--- a/src/diffusers/schedulers/scheduling_lms_discrete.py
+++ b/src/diffusers/schedulers/scheduling_lms_discrete.py
@@ -80,7 +80,7 @@ class LMSDiscreteScheduler(SchedulerMixin, ConfigMixin):
             "tensor_format",
             "0.5.0",
             "If you're running your code in PyTorch, you can safely remove this argument.",
-            kwargs,
+            take_from=kwargs,
         )
 
         if trained_betas is not None:

--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -106,7 +106,7 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
             "tensor_format",
             "0.5.0",
             "If you're running your code in PyTorch, you can safely remove this argument.",
-            kwargs,
+            take_from=kwargs,
         )
 
         if trained_betas is not None:
@@ -155,7 +155,9 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
             num_inference_steps (`int`):
                 the number of diffusion steps used when generating samples with a pre-trained model.
         """
-        deprecated_offset = deprecate("offset", "0.5.0", "Please pass `steps_offset` to `__init__` instead.", kwargs)
+        deprecated_offset = deprecate(
+            "offset", "0.5.0", "Please pass `steps_offset` to `__init__` instead.", take_from=kwargs
+        )
         offset = deprecated_offset or self.config.steps_offset
 
         self.num_inference_steps = num_inference_steps

--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -15,13 +15,13 @@
 # DISCLAIMER: This file is strongly influenced by https://github.com/ermongroup/ddim
 
 import math
-import warnings
 from typing import Optional, Tuple, Union
 
 import numpy as np
 import torch
 
 from ..configuration_utils import ConfigMixin, register_to_config
+from ..utils import deprecate
 from .scheduling_utils import SchedulerMixin, SchedulerOutput
 
 
@@ -102,12 +102,12 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         steps_offset: int = 0,
         **kwargs,
     ):
-        if "tensor_format" in kwargs:
-            warnings.warn(
-                "`tensor_format` is deprecated as an argument and will be removed in version `0.5.0`."
-                "If you're running your code in PyTorch, you can safely remove this argument.",
-                DeprecationWarning,
-            )
+        deprecate(
+            "tensor_format",
+            "0.5.0",
+            "If you're running your code in PyTorch, you can safely remove this argument.",
+            kwargs,
+        )
 
         if trained_betas is not None:
             self.betas = torch.from_numpy(trained_betas)
@@ -155,16 +155,8 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
             num_inference_steps (`int`):
                 the number of diffusion steps used when generating samples with a pre-trained model.
         """
-
-        offset = self.config.steps_offset
-
-        if "offset" in kwargs:
-            warnings.warn(
-                "`offset` is deprecated as an input argument to `set_timesteps` and will be removed in v0.4.0."
-                " Please pass `steps_offset` to `__init__` instead."
-            )
-
-            offset = kwargs["offset"]
+        deprecated_offset = deprecate("offset", "0.5.0", "Please pass `steps_offset` to `__init__` instead.", kwargs)
+        offset = deprecated_offset or self.config.steps_offset
 
         self.num_inference_steps = num_inference_steps
         step_ratio = self.config.num_train_timesteps // self.num_inference_steps

--- a/src/diffusers/schedulers/scheduling_sde_ve.py
+++ b/src/diffusers/schedulers/scheduling_sde_ve.py
@@ -81,7 +81,7 @@ class ScoreSdeVeScheduler(SchedulerMixin, ConfigMixin):
             "tensor_format",
             "0.5.0",
             "If you're running your code in PyTorch, you can safely remove this argument.",
-            kwargs,
+            take_from=kwargs,
         )
 
         # setable values

--- a/src/diffusers/schedulers/scheduling_sde_ve.py
+++ b/src/diffusers/schedulers/scheduling_sde_ve.py
@@ -15,14 +15,13 @@
 # DISCLAIMER: This file is strongly influenced by https://github.com/yang-song/score_sde_pytorch
 
 import math
-import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
 import torch
 
 from ..configuration_utils import ConfigMixin, register_to_config
-from ..utils import BaseOutput
+from ..utils import BaseOutput, deprecate
 from .scheduling_utils import SchedulerMixin, SchedulerOutput
 
 
@@ -78,12 +77,12 @@ class ScoreSdeVeScheduler(SchedulerMixin, ConfigMixin):
         correct_steps: int = 1,
         **kwargs,
     ):
-        if "tensor_format" in kwargs:
-            warnings.warn(
-                "`tensor_format` is deprecated as an argument and will be removed in version `0.5.0`."
-                "If you're running your code in PyTorch, you can safely remove this argument.",
-                DeprecationWarning,
-            )
+        deprecate(
+            "tensor_format",
+            "0.5.0",
+            "If you're running your code in PyTorch, you can safely remove this argument.",
+            kwargs,
+        )
 
         # setable values
         self.timesteps = None
@@ -139,11 +138,7 @@ class ScoreSdeVeScheduler(SchedulerMixin, ConfigMixin):
         )
 
     def set_seed(self, seed):
-        warnings.warn(
-            "The method `set_seed` is deprecated and will be removed in version `0.4.0`. Please consider passing a"
-            " generator instead.",
-            DeprecationWarning,
-        )
+        deprecate("set_seed", "0.4.0", "Please consider passing a generator instead.")
         torch.manual_seed(seed)
 
     def step_pred(

--- a/src/diffusers/schedulers/scheduling_sde_ve.py
+++ b/src/diffusers/schedulers/scheduling_sde_ve.py
@@ -138,7 +138,7 @@ class ScoreSdeVeScheduler(SchedulerMixin, ConfigMixin):
         )
 
     def set_seed(self, seed):
-        deprecate("set_seed", "0.4.0", "Please consider passing a generator instead.")
+        deprecate("set_seed", "0.5.0", "Please consider passing a generator instead.")
         torch.manual_seed(seed)
 
     def step_pred(

--- a/src/diffusers/schedulers/scheduling_sde_vp.py
+++ b/src/diffusers/schedulers/scheduling_sde_vp.py
@@ -17,11 +17,11 @@
 # TODO(Patrick, Anton, Suraj) - make scheduler framework independent and clean-up a bit
 
 import math
-import warnings
 
 import torch
 
 from ..configuration_utils import ConfigMixin, register_to_config
+from ..utils import deprecate
 from .scheduling_utils import SchedulerMixin
 
 
@@ -42,12 +42,12 @@ class ScoreSdeVpScheduler(SchedulerMixin, ConfigMixin):
 
     @register_to_config
     def __init__(self, num_train_timesteps=2000, beta_min=0.1, beta_max=20, sampling_eps=1e-3, **kwargs):
-        if "tensor_format" in kwargs:
-            warnings.warn(
-                "`tensor_format` is deprecated as an argument and will be removed in version `0.5.0`."
-                "If you're running your code in PyTorch, you can safely remove this argument.",
-                DeprecationWarning,
-            )
+        deprecate(
+            "tensor_format",
+            "0.5.0",
+            "If you're running your code in PyTorch, you can safely remove this argument.",
+            kwargs,
+        )
         self.sigmas = None
         self.discrete_sigmas = None
         self.timesteps = None

--- a/src/diffusers/schedulers/scheduling_sde_vp.py
+++ b/src/diffusers/schedulers/scheduling_sde_vp.py
@@ -46,7 +46,7 @@ class ScoreSdeVpScheduler(SchedulerMixin, ConfigMixin):
             "tensor_format",
             "0.5.0",
             "If you're running your code in PyTorch, you can safely remove this argument.",
-            kwargs,
+            take_from=kwargs,
         )
         self.sigmas = None
         self.discrete_sigmas = None

--- a/src/diffusers/schedulers/scheduling_utils.py
+++ b/src/diffusers/schedulers/scheduling_utils.py
@@ -11,12 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import warnings
 from dataclasses import dataclass
 
 import torch
 
-from ..utils import BaseOutput
+from ..utils import BaseOutput, deprecate
 
 
 SCHEDULER_CONFIG_NAME = "scheduler_config.json"
@@ -44,10 +43,10 @@ class SchedulerMixin:
     config_name = SCHEDULER_CONFIG_NAME
 
     def set_format(self, tensor_format="pt"):
-        warnings.warn(
-            "The method `set_format` is deprecated and will be removed in version `0.5.0`."
-            "If you're running your code in PyTorch, you can safely remove this function as the schedulers"
-            "are always in Pytorch",
-            DeprecationWarning,
+        deprecate(
+            "set_format",
+            "0.5.0",
+            "If you're running your code in PyTorch, you can safely remove this function as the schedulers are always"
+            " in Pytorch",
         )
         return self

--- a/src/diffusers/utils/__init__.py
+++ b/src/diffusers/utils/__init__.py
@@ -35,7 +35,7 @@ from .import_utils import (
 )
 from .logging import get_logger
 from .outputs import BaseOutput
-from .testing_utils import deprecate
+from .testing_utils import deprecate, floats_tensor, load_image, parse_flag_from_env, slow, torch_device
 
 
 logger = get_logger(__name__)

--- a/src/diffusers/utils/__init__.py
+++ b/src/diffusers/utils/__init__.py
@@ -15,6 +15,7 @@
 
 import os
 
+from .deprecation_utils import deprecate
 from .import_utils import (
     ENV_VARS_TRUE_AND_AUTO_VALUES,
     ENV_VARS_TRUE_VALUES,
@@ -35,7 +36,7 @@ from .import_utils import (
 )
 from .logging import get_logger
 from .outputs import BaseOutput
-from .testing_utils import deprecate, floats_tensor, load_image, parse_flag_from_env, slow, torch_device
+from .testing_utils import floats_tensor, load_image, parse_flag_from_env, slow, torch_device
 
 
 logger = get_logger(__name__)

--- a/src/diffusers/utils/__init__.py
+++ b/src/diffusers/utils/__init__.py
@@ -35,6 +35,7 @@ from .import_utils import (
 )
 from .logging import get_logger
 from .outputs import BaseOutput
+from .testing_utils import deprecate_args
 
 
 logger = get_logger(__name__)

--- a/src/diffusers/utils/__init__.py
+++ b/src/diffusers/utils/__init__.py
@@ -35,7 +35,7 @@ from .import_utils import (
 )
 from .logging import get_logger
 from .outputs import BaseOutput
-from .testing_utils import deprecate_args
+from .testing_utils import deprecate
 
 
 logger = get_logger(__name__)

--- a/src/diffusers/utils/deprecation_utils.py
+++ b/src/diffusers/utils/deprecation_utils.py
@@ -1,6 +1,5 @@
 import inspect
 import warnings
-from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 from packaging import version

--- a/src/diffusers/utils/deprecation_utils.py
+++ b/src/diffusers/utils/deprecation_utils.py
@@ -1,0 +1,50 @@
+import inspect
+import warnings
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+from packaging import version
+
+
+def deprecate(*args, take_from: Optional[Union[Dict, Any]] = None, standard_warn=True):
+    from .. import __version__
+
+    deprecated_kwargs = take_from
+    values = ()
+    if not isinstance(args[0], tuple):
+        args = (args,)
+
+    for attribute, version_name, message in args:
+        if version.parse(version.parse(__version__).base_version) >= version.parse(version_name):
+            raise ValueError(
+                f"The deprecation tuple {(attribute, version_name, message)} should be removed since diffusers'"
+                f" version {__version__} is >= {version_name}"
+            )
+
+        warning = None
+        if isinstance(deprecated_kwargs, dict) and attribute in deprecated_kwargs:
+            values += (deprecated_kwargs.pop(attribute),)
+            warning = f"The `{attribute}` argument is deprecated and will be removed in version {version_name}."
+        elif hasattr(deprecated_kwargs, attribute):
+            values += (getattr(deprecated_kwargs, attribute),)
+            warning = f"The `{attribute}` attribute is deprecated and will be removed in version {version_name}."
+        elif deprecated_kwargs is None:
+            warning = f"`{attribute}` is deprecated and will be removed in version {version_name}."
+
+        if warning is not None:
+            warning = warning + " " if standard_warn else ""
+            warnings.warn(warning + message, DeprecationWarning)
+
+    if isinstance(deprecated_kwargs, dict) and len(deprecated_kwargs) > 0:
+        call_frame = inspect.getouterframes(inspect.currentframe())[1]
+        filename = call_frame.filename
+        line_number = call_frame.lineno
+        function = call_frame.function
+        key, value = next(iter(deprecated_kwargs.items()))
+        raise TypeError(f"{function} in {filename} line {line_number-1} got an unexpected keyword argument `{key}`")
+
+    if len(values) == 0:
+        return
+    elif len(values) == 1:
+        return values[0]
+    return values

--- a/src/diffusers/utils/outputs.py
+++ b/src/diffusers/utils/outputs.py
@@ -15,7 +15,6 @@
 Generic utilities
 """
 
-import warnings
 from collections import OrderedDict
 from dataclasses import fields
 from typing import Any, Tuple
@@ -23,6 +22,7 @@ from typing import Any, Tuple
 import numpy as np
 
 from .import_utils import is_torch_available
+from .testing_utils import deprecate_args
 
 
 def is_tensor(x):
@@ -87,11 +87,7 @@ class BaseOutput(OrderedDict):
         if isinstance(k, str):
             inner_dict = {k: v for (k, v) in self.items()}
             if self.__class__.__name__ in ["StableDiffusionPipelineOutput", "ImagePipelineOutput"] and k == "sample":
-                warnings.warn(
-                    "The keyword 'samples' is deprecated and will be removed in version 0.4.0. Please use `.images` or"
-                    " `'images'` instead.",
-                    DeprecationWarning,
-                )
+                deprecate_args("samples", "0.4.0", "Please use `.images` or `'images'` instead.")
                 return inner_dict["images"]
             return inner_dict[k]
         else:

--- a/src/diffusers/utils/outputs.py
+++ b/src/diffusers/utils/outputs.py
@@ -22,7 +22,7 @@ from typing import Any, Tuple
 import numpy as np
 
 from .import_utils import is_torch_available
-from .testing_utils import deprecate_args
+from .testing_utils import deprecate
 
 
 def is_tensor(x):
@@ -87,7 +87,7 @@ class BaseOutput(OrderedDict):
         if isinstance(k, str):
             inner_dict = {k: v for (k, v) in self.items()}
             if self.__class__.__name__ in ["StableDiffusionPipelineOutput", "ImagePipelineOutput"] and k == "sample":
-                deprecate_args("samples", "0.4.0", "Please use `.images` or `'images'` instead.")
+                deprecate("samples", "0.4.0", "Please use `.images` or `'images'` instead.")
                 return inner_dict["images"]
             return inner_dict[k]
         else:

--- a/src/diffusers/utils/outputs.py
+++ b/src/diffusers/utils/outputs.py
@@ -21,8 +21,8 @@ from typing import Any, Tuple
 
 import numpy as np
 
+from .deprecation_utils import deprecate
 from .import_utils import is_torch_available
-from .testing_utils import deprecate
 
 
 def is_tensor(x):

--- a/src/diffusers/utils/outputs.py
+++ b/src/diffusers/utils/outputs.py
@@ -87,7 +87,7 @@ class BaseOutput(OrderedDict):
         if isinstance(k, str):
             inner_dict = {k: v for (k, v) in self.items()}
             if self.__class__.__name__ in ["StableDiffusionPipelineOutput", "ImagePipelineOutput"] and k == "sample":
-                deprecate("samples", "0.4.0", "Please use `.images` or `'images'` instead.")
+                deprecate("samples", "0.6.0", "Please use `.images` or `'images'` instead.")
                 return inner_dict["images"]
             return inner_dict[k]
         else:

--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 import random
 import re
@@ -6,7 +5,7 @@ import unittest
 import warnings
 from distutils.util import strtobool
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Union
 
 import torch
 
@@ -22,50 +21,6 @@ is_torch_higher_equal_than_1_12 = version.parse(version.parse(torch.__version__)
 
 if is_torch_higher_equal_than_1_12:
     torch_device = "mps" if torch.backends.mps.is_available() else torch_device
-
-
-def deprecate(*args, take_from: Optional[Union[Dict, Any]] = None, standard_warn=True):
-    from .. import __version__
-
-    deprecated_kwargs = take_from
-    values = ()
-    if not isinstance(args[0], tuple):
-        args = (args,)
-
-    for attribute, version_name, message in args:
-        if version.parse(version.parse(__version__).base_version) >= version.parse(version_name):
-            raise ValueError(
-                f"The deprecation tuple {(attribute, version_name, message)} should be removed since diffusers'"
-                f" version {__version__} is >= {version_name}"
-            )
-
-        warning = None
-        if isinstance(deprecated_kwargs, dict) and attribute in deprecated_kwargs:
-            values += (deprecated_kwargs.pop(attribute),)
-            warning = f"The `{attribute}` argument is deprecated and will be removed in version {version_name}."
-        elif hasattr(deprecated_kwargs, attribute):
-            values += (getattr(deprecated_kwargs, attribute),)
-            warning = f"The `{attribute}` attribute is deprecated and will be removed in version {version_name}."
-        elif deprecated_kwargs is None:
-            warning = f"`{attribute}` is deprecated and will be removed in version {version_name}."
-
-        if warning is not None:
-            warning = warning + " " if standard_warn else ""
-            warnings.warn(warning + message, DeprecationWarning)
-
-    if isinstance(deprecated_kwargs, dict) and len(deprecated_kwargs) > 0:
-        call_frame = inspect.getouterframes(inspect.currentframe())[1]
-        filename = call_frame.filename
-        line_number = call_frame.lineno
-        function = call_frame.function
-        key, value = next(iter(deprecated_kwargs.items()))
-        raise TypeError(f"{function} in {filename} line {line_number-1} got an unexpected keyword argument `{key}`")
-
-    if len(values) == 0:
-        return
-    elif len(values) == 1:
-        return values[0]
-    return values
 
 
 def parse_flag_from_env(key, default=False):

--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -24,7 +24,7 @@ if is_torch_higher_equal_than_1_12:
     torch_device = "mps" if torch.backends.mps.is_available() else torch_device
 
 
-def deprecate(*args, take_from=Optional[Union[Dict, Any]], standard_warn=True):
+def deprecate(*args, take_from: Optional[Union[Dict, Any]] = None, standard_warn=True):
     from .. import __version__
 
     deprecated_kwargs = take_from
@@ -35,22 +35,22 @@ def deprecate(*args, take_from=Optional[Union[Dict, Any]], standard_warn=True):
     for attribute, version_name, message in args:
         if version.parse(version.parse(__version__).base_version) >= version.parse(version_name):
             raise ValueError(
-                f"The deprecation tuple {(attribute, version, message)} should be removed since diffusers' version is"
-                f" >= {version}"
+                f"The deprecation tuple {(attribute, version_name, message)} should be removed since diffusers'"
+                f" version {__version__} is >= {version_name}"
             )
 
         warning = None
         if isinstance(deprecated_kwargs, dict) and attribute in deprecated_kwargs:
             values += (deprecated_kwargs.pop(attribute),)
-            warning = f"The `{attribute}` argument is deprecated and will be removed in version {version}."
+            warning = f"The `{attribute}` argument is deprecated and will be removed in version {version_name}."
         elif hasattr(deprecated_kwargs, attribute):
             values += (getattr(deprecated_kwargs, attribute),)
-            warning = f"The `{attribute}` argument is deprecated and will be removed in version {version}."
+            warning = f"The `{attribute}` attribute is deprecated and will be removed in version {version_name}."
         elif deprecated_kwargs is None:
-            warning = f"`{attribute}` is deprecated and will be removed in version {version}."
+            warning = f"`{attribute}` is deprecated and will be removed in version {version_name}."
 
         if warning is not None:
-            warning = warning if standard_warn else ""
+            warning = warning + " " if standard_warn else ""
             warnings.warn(warning + message, DeprecationWarning)
 
     if isinstance(deprecated_kwargs, dict) and len(deprecated_kwargs) > 0:

--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -32,6 +32,9 @@ def deprecate(*args, take_from: Optional[Union[Dict, Any]] = None, standard_warn
     if not isinstance(args[0], tuple):
         args = (args,)
 
+    import ipdb
+
+    ipdb.set_trace()
     for attribute, version_name, message in args:
         if version.parse(version.parse(__version__).base_version) >= version.parse(version_name):
             raise ValueError(

--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -14,7 +14,7 @@ import PIL.ImageOps
 import requests
 import warnings
 from packaging import version
-from . import __version__
+from .. import __version__
 
 
 global_rng = random.Random()

--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -32,9 +32,6 @@ def deprecate(*args, take_from: Optional[Union[Dict, Any]] = None, standard_warn
     if not isinstance(args[0], tuple):
         args = (args,)
 
-    import ipdb
-
-    ipdb.set_trace()
     for attribute, version_name, message in args:
         if version.parse(version.parse(__version__).base_version) >= version.parse(version_name):
             raise ValueError(

--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -2,7 +2,6 @@ import os
 import random
 import re
 import unittest
-import warnings
 from distutils.util import strtobool
 from pathlib import Path
 from typing import Union

--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -15,8 +15,6 @@ import PIL.ImageOps
 import requests
 from packaging import version
 
-from .. import __version__
-
 
 global_rng = random.Random()
 torch_device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -26,7 +24,10 @@ if is_torch_higher_equal_than_1_12:
     torch_device = "mps" if torch.backends.mps.is_available() else torch_device
 
 
-def deprecate(*args, deprecated_kwargs=Optional[Union[Dict, Any]], standard_warn=True):
+def deprecate(*args, take_from=Optional[Union[Dict, Any]], standard_warn=True):
+    from .. import __version__
+
+    deprecated_kwargs = take_from
     values = ()
     if not isinstance(args[0], tuple):
         args = (args,)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,13 +31,13 @@ warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
 def pytest_addoption(parser):
-    from diffusers.utils import pytest_addoption_shared
+    from diffusers.utils.testing_utils import pytest_addoption_shared
 
     pytest_addoption_shared(parser)
 
 
 def pytest_terminal_summary(terminalreporter):
-    from diffusers.utils import pytest_terminal_summary_main
+    from diffusers.utils.testing_utils import pytest_terminal_summary_main
 
     make_reports = terminalreporter.config.getoption("--make-reports")
     if make_reports:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,13 +31,13 @@ warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
 def pytest_addoption(parser):
-    from diffusers.testing_utils import pytest_addoption_shared
+    from diffusers.utils import pytest_addoption_shared
 
     pytest_addoption_shared(parser)
 
 
 def pytest_terminal_summary(terminalreporter):
-    from diffusers.testing_utils import pytest_terminal_summary_main
+    from diffusers.utils import pytest_terminal_summary_main
 
     make_reports = terminalreporter.config.getoption("--make-reports")
     if make_reports:

--- a/tests/test_layers_utils.py
+++ b/tests/test_layers_utils.py
@@ -22,7 +22,7 @@ import torch
 from diffusers.models.attention import AttentionBlock, SpatialTransformer
 from diffusers.models.embeddings import get_timestep_embedding
 from diffusers.models.resnet import Downsample2D, Upsample2D
-from diffusers.testing_utils import torch_device
+from diffusers.utils import torch_device
 
 
 torch.backends.cuda.matmul.allow_tf32 = False

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -22,8 +22,8 @@ import numpy as np
 import torch
 
 from diffusers.modeling_utils import ModelMixin
-from diffusers.utils import torch_device
 from diffusers.training_utils import EMAModel
+from diffusers.utils import torch_device
 
 
 class ModelTesterMixin:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -22,7 +22,7 @@ import numpy as np
 import torch
 
 from diffusers.modeling_utils import ModelMixin
-from diffusers.testing_utils import torch_device
+from diffusers.utils import torch_device
 from diffusers.training_utils import EMAModel
 
 

--- a/tests/test_models_unet.py
+++ b/tests/test_models_unet.py
@@ -19,7 +19,7 @@ import unittest
 import torch
 
 from diffusers import UNet2DConditionModel, UNet2DModel
-from diffusers.testing_utils import floats_tensor, slow, torch_device
+from diffusers.utils import floats_tensor, slow, torch_device
 
 from .test_modeling_common import ModelTesterMixin
 

--- a/tests/test_models_vae.py
+++ b/tests/test_models_vae.py
@@ -19,7 +19,7 @@ import torch
 
 from diffusers import AutoencoderKL
 from diffusers.modeling_utils import ModelMixin
-from diffusers.testing_utils import floats_tensor, torch_device
+from diffusers.utils import floats_tensor, torch_device
 
 from .test_modeling_common import ModelTesterMixin
 

--- a/tests/test_models_vq.py
+++ b/tests/test_models_vq.py
@@ -18,7 +18,7 @@ import unittest
 import torch
 
 from diffusers import VQModel
-from diffusers.testing_utils import floats_tensor, torch_device
+from diffusers.utils import floats_tensor, torch_device
 
 from .test_modeling_common import ModelTesterMixin
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -48,8 +48,7 @@ from diffusers import (
 )
 from diffusers.pipeline_utils import DiffusionPipeline
 from diffusers.schedulers.scheduling_utils import SCHEDULER_CONFIG_NAME
-from diffusers.utils import floats_tensor, load_image, slow, torch_device
-from diffusers.utils import CONFIG_NAME, WEIGHTS_NAME
+from diffusers.utils import CONFIG_NAME, WEIGHTS_NAME, floats_tensor, load_image, slow, torch_device
 from PIL import Image
 from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -48,7 +48,7 @@ from diffusers import (
 )
 from diffusers.pipeline_utils import DiffusionPipeline
 from diffusers.schedulers.scheduling_utils import SCHEDULER_CONFIG_NAME
-from diffusers.testing_utils import floats_tensor, load_image, slow, torch_device
+from diffusers.utils import floats_tensor, load_image, slow, torch_device
 from diffusers.utils import CONFIG_NAME, WEIGHTS_NAME
 from PIL import Image
 from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -18,7 +18,7 @@ import unittest
 import torch
 
 from diffusers import DDIMScheduler, DDPMScheduler, UNet2DModel
-from diffusers.testing_utils import slow
+from diffusers.utils import slow
 from diffusers.training_utils import set_seed
 
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -18,8 +18,8 @@ import unittest
 import torch
 
 from diffusers import DDIMScheduler, DDPMScheduler, UNet2DModel
-from diffusers.utils import slow
 from diffusers.training_utils import set_seed
+from diffusers.utils import slow
 
 
 torch.backends.cuda.matmul.allow_tf32 = False

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -19,7 +19,7 @@ import torch
 
 from diffusers import DDIMScheduler, DDPMScheduler, UNet2DModel
 from diffusers.training_utils import set_seed
-from diffusers.utils import slow
+from diffusers.utils.testing_utils import slow
 
 
 torch.backends.cuda.matmul.allow_tf32 = False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,151 @@
+# coding=utf-8
+# Copyright 2022 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from diffusers import __version__
+from diffusers.utils import deprecate
+
+
+class DeprecateTester(unittest.TestCase):
+
+    higher_version = ".".join([str(int(__version__.split(".")[0]) + 1)] + __version__.split(".")[1:])
+    lower_version = "0.0.1"
+
+    def test_deprecate_function_arg(self):
+        kwargs = {"deprecated_arg": 4}
+
+        with self.assertWarns(DeprecationWarning) as warning:
+            output = deprecate(("deprecated_arg", self.higher_version, "message"), take_from=kwargs)
+
+        assert output == 4
+        assert (
+            str(warning.warning)
+            == f"The `deprecated_arg` argument is deprecated and will be removed in version {self.higher_version}."
+            " message"
+        )
+
+    def test_deprecate_function_args(self):
+        kwargs = {"deprecated_arg_1": 4, "deprecated_arg_2": 8}
+        with self.assertWarns(DeprecationWarning) as warning:
+            output_1, output_2 = deprecate(
+                ("deprecated_arg_1", self.higher_version, "Hey"),
+                ("deprecated_arg_2", self.higher_version, "Hey"),
+                take_from=kwargs,
+            )
+        assert output_1 == 4
+        assert output_2 == 8
+        assert (
+            str(warning.warnings[0].message)
+            == "The `deprecated_arg_1` argument is deprecated and will be removed in version"
+            f" {self.higher_version}. Hey"
+        )
+        assert (
+            str(warning.warnings[1].message)
+            == "The `deprecated_arg_2` argument is deprecated and will be removed in version"
+            f" {self.higher_version}. Hey"
+        )
+
+    def test_deprecate_function_incorrect_arg(self):
+        kwargs = {"deprecated_arg": 4}
+
+        with self.assertRaises(TypeError) as error:
+            deprecate(("wrong_arg", self.higher_version, "message"), take_from=kwargs)
+
+        assert "test_deprecate_function_incorrect_arg in" in str(error.exception)
+        assert "line 52 got an unexpected keyword argument `deprecated_arg`" in str(error.exception)
+
+    def test_deprecate_arg_no_kwarg(self):
+        with self.assertWarns(DeprecationWarning) as warning:
+            deprecate(("deprecated_arg", self.higher_version, "message"))
+
+        assert (
+            str(warning.warning)
+            == f"`deprecated_arg` is deprecated and will be removed in version {self.higher_version}. message"
+        )
+
+    def test_deprecate_args_no_kwarg(self):
+        with self.assertWarns(DeprecationWarning) as warning:
+            deprecate(
+                ("deprecated_arg_1", self.higher_version, "Hey"),
+                ("deprecated_arg_2", self.higher_version, "Hey"),
+            )
+        assert (
+            str(warning.warnings[0].message)
+            == f"`deprecated_arg_1` is deprecated and will be removed in version {self.higher_version}. Hey"
+        )
+        assert (
+            str(warning.warnings[1].message)
+            == f"`deprecated_arg_2` is deprecated and will be removed in version {self.higher_version}. Hey"
+        )
+
+    def test_deprecate_class_obj(self):
+        class Args:
+            arg = 5
+
+        with self.assertWarns(DeprecationWarning) as warning:
+            arg = deprecate(("arg", self.higher_version, "message"), take_from=Args())
+
+        assert arg == 5
+        assert (
+            str(warning.warning)
+            == f"The `arg` attribute is deprecated and will be removed in version {self.higher_version}. message"
+        )
+
+    def test_deprecate_class_objs(self):
+        class Args:
+            arg = 5
+            foo = 7
+
+        with self.assertWarns(DeprecationWarning) as warning:
+            arg_1, arg_2 = deprecate(
+                ("arg", self.higher_version, "message"),
+                ("foo", self.higher_version, "message"),
+                ("does not exist", self.higher_version, "message"),
+                take_from=Args(),
+            )
+
+        assert arg_1 == 5
+        assert arg_2 == 7
+        assert (
+            str(warning.warning)
+            == f"The `arg` attribute is deprecated and will be removed in version {self.higher_version}. message"
+        )
+        assert (
+            str(warning.warnings[0].message)
+            == f"The `arg` attribute is deprecated and will be removed in version {self.higher_version}. message"
+        )
+        assert (
+            str(warning.warnings[1].message)
+            == f"The `foo` attribute is deprecated and will be removed in version {self.higher_version}. message"
+        )
+
+    def test_deprecate_incorrect_version(self):
+        kwargs = {"deprecated_arg": 4}
+
+        with self.assertRaises(ValueError) as error:
+            deprecate(("wrong_arg", self.lower_version, "message"), take_from=kwargs)
+
+        assert (
+            str(error.exception)
+            == "The deprecation tuple ('wrong_arg', '0.0.1', 'message') should be removed since diffusers' version"
+            f" {__version__} is >= {self.lower_version}"
+        )
+
+    def test_deprecate_incorrect_no_standard_warn(self):
+        with self.assertWarns(DeprecationWarning) as warning:
+            deprecate(("deprecated_arg", self.higher_version, "This message is better!!!"), standard_warn=False)
+
+        assert str(warning.warning) == "This message is better!!!"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,6 @@ from diffusers.utils import deprecate
 
 
 class DeprecateTester(unittest.TestCase):
-
     higher_version = ".".join([str(int(__version__.split(".")[0]) + 1)] + __version__.split(".")[1:])
     lower_version = "0.0.1"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,19 @@ class DeprecateTester(unittest.TestCase):
         kwargs = {"deprecated_arg": 4}
 
         with self.assertWarns(DeprecationWarning) as warning:
+            output = deprecate("deprecated_arg", self.higher_version, "message", take_from=kwargs)
+
+        assert output == 4
+        assert (
+            str(warning.warning)
+            == f"The `deprecated_arg` argument is deprecated and will be removed in version {self.higher_version}."
+            " message"
+        )
+
+    def test_deprecate_function_arg_tuple(self):
+        kwargs = {"deprecated_arg": 4}
+
+        with self.assertWarns(DeprecationWarning) as warning:
             output = deprecate(("deprecated_arg", self.higher_version, "message"), take_from=kwargs)
 
         assert output == 4
@@ -65,7 +78,8 @@ class DeprecateTester(unittest.TestCase):
             deprecate(("wrong_arg", self.higher_version, "message"), take_from=kwargs)
 
         assert "test_deprecate_function_incorrect_arg in" in str(error.exception)
-        assert "line 52 got an unexpected keyword argument `deprecated_arg`" in str(error.exception)
+        assert "line" in str(error.exception)
+        assert "got an unexpected keyword argument `deprecated_arg`" in str(error.exception)
 
     def test_deprecate_arg_no_kwarg(self):
         with self.assertWarns(DeprecationWarning) as warning:


### PR DESCRIPTION
# Improved deprecation functionality

We are introducing multiple deprecation cycles already and currently are missing structure on how to handle this exactly and by adding `**kwargs` to the scheduler config init we have lost functionality. More specifically:

- 1. We do not keep track when functionality should be removed as we forget to remove the deprecation cycle and the functionality (this happened twice now)
- 2. Right now when you pass a incorrect argument, e.g. `PNDMScheduler(num_inference_steps=5)` nothing happens because it's swallowed by **kwargs. **However** we should, just as before https://github.com/huggingface/diffusers/pull/651 throw a TypeError in this case.

=> This PR solves this by introducing a `deprecate` function (which should be mainly used by maintainers) that automatically forces us to remove deprecated functionality correctly + solves 2. by throwing a type error. In addition it removes boiler plate code and should make it more efficient for us to deprecate things.

The API of `deprecate` is as follows:

```python
new_arg = deprecate("old_arg", "0.7.0", "Please use `new_arg` instead", take_from=kwargs) or new_arg
```

=> This forces us to remove this statement when version >= 0.7.0, gives a nice default error message and makes sure that `kwargs` can only have deprecated args.

Please take a look into the changes here and the tests to better understand all the functionality
