### PR TITLE
[Textual Inversion] Do not update other embeddings

### DIFF
--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -548,6 +548,9 @@ def main():
     progress_bar.set_description("Steps")
     global_step = 0
 
+    # keep original embeddings as reference
+    orig_embeds_params = text_encoder.get_input_embeddings().weight.data.clone()
+
     for epoch in range(args.num_train_epochs):
         text_encoder.train()
         for step, batch in enumerate(train_dataloader):
@@ -585,19 +588,14 @@ def main():
                 loss = F.mse_loss(model_pred, target, reduction="none").mean([1, 2, 3]).mean()
                 accelerator.backward(loss)
 
-                # Zero out the gradients for all token embeddings except the newly added
-                # embeddings for the concept, as we only want to optimize the concept embeddings
-                if accelerator.num_processes > 1:
-                    grads = text_encoder.module.get_input_embeddings().weight.grad
-                else:
-                    grads = text_encoder.get_input_embeddings().weight.grad
-                # Get the index for tokens that we want to zero the grads for
-                index_grads_to_zero = torch.arange(len(tokenizer)) != placeholder_token_id
-                grads.data[index_grads_to_zero, :] = grads.data[index_grads_to_zero, :].fill_(0)
-
                 optimizer.step()
                 lr_scheduler.step()
                 optimizer.zero_grad()
+
+                # Let's make sure we don't update any embedding weights besides the newly added token
+                index_no_updates = torch.arange(len(tokenizer)) != placeholder_token_id
+                with torch.no_grad():
+                    text_encoder.get_input_embeddings().weight[index_no_updates] = orig_embeds_params[index_no_updates]
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:


### PR DESCRIPTION
This PR fixes: https://github.com/huggingface/diffusers/issues/507

Essentially we are just copy-pasting the original embeddings after every step to be 100% certain that they are not changed. 

I've checked this PR by running the following script:
```
#!/usr/bin/env bash
export MODEL_NAME="CompVis/stable-diffusion-v1-4"
export DATA_DIR="/home/patrick_huggingface_co/images/a_magical_forest"

accelerate launch /home/patrick_huggingface_co/diffusers/examples/textual_inversion/textual_inversion.py \
  --pretrained_model_name_or_path=$MODEL_NAME \
  --train_data_dir=$DATA_DIR \
  --learnable_property="object" \
  --placeholder_token="<cat-toy>" --initializer_token="toy" \
  --resolution=512 \
  --train_batch_size=1 \
  --gradient_accumulation_steps=4 \
  --max_train_steps=3000 \
  --learning_rate=5.0e-04 --scale_lr \
  --lr_scheduler="constant" \
  --lr_warmup_steps=0 \
  --output_dir="textual_inversion_cat"
```

with `"/home/patrick_huggingface_co/images/a_magical_forest"` being: https://huggingface.co/datasets/patrickvonplaten/images/tree/main/a_magical_forest

on a V100 and get only a tiny increase in memory and the same training speed.
Memory is increased by 100 MB from 11.49 to 11.59 GB. Training speed is stable at 1.2 s / iter