### PR TITLE
[Support PyTorch 1.8] Remove inference mode

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/safety_checker.py
+++ b/src/diffusers/pipelines/stable_diffusion/safety_checker.py
@@ -79,7 +79,7 @@ class StableDiffusionSafetyChecker(PreTrainedModel):
 
         return images, has_nsfw_concepts
 
-    @torch.inference_mode()
+    @torch.no_grad()
     def forward_onnx(self, clip_input: torch.FloatTensor, images: torch.FloatTensor):
         pooled_output = self.vision_model(clip_input)[1]  # pooled_output
         image_embeds = self.visual_projection(pooled_output)


### PR DESCRIPTION
Let's try to not force high PyTorch versions if we can avoid it.
Inference mode was only introduced in PyTorch 1.9. The safety checker is used in many different other libraries (mainly `ComVis/stable-diffusion`) and we don't want to force these libraries to use higher PyTorch versions.

cc @anton-l 