### PR TITLE
[GitBot] Automatically close issues after inactivitiy

### DIFF
--- a/utils/stale.py
+++ b/utils/stale.py
@@ -61,6 +61,7 @@ def main():
                 "[contributing guidelines](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md) "
                 "are likely to be ignored."
             )
+            issue.edit(labels=["stale"])
 
 
 if __name__ == "__main__":

--- a/utils/stale.py
+++ b/utils/stale.py
@@ -47,13 +47,22 @@ def main():
             and (dt.utcnow() - issue.created_at).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
-            # print(f"Would close issue {issue.number} since it has been 7 days of inactivity since bot mention.")
+            # Closes the issue after 7 days of inactivity since the Stalebot notification.
             issue.edit(state="closed")
+        elif (
+            "stale" in issue.get_labels()
+            and last_comment is not None
+            and last_comment.user.login != "github-actions[bot]"
+        ):
+            # Opens the issue if someone other than Stelebot commented.
+            issue.edit(state="open")
+            issue.remove_from_labels("stale")
         elif (
             (dt.utcnow() - issue.updated_at).days > 23
             and (dt.utcnow() - issue.created_at).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
+            # Post a Stalebot notification after 23 days of inactivity.
             issue.create_comment(
                 "This issue has been automatically marked as stale because it has not had "
                 "recent activity. If you think this still needs to be addressed "
@@ -61,7 +70,7 @@ def main():
                 "[contributing guidelines](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md) "
                 "are likely to be ignored."
             )
-            issue.edit(labels=["stale"])
+            issue.add_to_labels("stale")
 
 
 if __name__ == "__main__":

--- a/utils/stale.py
+++ b/utils/stale.py
@@ -42,8 +42,15 @@ def main():
         last_comment = comments[0] if len(comments) > 0 else None
         if (
             last_comment is not None
-            and last_comment.user.login != "github-actions[bot]"
-            and (dt.utcnow() - issue.updated_at).days > 23
+            and last_comment.user.login == "github-actions[bot]"
+            and (dt.utcnow() - issue.updated_at).days > 7
+            and (dt.utcnow() - issue.created_at).days >= 30
+            and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
+        ):
+            # print(f"Would close issue {issue.number} since it has been 7 days of inactivity since bot mention.")
+            issue.edit(state="closed")
+        elif (
+            (dt.utcnow() - issue.updated_at).days > 23
             and (dt.utcnow() - issue.created_at).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
@@ -54,7 +61,6 @@ def main():
                 "[contributing guidelines](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md) "
                 "are likely to be ignored."
             )
-            issue.edit(labels=["stale"])
 
 
 if __name__ == "__main__":

--- a/utils/stale.py
+++ b/utils/stale.py
@@ -54,7 +54,7 @@ def main():
             and last_comment is not None
             and last_comment.user.login != "github-actions[bot]"
         ):
-            # Opens the issue if someone other than Stelebot commented.
+            # Opens the issue if someone other than Stalebot commented.
             issue.edit(state="open")
             issue.remove_from_labels("stale")
         elif (


### PR DESCRIPTION
Let's close issues after too much inactivity - otherwise we won't be able to handle new issues => too much activity on the repo