### PR TITLE
[train_unconditional] fix applying clip_grad_norm_

### DIFF
--- a/examples/unconditional_image_generation/train_unconditional.py
+++ b/examples/unconditional_image_generation/train_unconditional.py
@@ -143,7 +143,8 @@ def main(args):
                 loss = F.mse_loss(noise_pred, noise)
                 accelerator.backward(loss)
 
-                accelerator.clip_grad_norm_(model.parameters(), 1.0)
+                if accelerator.sync_gradients:
+                    accelerator.clip_grad_norm_(model.parameters(), 1.0)
                 optimizer.step()
                 lr_scheduler.step()
                 if args.use_ema:


### PR DESCRIPTION
Fix gradient clipping when doing gradient accumulation. The gradients needs to clipped after they are synchronized when doing accumulation. cf huggingface/accelerate#641 (comment)
fixes #499

Although not sure why it only got triggered only in half-precision.