### PR TITLE
remove use_auth_token from for TI test

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -102,7 +102,6 @@ class ExamplesTestsAccelerate(unittest.TestCase):
             test_args = f"""
                 examples/textual_inversion/textual_inversion.py
                 --pretrained_model_name_or_path CompVis/stable-diffusion-v1-4
-                --use_auth_token
                 --train_data_dir docs/source/imgs
                 --learnable_property object
                 --placeholder_token <cat-toy>


### PR DESCRIPTION
The `test_textual_inversion` test was failing because it was passing the `--use_auth_token` arg, which is now removed.