### PR TITLE
[CLIPGuidedStableDiffusion] take the correct text embeddings

### DIFF
--- a/examples/community/clip_guided_stable_diffusion.py
+++ b/examples/community/clip_guided_stable_diffusion.py
@@ -284,7 +284,7 @@ class CLIPGuidedStableDiffusion(DiffusionPipeline):
             # perform clip guidance
             if clip_guidance_scale > 0:
                 text_embeddings_for_guidance = (
-                    text_embeddings.chunk(2)[0] if do_classifier_free_guidance else text_embeddings
+                    text_embeddings.chunk(2)[1] if do_classifier_free_guidance else text_embeddings
                 )
                 noise_pred, latents = self.cond_fn(
                     latents,


### PR DESCRIPTION
There was a major bug in the `CLIPGuidedStableDiffusion` pipeline. While doing CLIP guidance it was using the uncond embeddings if classifier free guidance was turned on. This PR fixes it. Thanks a lot for spotting this @keturn

Fixes: #596
