### PR TITLE
Fix tests for equivalence of DDIM and DDPM pipelines

### DIFF
--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -61,6 +61,7 @@ class DDIMPipeline(DiffusionPipeline):
             num_inference_steps (`int`, *optional*, defaults to 50):
                 The number of denoising steps. More denoising steps usually lead to a higher quality image at the
                 expense of slower inference.
+            use_clipped_model_output (`bool`, defaults to `False`): See documentation for `DDIMScheduler.step`
             output_type (`str`, *optional*, defaults to `"pil"`):
                 The output format of the generate image. Choose between
                 [PIL](https://pillow.readthedocs.io/en/stable/): `PIL.Image.Image` or `np.array`.

--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -44,6 +44,7 @@ class DDIMPipeline(DiffusionPipeline):
         generator: Optional[torch.Generator] = None,
         eta: float = 0.0,
         num_inference_steps: int = 50,
+        use_clipped_model_output: bool = False,
         output_type: Optional[str] = "pil",
         return_dict: bool = True,
         **kwargs,
@@ -89,7 +90,9 @@ class DDIMPipeline(DiffusionPipeline):
             # 2. predict previous mean of image x_t-1 and add variance depending on eta
             # eta corresponds to η in paper and should be between [0, 1]
             # do x_t -> x_t-1
-            image = self.scheduler.step(model_output, t, image, eta).prev_sample
+            image = self.scheduler.step(
+                model_output, t, image, eta, use_clipped_model_output=use_clipped_model_output
+            ).prev_sample
 
         image = (image / 2 + 0.5).clamp(0, 1)
         image = image.cpu().permute(0, 2, 3, 1).numpy()

--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -13,7 +13,7 @@
 
 # limitations under the License.
 
-
+import inspect
 from typing import Optional, Tuple, Union
 
 import torch
@@ -44,7 +44,7 @@ class DDIMPipeline(DiffusionPipeline):
         generator: Optional[torch.Generator] = None,
         eta: float = 0.0,
         num_inference_steps: int = 50,
-        use_clipped_model_output: bool = False,
+        use_clipped_model_output: Optional[bool] = None,
         output_type: Optional[str] = "pil",
         return_dict: bool = True,
         **kwargs,
@@ -61,7 +61,9 @@ class DDIMPipeline(DiffusionPipeline):
             num_inference_steps (`int`, *optional*, defaults to 50):
                 The number of denoising steps. More denoising steps usually lead to a higher quality image at the
                 expense of slower inference.
-            use_clipped_model_output (`bool`, defaults to `False`): See documentation for `DDIMScheduler.step`
+            use_clipped_model_output (`bool`, *optional*, defaults to `None`):
+                if `True` or `False`, see documentation for `DDIMScheduler.step`. If `None`, nothing is passed
+                downstream to the scheduler. So use `None` for schedulers which don't support this argument.
             output_type (`str`, *optional*, defaults to `"pil"`):
                 The output format of the generate image. Choose between
                 [PIL](https://pillow.readthedocs.io/en/stable/): `PIL.Image.Image` or `np.array`.
@@ -84,6 +86,14 @@ class DDIMPipeline(DiffusionPipeline):
         # set step values
         self.scheduler.set_timesteps(num_inference_steps)
 
+        # Ignore use_clipped_model_output if the scheduler doesn't accept this argument
+        accepts_use_clipped_model_output = "use_clipped_model_output" in set(
+            inspect.signature(self.scheduler.step).parameters.keys()
+        )
+        extra_kwargs = {}
+        if accepts_use_clipped_model_output:
+            extra_kwargs["use_clipped_model_output"] = use_clipped_model_output
+
         for t in self.progress_bar(self.scheduler.timesteps):
             # 1. predict noise model_output
             model_output = self.unet(image, t).sample
@@ -91,9 +101,7 @@ class DDIMPipeline(DiffusionPipeline):
             # 2. predict previous mean of image x_t-1 and add variance depending on eta
             # eta corresponds to η in paper and should be between [0, 1]
             # do x_t -> x_t-1
-            image = self.scheduler.step(
-                model_output, t, image, eta, use_clipped_model_output=use_clipped_model_output
-            ).prev_sample
+            image = self.scheduler.step(model_output, t, image, eta, **extra_kwargs).prev_sample
 
         image = (image / 2 + 0.5).clamp(0, 1)
         image = image.cpu().permute(0, 2, 3, 1).numpy()

--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -212,7 +212,10 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
             sample (`torch.FloatTensor`):
                 current instance of sample being created by diffusion process.
             eta (`float`): weight of noise for added noise in diffusion step.
-            use_clipped_model_output (`bool`): TODO
+            use_clipped_model_output (`bool`): if `True`, compute "corrected" `model_output` from the clipped
+                predicted original sample. Necessary because predicted original sample is clipped to [-1, 1] when
+                `self.config.clip_sample` is `True`. If no clipping has happened, "corrected" `model_output` would
+                coincide with the one provided as input and `use_clipped_model_output` will have not effect.
             generator: random number generator.
             return_dict (`bool`): option for returning tuple rather than DDIMSchedulerOutput class
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -470,7 +470,7 @@ class PipelineSlowTests(unittest.TestCase):
             num_inference_steps=1000,
             eta=1.0,
             output_type="numpy",
-            use_clipped_model_output=True,  # Need to make DDIM match DDPM
+            use_clipped_model_output=True,  # Need this to make DDIM match DDPM
         ).images
 
         # the values aren't exactly equal, but the images look the same visually
@@ -503,7 +503,7 @@ class PipelineSlowTests(unittest.TestCase):
             num_inference_steps=1000,
             eta=1.0,
             output_type="numpy",
-            use_clipped_model_output=True,  # Need to make DDIM match DDPM
+            use_clipped_model_output=True,  # Need this to make DDIM match DDPM
         ).images
 
         # the values aren't exactly equal, but the images look the same visually

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -445,6 +445,7 @@ class PipelineSlowTests(unittest.TestCase):
         assert isinstance(images, list)
         assert isinstance(images[0], PIL.Image.Image)
 
