### PR TITLE
[CI] Speed up slow tests

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cpu --cache-dir="$PIP_CACHE"
+        python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
         python -m pip install -e .[quality,test]
 
     - name: Environment

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   run_tests_cpu:
-    name: PyTorch tests
+    name: Diffusers tests
     runs-on: [ self-hosted, docker-gpu ]
     container:
       image: python:3.7

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -11,7 +11,6 @@ concurrency:
 
 env:
   HF_HOME: /mnt/cache
-  PIP_CACHE: /mnt/pip_cache
   OMP_NUM_THREADS: 8
   MKL_NUM_THREADS: 8
   PYTEST_TIMEOUT: 60
@@ -22,7 +21,7 @@ jobs:
     runs-on: [ self-hosted, docker-gpu ]
     container:
       image: python:3.7
-      options: --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache/ -v /mnt/pip_cache:/mnt/pip_cache
+      options: --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache/
 
     steps:
     - name: Checkout diffusers
@@ -34,7 +33,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cpu --cache-dir="$PIP_CACHE"
-        python -m pip install -e .[quality,test] --cache-dir="$PIP_CACHE"
+        python -m pip install -e .[quality,test]
 
     - name: Environment
       run: |

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   run_tests_cpu:
-    name: Diffusers tests
+    name: PyTorch tests
     runs-on: [ self-hosted, docker-gpu ]
     container:
       image: python:3.7

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [ self-hosted, docker-gpu ]
     container:
       image: python:3.7
-      options: --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache/ -v /mnt/pip_cache:/root/.cache/pip
+      options: --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache/ -v /mnt/pip_cache:/mnt/pip_cache
 
     steps:
     - name: Checkout diffusers
@@ -32,8 +32,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
-        python -m pip install -e .[quality,test]
+        python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cpu --cache-dir="$PIP_CACHE"
+        python -m pip install -e .[quality,test] --cache-dir="$PIP_CACHE"
 
     - name: Environment
       run: |

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [ self-hosted, docker-gpu ]
     container:
       image: python:3.7
-      options: --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache/ -v /mnt/pip_cache:/root/.cache/pip
 
     steps:
     - name: Checkout diffusers

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -11,6 +11,7 @@ concurrency:
 
 env:
   HF_HOME: /mnt/cache
+  PIP_CACHE: /mnt/pip_cache
   OMP_NUM_THREADS: 8
   MKL_NUM_THREADS: 8
   PYTEST_TIMEOUT: 60

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 env:
   HF_HOME: /mnt/cache

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   HF_HOME: /mnt/cache
+  PIP_CACHE: /mnt/pip_cache
   OMP_NUM_THREADS: 8
   MKL_NUM_THREADS: 8
   PYTEST_TIMEOUT: 1000
@@ -25,7 +26,7 @@ jobs:
     runs-on: [ self-hosted, docker-gpu, '${{ matrix.machine_type }}' ]
     container:
       image: nvcr.io/nvidia/pytorch:22.07-py3
-      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache/ -v /mnt/pip_cache:/root/.cache/pip
+      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:"$HF_HOME" -v /mnt/pip_cache:"$PIP_CACHE"
 
     steps:
     - name: Checkout diffusers
@@ -41,8 +42,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip uninstall -y torch torchvision torchtext
-        python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cu116
-        python -m pip install -e .[quality,test]
+        python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cu116 --cache-dir="$PIP_CACHE"
+        python -m pip install -e .[quality,test] --cache-dir="$PIP_CACHE"
 
     - name: Environment
       run: |
@@ -76,7 +77,7 @@ jobs:
     runs-on: [ self-hosted, docker-gpu, '${{ matrix.machine_type }}' ]
     container:
       image: nvcr.io/nvidia/pytorch:22.07-py3
-      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache/ -v /mnt/pip_cache:/root/.cache/pip
+      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:"$HF_HOME" -v /mnt/pip_cache:"$PIP_CACHE"
 
     steps:
     - name: Checkout diffusers
