### PR TITLE
[Examples] Update `unconditional_image_generation/train_unconditional.py` to include Weights and Biases Logger

### DIFF
--- a/examples/unconditional_image_generation/train_unconditional.py
+++ b/examples/unconditional_image_generation/train_unconditional.py
@@ -475,6 +475,16 @@ def main(args):
             if epoch % args.save_model_epochs == 0 or epoch == args.num_epochs - 1:
                 # save the model
                 pipeline.save_pretrained(args.output_dir)
+                
+                if "wandb" in args.logger:
+                    # log model checkpoint within a wandb artifact
+                    model_artifact = wandb.Artifact(
+                        f'{wandb.run.id}-{args.output_dir}', 
+                        type='model'
+                    )
+                    model_artifact.add_dir(args.output_dir)
+                    wandb.log_artifact(model_artifact, aliases=[f'step_{global_step}', f'epoch_{epoch}'])
+
                 if args.push_to_hub:
                     repo.push_to_hub(commit_message=f"Epoch {epoch}", blocking=False)
         accelerator.wait_for_everyone()


### PR DESCRIPTION
Unborked PR of #1209

> The current example uses Tensorboard as the only available logger. Adding Weights and Biases allows us to interact with the model metrics, alongside the saved model predictions and logged model checkpoints all in accessible dashboards. This makes viewing my batches of experiments and images a lot more streamlined.
The user-facing addition adds an argument for `logger` which can take one or more of the available options which are currently only [wandb, tensorboard].
[An example dashboard trained over few epochs can be seen here](https://wandb.ai/int_pb/train_unconditional-ddpm-ema-pokemon-64/runs/1c2k6o3t?workspace=user-a-sh0ts). Using both tensorboard and wandb generates an embedded tensorboard instance within wandb.