### PR TITLE
reorder model wrap + bug fix

### DIFF
--- a/examples/unconditional_image_generation/train_unconditional_ort.py
+++ b/examples/unconditional_image_generation/train_unconditional_ort.py
@@ -425,7 +425,7 @@ def main(args):
 
             with accelerator.accumulate(model):
                 # Predict the noise residual
-                model_output = model(noisy_images, timesteps, return_dict=True)[0]
+                model_output = model(noisy_images, timesteps, return_dict=False)[0]
 
                 if args.prediction_type == "epsilon":
                     loss = F.mse_loss(model_output, noise)  # this could have different weights!

--- a/examples/unconditional_image_generation/train_unconditional_ort.py
+++ b/examples/unconditional_image_generation/train_unconditional_ort.py
@@ -287,7 +287,6 @@ def main(args):
             "UpBlock2D",
         ),
     )
-    model = ORTModule(model)
     accepts_prediction_type = "prediction_type" in set(inspect.signature(DDPMScheduler.__init__).parameters.keys())
 
     if accepts_prediction_type:
@@ -358,6 +357,8 @@ def main(args):
         power=args.ema_power,
         max_value=args.ema_max_decay,
     )
+
+    model = ORTModule(model)
 
     # Handle the repository creation
     if accelerator.is_main_process:


### PR DESCRIPTION
Fixes return_dict bug and resolves the following pickling error when using UNet2DModel in instantiation of ema_model:

```
Traceback (most recent call last):
  File "train_unconditional_ort.py", line 452, in <module>
    main(args)
  File "train_unconditional_ort.py", line 327, in main
    ema_model = EMAModel(
  File "/home/prathikrao/diffusers/src/diffusers/training_utils.py", line 69, in __init__
    self.averaged_model = copy.deepcopy(model).eval()
  File "/opt/conda/envs/ptca/lib/python3.8/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/opt/conda/envs/ptca/lib/python3.8/copy.py", line 270, in _reconstruct
    state = deepcopy(state, memo)
  File "/opt/conda/envs/ptca/lib/python3.8/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/opt/conda/envs/ptca/lib/python3.8/copy.py", line 230, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/opt/conda/envs/ptca/lib/python3.8/copy.py", line 161, in deepcopy
    rv = reductor(4)
  File "/opt/conda/envs/ptca/lib/python3.8/site-packages/accelerate/utils/operations.py", line 493, in __getstate__
    raise pickle.PicklingError(
_pickle.PicklingError: Cannot pickle a prepared model with automatic mixed precision, please unwrap the model with `Accelerator.unwrap_model(model)` before pickling it.
```