### PR TITLE
[docs] add euler scheduler in docs, how to use differnet schedulers 

### DIFF
--- a/docs/source/api/pipelines/stable_diffusion.mdx
+++ b/docs/source/api/pipelines/stable_diffusion.mdx
@@ -31,6 +31,30 @@ For more details about how Stable Diffusion works and how it differs from the ba
 
 ## Tips
 
+### How to load and use different schedulers.
+
+The stable diffusion pipeline uses [`PNDMScheduler`] scheduler by default. But `diffusers` provides many other schedulers that can be used with the stable diffusion pipeline such as [`DDIMScheduler`], [`LMSDiscreteScheduler`], [`EulerDiscreteScheduler`], [`EulerAncestralDiscreteScheduler`] etc.
+To use a different scheduler, you can pass the `scheduler` argument to `from_pretrained` method of the pipeline. For example, to use the [`LMSDiscreteScheduler`], you can do the following:
+
+```python
+from diffusers import StableDiffusionPipeline, LMSDiscreteScheduler
+
+lms_scheduler = LMSDiscreteScheduler.from_config("CompVis/stable-diffusion-v1-4", subfolder="scheduler")
+pipeline = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", scheduler=lms_scheduler)
+```
+
+It's also possible to hot swap the `scheduler` by setting the `scheduler` attribute of the already loaded pipeline. For example, to use the [`EulerDiscreteScheduler`] with the pipeline loaded above, you can do the following:
+
+```python
+from diffusers import EulerDiscreteScheduler
+
+euler_scheduler = EulerDiscreteScheduler.from_config("CompVis/stable-diffusion-v1-4", subfolder="scheduler")
+pipeline.scheduler = euler_scheduler
+```
+
+
+### How to conver all use cases with multiple or single pipeline
+
 If you want to use all possible use cases in a single `DiffusionPipeline` you can either:
 - Make use of the [Stable Diffusion Mega Pipeline](https://github.com/huggingface/diffusers/tree/main/examples/community#stable-diffusion-mega) or 
 - Make use of the `components` functionality to instantiate all components in the most memory-efficient way:

--- a/docs/source/api/pipelines/stable_diffusion.mdx
+++ b/docs/source/api/pipelines/stable_diffusion.mdx
@@ -34,22 +34,13 @@ For more details about how Stable Diffusion works and how it differs from the ba
 ### How to load and use different schedulers.
 
 The stable diffusion pipeline uses [`PNDMScheduler`] scheduler by default. But `diffusers` provides many other schedulers that can be used with the stable diffusion pipeline such as [`DDIMScheduler`], [`LMSDiscreteScheduler`], [`EulerDiscreteScheduler`], [`EulerAncestralDiscreteScheduler`] etc.
-To use a different scheduler, you can pass the `scheduler` argument to `from_pretrained` method of the pipeline. For example, to use the [`LMSDiscreteScheduler`], you can do the following:
+To use a different scheduler, you can pass the `scheduler` argument to `from_pretrained` method of the pipeline. For example, to use the [`EulerDiscreteScheduler`], you can do the following:
 
 ```python
-from diffusers import StableDiffusionPipeline, LMSDiscreteScheduler
-
-lms_scheduler = LMSDiscreteScheduler.from_config("CompVis/stable-diffusion-v1-4", subfolder="scheduler")
-pipeline = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", scheduler=lms_scheduler)
-```
-
-It's also possible to hot swap the `scheduler` by setting the `scheduler` attribute of the already loaded pipeline. For example, to use the [`EulerDiscreteScheduler`] with the pipeline loaded above, you can do the following:
-
-```python
-from diffusers import EulerDiscreteScheduler
+from diffusers import StableDiffusionPipeline, EulerDiscreteScheduler
 
 euler_scheduler = EulerDiscreteScheduler.from_config("CompVis/stable-diffusion-v1-4", subfolder="scheduler")
-pipeline.scheduler = euler_scheduler
+pipeline = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", scheduler=euler_scheduler)
 ```
 
 

--- a/docs/source/api/schedulers.mdx
+++ b/docs/source/api/schedulers.mdx
@@ -117,6 +117,7 @@ Score SDE-VP is under construction.
 #### Euler scheduler
 
 Euler scheduler (Algorithm 2) from the paper [Elucidating the Design Space of Diffusion-Based Generative Models](https://arxiv.org/abs/2206.00364) by Karras et al. (2022). Based on the original [k-diffusion](https://github.com/crowsonkb/k-diffusion/blob/481677d114f6ea445aa009cf5bd7a9cdee909e47/k_diffusion/sampling.py#L51) implementation by Katherine Crowson.
+Fast scheduler which often times generates good outputs with 20-30 steps.
 
 [[autodoc]] EulerDiscreteScheduler
 
@@ -124,5 +125,6 @@ Euler scheduler (Algorithm 2) from the paper [Elucidating the Design Space of Di
 #### Euler Ancestral scheduler
 
 Ancestral sampling with Euler method steps. Based on the original (k-diffusion)[https://github.com/crowsonkb/k-diffusion/blob/481677d114f6ea445aa009cf5bd7a9cdee909e47/k_diffusion/sampling.py#L72] implementation by Katherine Crowson.
+Fast scheduler which often times generates good outputs with 20-30 steps.
 
 [[autodoc]] EulerAncestralDiscreteScheduler

--- a/docs/source/api/schedulers.mdx
+++ b/docs/source/api/schedulers.mdx
@@ -112,3 +112,17 @@ Score SDE-VP is under construction.
 </Tip>
 
 [[autodoc]] schedulers.scheduling_sde_vp.ScoreSdeVpScheduler
+
+
+#### Euler scheduler
+
+Euler scheduler (Algorithm 2) from the paper [Elucidating the Design Space of Diffusion-Based Generative Models](https://arxiv.org/abs/2206.00364) by Karras et al. (2022). Based on the original [k-diffusion](https://github.com/crowsonkb/k-diffusion/blob/481677d114f6ea445aa009cf5bd7a9cdee909e47/k_diffusion/sampling.py#L51) implementation by Katherine Crowson.
+
+[[autodoc]] EulerDiscreteScheduler
+
+
+#### Euler Ancestral scheduler
+
+Ancestral sampling with Euler method steps. Based on the original (k-diffusion)[https://github.com/crowsonkb/k-diffusion/blob/481677d114f6ea445aa009cf5bd7a9cdee909e47/k_diffusion/sampling.py#L72] implementation by Katherine Crowson.
+
+[[autodoc]] EulerAncestralDiscreteScheduler


### PR DESCRIPTION
This PR

- Adds the new euler schedulers in the doc.
- Adds a section in stable diffusion doc to explain how to use different schedulers wih the pipeline using the new API.