### PR TITLE
Avoid negative strides for tensors

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -281,15 +281,9 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
         latents = init_latents
 
         t_start = max(num_inference_steps - init_timestep + offset, 0)
+        timesteps = self.scheduler.timesteps[t_start:]
 
-        # Some schedulers like PNDM have timesteps as arrays
-        # It's more optimzed to move all timesteps to correct device beforehand
-        if torch.is_tensor(self.scheduler.timesteps):
-            timesteps_tensor = torch.tensor(self.scheduler.timesteps[t_start:], device=self.device)
-        else:
-            timesteps_tensor = torch.tensor(self.scheduler.timesteps.copy()[t_start:], device=self.device)
-
-        for i, t in enumerate(self.progress_bar(timesteps_tensor)):
+        for i, t in enumerate(self.progress_bar(timesteps)):
             t_index = t_start + i
 
             # expand the latents if we are doing classifier free guidance

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -284,7 +284,10 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
 
         # Some schedulers like PNDM have timesteps as arrays
         # It's more optimzed to move all timesteps to correct device beforehand
-        timesteps_tensor = torch.tensor(self.scheduler.timesteps[t_start:], device=self.device)
+        if torch.is_tensor(self.scheduler.timesteps):
+            timesteps_tensor = torch.tensor(self.scheduler.timesteps[t_start:], device=self.device)
+        else:
+            timesteps_tensor = torch.tensor(self.scheduler.timesteps.copy()[t_start:], device=self.device)
 
         for i, t in enumerate(self.progress_bar(timesteps_tensor)):
             t_index = t_start + i

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -315,7 +315,7 @@ class StableDiffusionInpaintPipeline(DiffusionPipeline):
         latents = init_latents
 
         t_start = max(num_inference_steps - init_timestep + offset, 0)
-        timesteps = self.scheduler.timesteps.copy()[t_start:]
+        timesteps = self.scheduler.timesteps[t_start:]
 
         for i, t in tqdm(enumerate(timesteps)):
             t_index = t_start + i

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -318,7 +318,10 @@ class StableDiffusionInpaintPipeline(DiffusionPipeline):
 
         # Some schedulers like PNDM have timesteps as arrays
         # It's more optimzed to move all timesteps to correct device beforehand
-        timesteps_tensor = torch.tensor(self.scheduler.timesteps[t_start:], device=self.device)
+        if torch.is_tensor(self.scheduler.timesteps):
+            timesteps_tensor = torch.tensor(self.scheduler.timesteps[t_start:], device=self.device)
+        else:
+            timesteps_tensor = torch.tensor(self.scheduler.timesteps.copy()[t_start:], device=self.device)
 
         for i, t in tqdm(enumerate(timesteps_tensor)):
             t_index = t_start + i

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -315,15 +315,9 @@ class StableDiffusionInpaintPipeline(DiffusionPipeline):
         latents = init_latents
 
         t_start = max(num_inference_steps - init_timestep + offset, 0)
+        timesteps = self.scheduler.timesteps.copy()[t_start:]
 
-        # Some schedulers like PNDM have timesteps as arrays
-        # It's more optimzed to move all timesteps to correct device beforehand
-        if torch.is_tensor(self.scheduler.timesteps):
-            timesteps_tensor = torch.tensor(self.scheduler.timesteps[t_start:], device=self.device)
-        else:
-            timesteps_tensor = torch.tensor(self.scheduler.timesteps.copy()[t_start:], device=self.device)
-
-        for i, t in tqdm(enumerate(timesteps_tensor)):
+        for i, t in tqdm(enumerate(timesteps)):
             t_index = t_start + i
             # expand the latents if we are doing classifier free guidance
             latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents


### PR DESCRIPTION
The original lines cause the following error for tensors.
```
At least one stride in the given numpy array is negative, and tensors with negative strides are not currently supported. (You can probably work around this by making a copy of your array  with array.copy().) 
```

The same operation is done here.

https://github.com/huggingface/diffusers/blob/f1484b81b0b763aa010fd2083df933305afb1812/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L253-L258

(Probably related to #551 )