### PR TITLE
[Textual Inversion] Correctly freeze token embeddings

### DIFF
--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -392,7 +392,7 @@ def main():
 
     # Initialise the newly added placeholder token with the embeddings of the initializer token
     token_embeds = text_encoder.get_input_embeddings().weight.data
-    original_token_embeds = token_embeds.detach().clone()
+    original_token_embeds = token_embeds.detach().clone().to(accelerator.device)
     token_embeds[placeholder_token_id] = token_embeds[initializer_token_id]
 
     # Freeze vae and unet
@@ -536,9 +536,7 @@ def main():
 
                 # Get the index for tokens that we want to freeze
                 index_fixed_tokens = torch.arange(len(tokenizer)) != placeholder_token_id
-                token_embeds.data[index_fixed_tokens, :] = original_token_embeds[index_fixed_tokens, :].to(
-                    accelerator.device
-                )
+                token_embeds.data[index_fixed_tokens, :] = original_token_embeds[index_fixed_tokens, :]
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -536,8 +536,9 @@ def main():
 
                 # Get the index for tokens that we want to freeze
                 index_fixed_tokens = torch.arange(len(tokenizer)) != placeholder_token_id
-                token_embeds.data[index_fixed_tokens, :] \
-                        = original_token_embeds[index_fixed_tokens, :].to(accelerator.device)
+                token_embeds.data[index_fixed_tokens, :] = original_token_embeds[index_fixed_tokens, :].to(
+                    accelerator.device
+                )
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -392,6 +392,7 @@ def main():
 
     # Initialise the newly added placeholder token with the embeddings of the initializer token
     token_embeds = text_encoder.get_input_embeddings().weight.data
+    original_token_embeds = text_encoder.detach().clone()
     token_embeds[placeholder_token_id] = token_embeds[initializer_token_id]
 
     # Freeze vae and unet
@@ -521,19 +522,17 @@ def main():
                 loss = F.mse_loss(noise_pred, noise, reduction="none").mean([1, 2, 3]).mean()
                 accelerator.backward(loss)
 
-                # Zero out the gradients for all token embeddings except the newly added
-                # embeddings for the concept, as we only want to optimize the concept embeddings
-                if accelerator.num_processes > 1:
-                    grads = text_encoder.module.get_input_embeddings().weight.grad
-                else:
-                    grads = text_encoder.get_input_embeddings().weight.grad
-                # Get the index for tokens that we want to zero the grads for
-                index_grads_to_zero = torch.arange(len(tokenizer)) != placeholder_token_id
-                grads.data[index_grads_to_zero, :] = grads.data[index_grads_to_zero, :].fill_(0)
-
                 optimizer.step()
                 lr_scheduler.step()
                 optimizer.zero_grad()
+
+                # Keep the token embeddings fixed except the newly added
+                # embeddings for the concept, as we only want to optimize the concept embeddings
+
+                # Get the index for tokens that we want to freeze
+                index_fixed_tokens = torch.arange(len(tokenizer)) != placeholder_token_id
+                text_encoder.get_input_embeddings().weight.data[index_fixed_tokens, :] \
+                        = original_token_embeds[index_fixed_tokens, :].to(accelerator.device)
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:


### PR DESCRIPTION
# What does this PR do?

In textual inversion example the token embeddings doesn't seem to be frozen correctly. Zero-ing out the gradient is not sufficient because the effect of weight decay causes non-zero updates. A naive solution would be caching the original token embeddings and re-assign them after every train step. 


## Who can review?
cc @patrickvonplaten @patil-suraj

