### PR TITLE
Fix the bug that torch version less than 1.12 throws TypeError

### DIFF
--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -204,7 +204,7 @@ try:
     if _torch_available:
         import torch
 
-        if torch.__version__ < version.Version("1.12"):
+        if version.Version(torch.__version__) < version.Version("1.12"):
             raise ValueError("PyTorch should be >= 1.12")
     logger.debug(f"Successfully imported xformers version {_xformers_version}")
 except importlib_metadata.PackageNotFoundError:


### PR DESCRIPTION
If the version of the torch is less than 1.12, the version comparison will throw a TypeError exception.
torch 1.11:
```python
TypeError: '<' not supported between instances of 'TorchVersion' and 'Version'
```
torch 1.9.1+cu102:
```python
TypeError: '<' not supported between instances of 'str' and 'Version'
```