### PR TITLE
Small performance improvements to some schedulers

### DIFF
--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -310,35 +310,19 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
         if self.config.algorithm_type == "dpmsolver++":
             # See https://arxiv.org/abs/2211.01095 for detailed derivations
             if self.config.solver_type == "midpoint":
-                alpha_t_exp_h = (alpha_t * (torch.exp(-h) - 1.0))
-                x_t = (
-                    (sigma_t / sigma_s0) * sample
-                    - alpha_t_exp_h * D0
-                    - 0.5 * alpha_t_exp_h * D1
-                )
+                alpha_t_exp_h = alpha_t * (torch.exp(-h) - 1.0)
+                x_t = (sigma_t / sigma_s0) * sample - alpha_t_exp_h * D0 - 0.5 * alpha_t_exp_h * D1
             elif self.config.solver_type == "heun":
                 exp_h = torch.exp(-h) - 1.0
-                x_t = (
-                    (sigma_t / sigma_s0) * sample
-                    - (alpha_t * exp_h) * D0
-                    + (alpha_t * (exp_h / h + 1.0)) * D1
-                )
+                x_t = (sigma_t / sigma_s0) * sample - (alpha_t * exp_h) * D0 + (alpha_t * (exp_h / h + 1.0)) * D1
         elif self.config.algorithm_type == "dpmsolver":
             # See https://arxiv.org/abs/2206.00927 for detailed derivations
             if self.config.solver_type == "midpoint":
-                sigma_t_exp_h = (sigma_t * (torch.exp(h) - 1.0))
-                x_t = (
-                    (alpha_t / alpha_s0) * sample
-                    - sigma_t_exp_h * D0
-                    - 0.5 * sigma_t_exp_h * D1
-                )
+                sigma_t_exp_h = sigma_t * (torch.exp(h) - 1.0)
+                x_t = (alpha_t / alpha_s0) * sample - sigma_t_exp_h * D0 - 0.5 * sigma_t_exp_h * D1
             elif self.config.solver_type == "heun":
