### PR TITLE
Convert Flax trained model to PyTorch

### DIFF
--- a/src/diffusers/modeling_flax_pytorch_utils.py
+++ b/src/diffusers/modeling_flax_pytorch_utils.py
@@ -13,11 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ PyTorch - Flax general utilities."""
+import os
+from pickle import UnpicklingError
 import re
 
+import numpy as np
+
+import jax
 import jax.numpy as jnp
-from flax.traverse_util import flatten_dict, unflatten_dict
 from jax.random import PRNGKey
+import diffusers
+from flax.traverse_util import flatten_dict, unflatten_dict
+from flax.serialization import from_bytes
 
 from .utils import logging
 
@@ -115,3 +122,141 @@ def convert_pytorch_state_dict_to_flax(pt_state_dict, flax_model, init_key=42):
         flax_state_dict[flax_key] = jnp.asarray(flax_tensor)
 
     return unflatten_dict(flax_state_dict)
+
+#####################
+# Flax => PyTorch #
+#####################
+
+
+def load_flax_checkpoint_in_pytorch_model(model, flax_checkpoint_path):
+    """Load flax checkpoints in a PyTorch model"""
+    flax_checkpoint_path = os.path.abspath(flax_checkpoint_path)
+    logger.info(f"Loading Flax weights from {flax_checkpoint_path}")
+
+    # import correct flax class
+    #flax_cls = getattr(transformers, "Flax" + model.__class__.__name__)
+    flax_cls = getattr(diffusers, "Flax" + model.__class__.__name__)
+
+    # load flax weight dict
+    with open(flax_checkpoint_path, "rb") as state_f:
+        try:
+            flax_state_dict = from_bytes(flax_cls, state_f.read())
+        except UnpicklingError:
+            raise EnvironmentError(f"Unable to convert {flax_checkpoint_path} to Flax deserializable object. ")
+
+    return load_flax_weights_in_pytorch_model(model, flax_state_dict)
+
+
+def load_flax_weights_in_pytorch_model(pt_model, flax_state):
+    """Load flax checkpoints in a PyTorch model"""
+
+    try:
+        import torch  # noqa: F401
+    except ImportError:
+        logger.error(
+            "Loading a Flax weights in PyTorch, requires both PyTorch and Flax to be installed. Please see"
+            " https://pytorch.org/ and https://flax.readthedocs.io/en/latest/installation.html for installation"
+            " instructions."
+        )
+        raise
+
+    # check if we have bf16 weights
+    is_type_bf16 = flatten_dict(jax.tree_util.tree_map(lambda x: x.dtype == jnp.bfloat16, flax_state)).values()
+    if any(is_type_bf16):
+        # convert all weights to fp32 if the are bf16 since torch.from_numpy can-not handle bf16
+        # and bf16 is not fully supported in PT yet.
+        logger.warning(
+            "Found ``bfloat16`` weights in Flax model. Casting all ``bfloat16`` weights to ``float32`` "
+            "before loading those in PyTorch model."
+        )
+        flax_state = jax.tree_util.tree_map(
+            lambda params: params.astype(np.float32) if params.dtype == jnp.bfloat16 else params, flax_state
+        )
+
+    pt_model.base_model_prefix = ""
+
+    flax_state_dict = flatten_dict(flax_state)
+    pt_model_dict = pt_model.state_dict()
+
+    load_model_with_head_into_base_model = (pt_model.base_model_prefix in flax_state) and (
+        pt_model.base_model_prefix not in set([k.split(".")[0] for k in pt_model_dict.keys()])
+    )
+    load_base_model_into_model_with_head = (pt_model.base_model_prefix not in flax_state) and (
+        pt_model.base_model_prefix in set([k.split(".")[0] for k in pt_model_dict.keys()])
+    )
+
+    # keep track of unexpected & missing keys
+    unexpected_keys = []
+    missing_keys = set(pt_model_dict.keys())
+
+    for flax_key_tuple, flax_tensor in flax_state_dict.items():
+        has_base_model_prefix = flax_key_tuple[0] == pt_model.base_model_prefix
+        require_base_model_prefix = ".".join((pt_model.base_model_prefix,) + flax_key_tuple) in pt_model_dict
+
+        # adapt flax_key to prepare for loading from/to base model only
+        if load_model_with_head_into_base_model and has_base_model_prefix:
+            flax_key_tuple = flax_key_tuple[1:]
+        elif load_base_model_into_model_with_head and require_base_model_prefix:
+            flax_key_tuple = (pt_model.base_model_prefix,) + flax_key_tuple
+
+        # rename flax weights to PyTorch format
+        if flax_key_tuple[-1] == "kernel" and flax_tensor.ndim == 4 and ".".join(flax_key_tuple) not in pt_model_dict:
+            # conv layer
+            flax_key_tuple = flax_key_tuple[:-1] + ("weight",)
+            flax_tensor = jnp.transpose(flax_tensor, (3, 2, 0, 1))
+        elif flax_key_tuple[-1] == "kernel" and ".".join(flax_key_tuple) not in pt_model_dict:
+            # linear layer
+            flax_key_tuple = flax_key_tuple[:-1] + ("weight",)
+            flax_tensor = flax_tensor.T
+        elif flax_key_tuple[-1] in ["scale", "embedding"]:
+            flax_key_tuple = flax_key_tuple[:-1] + ("weight",)
+
+        flax_key = ".".join(flax_key_tuple)
+
+        if flax_key in pt_model_dict:
+            if flax_tensor.shape != pt_model_dict[flax_key].shape:
+                raise ValueError(
+                    f"Flax checkpoint seems to be incorrect. Weight {flax_key_tuple} was expected "
+                    f"to be of shape {pt_model_dict[flax_key].shape}, but is {flax_tensor.shape}."
+                )
+            else:
+                # add weight to pytorch dict
+                flax_tensor = np.asarray(flax_tensor) if not isinstance(flax_tensor, np.ndarray) else flax_tensor
+                pt_model_dict[flax_key] = torch.from_numpy(flax_tensor)
+                # remove from missing keys
+                missing_keys.remove(flax_key)
+        else:
+            # weight is not expected by PyTorch model
+            unexpected_keys.append(flax_key)
+
+    pt_model.load_state_dict(pt_model_dict)
+
+    # re-transform missing_keys to list
+    missing_keys = list(missing_keys)
+
+    if len(unexpected_keys) > 0:
+        logger.warning(
+            "Some weights of the Flax model were not used when initializing the PyTorch model"
+            f" {pt_model.__class__.__name__}: {unexpected_keys}\n- This IS expected if you are initializing"
+            f" {pt_model.__class__.__name__} from a Flax model trained on another task or with another architecture"
+            " (e.g. initializing a BertForSequenceClassification model from a FlaxBertForPreTraining model).\n- This"
+            f" IS NOT expected if you are initializing {pt_model.__class__.__name__} from a Flax model that you expect"
+            " to be exactly identical (e.g. initializing a BertForSequenceClassification model from a"
+            " FlaxBertForSequenceClassification model)."
+        )
+    else:
+        logger.warning(f"All Flax model weights were used when initializing {pt_model.__class__.__name__}.\n")
+    if len(missing_keys) > 0:
+        logger.warning(
+            f"Some weights of {pt_model.__class__.__name__} were not initialized from the Flax model and are newly"
+            f" initialized: {missing_keys}\nYou should probably TRAIN this model on a down-stream task to be able to"
+            " use it for predictions and inference."
+        )
+    else:
+        logger.warning(
+            f"All the weights of {pt_model.__class__.__name__} were initialized from the Flax model.\n"
+            "If your task is similar to the task the model of the checkpoint was trained on, "
+            f"you can already use {pt_model.__class__.__name__} for predictions without further training."
+        )
+
+    return pt_model

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -385,6 +385,7 @@ class DiffusionPipeline(ConfigMixin):
         ```
         """
         cache_dir = kwargs.pop("cache_dir", DIFFUSERS_CACHE)
