### PR TITLE
Scale and shift in Resnet block

### DIFF
--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -311,7 +311,7 @@ class ResnetBlock2D(nn.Module):
         kernel=None,
         output_scale_factor=1.0,
         use_in_shortcut=None,
-        use_scale_shift_norm=False,
+        use_scale_shift_norm=True,
         up=False,
         down=False,
     ):
@@ -336,9 +336,7 @@ class ResnetBlock2D(nn.Module):
         self.conv1 = torch.nn.Conv2d(in_channels, out_channels, kernel_size=3, stride=1, padding=1)
 
         if temb_channels is not None:
-            self.time_emb_proj = torch.nn.Linear(
-                temb_channels, out_channels * 2 if use_scale_shift_norm else out_channels
-            )
+            self.time_emb_proj = torch.nn.Linear(temb_channels, out_channels * 2 if use_scale_shift_norm else out_channels)
         else:
             self.time_emb_proj = None
 

--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -311,6 +311,7 @@ class ResnetBlock2D(nn.Module):
         kernel=None,
         output_scale_factor=1.0,
         use_in_shortcut=None,
+        use_scale_shift_norm=False,
         up=False,
         down=False,
     ):
@@ -321,6 +322,7 @@ class ResnetBlock2D(nn.Module):
         out_channels = in_channels if out_channels is None else out_channels
         self.out_channels = out_channels
         self.use_conv_shortcut = conv_shortcut
+        self.use_scale_shift_norm = use_scale_shift_norm
         self.time_embedding_norm = time_embedding_norm
         self.up = up
         self.down = down
@@ -334,7 +336,7 @@ class ResnetBlock2D(nn.Module):
         self.conv1 = torch.nn.Conv2d(in_channels, out_channels, kernel_size=3, stride=1, padding=1)
 
         if temb_channels is not None:
-            self.time_emb_proj = torch.nn.Linear(temb_channels, out_channels)
+            self.time_emb_proj = torch.nn.Linear(temb_channels, out_channels * 2 if use_scale_shift_norm else out_channels)
         else:
             self.time_emb_proj = None
 
@@ -394,9 +396,14 @@ class ResnetBlock2D(nn.Module):
 
         if temb is not None:
             temb = self.time_emb_proj(self.nonlinearity(temb))[:, :, None, None]
-            hidden_states = hidden_states + temb
+            if self.use_scale_shift_norm:
+                temb_shift, temb_scale = torch.chunk(temb, 2, dim=1)
+                hidden_states = self.norm2(hidden_states)
+                hidden_states = hidden_states * (1 + temb_scale) + temb_shift
+            else:
+                hidden_states = hidden_states + temb
+                hidden_states = self.norm2(hidden_states)
 
-        hidden_states = self.norm2(hidden_states)
         hidden_states = self.nonlinearity(hidden_states)
 
         hidden_states = self.dropout(hidden_states)

--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -336,7 +336,9 @@ class ResnetBlock2D(nn.Module):
         self.conv1 = torch.nn.Conv2d(in_channels, out_channels, kernel_size=3, stride=1, padding=1)
 
         if temb_channels is not None:
-            self.time_emb_proj = torch.nn.Linear(temb_channels, out_channels * 2 if use_scale_shift_norm else out_channels)
+            self.time_emb_proj = torch.nn.Linear(
+                temb_channels, out_channels * 2 if use_scale_shift_norm else out_channels
+            )
         else:
             self.time_emb_proj = None
 


### PR DESCRIPTION
Implemented optional scale and shift (instead of currently only shift) based on timestep embedding, similarly to OpenAI's improved diffusion code.

However, it is currently not being used and I would appreciate some suggestions on how to best hook it up. Was `time_embedding_norm` intended for this (it is not being used)?