### PR TITLE
Raise an error when moving an fp16 pipeline to CPU

### DIFF
--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -168,9 +168,9 @@ class DiffusionPipeline(ConfigMixin):
             if isinstance(module, torch.nn.Module):
                 if module.dtype == torch.float16 and str(torch_device) in ["cpu", "mps"]:
                     raise ValueError(
-                        "pipeline loaded with `torch_dtype=torch.float16`  can not be put on CPU directly "
-                        "due to the lack of support for `float16` operations on CPU in PyTorch. "
-                        "Please remove the `torch_dtype=torch.float16` argument or set it to `torch_dtype=torch.float32` to use it on cpu"
+                        "Pipelines loaded with `torch_dtype=torch.float16` cannot be moved to `cpu` or `mps` "
+                        "due to the lack of support for `float16` operations on those devices in PyTorch. "
+                        "Please remove the `torch_dtype=torch.float16` argument, or use a `gpu` device."
                     )
                 module.to(torch_device)
         return self

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -166,7 +166,7 @@ class DiffusionPipeline(ConfigMixin):
         for name in module_names.keys():
             module = getattr(self, name)
             if isinstance(module, torch.nn.Module):
-                if module.dtype == torch.float16 and str(torch_device) == "cpu":
+                if module.dtype == torch.float16 and str(torch_device) in ["cpu", "mps"]:
                     raise ValueError(
                         "Cannot use `pipeline.to('cpu')` with a pipeline loaded with `torch_dtype=torch.float16` "
                         "due to the lack of support for `float16` operations on CPU in PyTorch."

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -168,8 +168,8 @@ class DiffusionPipeline(ConfigMixin):
             if isinstance(module, torch.nn.Module):
                 if module.dtype == torch.float16 and str(torch_device) == "cpu":
                     raise ValueError(
-                        f"Cannot use `pipeline.to('cpu')` with a pipeline loaded with `torch_dtype=torch.float16` "
-                        f"due to the lack of support for `float16` operations on CPU in PyTorch."
+                        "Cannot use `pipeline.to('cpu')` with a pipeline loaded with `torch_dtype=torch.float16` "
+                        "due to the lack of support for `float16` operations on CPU in PyTorch."
                     )
                 module.to(torch_device)
         return self

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -170,7 +170,7 @@ class DiffusionPipeline(ConfigMixin):
                     raise ValueError(
                         "Pipelines loaded with `torch_dtype=torch.float16` cannot be moved to `cpu` or `mps` "
                         "due to the lack of support for `float16` operations on those devices in PyTorch. "
-                        "Please remove the `torch_dtype=torch.float16` argument, or use a `gpu` device."
+                        "Please remove the `torch_dtype=torch.float16` argument, or use a `cuda` device."
                     )
                 module.to(torch_device)
         return self

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -166,6 +166,11 @@ class DiffusionPipeline(ConfigMixin):
         for name in module_names.keys():
             module = getattr(self, name)
             if isinstance(module, torch.nn.Module):
+                if module.dtype == torch.float16 and str(torch_device) == "cpu":
+                    raise ValueError(
+                        f"Cannot use `pipeline.to('cpu')` with a pipeline loaded with `torch_dtype=torch.float16` "
+                        f"due to the lack of support for `float16` operations on CPU in PyTorch."
+                    )
                 module.to(torch_device)
         return self
 

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -168,8 +168,9 @@ class DiffusionPipeline(ConfigMixin):
             if isinstance(module, torch.nn.Module):
                 if module.dtype == torch.float16 and str(torch_device) in ["cpu", "mps"]:
                     raise ValueError(
-                        "Cannot use `pipeline.to('cpu')` with a pipeline loaded with `torch_dtype=torch.float16` "
-                        "due to the lack of support for `float16` operations on CPU in PyTorch."
+                        "pipeline loaded with `torch_dtype=torch.float16`  can not be put on CPU directly "
+                        "due to the lack of support for `float16` operations on CPU in PyTorch. "
+                        "Please remove the `torch_dtype=torch.float16` argument or set it to `torch_dtype=torch.float32` to use it on cpu"
                     )
                 module.to(torch_device)
         return self

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -188,6 +188,17 @@ class PipelineFastTests(unittest.TestCase):
 
         return extract
 
+    def test_pipeline_fp16_cpu_error(self):
+        model = self.dummy_uncond_unet
+        scheduler = DDPMScheduler(num_train_timesteps=10)
+        pipe = DDIMPipeline(model.half(), scheduler)
+
+        if str(torch_device) == "cpu":
+            self.assertRaises(ValueError, pipe.to, torch_device)
+        else:
+            # moving the pipeline to GPU should work
+            pipe.to(torch_device)
+
     def test_ddim(self):
         unet = self.dummy_uncond_unet
         scheduler = DDIMScheduler()

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -193,7 +193,7 @@ class PipelineFastTests(unittest.TestCase):
         scheduler = DDPMScheduler(num_train_timesteps=10)
         pipe = DDIMPipeline(model.half(), scheduler)
 
-        if str(torch_device) == "cpu":
+        if str(torch_device) in ["cpu", "mps"]:
             self.assertRaises(ValueError, pipe.to, torch_device)
         else:
             # moving the pipeline to GPU should work


### PR DESCRIPTION
Since our default now is to recommend `fp16` models instead of using `autocast`, the cryptic CPU+fp16 errors might become more frequent among unsuspecting users:
`RuntimeError: "LayerNormKernelImpl" not implemented for 'Half'`

This PR adds an error when `pipe.to("cpu")` is used with an `fp16` model:
```
ValueError: Cannot use `pipeline.to('cpu')` with a pipeline loaded with `torch_dtype=torch.float16` due to the lack of support for `float16` operations on CPU in PyTorch.
```