### PR TITLE
Enable multi-process DataLoader for dreambooth

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -473,7 +473,7 @@ def main():
         return batch
 
     train_dataloader = torch.utils.data.DataLoader(
-        train_dataset, batch_size=args.train_batch_size, shuffle=True, collate_fn=collate_fn
+        train_dataset, batch_size=args.train_batch_size, shuffle=True, collate_fn=collate_fn, num_workers=1
     )
 
     # Scheduler and math around the number of training steps.


### PR DESCRIPTION
This simple change enables the DataLoader to prefetch the next data async. More info in the [docs](https://pytorch.org/docs/stable/data.html#single-and-multi-process-data-loading).

This resulted in a 35% speedup for me and utilizes the GPU power better (as the data loading is not blocking the GPU):

![image](https://user-images.githubusercontent.com/1972314/197361929-a0efd86f-ec6c-4d50-9283-be43da46d174.png)
*(green = new, blue = old)*

The same can probably also be applied to all the other DataLoaders but I do not have the time to test them.