### PR TITLE
`mps`: Alternative implementation for `repeat_interleave`

### DIFF
--- a/docs/source/optimization/mps.mdx
+++ b/docs/source/optimization/mps.mdx
@@ -19,7 +19,7 @@ specific language governing permissions and limitations under the License.
 - Mac computer with Apple silicon (M1/M2) hardware.
 - macOS 12.3 or later.
 - arm64 version of Python.
-- PyTorch [Preview (Nightly)](https://pytorch.org/get-started/locally/), version `1.13.0.dev20220830` or later.
+- PyTorch [Preview (Nightly)](https://pytorch.org/get-started/locally/), version `1.14.0.dev20221007` or later.
 
 ## Inference Pipeline
 

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -219,7 +219,12 @@ class StableDiffusionPipeline(DiffusionPipeline):
         text_embeddings = self.text_encoder(text_input_ids.to(self.device))[0]
 
         # duplicate text embeddings for each generation per prompt
-        text_embeddings = text_embeddings.repeat_interleave(num_images_per_prompt, dim=0)
+        if self.device.type == "mps":
+            # Workaround for `repeat_interleave`. Assumes 3 dims.
+            d0, d1, _ = text_embeddings.shape
+            text_embeddings = text_embeddings.repeat(1, num_images_per_prompt, 1).view(d0*num_images_per_prompt, d1, -1)
+        else:
+            text_embeddings = text_embeddings.repeat_interleave(num_images_per_prompt, dim=0)
 
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
@@ -257,7 +262,12 @@ class StableDiffusionPipeline(DiffusionPipeline):
             uncond_embeddings = self.text_encoder(uncond_input.input_ids.to(self.device))[0]
 
             # duplicate unconditional embeddings for each generation per prompt
-            uncond_embeddings = uncond_embeddings.repeat_interleave(batch_size * num_images_per_prompt, dim=0)
+            if self.device.type == "mps":
+                # Workaround for `repeat_interleave`. Assumes 3 dims.
+                d0, d1, _ = uncond_embeddings.shape
+                uncond_embeddings = uncond_embeddings.repeat(1, num_images_per_prompt, 1).view(d0*num_images_per_prompt, d1, -1)
+            else:
+                uncond_embeddings = uncond_embeddings.repeat_interleave(batch_size * num_images_per_prompt, dim=0)
 
             # For classifier free guidance, we need to do two forward passes.
             # Here we concatenate the unconditional and text embeddings into a single batch

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -218,7 +218,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
             text_input_ids = text_input_ids[:, : self.tokenizer.model_max_length]
         text_embeddings = self.text_encoder(text_input_ids.to(self.device))[0]
 
-        # duplicate text embeddings for each generation per prompt, using mps friendly method 
+        # duplicate text embeddings for each generation per prompt, using mps friendly method
         batch_size, seq_len, _ = text_embeddings.shape
         text_embeddings = text_embeddings.repeat(1, num_images_per_prompt, 1).view(
             batch_size * num_images_per_prompt, seq_len, -1

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -222,7 +222,9 @@ class StableDiffusionPipeline(DiffusionPipeline):
         if self.device.type == "mps":
             # Workaround for `repeat_interleave`. Assumes 3 dims.
             d0, d1, _ = text_embeddings.shape
-            text_embeddings = text_embeddings.repeat(1, num_images_per_prompt, 1).view(d0*num_images_per_prompt, d1, -1)
+            text_embeddings = text_embeddings.repeat(1, num_images_per_prompt, 1).view(
+                d0 * num_images_per_prompt, d1, -1
+            )
         else:
             text_embeddings = text_embeddings.repeat_interleave(num_images_per_prompt, dim=0)
 
@@ -265,7 +267,9 @@ class StableDiffusionPipeline(DiffusionPipeline):
             if self.device.type == "mps":
                 # Workaround for `repeat_interleave`. Assumes 3 dims.
                 d0, d1, _ = uncond_embeddings.shape
-                uncond_embeddings = uncond_embeddings.repeat(1, num_images_per_prompt, 1).view(d0*num_images_per_prompt, d1, -1)
+                uncond_embeddings = uncond_embeddings.repeat(1, num_images_per_prompt, 1).view(
+                    d0 * num_images_per_prompt, d1, -1
+                )
             else:
                 uncond_embeddings = uncond_embeddings.repeat_interleave(batch_size * num_images_per_prompt, dim=0)
 

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -219,9 +219,9 @@ class StableDiffusionPipeline(DiffusionPipeline):
         text_embeddings = self.text_encoder(text_input_ids.to(self.device))[0]
 
         # duplicate text embeddings for each generation per prompt, using mps friendly method
-        batch_size, seq_len, _ = text_embeddings.shape
+        bs_embed, seq_len, _ = text_embeddings.shape
         text_embeddings = text_embeddings.repeat(1, num_images_per_prompt, 1).view(
-            batch_size * num_images_per_prompt, seq_len, -1
+            bs_embed * num_images_per_prompt, seq_len, -1
         )
 
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
@@ -260,8 +260,8 @@ class StableDiffusionPipeline(DiffusionPipeline):
             uncond_embeddings = self.text_encoder(uncond_input.input_ids.to(self.device))[0]
 
             # duplicate unconditional embeddings for each generation per prompt, using mps friendly method
-            batch_size, seq_len, _ = uncond_embeddings.shape
-            uncond_embeddings = uncond_embeddings.repeat(1, num_images_per_prompt, 1).view(
+            seq_len = uncond_embeddings.shape[1]
+            uncond_embeddings = uncond_embeddings.repeat(batch_size, num_images_per_prompt, 1).view(
                 batch_size * num_images_per_prompt, seq_len, -1
             )
 

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -220,9 +220,8 @@ class StableDiffusionPipeline(DiffusionPipeline):
 
         # duplicate text embeddings for each generation per prompt, using mps friendly method
         bs_embed, seq_len, _ = text_embeddings.shape
-        text_embeddings = text_embeddings.repeat(1, num_images_per_prompt, 1).view(
-            bs_embed * num_images_per_prompt, seq_len, -1
-        )
+        text_embeddings = text_embeddings.repeat(1, num_images_per_prompt, 1)
+        text_embeddings = text_embeddings.view(bs_embed * num_images_per_prompt, seq_len, -1)
 
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
@@ -261,9 +260,8 @@ class StableDiffusionPipeline(DiffusionPipeline):
 
             # duplicate unconditional embeddings for each generation per prompt, using mps friendly method
             seq_len = uncond_embeddings.shape[1]
-            uncond_embeddings = uncond_embeddings.repeat(batch_size, num_images_per_prompt, 1).view(
-                batch_size * num_images_per_prompt, seq_len, -1
-            )
+            uncond_embeddings = uncond_embeddings.repeat(batch_size, num_images_per_prompt, 1)
+            uncond_embeddings = uncond_embeddings.view(batch_size * num_images_per_prompt, seq_len, -1)
 
             # For classifier free guidance, we need to do two forward passes.
             # Here we concatenate the unconditional and text embeddings into a single batch

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -221,9 +221,9 @@ class StableDiffusionPipeline(DiffusionPipeline):
         # duplicate text embeddings for each generation per prompt
         if self.device.type == "mps":
             # Workaround for `repeat_interleave`. Assumes 3 dims.
-            d0, d1, _ = text_embeddings.shape
+            batch_size, seq_len, _ = text_embeddings.shape
             text_embeddings = text_embeddings.repeat(1, num_images_per_prompt, 1).view(
-                d0 * num_images_per_prompt, d1, -1
+                batch_size * num_images_per_prompt, seq_len, -1
             )
         else:
             text_embeddings = text_embeddings.repeat_interleave(num_images_per_prompt, dim=0)
@@ -266,9 +266,9 @@ class StableDiffusionPipeline(DiffusionPipeline):
             # duplicate unconditional embeddings for each generation per prompt
             if self.device.type == "mps":
                 # Workaround for `repeat_interleave`. Assumes 3 dims.
-                d0, d1, _ = uncond_embeddings.shape
+                 batch_size, seq_len, _ = uncond_embeddings.shape
                 uncond_embeddings = uncond_embeddings.repeat(1, num_images_per_prompt, 1).view(
-                    d0 * num_images_per_prompt, d1, -1
+                    batch_size * num_images_per_prompt, seq_len, -1
                 )
             else:
                 uncond_embeddings = uncond_embeddings.repeat_interleave(batch_size * num_images_per_prompt, dim=0)


### PR DESCRIPTION
Fixes #760.

`repeat_interleave` was slowing things down, but not causing wrong outputs. Something between `v0.3.0` and `v0.4.0` (possibly some of the optimization changes) broke generation in `mps`. Fortunately, the latest `mps` version of PyTorch nightly (released today) works fine 😅, so I'm updating the documentation to recommend it.
