### PR TITLE
use memory_efficient_attention by default

### DIFF
--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -373,7 +373,7 @@ class BasicTransformerBlock(nn.Module):
                 self._set_use_memory_efficient_attention_xformers(True)
             except Exception as e:
                 warnings.warn(
-                    "Could not enable memory efficient attention by default. Make sure xformers is installed"
+                    "Could not enable memory efficient attention. Make sure xformers is installed"
                     f" correctly and a GPU is available: {e}"
                 )
 

--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
+import warnings
 from dataclasses import dataclass
 from typing import Optional
 
@@ -365,6 +366,16 @@ class BasicTransformerBlock(nn.Module):
             self.norm1 = nn.LayerNorm(dim)
             self.norm2 = nn.LayerNorm(dim)
         self.norm3 = nn.LayerNorm(dim)
+
+        # if xformers is installed try to use memory_efficient_attention by default
+        if is_xformers_available():
+            try:
+                self._set_use_memory_efficient_attention_xformers(True)
+            except Exception as e:
+                warnings.warn(
+                    "Could not enable memory efficient attention by default. Make sure xformers is installed"
+                    f" correctly and a GPU is available: {e}"
+                )
 
     def _set_attention_slice(self, slice_size):
         self.attn1._slice_size = slice_size


### PR DESCRIPTION
This PR allows to enable `memory_efficient_attention` by default if xformers is correctly installed.

Fxies #1343