### PR TITLE
[textual_inversion] unwrap_model text encoder before accessing weights

### DIFF
--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -470,7 +470,7 @@ def main():
     text_encoder.resize_token_embeddings(len(tokenizer))
 
     # Initialise the newly added placeholder token with the embeddings of the initializer token
-    token_embeds = text_encoder.get_input_embeddings().weight.data
+    token_embeds = accelerator.unwrap_model(text_encoder).get_input_embeddings().weight.data
     token_embeds[placeholder_token_id] = token_embeds[initializer_token_id]
 
     # Freeze vae and unet

--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -644,7 +644,9 @@ def main():
                 # Let's make sure we don't update any embedding weights besides the newly added token
                 index_no_updates = torch.arange(len(tokenizer)) != placeholder_token_id
                 with torch.no_grad():
-                    text_encoder.get_input_embeddings().weight[index_no_updates] = orig_embeds_params[index_no_updates]
+                    accelerator.unwrap_model(text_encoder).get_input_embeddings().weight[
+                        index_no_updates
+                    ] = orig_embeds_params[index_no_updates]
 
             # Checks if the accelerator has performed an optimization step behind the scenes
             if accelerator.sync_gradients:

--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -470,7 +470,7 @@ def main():
     text_encoder.resize_token_embeddings(len(tokenizer))
 
     # Initialise the newly added placeholder token with the embeddings of the initializer token
-    token_embeds = accelerator.unwrap_model(text_encoder).get_input_embeddings().weight.data
+    token_embeds = text_encoder.get_input_embeddings().weight.data
     token_embeds[placeholder_token_id] = token_embeds[initializer_token_id]
 
     # Freeze vae and unet
@@ -592,7 +592,7 @@ def main():
     progress_bar.set_description("Steps")
 
     # keep original embeddings as reference
-    orig_embeds_params = text_encoder.get_input_embeddings().weight.data.clone()
+    orig_embeds_params = accelerator.unwrap_model(text_encoder).get_input_embeddings().weight.data.clone()
 
     for epoch in range(first_epoch, args.num_train_epochs):
         text_encoder.train()


### PR DESCRIPTION
For mult-gpu training, the model should be unwrapped before calling any method on it. This PR fixes the call to `text_encoder.get_input_embeddings()` by first unwrapping the `text_encoder`.

cc @patrickvonplaten @williamberman @pcuenca 