### PR TITLE
Remove all local telemetry

### DIFF
--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -127,7 +127,8 @@ Our library gathers telemetry information during `from_pretrained()` requests.
 This data includes the version of Diffusers and PyTorch/Flax, the requested model or pipeline class,
 and the path to a pretrained checkpoint if it is hosted on the Hub.
 This usage data helps us debug issues and prioritize new features.
-No private data, such as paths to models saved locally on disk, is ever collected.
+Telemetry is only sent when loading models and pipelines from the HuggingFace Hub,
+and is not collected during local usage.
 
 We understand that not everyone wants to share additional information, and we respect your privacy,
 so you can disable telemetry collection by setting the `DISABLE_TELEMETRY` environment variable from your terminal:

--- a/src/diffusers/hub_utils.py
+++ b/src/diffusers/hub_utils.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 from uuid import uuid4
 
-import requests
 from huggingface_hub import HfFolder, whoami
 
 from . import __version__
@@ -56,7 +55,7 @@ def http_user_agent(user_agent: Union[Dict, str, None] = None) -> str:
     Formats a user-agent string with basic info about a request.
     """
     ua = f"diffusers/{__version__}; python/{sys.version.split()[0]}; session_id/{SESSION_ID}"
-    if DISABLE_TELEMETRY:
+    if DISABLE_TELEMETRY or HF_HUB_OFFLINE:
         return ua + "; telemetry/off"
     if is_torch_available():
         ua += f"; torch/{_torch_version}"
@@ -73,27 +72,6 @@ def http_user_agent(user_agent: Union[Dict, str, None] = None) -> str:
     elif isinstance(user_agent, str):
         ua += "; " + user_agent
     return ua
-
-
-def send_telemetry(data: Dict, name: str):
-    """
-    Sends logs to the Hub telemetry endpoint.
-
-    Args:
-        data: the fields to track, e.g. {"example_name": "dreambooth"}
-        name: a unique name to differentiate the telemetry logs, e.g. "diffusers_examples" or "diffusers_notebooks"
-    """
-    if DISABLE_TELEMETRY or HF_HUB_OFFLINE:
-        return
-
-    headers = {"user-agent": http_user_agent(data)}
-    endpoint = HUGGINGFACE_CO_TELEMETRY + name
-    try:
-        r = requests.head(endpoint, headers=headers)
-        r.raise_for_status()
-    except Exception:
-        # We don't want to error in case of connection errors of any kind.
-        pass
 
 
 def get_full_repo_name(model_id: str, organization: Optional[str] = None, token: Optional[str] = None):

--- a/src/diffusers/modeling_flax_utils.py
+++ b/src/diffusers/modeling_flax_utils.py
@@ -28,7 +28,6 @@ from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError, R
 from requests import HTTPError
 
 from . import __version__, is_torch_available
-from .hub_utils import send_telemetry
 from .modeling_flax_pytorch_utils import convert_pytorch_state_dict_to_flax
 from .utils import (
     CONFIG_NAME,
@@ -340,10 +339,6 @@ class FlaxModelMixin:
                     f"Error no file named {FLAX_WEIGHTS_NAME} or {WEIGHTS_NAME} found in directory "
                     f"{pretrained_path_with_subfolder}."
                 )
-            send_telemetry(
-                {"model_class": cls.__name__, "model_path": "local", "framework": "flax"},
-                name="diffusers_from_pretrained",
-            )
         else:
             try:
                 model_file = hf_hub_download(
@@ -358,10 +353,6 @@ class FlaxModelMixin:
                     user_agent=user_agent,
                     subfolder=subfolder,
                     revision=revision,
-                )
-                send_telemetry(
-                    {"model_class": cls.__name__, "model_path": "hub", "framework": "flax"},
-                    name="diffusers_from_pretrained",
                 )
 
             except RepositoryNotFoundError:

--- a/src/diffusers/modeling_utils.py
+++ b/src/diffusers/modeling_utils.py
@@ -26,7 +26,6 @@ from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError, R
 from requests import HTTPError
 
 from . import __version__
-from .hub_utils import send_telemetry
 from .utils import (
     CONFIG_NAME,
     DIFFUSERS_CACHE,
@@ -594,10 +593,6 @@ class ModelMixin(torch.nn.Module):
                 raise EnvironmentError(
                     f"Error no file named {weights_name} found in directory {pretrained_model_name_or_path}."
                 )
-            send_telemetry(
-                {"model_class": cls.__name__, "model_path": "local", "framework": "pytorch"},
-                name="diffusers_from_pretrained",
-            )
             return model_file
         else:
             try:
@@ -614,10 +609,6 @@ class ModelMixin(torch.nn.Module):
                     user_agent=user_agent,
                     subfolder=subfolder,
                     revision=revision,
-                )
-                send_telemetry(
-                    {"model_class": cls.__name__, "model_path": "hub", "framework": "pytorch"},
-                    name="diffusers_from_pretrained",
                 )
                 return model_file
 

--- a/src/diffusers/pipeline_flax_utils.py
+++ b/src/diffusers/pipeline_flax_utils.py
@@ -29,7 +29,7 @@ from PIL import Image
 from tqdm.auto import tqdm
 
 from .configuration_utils import ConfigMixin
-from .hub_utils import http_user_agent, send_telemetry
+from .hub_utils import http_user_agent
 from .modeling_flax_utils import FLAX_WEIGHTS_NAME, FlaxModelMixin
 from .schedulers.scheduling_utils_flax import SCHEDULER_CONFIG_NAME, FlaxSchedulerMixin
 from .utils import CONFIG_NAME, DIFFUSERS_CACHE, BaseOutput, is_transformers_available, logging
@@ -346,16 +346,8 @@ class FlaxDiffusionPipeline(ConfigMixin):
                 ignore_patterns=ignore_patterns,
                 user_agent=user_agent,
             )
-            send_telemetry(
-                {"pipeline_class": requested_pipeline_class, "pipeline_path": "hub", "framework": "flax"},
-                name="diffusers_from_pretrained",
-            )
         else:
             cached_folder = pretrained_model_name_or_path
-            send_telemetry(
-                {"pipeline_class": cls.__name__, "pipeline_path": "local", "framework": "flax"},
-                name="diffusers_from_pretrained",
-            )
 
         config_dict = cls.load_config(cached_folder)
 

--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -33,7 +33,7 @@ from tqdm.auto import tqdm
 
 from .configuration_utils import ConfigMixin
 from .dynamic_modules_utils import get_class_from_dynamic_module
-from .hub_utils import http_user_agent, send_telemetry
+from .hub_utils import http_user_agent
 from .modeling_utils import _LOW_CPU_MEM_USAGE_DEFAULT
 from .schedulers.scheduling_utils import SCHEDULER_CONFIG_NAME
 from .utils import (
@@ -509,16 +509,8 @@ class DiffusionPipeline(ConfigMixin):
                 ignore_patterns=ignore_patterns,
                 user_agent=user_agent,
             )
-            send_telemetry(
-                {"pipeline_class": requested_pipeline_class, "pipeline_path": "hub", "framework": "pytorch"},
-                name="diffusers_from_pretrained",
-            )
         else:
             cached_folder = pretrained_model_name_or_path
-            send_telemetry(
-                {"pipeline_class": cls.__name__, "pipeline_path": "local", "framework": "pytorch"},
-                name="diffusers_from_pretrained",
-            )
 
         config_dict = cls.load_config(cached_folder)
 


### PR DESCRIPTION
This removes v0.10.0's `send_telemetry` from local pipeline loaders completely, leaving only the requested pipeline/model classes when loading them from the HF hub.