### PR TITLE
Flax: Flip sin to cos in time embeddings

### DIFF
--- a/src/diffusers/models/embeddings_flax.py
+++ b/src/diffusers/models/embeddings_flax.py
@@ -88,4 +88,6 @@ class FlaxTimesteps(nn.Module):
 
     @nn.compact
     def __call__(self, timesteps):
-        return get_sinusoidal_embeddings(timesteps, embedding_dim=self.dim, freq_shift=self.freq_shift)
+        return get_sinusoidal_embeddings(
+            timesteps, embedding_dim=self.dim, freq_shift=self.freq_shift, flip_sin_to_cos=True
+        )


### PR DESCRIPTION
This was assumed in the previous implementation, but now (0b61cea347e9b464fb03506cb78a49d38e1c74ee) the default is the opposite.

Fixes #1145.