### PR TITLE
Allow k pipeline to generate > 1 images

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_k_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_k_diffusion.py
@@ -439,6 +439,7 @@ class StableDiffusionKDiffusionPipeline(DiffusionPipeline):
         # 6. Define model function
         def model_fn(x, t):
             latent_model_input = torch.cat([x] * 2)
+            t = torch.cat([t] * 2)
 
             noise_pred = self.k_diffusion_model(latent_model_input, t, cond=text_embeddings)
 


### PR DESCRIPTION
K samplers expand the sigmas to match the batch dimension of the input sample, for example here: https://github.com/crowsonkb/k-diffusion/blob/master/k_diffusion/sampling.py#LL128

However, we later expand the input inside `model_fn` to account for cfg, but the `t` remained untouched. This fails for batch sizes > 1.

Initially reported in the forums: https://discuss.huggingface.co/t/how-do-i-set-up-multiple-samples-to-display-in-a-colab-notebook-with-k-diffusion/27567