### PR TITLE
Dreambooth: fix #1566: Use autocast to correct full vs half precision error

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -11,6 +11,8 @@ import torch.nn.functional as F
 import torch.utils.checkpoint
 from torch.utils.data import Dataset
 
+from  torch.cuda.amp import autocast #Autocast for proper type casting half vs full
+
 from accelerate import Accelerator
 from accelerate.logging import get_logger
 from accelerate.utils import set_seed
@@ -629,7 +631,8 @@ def main(args):
                 encoder_hidden_states = text_encoder(batch["input_ids"])[0]
 
                 # Predict the noise residual
-                model_pred = unet(noisy_latents, timesteps, encoder_hidden_states).sample
+                with autocast():
+                    model_pred = unet(noisy_latents, timesteps, encoder_hidden_states).sample
 
                 # Get the target for loss depending on the prediction type
                 if noise_scheduler.config.prediction_type == "epsilon":

--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 import torch.utils.checkpoint
 from torch.utils.data import Dataset
 
-from  torch.cuda.amp import autocast
+from torch.cuda.amp import autocast
 
 from accelerate import Accelerator
 from accelerate.logging import get_logger

--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -11,7 +11,6 @@ import torch.nn.functional as F
 import torch.utils.checkpoint
 from torch.utils.data import Dataset
 
-# Autocast for proper type casting half vs full
 from  torch.cuda.amp import autocast
 
 from accelerate import Accelerator

--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -11,7 +11,8 @@ import torch.nn.functional as F
 import torch.utils.checkpoint
 from torch.utils.data import Dataset
 
-from  torch.cuda.amp import autocast #Autocast for proper type casting half vs full
+# Autocast for proper type casting half vs full
+from  torch.cuda.amp import autocast
 
 from accelerate import Accelerator
 from accelerate.logging import get_logger


### PR DESCRIPTION
To address Dreambooth: fix #1566, a potential solution using autocast.

Further documentation here: https://discuss.pytorch.org/t/training-with-half-precision/11815/17

Using suggested implementation from here: https://discuss.pytorch.org/t/runtimeerror-input-type-torch-cuda-floattensor-and-weight-type-torch-halftensor-should-be-the-same/104312/6