### PR TITLE
textual inversion fp16 auto mixed training

### DIFF
--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -542,7 +542,7 @@ def main():
                 autocast_context = torch.autocast("cuda")
                 gradient_scaler = torch.cuda.amp.GradScaler()
             else:
-                autocast_context = nullcontext
+                autocast_context = nullcontext()
                 gradient_scaler = None
             with accelerator.accumulate(text_encoder), autocast_context:
                 # Convert images to latent space


### PR DESCRIPTION
Adding auto mixed precision training following https://pytorch.org/tutorials/recipes/recipes/amp_recipe.html

re: https://github.com/huggingface/diffusers/issues/1543

I'm really doing copy-pasta here should have someone more familiar with amp check that this is correct. 

Also note that there is a separate mixed precision flag that is passed to the accelerator object. I'm not familiar with how that's different than using the torch amp context, but with just passing it, we still get the error. If needed I can do more digging into accelerate to see what it does (docs are pretty high level).

Currently letting it train to compare results with fp32 