### PR TITLE
Fix padding in dreambooth

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -496,7 +496,12 @@ def main(args):
         pixel_values = torch.stack(pixel_values)
         pixel_values = pixel_values.to(memory_format=torch.contiguous_format).float()
 
-        input_ids = tokenizer.pad({"input_ids": input_ids}, padding=True, return_tensors="pt").input_ids
+        input_ids = tokenizer.pad(
+            {"input_ids": input_ids},
+            padding="max_length",
+            max_length=tokenizer.model_max_length,
+            return_tensors="pt",
+        ).input_ids
 
         batch = {
             "input_ids": input_ids,


### PR DESCRIPTION
Fix padding in dreambooth as it is done in inference.

https://github.com/huggingface/diffusers/blob/de00c632174704d6d92405120f171e58b38e0ee8/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L231-L236


- [Reference by kohya_ss](https://note.com/kohya_ss/n/nee3ed1649fb6) (in Japanese):
     - They say this is one of the difference between https://github.com/XavierXiao/Dreambooth-Stable-Diffusion/ and https://github.com/huggingface/diffusers and padding like this PR made better results