### PR TITLE
[examples] update transfomers version 

### DIFF
--- a/examples/dreambooth/README.md
+++ b/examples/dreambooth/README.md
@@ -11,7 +11,7 @@ Before running the scripts, make sure to install the library's training dependen
 
 ```bash
 pip install git+https://github.com/huggingface/diffusers.git
-pip install -r requirements.txt
+pip install -U -r requirements.txt
 ```
 
 And initialize an [🤗Accelerate](https://github.com/huggingface/accelerate/) environment with:

--- a/examples/dreambooth/requirements.txt
+++ b/examples/dreambooth/requirements.txt
@@ -1,6 +1,6 @@
 accelerate
 torchvision
-transformers
+transformers>=4.21.0
 ftfy
 tensorboard
 modelcards

--- a/examples/textual_inversion/README.md
+++ b/examples/textual_inversion/README.md
@@ -17,7 +17,7 @@ Colab for inference
 Before running the scripts, make sure to install the library's training dependencies:
 
 ```bash
-pip install diffusers[training] accelerate transformers
+pip install diffusers"[training]" accelerate "transformers>=4.21.0"
 ```
 
 And initialize an [🤗Accelerate](https://github.com/huggingface/accelerate/) environment with:

--- a/examples/textual_inversion/requirements.txt
+++ b/examples/textual_inversion/requirements.txt
@@ -1,3 +1,3 @@
 accelerate
 torchvision
-transformers
+transformers>=4.21.0


### PR DESCRIPTION
This PR updates the minimum version of `transformers` to `4.21.0` as the `subfolder` argument is not supported in previous versions.

Fixes #579