### PR TITLE
[Docs] improve img2img example

### DIFF
--- a/docs/source/using-diffusers/img2img.mdx
+++ b/docs/source/using-diffusers/img2img.mdx
@@ -33,7 +33,7 @@ url = "https://raw.githubusercontent.com/CompVis/stable-diffusion/main/assets/st
 
 response = requests.get(url)
 init_image = Image.open(BytesIO(response.content)).convert("RGB")
-init_image = init_image.resize((768, 512))
+init_image.thumbnail((768, 768))
 
 prompt = "A fantasy landscape, trending on artstation"
 


### PR DESCRIPTION
1. In [img2img example](https://huggingface.co/docs/diffusers/v0.7.0/en/using-diffusers/img2img#textguided-imagetoimage-generation). This code force change input image ratio. This is not a good practice, since the init image [will be preprocessed and keep aspect ratio](https://github.com/huggingface/diffusers/blob/555203e1faa32cfa07c6128c09a8352031d7a969/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py#L29).

2. Use `init_image.thumbnail()` can resize the image and keep its original aspect ratio, which avoid `CUDA out of memory` runtime error for large input image.