### PR TITLE
Restore compatibility with deprecated `StableDiffusionOnnxPipeline`

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_onnx_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_onnx_stable_diffusion.py
@@ -18,6 +18,7 @@ logger = logging.get_logger(__name__)
 
 
 class OnnxStableDiffusionPipeline(DiffusionPipeline):
+    vae_encoder: OnnxRuntimeModel
     vae_decoder: OnnxRuntimeModel
     text_encoder: OnnxRuntimeModel
     tokenizer: CLIPTokenizer


### PR DESCRIPTION
I think it broke in #552, but it was meant to be deprecated until `1.0.0`.