### PR TITLE
Add pred_original_sample to FlaxDDIMScheduler.step output

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddim_flax.py
+++ b/src/diffusers/schedulers/scheduling_ddim_flax.py
@@ -290,7 +290,7 @@ class FlaxDDIMScheduler(FlaxSchedulerMixin, ConfigMixin):
         if not return_dict:
             return (prev_sample, state)
 
-        return FlaxDDIMSchedulerOutput(prev_sample=prev_sample, state=state)
+        return FlaxDDIMSchedulerOutput(prev_sample=prev_sample, state=state, pred_original_sample=pred_original_sample)
 
     def add_noise(
         self,

--- a/src/diffusers/schedulers/scheduling_utils_flax.py
+++ b/src/diffusers/schedulers/scheduling_utils_flax.py
@@ -36,9 +36,13 @@ class FlaxSchedulerOutput(BaseOutput):
         prev_sample (`jnp.ndarray` of shape `(batch_size, num_channels, height, width)` for images):
             Computed sample (x_{t-1}) of previous timestep. `prev_sample` should be used as next model input in the
             denoising loop.
+        pred_original_sample (`jnp.ndarray` of shape `(batch_size, num_channels, height, width)` for images):
+            The predicted denoised sample (x_{0}) based on the model output from the current timestep.
+            `pred_original_sample` can be used to preview progress or for guidance.
     """
 
     prev_sample: jnp.ndarray
+    pred_original_sample: Optional[jnp.ndarray] = None
 
 
 class FlaxSchedulerMixin:


### PR DESCRIPTION
We already calculate `pred_original_sample` in `FlaxDDIMScheduler.step` but we don't returned like we do in the pytorch implementation `DDIMScheduler.step`. This PR aims to add this in the returned result, and those are the changes:

- Added attribute `pred_original_sample` to class `FlaxSchedulerOutput` 
- Added `pred_original_sample` to result returned in `FlaxDDIMScheduler.step` 