### PR TITLE
Begin simplifying CrossAttention so that it works better on the Apple Neural Engine

### DIFF
--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -279,7 +279,7 @@ class CrossAttention(nn.Module):
 
     def _attention(self, query, key, value):
         batch_size, sequence_length, heads, last_dim = query.shape
-        attn = torch.einsum('bjhd,bihd->bhji', query, key)
+        attn = torch.einsum("bjhd,bihd->bhji", query, key)
         attn = (attn * self.scale).softmax(dim=-1)
 
         value = value.permute(0, 2, 1, 3)

--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -288,20 +288,6 @@ class CrossAttention(nn.Module):
         attn = attn.permute(0, 2, 1, 3)
         return attn.reshape(batch_size, sequence_length, self.heads * last_dim)
 
-        # attention_scores = torch.baddbmm(
-        #     torch.empty(query.shape[0], query.shape[1], key.shape[1], dtype=query.dtype, device=query.device),
-        #     query,
-        #     key.transpose(-1, -2),
-        #     beta=0,
-        #     alpha=self.scale,
-        # )
-        # attention_probs = attention_scores.softmax(dim=-1)
-        # # compute attention output
-        # hidden_states = torch.matmul(attention_probs, value)
-        # # reshape hidden_states
-        # hidden_states = self.reshape_batch_dim_to_heads(hidden_states)
-        # return hidden_states
-
     def _sliced_attention(self, query, key, value, sequence_length, dim):
         batch_size_attention = query.shape[0]
         hidden_states = torch.zeros(

--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -288,6 +288,20 @@ class CrossAttention(nn.Module):
         attn = attn.permute(0, 2, 1, 3)
         return attn.reshape(batch_size, sequence_length, self.heads * last_dim)
 
+        # attention_scores = torch.baddbmm(
+        #     torch.empty(query.shape[0], query.shape[1], key.shape[1], dtype=query.dtype, device=query.device),
+        #     query,
+        #     key.transpose(-1, -2),
+        #     beta=0,
+        #     alpha=self.scale,
+        # )
+        # attention_probs = attention_scores.softmax(dim=-1)
+        # # compute attention output
+        # hidden_states = torch.matmul(attention_probs, value)
+        # # reshape hidden_states
+        # hidden_states = self.reshape_batch_dim_to_heads(hidden_states)
+        # return hidden_states
+
     def _sliced_attention(self, query, key, value, sequence_length, dim):
         batch_size_attention = query.shape[0]
         hidden_states = torch.zeros(

--- a/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
+++ b/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
@@ -179,7 +179,7 @@ LDMBERT_PRETRAINED_MODEL_ARCHIVE_LIST = [
 
 
 LDMBERT_PRETRAINED_CONFIG_ARCHIVE_MAP = {
-    "ldm-bert": "https://huggingface.co/ldm-bert/resolve/main/config.json",
+    "ldm-bert": "https://huggingface.co/valhalla/ldm-bert/blob/main/config.json",
 }
 
 


### PR DESCRIPTION
Hi folks,

This is to [address this issue](https://github.com/huggingface/diffusers/issues/669).

I converted this CrossAttention portion with coremltools, and it does in fact remove about 4 reshape operation and a few transposes, getting down to, 4 transposes and 4 reshapes left.

Unfortunately, it seems that is still too many to compile on the ANE.

Any ideas about what else I could do to simplify this? I took a stab at using another einsum for the attn and value matmul, but I don't think I was doing it correctly.