### PR TITLE
Fix wrong link in text2img fine-tuning documentation

### DIFF
--- a/docs/source/training/text2image.mdx
+++ b/docs/source/training/text2image.mdx
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 
 # Stable Diffusion text-to-image fine-tuning
 
-The [`train_text_to_image.py`](https://github.com/huggingface/diffusers/tree/main/examples/textual_inversion) script shows how to fine-tune the stable diffusion model on your own dataset.
+The [`train_text_to_image.py`](https://github.com/huggingface/diffusers/tree/main/examples/text_to_image) script shows how to fine-tune the stable diffusion model on your own dataset.
 
 <Tip warning={true}>
 


### PR DESCRIPTION
The documentation for text2img fine-tuning [here](https://huggingface.co/docs/diffusers/training/text2image) has the wrong link to the script on GitHub, it directs to the textual inversion script.

I've updated it with the correct link in this PR.