### PR TITLE
Improve pipeline_stable_diffusion_inpaint_legacy.py

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint_legacy.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint_legacy.py
@@ -432,7 +432,7 @@ class StableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
         guidance_scale: Optional[float] = 7.5,
         negative_prompt: Optional[Union[str, List[str]]] = None,
         num_images_per_prompt: Optional[int] = 1,
-        add_predicted_noise: Optional[bool] = True,
+        add_predicted_noise: Optional[bool] = False,
         eta: Optional[float] = 0.0,
         generator: Optional[torch.Generator] = None,
         output_type: Optional[str] = "pil",

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint_legacy.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint_legacy.py
@@ -432,6 +432,7 @@ class StableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
         guidance_scale: Optional[float] = 7.5,
         negative_prompt: Optional[Union[str, List[str]]] = None,
         num_images_per_prompt: Optional[int] = 1,
+        add_predicted_noise: Optional[bool] = True,
         eta: Optional[float] = 0.0,
         generator: Optional[torch.Generator] = None,
         output_type: Optional[str] = "pil",
@@ -473,6 +474,9 @@ class StableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
                 if `guidance_scale` is less than `1`).
             num_images_per_prompt (`int`, *optional*, defaults to 1):
                 The number of images to generate per prompt.
+            add_predicted_noise (`bool`, *optional*, defaults to True):
+                Use predicted noise instead of random noise when constructing noisy versions of the original image in
+                the reverse diffusion process
             eta (`float`, *optional*, defaults to 0.0):
                 Corresponds to parameter eta (η) in the DDIM paper: https://arxiv.org/abs/2010.02502. Only applies to
                 [`schedulers.DDIMScheduler`], will be ignored for others.
@@ -563,7 +567,12 @@ class StableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
                 # compute the previous noisy sample x_t -> x_t-1
                 latents = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs).prev_sample
                 # masking
-                init_latents_proper = self.scheduler.add_noise(init_latents_orig, noise, torch.tensor([t]))
+                if add_predicted_noise:
+                    init_latents_proper = self.scheduler.add_noise(
+                        init_latents_orig, noise_pred_uncond, torch.tensor([t])
+                    )
+                else:
+                    init_latents_proper = self.scheduler.add_noise(init_latents_orig, noise, torch.tensor([t]))
 
                 latents = (init_latents_proper * mask) + (latents * (1 - mask))
 


### PR DESCRIPTION
This is basically a one-line change to the file `pipeline_stable_diffusion_inpaint_legacy.py`.
I allow the possibility of replacing
`init_latents_proper = self.scheduler.add_noise(init_latents_orig, noise, torch.tensor([t]))`
by
`init_latents_proper = self.scheduler.add_noise(init_latents_orig, noise_pred_uncond, torch.tensor([t]))`
with the argument `add_predicted_noise` now default to `True` (i.e., use the latter option by default). 
(Maybe it is better to keep the default argument as `False`, and maybe we can find a better name for this argument.)

What I am doing here is that I use the unconditionally predicted noise instead of the initial noise to create the diffused samples used in the reverse diffusion process, and as argued in [this paper](https://www.amazon.science/publications/diffusion-prior-for-online-decision-making-a-case-study-of-thompson-sampling) this leads to more coherent result.
It turns out however that I did fail two of the three tests when I run `tests/pipelines/stable_diffusion/test_stable_diffusion_inpaint_legacy.py`. These are assertions errors `AssertionError: assert 0.012784755849838236 < 0.01` and `AssertionError: assert 0.01317704176902773 < 0.01`.
I doubt this is a natural consequence of the change of the algorithm and as the difference is small I don't think that is a severe problem.

Anyway, the difference in inpainted result is very pronouncing.
In the following, I compare results from Automatic1111 webui DDIM inpainting (top row), the original inpaint_legacy script (middle row), and the modified inpaint_legacy script (bottom row). For the latter two I use the same random seeds.
Denoising strength is set to 1 so that the masked area are completely ignored

**Example 1**
model: SD 1.4
cfg: 10
Input:
![guinea_pig-masked](https://user-images.githubusercontent.com/24396911/206156962-81da2014-f7ae-46ec-a678-b71b349b27a7.png)
Prompt: guinea pig
![collage](https://user-images.githubusercontent.com/24396911/206157265-92a09212-8e8a-4f45-b36e-7558a550fbc6.png)

**Example 2**
model: [Linaqruf](https://huggingface.co/Linaqruf)/[anything-v3.0](https://huggingface.co/Linaqruf/anything-v3.0)
cfg: 7.5
Input:
![chise1-masked](https://user-images.githubusercontent.com/24396911/206144389-db8e71b5-c504-41a0-9553-16b426194adf.jpg)
Prompt: anime girl with blue hair in dress
![collage](https://user-images.githubusercontent.com/24396911/206145285-81ee5424-c5fc-419d-a2fc-578881693e4b.png)


