### PR TITLE
[Dreambooth] Add a function to log interim generation

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -34,7 +34,9 @@ logger = get_logger(__name__)
 
 def import_model_class_from_model_name_or_path(pretrained_model_name_or_path: str, revision: str):
     text_encoder_config = PretrainedConfig.from_pretrained(
-        pretrained_model_name_or_path, subfolder="text_encoder", revision=revision,
+        pretrained_model_name_or_path,
+        subfolder="text_encoder",
+        revision=revision,
     )
     model_class = text_encoder_config.architectures[0]
 
@@ -100,7 +102,10 @@ def parse_args(input_args=None):
         help="The prompt to specify images in the same class as provided instance images.",
     )
     parser.add_argument(
-        "--with_prior_preservation", default=False, action="store_true", help="Flag to add prior preservation loss.",
+        "--with_prior_preservation",
+        default=False,
+        action="store_true",
+        help="Flag to add prior preservation loss.",
     )
     parser.add_argument("--prior_loss_weight", type=float, default=1.0, help="The weight of prior preservation loss.")
     parser.add_argument(
@@ -481,10 +486,17 @@ def main(args):
 
     # Load the tokenizer
     if args.tokenizer_name:
-        tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_name, revision=args.revision, use_fast=False,)
+        tokenizer = AutoTokenizer.from_pretrained(
+            args.tokenizer_name,
+            revision=args.revision,
+            use_fast=False,
+        )
     elif args.pretrained_model_name_or_path:
         tokenizer = AutoTokenizer.from_pretrained(
-            args.pretrained_model_name_or_path, subfolder="tokenizer", revision=args.revision, use_fast=False,
+            args.pretrained_model_name_or_path,
+            subfolder="tokenizer",
+            revision=args.revision,
+            use_fast=False,
         )
 
     # import correct text encoder class
@@ -492,11 +504,19 @@ def main(args):
 
     # Load models and create wrapper for stable diffusion
     text_encoder = text_encoder_cls.from_pretrained(
-        args.pretrained_model_name_or_path, subfolder="text_encoder", revision=args.revision,
+        args.pretrained_model_name_or_path,
+        subfolder="text_encoder",
+        revision=args.revision,
     )
-    vae = AutoencoderKL.from_pretrained(args.pretrained_model_name_or_path, subfolder="vae", revision=args.revision,)
+    vae = AutoencoderKL.from_pretrained(
+        args.pretrained_model_name_or_path,
+        subfolder="vae",
+        revision=args.revision,
+    )
     unet = UNet2DConditionModel.from_pretrained(
-        args.pretrained_model_name_or_path, subfolder="unet", revision=args.revision,
+        args.pretrained_model_name_or_path,
+        subfolder="unet",
+        revision=args.revision,
     )
 
     if is_xformers_available():

--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -417,6 +417,11 @@ def main(args):
 
     if args.seed is not None:
         set_seed(args.seed)
+        g = torch.Generator(device=accelerator.device.type)
+        g.manual_seed(args.seed)
+    else:
+        g = torch.Generator(device=accelerator.device.type)
+        g.manual_seed(42)
 
     if args.with_prior_preservation:
         class_images_dir = Path(args.class_data_dir)
@@ -727,9 +732,6 @@ def main(args):
 
                 if global_step % args.generating_progress_steps == 0:
                     if accelerator.is_main_process:
-                        g = torch.Generator(device=accelerator.device.type)
-                        g.manual_seed(42)
-
                         # generate and save the image
                         pipeline = DiffusionPipeline.from_pretrained(
                             args.pretrained_model_name_or_path,

--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -163,7 +163,7 @@ def parse_args(input_args=None):
         "--generating_progress_steps",
         type=int,
         default=500,
-        help=("Save an image generated from the model every X steps."),
+        help="Save an image generated from the model every X steps.",
     )
     parser.add_argument(
         "--resume_from_checkpoint",

--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -34,9 +34,7 @@ logger = get_logger(__name__)
 
 def import_model_class_from_model_name_or_path(pretrained_model_name_or_path: str, revision: str):
     text_encoder_config = PretrainedConfig.from_pretrained(
-        pretrained_model_name_or_path,
-        subfolder="text_encoder",
-        revision=revision,
+        pretrained_model_name_or_path, subfolder="text_encoder", revision=revision,
     )
     model_class = text_encoder_config.architectures[0]
 
@@ -102,10 +100,7 @@ def parse_args(input_args=None):
         help="The prompt to specify images in the same class as provided instance images.",
     )
     parser.add_argument(
-        "--with_prior_preservation",
-        default=False,
-        action="store_true",
-        help="Flag to add prior preservation loss.",
+        "--with_prior_preservation", default=False, action="store_true", help="Flag to add prior preservation loss.",
     )
     parser.add_argument("--prior_loss_weight", type=float, default=1.0, help="The weight of prior preservation loss.")
     parser.add_argument(
@@ -163,9 +158,7 @@ def parse_args(input_args=None):
         "--generating_progress_steps",
         type=int,
         default=500,
-        help=(
-            "Save an image generated from the model every X steps."
-        ),
+        help=("Save an image generated from the model every X steps."),
     )
     parser.add_argument(
         "--resume_from_checkpoint",
@@ -483,17 +476,10 @@ def main(args):
 
     # Load the tokenizer
     if args.tokenizer_name:
-        tokenizer = AutoTokenizer.from_pretrained(
-            args.tokenizer_name,
-            revision=args.revision,
-            use_fast=False,
-        )
+        tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_name, revision=args.revision, use_fast=False,)
     elif args.pretrained_model_name_or_path:
         tokenizer = AutoTokenizer.from_pretrained(
-            args.pretrained_model_name_or_path,
-            subfolder="tokenizer",
-            revision=args.revision,
-            use_fast=False,
+            args.pretrained_model_name_or_path, subfolder="tokenizer", revision=args.revision, use_fast=False,
         )
 
     # import correct text encoder class
@@ -501,19 +487,11 @@ def main(args):
 
     # Load models and create wrapper for stable diffusion
     text_encoder = text_encoder_cls.from_pretrained(
-        args.pretrained_model_name_or_path,
-        subfolder="text_encoder",
-        revision=args.revision,
+        args.pretrained_model_name_or_path, subfolder="text_encoder", revision=args.revision,
     )
-    vae = AutoencoderKL.from_pretrained(
-        args.pretrained_model_name_or_path,
-        subfolder="vae",
-        revision=args.revision,
-    )
+    vae = AutoencoderKL.from_pretrained(args.pretrained_model_name_or_path, subfolder="vae", revision=args.revision,)
     unet = UNet2DConditionModel.from_pretrained(
-        args.pretrained_model_name_or_path,
-        subfolder="unet",
-        revision=args.revision,
+        args.pretrained_model_name_or_path, subfolder="unet", revision=args.revision,
     )
 
     if is_xformers_available():


### PR DESCRIPTION
This pull request allows to log interim generation during Dreambooth. 

**Usage**
add an argument `--generating_progress_steps <int>`. The process generates an interim image per steps you choose.
To be able to generate deterministically, you can also set `--seed` argument such as `--seed 42`.

Generated images are stored at  `f"{args.output_dir}/logs/`.

*This PR is almost same as #1711 . To avoid throw PR from `main`, I reopen this one.*