### PR TITLE
[dreambooth] fix applying clip_grad_norm_

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -566,7 +566,8 @@ def main():
                     loss = F.mse_loss(noise_pred, noise, reduction="none").mean([1, 2, 3]).mean()
 
                 accelerator.backward(loss)
-                accelerator.clip_grad_norm_(unet.parameters(), args.max_grad_norm)
+                if accelerator.sync_gradients:
+                    accelerator.clip_grad_norm_(unet.parameters(), args.max_grad_norm)
                 optimizer.step()
                 lr_scheduler.step()
                 optimizer.zero_grad()


### PR DESCRIPTION
Fix gradient clipping when doing gradient accumulation. The gradients needs to clipped after they are synchronized when doing accumulation. cf https://github.com/huggingface/accelerate/issues/641#issuecomment-1219910080
fixes #668

Although not sure why it only got triggered only in half-precision.