### PR TITLE
Fix lr-scaling store_true & default=True cli argument for textual_inversion training.

### DIFF
--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -116,7 +116,7 @@ def parse_args():
     parser.add_argument(
         "--scale_lr",
         action="store_true",
-        default=True,
+        default=False,
         help="Scale the learning rate by the number of GPUs, gradient accumulation steps, and batch size.",
     )
     parser.add_argument(


### PR DESCRIPTION
`action="store_true"` means that the default action will be to set the value to `False`, and then if provided, set the value to `True`. Currently the default is manually set as 'True', therefore no-matter-what it will be True.