### PR TITLE
Minor package fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+include LICENSE
 include src/diffusers/utils/model_card_template.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <br>
-    <img src="docs/source/imgs/diffusers_library.jpg" width="400"/>
+    <img src="https://github.com/huggingface/diffusers/raw/main/docs/source/imgs/diffusers_library.jpg" width="400"/>
     <br>
 <p>
 <p align="center">


### PR DESCRIPTION
1. Add `LICENSE` to the pip wheel (thanks to the conda CI for picking up on that https://github.com/conda-forge/diffusers-feedstock/pull/12)
2. Use an absolute url for the diffusers image to make it show up on pypi: https://pypi.org/project/diffusers/