### PR TITLE
Added pixel_values argument name during image_encoder call to avoid breaking execution

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_image_variation.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_image_variation.py
@@ -231,7 +231,7 @@ class StableDiffusionImageVariationPipeline(DiffusionPipeline):
             image = self.feature_extractor(images=image, return_tensors="pt").pixel_values
 
         image = image.to(device=device, dtype=dtype)
-        image_embeddings = self.image_encoder(image).image_embeds
+        image_embeddings = self.image_encoder(pixel_values=image).image_embeds
         image_embeddings = image_embeddings.unsqueeze(1)
 
         # duplicate image embeddings for each generation per prompt, using mps friendly method


### PR DESCRIPTION
The pipeline was breaking because we were missing the pixel_values argument name. Just added to make it work :)