### PR TITLE
[Accelerate model loading] Fix meta device and super low memory usage

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -119,14 +119,13 @@ class StableDiffusionPipeline(DiffusionPipeline):
         # set slice_size = `None` to disable `attention slicing`
         self.enable_attention_slicing(None)
 
-    def cuda_with_minimal_gpu_usage(self):
+    def enable_sequential_gpu_placement(self):
         if is_accelerate_available():
             from accelerate import cpu_offload
         else:
             raise ImportError("Please install accelerate via `pip install accelerate`")
 
         device = torch.device("cuda")
-        self.enable_attention_slicing(1)
 
         for cpu_offloaded_model in [self.unet, self.text_encoder, self.vae, self.safety_checker]:
             cpu_offload(cpu_offloaded_model, device)

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -119,7 +119,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
         # set slice_size = `None` to disable `attention slicing`
         self.enable_attention_slicing(None)
 
-    def enable_sequential_gpu_placement(self):
+    def enable_sequential_cpu_offload(self):
         if is_accelerate_available():
             from accelerate import cpu_offload
         else:

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion.py
@@ -15,6 +15,7 @@
 
 import gc
 import random
+import time
 import unittest
 
 import numpy as np
@@ -730,3 +731,39 @@ class StableDiffusionPipelineIntegrationTests(unittest.TestCase):
             )
         assert test_callback_fn.has_been_called
         assert number_of_steps == 51
+
+    def test_stable_diffusion_accelerate_auto_device(self):
+        pipeline_id = "CompVis/stable-diffusion-v1-4"
+
+        start_time = time.time()
+        pipeline_normal_load = StableDiffusionPipeline.from_pretrained(
+            pipeline_id, revision="fp16", torch_dtype=torch.float16, use_auth_token=True
+        )
+        pipeline_normal_load.to(torch_device)
+        normal_load_time = time.time() - start_time
+
+        start_time = time.time()
+        _ = StableDiffusionPipeline.from_pretrained(
+            pipeline_id, revision="fp16", torch_dtype=torch.float16, use_auth_token=True, device_map="auto"
+        )
+        meta_device_load_time = time.time() - start_time
+
+        assert 2 * meta_device_load_time < normal_load_time
+
+    @unittest.skipIf(torch_device == "cpu", "This test is supposed to run on GPU")
+    def test_stable_diffusion_pipeline_with_unet_on_gpu_only(self):
+        torch.cuda.empty_cache()
+        torch.cuda.reset_max_memory_allocated()
+
+        pipeline_id = "CompVis/stable-diffusion-v1-4"
+        prompt = "Andromeda galaxy in a bottle"
+
+        pipeline = StableDiffusionPipeline.from_pretrained(pipeline_id, revision="fp16", torch_dtype=torch.float16)
+        pipeline.enable_attention_slicing(1)
+        pipeline.enable_sequential_gpu_placement()
+
+        _ = pipeline(prompt, num_inference_steps=5)
+
+        mem_bytes = torch.cuda.max_memory_allocated()
+        # make sure that less than 1.5 GB is allocated
+        assert mem_bytes < 1.5 * 10**9

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion.py
@@ -760,7 +760,7 @@ class StableDiffusionPipelineIntegrationTests(unittest.TestCase):
 
         pipeline = StableDiffusionPipeline.from_pretrained(pipeline_id, revision="fp16", torch_dtype=torch.float16)
         pipeline.enable_attention_slicing(1)
-        pipeline.enable_sequential_gpu_placement()
+        pipeline.enable_sequential_cpu_offload()
 
         _ = pipeline(prompt, num_inference_steps=5)
 


### PR DESCRIPTION
The tests:

```
FAILED tests/test_pipelines.py::PipelineSlowTests::test_stable_diffusion_accelerate_load_reduces_memory_footprint
FAILED tests/test_pipelines.py::PipelineSlowTests::test_stable_diffusion_pipeline_with_unet_on_gpu_only
```

are currently failing on main. 

Also this PR renames:
`cuda_with_minimal_gpu_usage` to `enable_sequential_cpu_offload` as it's a more fitting name and disentangled `enable_attention_slicing` from `cpu_offload`

Related original PR: https://github.com/huggingface/diffusers/pull/850

@piEsposito does this work for you? 