### PR TITLE
Remove spurious arg in training scripts

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -491,7 +491,7 @@ def main(args):
 
     if is_xformers_available():
         try:
-            unet.enable_xformers_memory_efficient_attention(True)
+            unet.enable_xformers_memory_efficient_attention()
         except Exception as e:
             logger.warning(
                 "Could not enable memory efficient attention. Make sure xformers is installed"

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -367,7 +367,7 @@ def main():
 
     if is_xformers_available():
         try:
-            unet.enable_xformers_memory_efficient_attention(True)
+            unet.enable_xformers_memory_efficient_attention()
         except Exception as e:
             logger.warning(
                 "Could not enable memory efficient attention. Make sure xformers is installed"

--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -442,7 +442,7 @@ def main():
 
     if is_xformers_available():
         try:
-            unet.enable_xformers_memory_efficient_attention(True)
+            unet.enable_xformers_memory_efficient_attention()
         except Exception as e:
             logger.warning(
                 "Could not enable memory efficient attention. Make sure xformers is installed"


### PR DESCRIPTION
The `True` causes an exception and then xformers is not enabled.
Reported in discord: https://discord.com/channels/879548962464493619/1014556809928904794/1050863595086434435

Fixes #1643.