### PR TITLE
Fix DDIM for eta>0 and a cpu generator

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -300,9 +300,13 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
                     # randn does not work reproducibly on mps
                     variance_noise = torch.randn(model_output.shape, dtype=model_output.dtype, generator=generator)
                     variance_noise = variance_noise.to(device)
-                else:
+                elif generator is not None and generator.device.type == device.type:
                     variance_noise = torch.randn(
                         model_output.shape, generator=generator, device=device, dtype=model_output.dtype
+                    )
+                else:
+                    variance_noise = torch.randn(model_output.shape, generator=generator, dtype=model_output.dtype).to(
+                        device
                     )
             variance = self._get_variance(timestep, prev_timestep) ** (0.5) * eta * variance_noise
 

--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -305,9 +305,9 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
                         model_output.shape, generator=generator, device=device, dtype=model_output.dtype
                     )
                 else:
-                    variance_noise = torch.randn(model_output.shape, generator=generator, dtype=model_output.dtype).to(
-                        device
-                    )
+                    variance_noise = torch.randn(model_output.shape, generator=generator, dtype=model_output.dtype)
+                        variance_noise = variance_noise.to(device)
+
             variance = self._get_variance(timestep, prev_timestep) ** (0.5) * eta * variance_noise
 
             prev_sample = prev_sample + variance


### PR DESCRIPTION
Follow-up to https://github.com/huggingface/diffusers/pull/1189
Allows DDIM to still be used with a cpu generator and eta>0 in `DDIMPipeline`