### PR TITLE
Fix Compatibility with Nvidia NGC Containers

### DIFF
--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -27,7 +27,9 @@ if is_torch_available():
     )
 
     if is_torch_higher_equal_than_1_12:
-        torch_device = "mps" if torch.backends.mps.is_available() else torch_device
+        # Some builds of torch 1.12 don't have the mps backend registered. See #892 for more details
+        mps_backend_registered = hasattr(torch.backends, "mps")
+        torch_device = "mps" if (mps_backend_registered and torch.backends.mps.is_available()) else torch_device
 
 
 def get_tests_dir(append_path=None):


### PR DESCRIPTION
Fixes #892

`diffusers` 0.4.0+ currently assumes that torch >= 1.12.0 has MPS registered as a backend, but this does not seem to be the case in nvidia's NGC pytorch containers.

This PR makes the MPS availability check a little more robust.

P.S. Wasn't sure how/if to add a test for this. If a maintainer could point me in the right direction I'd be happy to update the PR.