### PR TITLE
Handle missing global_step key in scripts/convert_original_stable_diffusion_to_diffusers.py

### DIFF
--- a/scripts/convert_original_stable_diffusion_to_diffusers.py
+++ b/scripts/convert_original_stable_diffusion_to_diffusers.py
@@ -796,23 +796,33 @@ if __name__ == "__main__":
     prediction_type = args.prediction_type
 
     checkpoint = torch.load(args.checkpoint_path)
-    global_step = checkpoint["global_step"]
+
+    # Sometimes models don't have the global_step item
+    if "global_step" in checkpoint:
+        global_step = checkpoint["global_step"]
+    else:
+        print("global_step key not found in model")
+        global_step = None
     checkpoint = checkpoint["state_dict"]
 
     if args.original_config_file is None:
         key_name = "model.diffusion_model.input_blocks.2.1.transformer_blocks.0.attn2.to_k.weight"
 
         if key_name in checkpoint and checkpoint[key_name].shape[-1] == 1024:
-            # model_type = "v2"
-            os.system(
-                "wget https://raw.githubusercontent.com/Stability-AI/stablediffusion/main/configs/stable-diffusion/v2-inference-v.yaml"
-            )
+            if not os.path.isfile("v2-inference-v.yaml"):
+                # model_type = "v2"
+                os.system(
+                    "wget https://raw.githubusercontent.com/Stability-AI/stablediffusion/main/configs/stable-diffusion/v2-inference-v.yaml"
+                    " -O v2-inference-v.yaml"
+                )
             args.original_config_file = "./v2-inference-v.yaml"
         else:
-            # model_type = "v1"
-            os.system(
-                "wget https://raw.githubusercontent.com/CompVis/stable-diffusion/main/configs/stable-diffusion/v1-inference.yaml"
-            )
+            if not os.path.isfile("v1-inference.yaml"):
+                # model_type = "v1"
+                os.system(
+                    "wget https://raw.githubusercontent.com/CompVis/stable-diffusion/main/configs/stable-diffusion/v1-inference.yaml"
+                    " -O v1-inference.yaml"
+                )
             args.original_config_file = "./v1-inference.yaml"
 
     original_config = OmegaConf.load(args.original_config_file)


### PR DESCRIPTION
I was running into issues converting a .ckpt to Diffusers format where the model didn't have the `global_step` key. The model I was converting was merged via the WebUI's checkpoint merger.

If `global_step` isn't present then just set it to `None` and let the checks on line 833 figure out what to do.

Also, check if the config file exists before downloading it and skip downloading it if it does.