### PR TITLE
Fix ONNX img2img preprocessing

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_onnx_stable_diffusion_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_onnx_stable_diffusion_img2img.py
@@ -332,6 +332,9 @@ class OnnxStableDiffusionImg2ImgPipeline(DiffusionPipeline):
                 f" {type(callback_steps)}."
             )
 
+        if generator is None:
+            generator = np.random
+
         # set timesteps
         self.scheduler.set_timesteps(num_inference_steps)
 


### PR DESCRIPTION
I had some issues with a previous version of running img2img, it looks like that was fixed in a [previous commit](https://github.com/peterto/diffusers/commit/a40095dd226ac129e834ec4f709b998ae9ac4e90), but that commit removed code to set generator to a value if it is "None" thereby causing img2img generation to fail. Adding these lines back in fixes it for me (in combination of the previous commit).

