### PR TITLE
[addresses issue #1642] add add_noise to scheduling-sde-ve 

### DIFF
--- a/src/diffusers/schedulers/scheduling_sde_ve.py
+++ b/src/diffusers/schedulers/scheduling_sde_ve.py
@@ -274,6 +274,6 @@ class ScoreSdeVeScheduler(SchedulerMixin, ConfigMixin):
         noise = torch.randn_like(original_samples) * sigmas[:, None, None, None]
         noisy_samples = noise + original_samples
         return noisy_samples
-        
+
     def __len__(self):
         return self.config.num_train_timesteps

--- a/src/diffusers/schedulers/scheduling_sde_ve.py
+++ b/src/diffusers/schedulers/scheduling_sde_ve.py
@@ -262,5 +262,18 @@ class ScoreSdeVeScheduler(SchedulerMixin, ConfigMixin):
 
         return SchedulerOutput(prev_sample=prev_sample)
 
+    def add_noise(
+        self,
+        original_samples: torch.FloatTensor,
+        noise: torch.FloatTensor,
+        timesteps: torch.FloatTensor,
+    ) -> torch.FloatTensor:
+        # Make sure sigmas and timesteps have the same device and dtype as original_samples
+        timesteps = timesteps.to(original_samples.device)
+        sigmas = self.discrete_sigmas.to(original_samples.device)[timesteps]
+        noise = torch.randn_like(original_samples) * sigmas[:, None, None, None]
+        noisy_samples = noise + original_samples
+        return noisy_samples
+        
     def __len__(self):
         return self.config.num_train_timesteps


### PR DESCRIPTION
This PR adds `add_noise` method to `scheduling_sde_vp.py` (addresses issues https://github.com/huggingface/diffusers/issues/1642)

My implementation is derived from the below author's codebase 
https://github.com/yang-song/score_sde_pytorch/blob/ef5cb679a4897a40d20e94d8d0e2124c3a48fb8c/losses.py#L109-L117