@@ -92,8 +93,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip uninstall -y torch torchvision torchtext
-        python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cu116
-        python -m pip install -e .[quality,test,training]
+        python -m pip --cache-dir=/mnt/pip_cache install torch --extra-index-url https://download.pytorch.org/whl/cu116 --cache-dir="$PIP_CACHE"
+        python -m pip install -e .[quality,test,training] --cache-dir="$PIP_CACHE"
 
     - name: Environment
       run: |

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: [ self-hosted, docker-gpu, '${{ matrix.machine_type }}' ]
     container:
       image: nvcr.io/nvidia/pytorch:22.07-py3
-      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:"$HF_HOME" -v /mnt/pip_cache:"$PIP_CACHE"
+      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache -v /mnt/pip_cache:/mnt/pip_cache
 
     steps:
     - name: Checkout diffusers
@@ -77,7 +77,7 @@ jobs:
     runs-on: [ self-hosted, docker-gpu, '${{ matrix.machine_type }}' ]
     container:
       image: nvcr.io/nvidia/pytorch:22.07-py3
-      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:"$HF_HOME" -v /mnt/pip_cache:"$PIP_CACHE"
+      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache -v /mnt/pip_cache:/mnt/pip_cache
 
     steps:
     - name: Checkout diffusers

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -19,11 +19,7 @@ env:
 jobs:
   run_tests_single_gpu:
     name: Diffusers tests
-    strategy:
-      fail-fast: false
-      matrix:
-        machine_type: [ single-gpu ]
-    runs-on: [ self-hosted, docker-gpu, '${{ matrix.machine_type }}' ]
+    runs-on: [ self-hosted, docker-gpu, single-gpu ]
     container:
       image: nvcr.io/nvidia/pytorch:22.07-py3
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache -v /mnt/pip_cache:/mnt/pip_cache
@@ -70,11 +66,7 @@ jobs:
 
   run_examples_single_gpu:
     name: Examples tests
-    strategy:
-      fail-fast: false
-      matrix:
-        machine_type: [ single-gpu ]
-    runs-on: [ self-hosted, docker-gpu, '${{ matrix.machine_type }}' ]
+    runs-on: [ self-hosted, docker-gpu, single-gpu ]
     container:
       image: nvcr.io/nvidia/pytorch:22.07-py3
       options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache -v /mnt/pip_cache:/mnt/pip_cache

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   HF_HOME: /mnt/cache
-  PIP_CACHE: /mnt/pip_cache
   OMP_NUM_THREADS: 8
   MKL_NUM_THREADS: 8
   PYTEST_TIMEOUT: 1000
@@ -22,7 +21,7 @@ jobs:
     runs-on: [ self-hosted, docker-gpu, single-gpu ]
     container:
       image: nvcr.io/nvidia/pytorch:22.07-py3
-      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache -v /mnt/pip_cache:/mnt/pip_cache
+      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache
 
     steps:
     - name: Checkout diffusers
@@ -38,8 +37,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip uninstall -y torch torchvision torchtext
-        python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cu116 --cache-dir="$PIP_CACHE"
-        python -m pip install -e .[quality,test] --cache-dir="$PIP_CACHE"
+        python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cu116
+        python -m pip install -e .[quality,test]
 
     - name: Environment
       run: |
@@ -69,7 +68,7 @@ jobs:
     runs-on: [ self-hosted, docker-gpu, single-gpu ]
     container:
       image: nvcr.io/nvidia/pytorch:22.07-py3
-      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache -v /mnt/pip_cache:/mnt/pip_cache
+      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache
 
     steps:
     - name: Checkout diffusers
@@ -85,8 +84,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip uninstall -y torch torchvision torchtext
-        python -m pip --cache-dir=/mnt/pip_cache install torch --extra-index-url https://download.pytorch.org/whl/cu116 --cache-dir="$PIP_CACHE"
-        python -m pip install -e .[quality,test,training] --cache-dir="$PIP_CACHE"
+        python -m pip install torch --extra-index-url https://download.pytorch.org/whl/cu116
+        python -m pip install -e .[quality,test,training]
 
     - name: Environment
       run: |

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 env:
   HF_HOME: /mnt/cache
@@ -22,7 +25,7 @@ jobs:
     runs-on: [ self-hosted, docker-gpu, '${{ matrix.machine_type }}' ]
     container:
       image: nvcr.io/nvidia/pytorch:22.07-py3
