### PR TITLE
Support grayscale images in `numpy_to_pil`

### DIFF
--- a/src/diffusers/pipeline_flax_utils.py
+++ b/src/diffusers/pipeline_flax_utils.py
@@ -444,7 +444,11 @@ class FlaxDiffusionPipeline(ConfigMixin):
         if images.ndim == 3:
             images = images[None, ...]
         images = (images * 255).round().astype("uint8")
-        pil_images = [Image.fromarray(image) for image in images]
+        if images.shape[-1] == 1:
+            # special case for grayscale (single channel) images
+            pil_images = [Image.fromarray(image.squeeze(), mode="L") for image in images]
+        else:
+            pil_images = [Image.fromarray(image) for image in images]
 
         return pil_images
 

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -625,7 +625,11 @@ class DiffusionPipeline(ConfigMixin):
         if images.ndim == 3:
             images = images[None, ...]
         images = (images * 255).round().astype("uint8")
-        pil_images = [Image.fromarray(image) for image in images]
+        if images.shape[-1] == 1:
+            # special case for grayscale (single channel) images
+            pil_images = [Image.fromarray(image.squeeze(), mode="L") for image in images]
+        else:
+            pil_images = [Image.fromarray(image) for image in images]
 
         return pil_images
 


### PR DESCRIPTION
This fixes the error when trying to convert single-channel arrays to PIL

```python
images = np.random.rand(2, 32, 32, 1)
numpy_to_pil(images)  
```
Before: 
> TypeError: Cannot handle this data type: (1, 1, 1), |u1

After: 
> [<PIL.Image.Image image mode=L size=32x32 at 0x7FCF8F8FE690>,
> <PIL.Image.Image image mode=L size=32x32 at 0x7FCF8F8FE6D0>]

Closes #488
