### PR TITLE
Avoid duplicating PyTorch + safetensors downloads.

### DIFF
--- a/src/diffusers/pipeline_utils.py
+++ b/src/diffusers/pipeline_utils.py
@@ -495,6 +495,8 @@ class DiffusionPipeline(ConfigMixin):
                 )
                 if is_safetensors_compatible(info):
                     ignore_patterns.append("*.bin")
+                else:
+                    ignore_patterns.append("*.safetensors")
 
             # download all allow_patterns
             cached_folder = snapshot_download(


### PR DESCRIPTION
Duplication happens when there are safetensors versions of _some_ files in the repo but not all.

Ideally, we should just download safetensors files when they are available, and fallback to PyTorch when they are not. This could be done by retrieving the list of files in the repo using `list_repo_files` (or `model_info`) and filtering them to keep the ones we want. A similar mechanism could be applied to download `fp16` versions when they exist.

Addresses #1811.