-      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache/ -v /mnt/pip_cache:/root/.cache/pip
 
     steps:
     - name: Checkout diffusers
@@ -73,7 +76,7 @@ jobs:
     runs-on: [ self-hosted, docker-gpu, '${{ matrix.machine_type }}' ]
     container:
       image: nvcr.io/nvidia/pytorch:22.07-py3
-      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+      options: --gpus 0 --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache/ -v /mnt/pip_cache:/root/.cache/pip
 
     steps:
     - name: Checkout diffusers

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ _deps = [
     "jaxlib>=0.1.65,<=0.3.6",
     "modelcards>=0.1.4",
     "numpy",
-    "onnxruntime-gpu",
+    "onnxruntime",
     "pytest",
     "pytest-timeout",
     "pytest-xdist",
@@ -178,7 +178,7 @@ extras["docs"] = deps_list("hf-doc-builder")
 extras["training"] = deps_list("accelerate", "datasets", "tensorboard", "modelcards")
 extras["test"] = deps_list(
     "datasets",
-    "onnxruntime-gpu",
+    "onnxruntime",
     "pytest",
     "pytest-timeout",
     "pytest-xdist",

--- a/src/diffusers/dependency_versions_table.py
+++ b/src/diffusers/dependency_versions_table.py
@@ -17,7 +17,7 @@ deps = {
     "jaxlib": "jaxlib>=0.1.65,<=0.3.6",
     "modelcards": "modelcards>=0.1.4",
     "numpy": "numpy",
-    "onnxruntime-gpu": "onnxruntime-gpu",
+    "onnxruntime": "onnxruntime",
     "pytest": "pytest",
     "pytest-timeout": "pytest-timeout",
     "pytest-xdist": "pytest-xdist",

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1422,18 +1422,18 @@ class PipelineTesterMixin(unittest.TestCase):
     @slow
     def test_stable_diffusion_onnx(self):
         sd_pipe = StableDiffusionOnnxPipeline.from_pretrained(
-            "CompVis/stable-diffusion-v1-4", revision="onnx", provider="CUDAExecutionProvider", use_auth_token=True
+            "CompVis/stable-diffusion-v1-4", revision="onnx", provider="CPUExecutionProvider", use_auth_token=True
         )
 
         prompt = "A painting of a squirrel eating a burger"
         np.random.seed(0)
-        output = sd_pipe([prompt], guidance_scale=6.0, num_inference_steps=20, output_type="np")
+        output = sd_pipe([prompt], guidance_scale=6.0, num_inference_steps=5, output_type="np")
         image = output.images
 
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 512, 512, 3)
-        expected_slice = np.array([0.0385, 0.0252, 0.0234, 0.0287, 0.0358, 0.0287, 0.0276, 0.0235, 0.0010])
+        expected_slice = np.array([0.3602, 0.3688, 0.3652, 0.3895, 0.3782, 0.3747, 0.3927, 0.4241, 0.4327])
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-3
 
     @slow
@@ -1592,7 +1592,7 @@ class PipelineTesterMixin(unittest.TestCase):
                 assert latents.shape == (1, 4, 64, 64)
                 latents_slice = latents[0, -3:, -3:, -1]
                 expected_slice = np.array(
-                    [-0.6254, -0.2742, -1.0710, 0.2296, -1.1683, 0.6913, -2.0605, -0.0682, 0.9700]
+                    [-0.5950, -0.3039, -1.1672, 0.1594, -1.1572, 0.6719, -1.9712, -0.0403, 0.9592]
                 )
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 1e-3
 
@@ -1606,6 +1606,6 @@ class PipelineTesterMixin(unittest.TestCase):
         prompt = "Andromeda galaxy in a bottle"
 
         np.random.seed(0)
-        pipe(prompt=prompt, num_inference_steps=50, guidance_scale=7.5, callback=test_callback_fn, callback_steps=1)
+        pipe(prompt=prompt, num_inference_steps=5, guidance_scale=7.5, callback=test_callback_fn, callback_steps=1)
         assert test_callback_fn.has_been_called
-        assert number_of_steps == 51
+        assert number_of_steps == 6


### PR DESCRIPTION
* Use a local Hub cache instead of NFS
* Less ONNX pipeline steps, use CPU runtime (needs a custom docker image for CUDA to work)