### PR TITLE
Rename frame filename in interpolation community example

### DIFF
--- a/examples/community/interpolate_stable_diffusion.py
+++ b/examples/community/interpolate_stable_diffusion.py
@@ -517,7 +517,7 @@ class StableDiffusionWalkPipeline(DiffusionPipeline):
                     noise_batch, embeds_batch = None, None
 
                     for image in outputs["images"]:
-                        frame_filepath = str(save_path / f"frame_{frame_idx}.png")
+                        frame_filepath = str(save_path / f"frame_{frame_idx:06d}.png")
                         image.save(frame_filepath)
                         frame_filepaths.append(frame_filepath)
                         frame_idx += 1


### PR DESCRIPTION
Frame filename right now is `frame_{frame_idx}.png`, which leads to frames like `frame_1.png`, `frame_10.png`, etc. This is an issue if you end up wanting to ffmpeg them together later. 

This pr updates to do `frame_{frame_idx:06d}.png` so frame filenames will be friendlier with glob patterns, keeping files sorted: `frame_000001.png`, `frame_000010.png`, etc. 