+    # Make sure the test passes for different values of random seed
     @parameterized.expand([(0,), (4,)])
     def test_ddpm_ddim_equality(self, seed):
         model_id = "google/ddpm-cifar10-32"
@@ -469,12 +470,13 @@ class PipelineSlowTests(unittest.TestCase):
             num_inference_steps=1000,
             eta=1.0,
             output_type="numpy",
-            use_clipped_model_output=True,
+            use_clipped_model_output=True,  # Need to make DDIM match DDPM
         ).images
 
         # the values aren't exactly equal, but the images look the same visually
         assert np.abs(ddpm_image - ddim_image).max() < 1e-1
 
+    # Make sure the test passes for different values of random seed
     @parameterized.expand([(0,), (4,)])
     def test_ddpm_ddim_equality_batched(self, seed):
         model_id = "google/ddpm-cifar10-32"
@@ -501,7 +503,7 @@ class PipelineSlowTests(unittest.TestCase):
             num_inference_steps=1000,
             eta=1.0,
             output_type="numpy",
-            use_clipped_model_output=True,
+            use_clipped_model_output=True,  # Need to make DDIM match DDPM
         ).images
 
         # the values aren't exactly equal, but the images look the same visually

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -20,8 +20,9 @@ import tempfile
 import unittest
 
 import numpy as np
-import PIL
 import torch
+
+import PIL
 from diffusers import (
     AutoencoderKL,
     DDIMPipeline,


### PR DESCRIPTION
Closes #553 

DDIM and DDPM pipelines are equivalent only if `DDIM` scheduler is called with `use_clipped_model_output=True`. Currently it's not possible to pass this argument from the pipeline, and so `test_ddpm_ddim_equality_batched` was [failing](https://github.com/huggingface/diffusers/blob/95414bd6bf9bb34a312a7c55f10ba9b379f33890/tests/test_pipelines.py#L471). The unbatched version `test_ddpm_ddim_equality` was also failing if one changed the random seed (e.g. to 4), as described in the issue.

This PR:
- allows passing `use_clipped_model_output` from DDIM pipeline to the scheduler
- calls DDIM with `use_clipped_model_output=True` in `test_ddpm_ddim_equality_batched` and `test_ddpm_ddim_equality`

As a result, both tests are passing  (each runs for 2 values of the seed)
<img width="1033" alt="Captura de Pantalla 2022-10-30 a las 14 34 10" src="https://user-images.githubusercontent.com/23200558/198881399-86dad41c-e2f0-48ae-b424-66b656494007.png">
