### PR TITLE
fix `F.interpolate()` for large batch sizes

### DIFF
--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -48,6 +48,10 @@ class Upsample2D(nn.Module):
         if dtype == torch.bfloat16:
             hidden_states = hidden_states.to(torch.float32)
 
+        # upsample_nearest_nhwc fails with large batch sizes. see https://github.com/huggingface/diffusers/issues/984
+        if hidden_states.shape[0] >= 64:
+            hidden_states = hidden_states.contiguous()
+
         # if `output_size` is passed we force the interpolation output
         # size and do not make use of `scale_factor=2`
         if output_size is None:

--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -380,6 +380,10 @@ class ResnetBlock2D(nn.Module):
         hidden_states = self.nonlinearity(hidden_states)
 
         if self.upsample is not None:
+            # upsample_nearest_nhwc fails with large batch sizes. see https://github.com/huggingface/diffusers/issues/984
+            if hidden_states.shape[0] >= 64:
+                input_tensor = input_tensor.contiguous()
+                hidden_states = hidden_states.contiguous()
             input_tensor = self.upsample(input_tensor)
             hidden_states = self.upsample(hidden_states)
         elif self.downsample is not None:


### PR DESCRIPTION
Fixes https://github.com/huggingface/diffusers/issues/984.
It seems that `F.interpolate(hidden_states, scale_factor=2.0, mode="nearest")` breaks for batch sizes > 64 when `hidden_states` uses channels last format. See https://github.com/pytorch/pytorch/issues/81665 and https://github.com/huggingface/diffusers/issues/984

This PR proposes to force a contiguous format for hidden states when `bsz > 64`. Credits to @pcuenca for the find.

The following now works (after applying the [memory efficient PR](https://github.com/huggingface/diffusers/pull/532) + this PR)
```python
pipe = StableDiffusionPipeline.from_pretrained(
    "CompVis/stable-diffusion-v1-4", 
    use_auth_token=True,
    revision="fp16",
    torch_dtype=torch.float16,
).to("cuda")

batch_size = 32

with torch.inference_mode():
    image = pipe([prompt] * batch_size, num_inference_steps=5).images[0]
```

cc @pcuenca @patrickvonplaten @patil-suraj 