### PR TITLE
[Deprecate] Correct stacklevel

### DIFF
--- a/src/diffusers/utils/deprecation_utils.py
+++ b/src/diffusers/utils/deprecation_utils.py
@@ -32,7 +32,7 @@ def deprecate(*args, take_from: Optional[Union[Dict, Any]] = None, standard_warn
 
         if warning is not None:
             warning = warning + " " if standard_warn else ""
-            warnings.warn(warning + message, FutureWarning)
+            warnings.warn(warning + message, FutureWarning, stacklevel=2)
 
     if isinstance(deprecated_kwargs, dict) and len(deprecated_kwargs) > 0:
         call_frame = inspect.getouterframes(inspect.currentframe())[1]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -167,4 +167,4 @@ class DeprecateTester(unittest.TestCase):
         with self.assertWarns(FutureWarning) as warning:
             deprecate(("deprecated_arg", self.higher_version, "This message is better!!!"), standard_warn=False)
         assert str(warning.warning) == "This message is better!!!"
-        assert warning.filename == "/home/patrick_huggingface_co/diffusers/tests/test_utils.py"
+        assert "diffusers/tests/test_utils.py" in warning.filename

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -162,3 +162,9 @@ class DeprecateTester(unittest.TestCase):
             deprecate(("deprecated_arg", self.higher_version, "This message is better!!!"), standard_warn=False)
 
         assert str(warning.warning) == "This message is better!!!"
+
+    def test_deprecate_stacklevel(self):
+        with self.assertWarns(FutureWarning) as warning:
+            deprecate(("deprecated_arg", self.higher_version, "This message is better!!!"), standard_warn=False)
+        assert str(warning.warning) == "This message is better!!!"
+        assert warning.filename == "/home/patrick_huggingface_co/diffusers/tests/test_utils.py"


### PR DESCRIPTION
Corrects the stacklevel of `deprecate` to make it easier for users to adapt their code. Thanks for the issue @keturn 