### PR TITLE
[Tests] Fix `mps` reproducibility issue when running with pytest-xdist

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -79,6 +79,7 @@ jobs:
       run: |
         ${CONDA_RUN} python -m pip install --upgrade pip
         ${CONDA_RUN} python -m pip install -e .[quality,test]
+        ${CONDA_RUN} python -m pip uninstall -y pytest-xdist  # reproducibility issues with mps + multiprocessing
         ${CONDA_RUN} python -m pip install --pre torch==${MPS_TORCH_VERSION} --extra-index-url https://download.pytorch.org/whl/test/cpu
 
     - name: Environment
@@ -89,7 +90,7 @@ jobs:
     - name: Run all fast tests on MPS
       shell: arch -arch arm64 bash {0}
       run: |
-        ${CONDA_RUN} python -m pytest -n 4 --max-worker-restart=0 --dist=loadfile -s -v --make-reports=tests_torch_mps tests/
+        ${CONDA_RUN} python -m pytest -s -v --make-reports=tests_torch_mps tests/
 
     - name: Failure short reports
       if: ${{ failure() }}

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -79,7 +79,6 @@ jobs:
       run: |
         ${CONDA_RUN} python -m pip install --upgrade pip
         ${CONDA_RUN} python -m pip install -e .[quality,test]
-        ${CONDA_RUN} python -m pip uninstall -y pytest-xdist  # reproducibility issues with mps + multiprocessing
         ${CONDA_RUN} python -m pip install --pre torch==${MPS_TORCH_VERSION} --extra-index-url https://download.pytorch.org/whl/test/cpu
 
     - name: Environment
@@ -90,7 +89,7 @@ jobs:
     - name: Run all fast tests on MPS
       shell: arch -arch arm64 bash {0}
       run: |
-        ${CONDA_RUN} python -m pytest -s -v --make-reports=tests_torch_mps tests/
+        ${CONDA_RUN} python -m pytest -n 1 -s -v --make-reports=tests_torch_mps tests/
 
     - name: Failure short reports
       if: ${{ failure() }}

--- a/tests/pipelines/ddim/test_ddim.py
+++ b/tests/pipelines/ddim/test_ddim.py
@@ -52,7 +52,8 @@ class DDIMPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         # Warmup pass when using mps (see #372)
         if torch_device == "mps":
-            _ = ddpm(num_inference_steps=1)
+            generator = torch.manual_seed(42)
+            _ = ddpm(generator=generator, num_inference_steps=2, output_type="numpy").images
 
         generator = torch.manual_seed(0)
         image = ddpm(generator=generator, num_inference_steps=2, output_type="numpy").images

--- a/tests/pipelines/ddim/test_ddim.py
+++ b/tests/pipelines/ddim/test_ddim.py
@@ -43,48 +43,6 @@ class DDIMPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         return model
 
     def test_inference(self):
-        # Warmup pass when using mps (see #372)
-        if torch_device == "mps":
-            unet = self.dummy_uncond_unet
-            scheduler = DDIMScheduler()
-
-            ddpm = DDIMPipeline(unet=unet, scheduler=scheduler)
-            ddpm.to(torch_device)
-            ddpm.set_progress_bar_config(disable=None)
-
-            generator = torch.manual_seed(0)
-            _ = ddpm(generator=generator, num_inference_steps=2)
-            del unet, scheduler, ddpm
-
-        unet = self.dummy_uncond_unet
-        scheduler = DDIMScheduler()
-
-        ddpm = DDIMPipeline(unet=unet, scheduler=scheduler)
-        ddpm.to(torch_device)
-        ddpm.set_progress_bar_config(disable=None)
-
-        # Warmup pass when using mps (see #372)
-        if torch_device == "mps":
-            _ = ddpm(num_inference_steps=1)
-
-        generator = torch.manual_seed(0)
-        image = ddpm(generator=generator, num_inference_steps=2, output_type="numpy").images
-
-        generator = torch.manual_seed(0)
-        image_from_tuple = ddpm(generator=generator, num_inference_steps=2, output_type="numpy", return_dict=False)[0]
-
-        image_slice = image[0, -3:, -3:, -1]
-        image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
-
-        assert image.shape == (1, 32, 32, 3)
-        expected_slice = np.array(
-            [1.000e00, 5.717e-01, 4.717e-01, 1.000e00, 0.000e00, 1.000e00, 3.000e-04, 0.000e00, 9.000e-04]
-        )
-        tolerance = 1e-2 if torch_device != "mps" else 3e-2
-        assert np.abs(image_slice.flatten() - expected_slice).max() < tolerance
-        assert np.abs(image_from_tuple_slice.flatten() - expected_slice).max() < tolerance
-
-    def test_inference_2(self):
         unet = self.dummy_uncond_unet
         scheduler = DDIMScheduler()
 

--- a/tests/pipelines/ddim/test_ddim.py
+++ b/tests/pipelines/ddim/test_ddim.py
@@ -52,8 +52,7 @@ class DDIMPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         # Warmup pass when using mps (see #372)
         if torch_device == "mps":
-            _ = ddpm(num_inference_steps=5)
-            _ = ddpm(num_inference_steps=5)
+            _ = ddpm(num_inference_steps=1)
 
         generator = torch.manual_seed(0)
         image = ddpm(generator=generator, num_inference_steps=2, output_type="numpy").images
@@ -82,7 +81,7 @@ class DDIMPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         # Warmup pass when using mps (see #372)
         if torch_device == "mps":
-            _ = ddpm(num_inference_steps=5)
+            _ = ddpm(num_inference_steps=1)
 
         generator = torch.manual_seed(0)
         image = ddpm(generator=generator, num_inference_steps=2, output_type="numpy").images


### PR DESCRIPTION
`DDIMPipelineFastTests.test_inference` fails the first time it's launched with `pytest -n 4`, but passes the second time. This PR makes sure that the tests run in a single process