### PR TITLE
Fix ONNX conversion script opset argument type

### DIFF
--- a/scripts/convert_stable_diffusion_checkpoint_to_onnx.py
+++ b/scripts/convert_stable_diffusion_checkpoint_to_onnx.py
@@ -206,7 +206,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--opset",
         default=14,
-        type=str,
+        type=int,
         help="The version of the ONNX operator set to use.",
     )
 


### PR DESCRIPTION
The opset argument should be an `int` but was set as a `str`. This caused torch.onnx.export to fail when users specified a non-default opset version.