+        from_flax = kwargs.pop("from_flax", False)
         resume_download = kwargs.pop("resume_download", False)
         force_download = kwargs.pop("force_download", False)
         proxies = kwargs.pop("proxies", None)
@@ -398,6 +399,8 @@ class DiffusionPipeline(ConfigMixin):
         device_map = kwargs.pop("device_map", None)
         low_cpu_mem_usage = kwargs.pop("low_cpu_mem_usage", _LOW_CPU_MEM_USAGE_DEFAULT)
 
+        from_pt = not from_flax
+        
         if low_cpu_mem_usage and not is_accelerate_available():
             low_cpu_mem_usage = False
             logger.warn(

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -629,6 +629,8 @@ class DiffusionPipeline(ConfigMixin):
 
                 # check if the module is in a subdirectory
                 if os.path.isdir(os.path.join(cached_folder, name)):
+                    if from_flax:
+                        loading_kwargs['from_flax'] = True
                     loaded_sub_model = load_method(os.path.join(cached_folder, name), **loading_kwargs)
                 else:
                     # else load from the root directory


### PR DESCRIPTION
Based on #1161. I've mostly taken and adapted Flax->PT code from [transformers](https://github.com/huggingface/transformers).

My test scenario is currently this:
```python
from diffusers import FlaxStableDiffusionPipeline, StableDiffusionPipeline
from diffusers import AutoencoderKL, UNet2DConditionModel
import jax.numpy as jnp

pipe, params = FlaxStableDiffusionPipeline.from_pretrained('CompVis/stable-diffusion-v1-4', revision='bf16', dtype=jnp.bfloat16)
pipe.save_pretrained('output-flax', params)


vae = AutoencoderKL.from_pretrained('output-flax/vae', from_flax=True)
unet = UNet2DConditionModel.from_pretrained('output-flax/unet', from_flax=True)
pipe2 = StableDiffusionPipeline.from_pretrained('output-flax', from_flax=True)
```

VAE and UNet load, but I have yet to test, if they run without problems.

The last line of my test code for the pipeline currently fails with:

```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ test.py:11 in <module>                                                                           │
│                                                                                                  │
│    8                                                                                             │
│    9 vae = AutoencoderKL.from_pretrained('output-flax/vae', from_flax=True)                      │
│   10 unet = UNet2DConditionModel.from_pretrained('output-flax/unet', from_flax=True)             │
│ ❱ 11 pipe2 = StableDiffusionPipeline.from_pretrained('output-flax', from_flax=True)              │
│   12                                                                                             │
│                                                                                                  │
│ diffusers/src/diffusers/pipeline_utils.py:632 in                                                 │
│ from_pretrained                                                                                  │
│                                                                                                  │
│   629 │   │   │   │                                                                              │
│   630 │   │   │   │   # check if the module is in a subdirectory                                 │
│   631 │   │   │   │   if os.path.isdir(os.path.join(cached_folder, name)):                       │
│ ❱ 632 │   │   │   │   │   loaded_sub_model = load_method(os.path.join(cached_folder, name), **   │
│   633 │   │   │   │   else:                                                                      │
│   634 │   │   │   │   │   # else load from the root directory                                    │
│   635 │   │   │   │   │   loaded_sub_model = load_method(cached_folder, **loading_kwargs)        │
│                                                                                                  │
│ miniconda3/lib/python3.9/site-packages/transformers/modeling_utils.py:1815 in                    │
│ from_pretrained                                                                                  │
│                                                                                                  │
│   1812 │   │   │   │   │   │   "weights."                                                        │
│   1813 │   │   │   │   │   )                                                                     │
│   1814 │   │   │   │   elif os.path.join(pretrained_model_name_or_path, FLAX_WEIGHTS_NAME):      │
│ ❱ 1815 │   │   │   │   │   raise EnvironmentError(                                               │
│   1816 │   │   │   │   │   │   f"Error no file named {WEIGHTS_NAME} found in directory {pretrai  │
│   1817 │   │   │   │   │   │   "there is a file for Flax weights. Use `from_flax=True` to load   │
│   1818 │   │   │   │   │   │   "weights."                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
OSError: Error no file named pytorch_model.bin found in directory output-flax/text_encoder but there is a file for Flax weights. Use `from_flax=True` to load this model from those weights.
```

Not sure if this needs fixing in `diffusers` or in `transformers`, though I assume it should be possible to get this to work without modifying `transformers`.

@patrickvonplaten 