### PR TITLE
[StableDiffusionInpaint] Correct test

### DIFF
--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_inpaint.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_inpaint.py
@@ -228,7 +228,6 @@ class StableDiffusionInpaintPipelineIntegrationTests(unittest.TestCase):
             model_id,
             safety_checker=None,
             scheduler=pndm,
-            device_map="auto",
             torch_dtype=torch.float16,
         )
         pipe.to(torch_device)
@@ -244,7 +243,7 @@ class StableDiffusionInpaintPipelineIntegrationTests(unittest.TestCase):
             image=init_image,
             mask_image=mask_image,
             generator=generator,
-            num_inference_steps=5,
+            num_inference_steps=2,
             output_type="np",
         )
 


### PR DESCRIPTION
It seems like cpu_offload + `device_map="auto"` currently doesn't work well with `accelerate`. Remove `device_map="auto"`.