### PR TITLE
Edited attention.py for older xformers

### DIFF
--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -557,6 +557,9 @@ class CrossAttention(nn.Module):
         return hidden_states
 
     def _memory_efficient_attention_xformers(self, query, key, value):
+        query = query.contiguous()
+        key = key.contiguous()
+        value = value.contiguous()
         hidden_states = xformers.ops.memory_efficient_attention(query, key, value, attn_bias=None)
         hidden_states = self.reshape_batch_dim_to_heads(hidden_states)
         return hidden_states


### PR DESCRIPTION
Older versions of xformers require query, key, value to be contiguous, this calls .contiguous() on q/k/v before passing to xformers.

Tested with 0.14 version of xformers built by [metrolobo](https://github.com/metrolobo), specifically, [this release](https://github.com/metrolobo/xformers_wheels/releases/tag/1d31a3ac_various_6), on T4 GPU and torch==1.12.0+cu113. It seemed this problem isn't encountered on other versions. 

Testing with the 'official' release on pip isn't possible, as the 0.13 version currently on pip cannot be installed, regardless of gpu/version. 

Edit: I did not run test with the other versions of prebuilt wheels, or other GPU but T4. Let me know if it fails on other versions.