### PR TITLE
Fix wrong type checking in `convert_diffusers_to_original_stable_diffusion.py` 

### DIFF
--- a/scripts/convert_diffusers_to_original_stable_diffusion.py
+++ b/scripts/convert_diffusers_to_original_stable_diffusion.py
@@ -260,8 +260,6 @@ def convert_text_enc_state_dict(text_enc_dict):
     return text_enc_dict
 
 
-IS_V20_MODEL = True
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 

--- a/scripts/convert_diffusers_to_original_stable_diffusion.py
+++ b/scripts/convert_diffusers_to_original_stable_diffusion.py
@@ -209,7 +209,7 @@ textenc_pattern = re.compile("|".join(protected.keys()))
 code2idx = {"q": 0, "k": 1, "v": 2}
 
 
-def convert_text_enc_state_dict_v20(text_enc_dict: dict[str, torch.Tensor]):
+def convert_text_enc_state_dict_v20(text_enc_dict):
     new_state_dict = {}
     capture_qkv_weight = {}
     capture_qkv_bias = {}
@@ -256,7 +256,7 @@ def convert_text_enc_state_dict_v20(text_enc_dict: dict[str, torch.Tensor]):
     return new_state_dict
 
 
-def convert_text_enc_state_dict(text_enc_dict: dict[str, torch.Tensor]):
+def convert_text_enc_state_dict(text_enc_dict):
     return text_enc_dict
 
 


### PR DESCRIPTION
This fixes the `text_enc_dict: dict[str, torch.Tensor]` that is erroring out:
```
Traceback (most recent call last):
  File "convert_diffusers_to_original_stable_diffusion.py", line 212, in <module>
      def convert_text_enc_state_dict_v20(text_enc_dict: dict[str, torch.Tensor]):
TypeError: 'type' object is not subscriptable
``` 

Another solution would be to add a `from typing import Dict`, but since we don't type check anywhere I think removing the `dict[str, torch.Tensor]` as done in this PR makes more sense.

cc @lawfordp2017 