-                exp_h = (torch.exp(h) - 1.0)
-                x_t = (
-                    (alpha_t / alpha_s0) * sample
-                    - (sigma_t * exp_h) * D0
-                    - (sigma_t * (exp_h / h - 1.0)) * D1
-                )
+                exp_h = torch.exp(h) - 1.0
+                x_t = (alpha_t / alpha_s0) * sample - (sigma_t * exp_h) * D0 - (sigma_t * (exp_h / h - 1.0)) * D1
         return x_t
 
     def multistep_dpm_solver_third_order_update(

--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -310,30 +310,34 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
         if self.config.algorithm_type == "dpmsolver++":
             # See https://arxiv.org/abs/2211.01095 for detailed derivations
             if self.config.solver_type == "midpoint":
+                alpha_t_exp_h = (alpha_t * (torch.exp(-h) - 1.0))
                 x_t = (
                     (sigma_t / sigma_s0) * sample
-                    - (alpha_t * (torch.exp(-h) - 1.0)) * D0
-                    - 0.5 * (alpha_t * (torch.exp(-h) - 1.0)) * D1
+                    - alpha_t_exp_h * D0
+                    - 0.5 * alpha_t_exp_h * D1
                 )
             elif self.config.solver_type == "heun":
+                exp_h = torch.exp(-h) - 1.0
                 x_t = (
                     (sigma_t / sigma_s0) * sample
-                    - (alpha_t * (torch.exp(-h) - 1.0)) * D0
-                    + (alpha_t * ((torch.exp(-h) - 1.0) / h + 1.0)) * D1
+                    - (alpha_t * exp_h) * D0
+                    + (alpha_t * (exp_h / h + 1.0)) * D1
                 )
         elif self.config.algorithm_type == "dpmsolver":
             # See https://arxiv.org/abs/2206.00927 for detailed derivations
             if self.config.solver_type == "midpoint":
+                sigma_t_exp_h = (sigma_t * (torch.exp(h) - 1.0))
                 x_t = (
                     (alpha_t / alpha_s0) * sample
-                    - (sigma_t * (torch.exp(h) - 1.0)) * D0
-                    - 0.5 * (sigma_t * (torch.exp(h) - 1.0)) * D1
+                    - sigma_t_exp_h * D0
+                    - 0.5 * sigma_t_exp_h * D1
                 )
             elif self.config.solver_type == "heun":
+                exp_h = (torch.exp(h) - 1.0)
                 x_t = (
                     (alpha_t / alpha_s0) * sample
-                    - (sigma_t * (torch.exp(h) - 1.0)) * D0
-                    - (sigma_t * ((torch.exp(h) - 1.0) / h - 1.0)) * D1
+                    - (sigma_t * exp_h) * D0
+                    - (sigma_t * (exp_h / h - 1.0)) * D1
                 )
         return x_t
 
@@ -376,19 +380,21 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
         D2 = (1.0 / (r0 + r1)) * (D1_0 - D1_1)
         if self.config.algorithm_type == "dpmsolver++":
             # See https://arxiv.org/abs/2206.00927 for detailed derivations
+            exp_h = torch.exp(-h) - 1.0
             x_t = (
                 (sigma_t / sigma_s0) * sample
-                - (alpha_t * (torch.exp(-h) - 1.0)) * D0
-                + (alpha_t * ((torch.exp(-h) - 1.0) / h + 1.0)) * D1
-                - (alpha_t * ((torch.exp(-h) - 1.0 + h) / h**2 - 0.5)) * D2
+                - (alpha_t * exp_h) * D0
+                + (alpha_t * (exp_h / h + 1.0)) * D1
+                - (alpha_t * ((exp_h + h) / h**2 - 0.5)) * D2
             )
         elif self.config.algorithm_type == "dpmsolver":
             # See https://arxiv.org/abs/2206.00927 for detailed derivations
+            exp_h = torch.exp(h) - 1.0
             x_t = (
                 (alpha_t / alpha_s0) * sample
-                - (sigma_t * (torch.exp(h) - 1.0)) * D0
-                - (sigma_t * ((torch.exp(h) - 1.0) / h - 1.0)) * D1
-                - (sigma_t * ((torch.exp(h) - 1.0 - h) / h**2 - 0.5)) * D2
+                - (sigma_t * exp_h) * D0
+                - (sigma_t * (exp_h / h - 1.0)) * D1
+                - (sigma_t * ((exp_h - h) / h**2 - 0.5)) * D2
             )
         return x_t
 

--- a/src/diffusers/schedulers/scheduling_euler_ancestral_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_ancestral_discrete.py
@@ -202,10 +202,10 @@ class EulerAncestralDiscreteScheduler(SchedulerMixin, ConfigMixin):
 
         # 1. compute predicted original sample (x_0) from sigma-scaled predicted noise
         pred_original_sample = sample - sigma * model_output
-        sigma_from = self.sigmas[step_index]
-        sigma_to = self.sigmas[step_index + 1]
-        sigma_up = (sigma_to**2 * (sigma_from**2 - sigma_to**2) / sigma_from**2) ** 0.5
-        sigma_down = (sigma_to**2 - sigma_up**2) ** 0.5
+        sigma_from = self.sigmas[step_index] ** 2
+        sigma_to = self.sigmas[step_index + 1] ** 2
+        sigma_up = (sigma_to * (sigma_from - sigma_to) / sigma_from) ** 0.5
+        sigma_down = (sigma_to - sigma_up**2) ** 0.5
 
         # 2. Convert to an ODE derivative
         derivative = (sample - pred_original_sample) / sigma


### PR DESCRIPTION
Small performance improvements to `dpmsolver_multistep` and `euler_ancestral_discrete` by avoiding redundant calculations. 
Vectorized the loop in `lms_discrete`.

Some example benchmarks with code below:

**DPMSolverMultistepScheduler**

> 100 steps: 
> before: 3.6375 sec
> after:    3,3583 sec

**LMSDiscreteScheduler**

> 100 steps: input shapes = [10,3,512,512]
> before: 4.6478 sec
> after:    4.5001 sec

> 100 steps with input shapes= [1,3,512,512]
> before: 0.4579 sec
> after:  0.3554 sec


```python3
    import time
    scheduler = LMSDiscreteScheduler()
    model_output = torch.randn(torch.Size([10, 3, 512, 512]))
    sample = torch.randn(torch.Size([10, 3, 512, 512]))

    scheduler.set_timesteps(100)

    avg = []
    num_test = 10
    for i in range(num_test):
        start_time = time.perf_counter_ns()
        for step in scheduler.timesteps:
            scheduler.step(model_output, step, sample)
        duration_ns = time.perf_counter_ns() - start_time
        avg.append(duration_ns)

    print("duration_ns", sum(avg) / num_test)
```
