### PR TITLE
Include Negative Prompt in Pipeline Tests

### DIFF
--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -89,6 +89,7 @@ class DownloadTests(unittest.TestCase):
 
     def test_download_no_safety_checker(self):
         prompt = "hello"
+        negative_prompt = "good_bye"
         pipe = StableDiffusionPipeline.from_pretrained(
             "hf-internal-testing/tiny-stable-diffusion-torch", safety_checker=None
         )
@@ -107,12 +108,13 @@ class DownloadTests(unittest.TestCase):
             generator = torch.manual_seed(0)
         else:
             generator = torch.Generator(device=torch_device).manual_seed(0)
-        out_2 = pipe_2(prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+        out_2 = pipe_2(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         assert np.max(np.abs(out - out_2)) < 1e-3
 
     def test_load_no_safety_checker_explicit_locally(self):
         prompt = "hello"
+        negative_prompt = "good_bye"
         pipe = StableDiffusionPipeline.from_pretrained(
             "hf-internal-testing/tiny-stable-diffusion-torch", safety_checker=None
         )
@@ -122,7 +124,7 @@ class DownloadTests(unittest.TestCase):
             generator = torch.manual_seed(0)
         else:
             generator = torch.Generator(device=torch_device).manual_seed(0)
-        out = pipe(prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+        out = pipe(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             pipe.save_pretrained(tmpdirname)
@@ -135,12 +137,13 @@ class DownloadTests(unittest.TestCase):
             else:
                 generator = torch.Generator(device=torch_device).manual_seed(0)
 
-            out_2 = pipe_2(prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+            out_2 = pipe_2(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         assert np.max(np.abs(out - out_2)) < 1e-3
 
     def test_load_no_safety_checker_default_locally(self):
         prompt = "hello"
+        negative_prompt = "good_bye"
         pipe = StableDiffusionPipeline.from_pretrained("hf-internal-testing/tiny-stable-diffusion-torch")
         pipe = pipe.to(torch_device)
         if torch_device == "mps":
@@ -148,7 +151,7 @@ class DownloadTests(unittest.TestCase):
             generator = torch.manual_seed(0)
         else:
             generator = torch.Generator(device=torch_device).manual_seed(0)
-        out = pipe(prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+        out = pipe(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             pipe.save_pretrained(tmpdirname)
@@ -161,7 +164,7 @@ class DownloadTests(unittest.TestCase):
             else:
                 generator = torch.Generator(device=torch_device).manual_seed(0)
 
-            out_2 = pipe_2(prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+            out_2 = pipe_2(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         assert np.max(np.abs(out - out_2)) < 1e-3
 
@@ -224,7 +227,7 @@ class CustomPipelineTests(unittest.TestCase):
         # https://github.com/huggingface/diffusers/blob/main/examples/community/clip_guided_stable_diffusion.py
         assert pipeline.__class__.__name__ == "CLIPGuidedStableDiffusion"
 
-        image = pipeline("a prompt", num_inference_steps=2, output_type="np").images[0]
+        image = pipeline("a prompt", "negative_prompt", num_inference_steps=2, output_type="np").images[0]
         assert image.shape == (512, 512, 3)
 
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -99,7 +99,7 @@ class DownloadTests(unittest.TestCase):
             generator = torch.manual_seed(0)
         else:
             generator = torch.Generator(device=torch_device).manual_seed(0)
-        out = pipe(prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+        out = pipe(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         pipe_2 = StableDiffusionPipeline.from_pretrained("hf-internal-testing/tiny-stable-diffusion-torch")
         pipe_2 = pipe_2.to(torch_device)
@@ -227,7 +227,7 @@ class CustomPipelineTests(unittest.TestCase):
         # https://github.com/huggingface/diffusers/blob/main/examples/community/clip_guided_stable_diffusion.py
         assert pipeline.__class__.__name__ == "CLIPGuidedStableDiffusion"
 
-        image = pipeline("a prompt", "negative_prompt", num_inference_steps=2, output_type="np").images[0]
+        image = pipeline("a prompt", negative_prompt="negative_prompt", num_inference_steps=2, output_type="np").images[0]
         assert image.shape == (512, 512, 3)
 
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -99,7 +99,7 @@ class DownloadTests(unittest.TestCase):
             generator = torch.manual_seed(0)
         else:
             generator = torch.Generator(device=torch_device).manual_seed(0)
-        out = pipe(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+        out = pipe(prompt, negative_prompt=negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         pipe_2 = StableDiffusionPipeline.from_pretrained("hf-internal-testing/tiny-stable-diffusion-torch")
         pipe_2 = pipe_2.to(torch_device)
@@ -108,7 +108,7 @@ class DownloadTests(unittest.TestCase):
             generator = torch.manual_seed(0)
         else:
             generator = torch.Generator(device=torch_device).manual_seed(0)
-        out_2 = pipe_2(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+        out_2 = pipe_2(prompt, negative_prompt=negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         assert np.max(np.abs(out - out_2)) < 1e-3
 
@@ -124,7 +124,7 @@ class DownloadTests(unittest.TestCase):
             generator = torch.manual_seed(0)
         else:
             generator = torch.Generator(device=torch_device).manual_seed(0)
-        out = pipe(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+        out = pipe(prompt, negative_prompt=negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             pipe.save_pretrained(tmpdirname)
@@ -137,7 +137,7 @@ class DownloadTests(unittest.TestCase):
             else:
                 generator = torch.Generator(device=torch_device).manual_seed(0)
 
-            out_2 = pipe_2(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+            out_2 = pipe_2(prompt, negative_prompt=negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         assert np.max(np.abs(out - out_2)) < 1e-3
 
@@ -151,7 +151,7 @@ class DownloadTests(unittest.TestCase):
             generator = torch.manual_seed(0)
         else:
             generator = torch.Generator(device=torch_device).manual_seed(0)
-        out = pipe(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+        out = pipe(prompt, negative_prompt=negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             pipe.save_pretrained(tmpdirname)
@@ -164,7 +164,7 @@ class DownloadTests(unittest.TestCase):
             else:
                 generator = torch.Generator(device=torch_device).manual_seed(0)
 
-            out_2 = pipe_2(prompt, negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
+            out_2 = pipe_2(prompt, negative_prompt=negative_prompt, num_inference_steps=2, generator=generator, output_type="numpy").images
 
         assert np.max(np.abs(out - out_2)) < 1e-3
 


### PR DESCRIPTION
Found that Negative Prompt is not specifically called in the Standard Test Environments
- Figured for testing consistency both prompt and neg prompt should be checked with a value other than None
- Add negative_prompt = "good_bye" to the Pipeline test and call it in the proceeding out = pipe() call
- Where image is called and "a_prompt" is used negative_prompt is set to "negative"

Edit: I hope I entered this PR correctly, any assistance is appreciated.