### PR TITLE
support bf16 for stable diffusion

### DIFF
--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -41,6 +41,8 @@ class Upsample2D(nn.Module):
             return self.conv(hidden_states)
 
         # Cast to float32 to as 'upsample_nearest2d_out_frame' op does not support bfloat16
+        # TODO(Suraj): Remove this cast once the issue is fixed in PyTorch
+        # https://github.com/pytorch/pytorch/issues/86679
         dtype = hidden_states.dtype
         if dtype == torch.bfloat16:
             hidden_states = hidden_states.to(torch.float32)

--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -40,12 +40,21 @@ class Upsample2D(nn.Module):
         if self.use_conv_transpose:
             return self.conv(hidden_states)
 
+        # Cast to float32 to as 'upsample_nearest2d_out_frame' op does not support bfloat16
+        dtype = hidden_states.dtype
+        if dtype == torch.bfloat16:
+            hidden_states = hidden_states.to(torch.float32)
+
         # if `output_size` is passed we force the interpolation output
         # size and do not make use of `scale_factor=2`
         if output_size is None:
             hidden_states = F.interpolate(hidden_states, scale_factor=2.0, mode="nearest")
         else:
             hidden_states = F.interpolate(hidden_states, size=output_size, mode="nearest")
+
+        # If the input is bfloat16, we cast back to bfloat16
+        if dtype == torch.bfloat16:
+            hidden_states = hidden_states.to(dtype)
 
         # TODO(Suraj, Patrick) - clean up after weight dicts are correctly renamed
         if self.use_conv:

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -327,13 +327,9 @@ class StableDiffusionPipeline(DiffusionPipeline):
         image = self.vae.decode(latents).sample
 
         image = (image / 2 + 0.5).clamp(0, 1)
-        image = image.cpu().permute(0, 2, 3, 1)
 
-        # cast to float32 to as numpy doesn't support bfloat16
-        if image.dtype == torch.bfloat16:
-            image = image.to(torch.float32).numpy()
-        else:
-            image = image.numpy()
+        # we always cast to float32 as this does not cause significant overhead and is compatible with bfloa16
+        image = image.cpu().permute(0, 2, 3, 1).float().numpy()
 
         safety_checker_input = self.feature_extractor(self.numpy_to_pil(image), return_tensors="pt").to(self.device)
         image, has_nsfw_concept = self.safety_checker(

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -327,7 +327,13 @@ class StableDiffusionPipeline(DiffusionPipeline):
         image = self.vae.decode(latents).sample
 
         image = (image / 2 + 0.5).clamp(0, 1)
-        image = image.cpu().permute(0, 2, 3, 1).numpy()
+        image = image.cpu().permute(0, 2, 3, 1)
+
+        # cast to float32 to as numpy doesn't support bfloat16
+        if image.dtype == torch.bfloat16:
+            image = image.to(torch.float32).numpy()
+        else:
+            image = image.numpy()
 
         safety_checker_input = self.feature_extractor(self.numpy_to_pil(image), return_tensors="pt").to(self.device)
         image, has_nsfw_concept = self.safety_checker(

--- a/src/diffusers/pipelines/stable_diffusion/safety_checker.py
+++ b/src/diffusers/pipelines/stable_diffusion/safety_checker.py
@@ -36,16 +36,9 @@ class StableDiffusionSafetyChecker(PreTrainedModel):
         pooled_output = self.vision_model(clip_input)[1]  # pooled_output
         image_embeds = self.visual_projection(pooled_output)
 
-        special_cos_dist = cosine_distance(image_embeds, self.special_care_embeds).cpu()
-        cos_dist = cosine_distance(image_embeds, self.concept_embeds).cpu()
-
-        # cast to float32 to as numpy does not support bfloat16
-        if image_embeds.dtype == torch.bfloat16:
-            special_cos_dist = special_cos_dist.float().numpy()
-            cos_dist = cos_dist.float().numpy()
-        else:
-            special_cos_dist = special_cos_dist.numpy()
-            cos_dist = cos_dist.numpy()
+        # we always cast to float32 as this does not cause significant overhead and is compatible with bfloa16
+        special_cos_dist = cosine_distance(image_embeds, self.special_care_embeds).cpu().float().numpy()
+        cos_dist = cosine_distance(image_embeds, self.concept_embeds).cpu().float().numpy()
 
         result = []
         batch_size = image_embeds.shape[0]

--- a/src/diffusers/pipelines/stable_diffusion/safety_checker.py
+++ b/src/diffusers/pipelines/stable_diffusion/safety_checker.py
@@ -36,8 +36,16 @@ class StableDiffusionSafetyChecker(PreTrainedModel):
         pooled_output = self.vision_model(clip_input)[1]  # pooled_output
         image_embeds = self.visual_projection(pooled_output)
 
-        special_cos_dist = cosine_distance(image_embeds, self.special_care_embeds).cpu().numpy()
-        cos_dist = cosine_distance(image_embeds, self.concept_embeds).cpu().numpy()
+        special_cos_dist = cosine_distance(image_embeds, self.special_care_embeds).cpu()
+        cos_dist = cosine_distance(image_embeds, self.concept_embeds).cpu()
+
+        # cast to float32 to as numpy does not support bfloat16
+        if image_embeds == torch.bfloat16:
+            special_cos_dist = special_cos_dist.float().numpy()
+            cos_dist = cos_dist.float().numpy()
+        else:
+            special_cos_dist = special_cos_dist.numpy()
+            cos_dist = cos_dist.numpy()
 
         result = []
         batch_size = image_embeds.shape[0]

--- a/src/diffusers/pipelines/stable_diffusion/safety_checker.py
+++ b/src/diffusers/pipelines/stable_diffusion/safety_checker.py
@@ -40,7 +40,7 @@ class StableDiffusionSafetyChecker(PreTrainedModel):
         cos_dist = cosine_distance(image_embeds, self.concept_embeds).cpu()
 
         # cast to float32 to as numpy does not support bfloat16
-        if image_embeds == torch.bfloat16:
+        if image_embeds.dtype == torch.bfloat16:
             special_cos_dist = special_cos_dist.float().numpy()
             cos_dist = cos_dist.float().numpy()
         else:


### PR DESCRIPTION
Currently stable diffusion (or diffusers in general) doesn't work with `bf16` as  nearest upsampling in torch is not supported in `bf16`. 

Minimal code to reproduce:

```python
import torch
import torch.nn.functional as F

image = torch.randn(1, 4, 32, 32).to(device="cuda", dtype=torch.bfloat16)
out = F.interpolate(image, size=(64, 64), mode="nearest")
```

Addinatly, in `pipelines` we need to cast the images to `fp32` as `bf16` is not yet supported in `numpy`.

This is a draft PR to enable `bf16` training/inference for stable diffusion by casting `input` to `fp32` where `bf16` is not supported.

Not sure if this is the right way, curious to you hear your feedback @patrickvonplaten @NouamaneTazi 

fixes #771