### PR TITLE
Feature/remove telemetry

### DIFF
--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -120,25 +120,3 @@ git pull
 ```
 
 Your Python environment will find the `main` version of 🤗 Diffusers on the next run.
-
-## Notice on telemetry logging
-
-Our library gathers telemetry information during `from_pretrained()` requests.
-This data includes the version of Diffusers and PyTorch/Flax, the requested model or pipeline class,
-and the path to a pretrained checkpoint if it is hosted on the Hub.
-This usage data helps us debug issues and prioritize new features.
-Telemetry is only sent when loading models and pipelines from the HuggingFace Hub,
-and is not collected during local usage.
-
-We understand that not everyone wants to share additional information, and we respect your privacy,
-so you can disable telemetry collection by setting the `DISABLE_TELEMETRY` environment variable from your terminal:
-
-On Linux/MacOS:
-```bash
-export DISABLE_TELEMETRY=YES
-```
-
-On Windows:
-```bash
-set DISABLE_TELEMETRY=YES
-```

--- a/src/diffusers/hub_utils.py
+++ b/src/diffusers/hub_utils.py
@@ -44,16 +44,14 @@ logger = logging.get_logger(__name__)
 
 
 MODEL_CARD_TEMPLATE_PATH = Path(__file__).parent / "utils" / "model_card_template.md"
-SESSION_ID = uuid4().hex
 HF_HUB_OFFLINE = os.getenv("HF_HUB_OFFLINE", "").upper() in ENV_VARS_TRUE_VALUES
 
 
-def http_user_agent(user_agent: Union[Dict, str, None] = None) -> str:
+def http_user_agent(*_args) -> str:
     """
     Formats a user-agent string with basic info about a request.
     """
-    ua = f"diffusers/{__version__}; python/{sys.version.split()[0]}; session_id/{SESSION_ID}"
-    return ua + "; telemetry/off"
+    return "telemetry/off"
 
 
 def get_full_repo_name(model_id: str, organization: Optional[str] = None, token: Optional[str] = None):

--- a/src/diffusers/hub_utils.py
+++ b/src/diffusers/hub_utils.py
@@ -46,8 +46,6 @@ logger = logging.get_logger(__name__)
 MODEL_CARD_TEMPLATE_PATH = Path(__file__).parent / "utils" / "model_card_template.md"
 SESSION_ID = uuid4().hex
 HF_HUB_OFFLINE = os.getenv("HF_HUB_OFFLINE", "").upper() in ENV_VARS_TRUE_VALUES
-DISABLE_TELEMETRY = os.getenv("DISABLE_TELEMETRY", "").upper() in ENV_VARS_TRUE_VALUES
-HUGGINGFACE_CO_TELEMETRY = HUGGINGFACE_CO_RESOLVE_ENDPOINT + "/api/telemetry/"
 
 
 def http_user_agent(user_agent: Union[Dict, str, None] = None) -> str:
@@ -55,23 +53,7 @@ def http_user_agent(user_agent: Union[Dict, str, None] = None) -> str:
     Formats a user-agent string with basic info about a request.
     """
     ua = f"diffusers/{__version__}; python/{sys.version.split()[0]}; session_id/{SESSION_ID}"
-    if DISABLE_TELEMETRY or HF_HUB_OFFLINE:
-        return ua + "; telemetry/off"
-    if is_torch_available():
-        ua += f"; torch/{_torch_version}"
-    if is_flax_available():
-        ua += f"; jax/{_jax_version}"
-        ua += f"; flax/{_flax_version}"
-    if is_onnx_available():
-        ua += f"; onnxruntime/{_onnxruntime_version}"
-    # CI will set this value to True
-    if os.environ.get("DIFFUSERS_IS_CI", "").upper() in ENV_VARS_TRUE_VALUES:
-        ua += "; is_ci/true"
-    if isinstance(user_agent, dict):
-        ua += "; " + "; ".join(f"{k}/{v}" for k, v in user_agent.items())
-    elif isinstance(user_agent, str):
-        ua += "; " + user_agent
-    return ua
+    return ua + "; telemetry/off"
 
 
 def get_full_repo_name(model_id: str, organization: Optional[str] = None, token: Optional[str] = None):

--- a/src/diffusers/modeling_flax_utils.py
+++ b/src/diffusers/modeling_flax_utils.py
@@ -459,12 +459,13 @@ class FlaxModelMixin:
             del state[unexpected_key]
 
         if len(unexpected_keys) > 0:
-            logger.warning(
-                f"Some weights of the model checkpoint at {pretrained_model_name_or_path} were not used when"
-                f" initializing {model.__class__.__name__}: {unexpected_keys}\n- This IS expected if you are"
-                f" initializing {model.__class__.__name__} from the checkpoint of a model trained on another task or"
-                " with another architecture."
-            )
+            # logger.warning(
+            #     f"Some weights of the model checkpoint at {pretrained_model_name_or_path} were not used when"
+            #     f" initializing {model.__class__.__name__}: {unexpected_keys}\n- This IS expected if you are"
+            #     f" initializing {model.__class__.__name__} from the checkpoint of a model trained on another task or"
+            #     " with another architecture."
+            # )
+            pass
         else:
             logger.info(f"All model checkpoint weights were used when initializing {model.__class__.__name__}.\n")
 

--- a/src/diffusers/modeling_utils.py
+++ b/src/diffusers/modeling_utils.py
@@ -714,16 +714,17 @@ class ModelMixin(torch.nn.Module):
             raise RuntimeError(f"Error(s) in loading state_dict for {model.__class__.__name__}:\n\t{error_msg}")
 
         if len(unexpected_keys) > 0:
-            logger.warning(
-                f"Some weights of the model checkpoint at {pretrained_model_name_or_path} were not used when"
-                f" initializing {model.__class__.__name__}: {unexpected_keys}\n- This IS expected if you are"
-                f" initializing {model.__class__.__name__} from the checkpoint of a model trained on another task"
-                " or with another architecture (e.g. initializing a BertForSequenceClassification model from a"
-                " BertForPreTraining model).\n- This IS NOT expected if you are initializing"
-                f" {model.__class__.__name__} from the checkpoint of a model that you expect to be exactly"
-                " identical (initializing a BertForSequenceClassification model from a"
-                " BertForSequenceClassification model)."
-            )
+            # logger.warning(
+            #     f"Some weights of the model checkpoint at {pretrained_model_name_or_path} were not used when"
+            #     f" initializing {model.__class__.__name__}: {unexpected_keys}\n- This IS expected if you are"
+            #     f" initializing {model.__class__.__name__} from the checkpoint of a model trained on another task"
+            #     " or with another architecture (e.g. initializing a BertForSequenceClassification model from a"
+            #     " BertForPreTraining model).\n- This IS NOT expected if you are initializing"
+            #     f" {model.__class__.__name__} from the checkpoint of a model that you expect to be exactly"
+            #     " identical (initializing a BertForSequenceClassification model from a"
+            #     " BertForSequenceClassification model)."
+            # )
+            pass
         else:
             logger.info(f"All model checkpoint weights were used when initializing {model.__class__.__name__}.\n")
         if len(missing_keys) > 0:


### PR DESCRIPTION
Although it was stated in issue #1685 that telemetry has been fully removed, it hadn't been fully removed from the diffuses library

This PR fully removes the ability to send telemetry data from the diffusers library.

- Removes unique session id identifier
- Removes references to telemetry in documentation. 
- Removes ability to send telemetry from `hub_utils.py` function `http_user_agent`

Telemetry collection is presumably still occurring on huggingface.co servers as the server code relies on the `telemetry/off` flag when sending a request to the severs in order to tell the servers not to use telemetry.

Even when telemetry was disabled in the past, a session ID, python and diffusers library versions were being transmitted to huggingface.co servers.

Why was / is it required to send a session ID from the client's server to huggingface.co? This has been removed.