### PR TITLE
Fix dreambooth loss type with prior_preservation and fp16

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -544,7 +544,7 @@ def main():
                     noise, noise_prior = torch.chunk(noise, 2, dim=0)
 
                     # Compute instance loss
-                    loss = F.mse_loss(noise_pred, noise, reduction="none").mean([1, 2, 3]).mean()
+                    loss = F.mse_loss(noise_pred.float(), noise.float(), reduction="none").mean([1, 2, 3]).mean()
 
                     # Compute prior loss
                     prior_loss = F.mse_loss(noise_pred_prior.float(), noise_prior.float(), reduction="mean")


### PR DESCRIPTION
This will make the float16 loss terms compatible with accelerate.
Fixes https://github.com/huggingface/diffusers/issues/817