### PR TITLE
[Docs] Improve docs

### DIFF
--- a/docs/source/api/diffusion_pipeline.mdx
+++ b/docs/source/api/diffusion_pipeline.mdx
@@ -30,11 +30,6 @@ Any pipeline object can be saved locally with [`~DiffusionPipeline.save_pretrain
 
 ## DiffusionPipeline
 [[autodoc]] DiffusionPipeline
-	- from_pretrained
-	- save_pretrained
-	- to
-	- device
-	- components
 
 ## ImagePipelineOutput
 By default diffusion pipelines return an object of class

--- a/docs/source/api/diffusion_pipeline.mdx
+++ b/docs/source/api/diffusion_pipeline.mdx
@@ -30,8 +30,17 @@ Any pipeline object can be saved locally with [`~DiffusionPipeline.save_pretrain
 
 ## DiffusionPipeline
 [[autodoc]] DiffusionPipeline
+	- all
+	- __call__
+	- device
+	- to
 
 ## ImagePipelineOutput
 By default diffusion pipelines return an object of class
 
 [[autodoc]] pipelines.ImagePipelineOutput
+
+## AudioPipelineOutput
+By default diffusion pipelines return an object of class
+
+[[autodoc]] pipelines.AudioPipelineOutput

--- a/docs/source/api/pipelines/alt_diffusion.mdx
+++ b/docs/source/api/pipelines/alt_diffusion.mdx
@@ -69,9 +69,15 @@ If you want to use all possible use cases in a single `DiffusionPipeline` we rec
 
 ## AltDiffusionPipelineOutput
 [[autodoc]] pipelines.alt_diffusion.AltDiffusionPipelineOutput
+	- all
+	- __call__
 
 ## AltDiffusionPipeline
 [[autodoc]] AltDiffusionPipeline
+	- all
+	- __call__
 
 ## AltDiffusionImg2ImgPipeline
 [[autodoc]] AltDiffusionImg2ImgPipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/alt_diffusion.mdx
+++ b/docs/source/api/pipelines/alt_diffusion.mdx
@@ -72,12 +72,6 @@ If you want to use all possible use cases in a single `DiffusionPipeline` we rec
 
 ## AltDiffusionPipeline
 [[autodoc]] AltDiffusionPipeline
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing
 
 ## AltDiffusionImg2ImgPipeline
 [[autodoc]] AltDiffusionImg2ImgPipeline
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing

--- a/docs/source/api/pipelines/audio_diffusion.mdx
+++ b/docs/source/api/pipelines/audio_diffusion.mdx
@@ -91,12 +91,6 @@ display(Audio(output.audios[0], rate=pipe.mel.get_sample_rate()))
 
 ## AudioDiffusionPipeline
 [[autodoc]] AudioDiffusionPipeline
-    - __call__
-    - encode
-    - slerp
-
 
 ## Mel
 [[autodoc]] Mel
-    - audio_slice_to_image
-    - image_to_audio

--- a/docs/source/api/pipelines/audio_diffusion.mdx
+++ b/docs/source/api/pipelines/audio_diffusion.mdx
@@ -91,6 +91,8 @@ display(Audio(output.audios[0], rate=pipe.mel.get_sample_rate()))
 
 ## AudioDiffusionPipeline
 [[autodoc]] AudioDiffusionPipeline
+	- all
+	- __call__
 
 ## Mel
 [[autodoc]] Mel

--- a/docs/source/api/pipelines/cycle_diffusion.mdx
+++ b/docs/source/api/pipelines/cycle_diffusion.mdx
@@ -96,3 +96,5 @@ image.save("black_to_blue.png")
 
 ## CycleDiffusionPipeline
 [[autodoc]] CycleDiffusionPipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/cycle_diffusion.mdx
+++ b/docs/source/api/pipelines/cycle_diffusion.mdx
@@ -96,4 +96,3 @@ image.save("black_to_blue.png")
 
 ## CycleDiffusionPipeline
 [[autodoc]] CycleDiffusionPipeline
-	- __call__

--- a/docs/source/api/pipelines/dance_diffusion.mdx
+++ b/docs/source/api/pipelines/dance_diffusion.mdx
@@ -30,3 +30,5 @@ The original codebase of this implementation can be found [here](https://github.
 
 ## DanceDiffusionPipeline
 [[autodoc]] DanceDiffusionPipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/dance_diffusion.mdx
+++ b/docs/source/api/pipelines/dance_diffusion.mdx
@@ -30,4 +30,3 @@ The original codebase of this implementation can be found [here](https://github.
 
 ## DanceDiffusionPipeline
 [[autodoc]] DanceDiffusionPipeline
-    - __call__

--- a/docs/source/api/pipelines/ddim.mdx
+++ b/docs/source/api/pipelines/ddim.mdx
@@ -32,4 +32,3 @@ For questions, feel free to contact the author on [tsong.me](https://tsong.me/).
 
 ## DDIMPipeline
 [[autodoc]] DDIMPipeline
-    - __call__

--- a/docs/source/api/pipelines/ddim.mdx
+++ b/docs/source/api/pipelines/ddim.mdx
@@ -32,3 +32,5 @@ For questions, feel free to contact the author on [tsong.me](https://tsong.me/).
 
 ## DDIMPipeline
 [[autodoc]] DDIMPipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/ddpm.mdx
+++ b/docs/source/api/pipelines/ddpm.mdx
@@ -33,4 +33,3 @@ The original codebase of this paper can be found [here](https://github.com/hojon
 
 # DDPMPipeline
 [[autodoc]] DDPMPipeline
-    - __call__

--- a/docs/source/api/pipelines/ddpm.mdx
+++ b/docs/source/api/pipelines/ddpm.mdx
@@ -33,3 +33,5 @@ The original codebase of this paper can be found [here](https://github.com/hojon
 
 # DDPMPipeline
 [[autodoc]] DDPMPipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/latent_diffusion.mdx
+++ b/docs/source/api/pipelines/latent_diffusion.mdx
@@ -40,8 +40,6 @@ The original codebase can be found [here](https://github.com/CompVis/latent-diff
 
 ## LDMTextToImagePipeline
 [[autodoc]] LDMTextToImagePipeline
-    - __call__
 
 ## LDMSuperResolutionPipeline
 [[autodoc]] LDMSuperResolutionPipeline
-    - __call__

--- a/docs/source/api/pipelines/latent_diffusion.mdx
+++ b/docs/source/api/pipelines/latent_diffusion.mdx
@@ -40,6 +40,10 @@ The original codebase can be found [here](https://github.com/CompVis/latent-diff
 
 ## LDMTextToImagePipeline
 [[autodoc]] LDMTextToImagePipeline
+	- all
+	- __call__
 
 ## LDMSuperResolutionPipeline
 [[autodoc]] LDMSuperResolutionPipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/latent_diffusion_uncond.mdx
+++ b/docs/source/api/pipelines/latent_diffusion_uncond.mdx
@@ -38,3 +38,5 @@ The original codebase can be found [here](https://github.com/CompVis/latent-diff
 
 ## LDMPipeline
 [[autodoc]] LDMPipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/latent_diffusion_uncond.mdx
+++ b/docs/source/api/pipelines/latent_diffusion_uncond.mdx
@@ -38,4 +38,3 @@ The original codebase can be found [here](https://github.com/CompVis/latent-diff
 
 ## LDMPipeline
 [[autodoc]] LDMPipeline
-    - __call__

--- a/docs/source/api/pipelines/paint_by_example.mdx
+++ b/docs/source/api/pipelines/paint_by_example.mdx
@@ -69,4 +69,6 @@ image
 ```
 
 ## PaintByExamplePipeline
-[[autodoc]] pipelines.paint_by_example.pipeline_paint_by_example.PaintByExamplePipeline
+[[autodoc]] PaintByExamplePipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/paint_by_example.mdx
+++ b/docs/source/api/pipelines/paint_by_example.mdx
@@ -70,4 +70,3 @@ image
 
 ## PaintByExamplePipeline
 [[autodoc]] pipelines.paint_by_example.pipeline_paint_by_example.PaintByExamplePipeline
-    - __call__

--- a/docs/source/api/pipelines/pndm.mdx
+++ b/docs/source/api/pipelines/pndm.mdx
@@ -31,5 +31,3 @@ The original codebase can be found [here](https://github.com/luping-liu/PNDM).
 
 ## PNDMPipeline
 [[autodoc]] pipelines.pndm.pipeline_pndm.PNDMPipeline
-    - __call__
-

--- a/docs/source/api/pipelines/pndm.mdx
+++ b/docs/source/api/pipelines/pndm.mdx
@@ -30,4 +30,6 @@ The original codebase can be found [here](https://github.com/luping-liu/PNDM).
 
 
 ## PNDMPipeline
-[[autodoc]] pipelines.pndm.pipeline_pndm.PNDMPipeline
+[[autodoc]] PNDMPipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/repaint.mdx
+++ b/docs/source/api/pipelines/repaint.mdx
@@ -72,4 +72,6 @@ inpainted_image = output.images[0]
 ```
 
 ## RePaintPipeline
-[[autodoc]] pipelines.repaint.pipeline_repaint.RePaintPipeline
+[[autodoc]] RePaintPipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/repaint.mdx
+++ b/docs/source/api/pipelines/repaint.mdx
@@ -73,5 +73,3 @@ inpainted_image = output.images[0]
 
 ## RePaintPipeline
 [[autodoc]] pipelines.repaint.pipeline_repaint.RePaintPipeline
-    - __call__
-

--- a/docs/source/api/pipelines/score_sde_ve.mdx
+++ b/docs/source/api/pipelines/score_sde_ve.mdx
@@ -32,5 +32,3 @@ This pipeline implements the Variance Expanding (VE) variant of the method.
 
 ## ScoreSdeVePipeline
 [[autodoc]] ScoreSdeVePipeline
-    - __call__
-

--- a/docs/source/api/pipelines/score_sde_ve.mdx
+++ b/docs/source/api/pipelines/score_sde_ve.mdx
@@ -32,3 +32,5 @@ This pipeline implements the Variance Expanding (VE) variant of the method.
 
 ## ScoreSdeVePipeline
 [[autodoc]] ScoreSdeVePipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/stable_diffusion.mdx
+++ b/docs/source/api/pipelines/stable_diffusion.mdx
@@ -73,51 +73,18 @@ If you want to use all possible use cases in a single `DiffusionPipeline` you ca
 
 ## StableDiffusionPipeline
 [[autodoc]] StableDiffusionPipeline
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing
-	- enable_vae_slicing
-	- disable_vae_slicing
-	- enable_xformers_memory_efficient_attention
-	- disable_xformers_memory_efficient_attention
 
 ## StableDiffusionImg2ImgPipeline
 [[autodoc]] StableDiffusionImg2ImgPipeline
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing
-	- enable_xformers_memory_efficient_attention
-	- disable_xformers_memory_efficient_attention
 
 ## StableDiffusionInpaintPipeline
 [[autodoc]] StableDiffusionInpaintPipeline
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing
-	- enable_xformers_memory_efficient_attention
-	- disable_xformers_memory_efficient_attention
 
 ## StableDiffusionDepth2ImgPipeline
 [[autodoc]] StableDiffusionDepth2ImgPipeline
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing
-	- enable_xformers_memory_efficient_attention
-	- disable_xformers_memory_efficient_attention
 
 ## StableDiffusionImageVariationPipeline
 [[autodoc]] StableDiffusionImageVariationPipeline
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing
-	- enable_xformers_memory_efficient_attention
-	- disable_xformers_memory_efficient_attention
-
 
 ## StableDiffusionUpscalePipeline
 [[autodoc]] StableDiffusionUpscalePipeline
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing
-	- enable_xformers_memory_efficient_attention
-	- disable_xformers_memory_efficient_attention

--- a/docs/source/api/pipelines/stable_diffusion.mdx
+++ b/docs/source/api/pipelines/stable_diffusion.mdx
@@ -73,18 +73,56 @@ If you want to use all possible use cases in a single `DiffusionPipeline` you ca
 
 ## StableDiffusionPipeline
 [[autodoc]] StableDiffusionPipeline
+	- all
+	- __call__
+	- enable_attention_slicing
+	- disable_attention_slicing
+	- enable_xformers_memory_efficient_attention
+	- disable_xformers_memory_efficient_attention
+
+
 
 ## StableDiffusionImg2ImgPipeline
 [[autodoc]] StableDiffusionImg2ImgPipeline
+	- all
+	- __call__
+	- enable_attention_slicing
+	- disable_attention_slicing
+	- enable_xformers_memory_efficient_attention
+	- disable_xformers_memory_efficient_attention
 
 ## StableDiffusionInpaintPipeline
 [[autodoc]] StableDiffusionInpaintPipeline
+	- all
+	- __call__
+	- enable_attention_slicing
+	- disable_attention_slicing
+	- enable_xformers_memory_efficient_attention
+	- disable_xformers_memory_efficient_attention
 
 ## StableDiffusionDepth2ImgPipeline
 [[autodoc]] StableDiffusionDepth2ImgPipeline
+	- all
+	- __call__
+	- enable_attention_slicing
+	- disable_attention_slicing
+	- enable_xformers_memory_efficient_attention
+	- disable_xformers_memory_efficient_attention
 
 ## StableDiffusionImageVariationPipeline
 [[autodoc]] StableDiffusionImageVariationPipeline
+	- all
+	- __call__
+	- enable_attention_slicing
+	- disable_attention_slicing
+	- enable_xformers_memory_efficient_attention
+	- disable_xformers_memory_efficient_attention
 
 ## StableDiffusionUpscalePipeline
 [[autodoc]] StableDiffusionUpscalePipeline
+	- all
+	- __call__
+	- enable_attention_slicing
+	- disable_attention_slicing
+	- enable_xformers_memory_efficient_attention
+	- disable_xformers_memory_efficient_attention

--- a/docs/source/api/pipelines/stable_diffusion_safe.mdx
+++ b/docs/source/api/pipelines/stable_diffusion_safe.mdx
@@ -84,7 +84,3 @@ To use a different scheduler, you can either change it via the [`ConfigMixin.fro
 
 ## StableDiffusionPipelineSafe
 [[autodoc]] StableDiffusionPipelineSafe
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing
-

--- a/docs/source/api/pipelines/stable_diffusion_safe.mdx
+++ b/docs/source/api/pipelines/stable_diffusion_safe.mdx
@@ -81,6 +81,10 @@ To use a different scheduler, you can either change it via the [`ConfigMixin.fro
 
 ## StableDiffusionSafePipelineOutput
 [[autodoc]] pipelines.stable_diffusion_safe.StableDiffusionSafePipelineOutput
+	- all
+	- __call__
 
 ## StableDiffusionPipelineSafe
 [[autodoc]] StableDiffusionPipelineSafe
+	- all
+	- __call__

--- a/docs/source/api/pipelines/stochastic_karras_ve.mdx
+++ b/docs/source/api/pipelines/stochastic_karras_ve.mdx
@@ -32,4 +32,3 @@ This pipeline implements the Stochastic sampling tailored to the Variance-Expand
 
 ## KarrasVePipeline
 [[autodoc]] KarrasVePipeline
-    - __call__

--- a/docs/source/api/pipelines/stochastic_karras_ve.mdx
+++ b/docs/source/api/pipelines/stochastic_karras_ve.mdx
@@ -32,3 +32,5 @@ This pipeline implements the Stochastic sampling tailored to the Variance-Expand
 
 ## KarrasVePipeline
 [[autodoc]] KarrasVePipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/unclip.mdx
+++ b/docs/source/api/pipelines/unclip.mdx
@@ -24,10 +24,10 @@ The unCLIP model in diffusers comes from kakaobrain's karlo and the original cod
 | Pipeline | Tasks | Colab
 |---|---|:---:|
 | [pipeline_unclip.py](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/unclip/pipeline_unclip.py) | *Text-to-Image Generation* | - |
+| [pipeline_unclip_image_variation.py](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/unclip/pipeline_unclip_image_variation.py) | *Image-Guided Image Generation* | - |
 
 
 ## UnCLIPPipeline
-[[autodoc]] pipelines.unclip.pipeline_unclip.UnCLIPPipeline
-    - __call__
-[[autodoc]] pipelines.unclip.pipeline_unclip_image_variation.UnCLIPImageVariationPipeline
-    - __call__
+[[autodoc]] UnCLIPPipeline
+
+[[autodoc]] UnCLIPImageVariationPipeline

--- a/docs/source/api/pipelines/unclip.mdx
+++ b/docs/source/api/pipelines/unclip.mdx
@@ -29,5 +29,9 @@ The unCLIP model in diffusers comes from kakaobrain's karlo and the original cod
 
 ## UnCLIPPipeline
 [[autodoc]] UnCLIPPipeline
+	- all
+	- __call__
 
 [[autodoc]] UnCLIPImageVariationPipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/versatile_diffusion.mdx
+++ b/docs/source/api/pipelines/versatile_diffusion.mdx
@@ -56,9 +56,15 @@ To use a different scheduler, you can either change it via the [`ConfigMixin.fro
 
 ## VersatileDiffusionTextToImagePipeline
 [[autodoc]] VersatileDiffusionTextToImagePipeline
+	- all
+	- __call__
 
 ## VersatileDiffusionImageVariationPipeline
 [[autodoc]] VersatileDiffusionImageVariationPipeline
+	- all
+	- __call__
 
 ## VersatileDiffusionDualGuidedPipeline
 [[autodoc]] VersatileDiffusionDualGuidedPipeline
+	- all
+	- __call__

--- a/docs/source/api/pipelines/versatile_diffusion.mdx
+++ b/docs/source/api/pipelines/versatile_diffusion.mdx
@@ -56,18 +56,9 @@ To use a different scheduler, you can either change it via the [`ConfigMixin.fro
 
 ## VersatileDiffusionTextToImagePipeline
 [[autodoc]] VersatileDiffusionTextToImagePipeline
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing
 
 ## VersatileDiffusionImageVariationPipeline
 [[autodoc]] VersatileDiffusionImageVariationPipeline
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing
 
 ## VersatileDiffusionDualGuidedPipeline
 [[autodoc]] VersatileDiffusionDualGuidedPipeline
-	- __call__
-	- enable_attention_slicing
-	- disable_attention_slicing

--- a/docs/source/api/pipelines/vq_diffusion.mdx
+++ b/docs/source/api/pipelines/vq_diffusion.mdx
@@ -31,4 +31,3 @@ The original codebase can be found [here](https://github.com/microsoft/VQ-Diffus
 
 ## VQDiffusionPipeline
 [[autodoc]] pipelines.vq_diffusion.pipeline_vq_diffusion.VQDiffusionPipeline
-    - __call__

--- a/docs/source/api/pipelines/vq_diffusion.mdx
+++ b/docs/source/api/pipelines/vq_diffusion.mdx
@@ -30,4 +30,6 @@ The original codebase can be found [here](https://github.com/microsoft/VQ-Diffus
 
 
 ## VQDiffusionPipeline
-[[autodoc]] pipelines.vq_diffusion.pipeline_vq_diffusion.VQDiffusionPipeline
+[[autodoc]] VQDiffusionPipeline
+	- all
+	- __call__


### PR DESCRIPTION
Make sure docs always show all methods. 
Here some very nice documentation of how the `doc-builder` behaves: https://github.com/huggingface/doc-builder#writing-api-documentation

See differences between:
- https://huggingface.co/docs/diffusers/main/en/api/diffusion_pipeline#diffusers.DiffusionPipeline (new) and
- https://huggingface.co/docs/diffusers/v0.11.0/en/api/diffusion_pipeline#diffusers.DiffusionPipeline (old)

Using:

```
- all
```

is important to not "suppress" other methods. So by default, we should just always use:

```
- all
- __call__
```
