### PR TITLE
Multiprompt dreambooth

### DIFF
--- a/examples/dreambooth/README.md
+++ b/examples/dreambooth/README.md
@@ -317,6 +317,39 @@ python train_dreambooth_flax.py \
   --max_train_steps=800
 ```
 
+### Learning multiple concepts
+In order to have your model learn multiple instances at once, we simply add in additional data directories and prompts to our `instance_data_dir` and `instance_prompt` (as well as `class_data_dir` and `class_prompt` if `with_prior_preservation` is specified.)
+
+```bash
+export MODEL_NAME="CompVis/stable-diffusion-v1-4"
+export INSTANCE_DIR_1="path-to-instance-images-concept-1"
+export INSTANCE_DIR_2="path-to-instance-images-concept-2"
+export CLASS_DIR_1="path-to-class-images-class-1"
+export CLASS_DIR_2="path-to-class-images-class-2"
+export OUTPUT_DIR="path-to-save-model"
+
+accelerate launch train_dreambooth.py \
+  --pretrained_model_name_or_path=$MODEL_NAME  \
+  --train_text_encoder \
+  --instance_data_dir="$INSTANCE_DIR_1,$INSTANCE_DIR_2" \
+  --class_data_dir="$CLASS_DIR_1,$CLASS_DIR_2" \
+  --output_dir=$OUTPUT_DIR \
+  --with_prior_preservation --prior_loss_weight=1.0 \
+  --instance_prompt="a photo of a sks1 dog,a photo of a sks2 person" \
+  --class_prompt="a photo of a dog,a photo of a person" \
+  --resolution=512 \
+  --train_batch_size=1 \
+  --use_8bit_adam \
+  --gradient_checkpointing \
+  --learning_rate=2e-6 \
+  --lr_scheduler="constant" \
+  --lr_warmup_steps=0 \
+  --num_class_images=200 \
+  --max_train_steps=800
+```
+
+This example shows training for 2 concepts, but the model can be trained on any number of new concepts.
+
 ### Training with xformers:
 You can enable memory efficient attention by [installing xFormers](https://github.com/facebookresearch/xformers#installing-xformers) and padding the `--enable_xformers_memory_efficient_attention` argument to the script. This is not available with the Flax/JAX implementation.
 

--- a/examples/dreambooth/README.md
+++ b/examples/dreambooth/README.md
@@ -318,14 +318,14 @@ python train_dreambooth_flax.py \
 ```
 
 ### Learning multiple concepts
-In order to have your model learn multiple instances at once, we simply add in additional data directories and prompts to our `instance_data_dir` and `instance_prompt` (as well as `class_data_dir` and `class_prompt` if `with_prior_preservation` is specified.)
+In order to have your model learn multiple instances at once, we simply add in additional data directories and prompts to our `instance_data_dir` and `instance_prompt` (as well as `class_data_dir` and `class_prompt` if `with_prior_preservation` is specified).
 
 ```bash
 export MODEL_NAME="CompVis/stable-diffusion-v1-4"
 export INSTANCE_DIR_1="path-to-instance-images-concept-1"
 export INSTANCE_DIR_2="path-to-instance-images-concept-2"
-export CLASS_DIR_1="path-to-class-images-class-1"
-export CLASS_DIR_2="path-to-class-images-class-2"
+export CLASS_DIR_1="path-to-class-images-dog"
+export CLASS_DIR_2="path-to-class-images-person"
 export OUTPUT_DIR="path-to-save-model"
 
 accelerate launch train_dreambooth.py \

--- a/examples/dreambooth/README.md
+++ b/examples/dreambooth/README.md
@@ -204,6 +204,39 @@ accelerate launch train_dreambooth.py \
   --max_train_steps=800
 ```
 
+### Learning multiple concepts
+In order to have your model learn multiple concepts at once, we simply add in additional data directories and prompts to our `instance_data_dir` and `instance_prompt` (as well as `class_data_dir` and `class_prompt` if `with_prior_preservation` is specified).
+
+```bash
+export MODEL_NAME="CompVis/stable-diffusion-v1-4"
+export INSTANCE_DIR_1="path-to-instance-images-concept-1"
+export INSTANCE_DIR_2="path-to-instance-images-concept-2"
+export CLASS_DIR_1="path-to-class-images-dog"
+export CLASS_DIR_2="path-to-class-images-person"
+export OUTPUT_DIR="path-to-save-model"
+
+accelerate launch train_dreambooth.py \
+  --pretrained_model_name_or_path=$MODEL_NAME  \
+  --train_text_encoder \
+  --instance_data_dir="$INSTANCE_DIR_1,$INSTANCE_DIR_2" \
+  --class_data_dir="$CLASS_DIR_1,$CLASS_DIR_2" \
+  --output_dir=$OUTPUT_DIR \
+  --with_prior_preservation --prior_loss_weight=1.0 \
+  --instance_prompt="a photo of a sks1 dog,a photo of a sks2 person" \
+  --class_prompt="a photo of a dog,a photo of a person" \
+  --resolution=512 \
+  --train_batch_size=1 \
+  --use_8bit_adam \
+  --gradient_checkpointing \
+  --learning_rate=2e-6 \
+  --lr_scheduler="constant" \
+  --lr_warmup_steps=0 \
+  --num_class_images=200 \
+  --max_train_steps=800
+```
+
+This example shows training for 2 concepts, but the model can be trained on any number of new concepts.
+
 ### Using DreamBooth for other pipelines than Stable Diffusion
 
 Altdiffusion also support dreambooth now, the runing comman is basically the same as abouve, all you need to do is replace the `MODEL_NAME` like this:
@@ -242,6 +275,7 @@ For faster training on TPUs and GPUs you can leverage the flax training example.
 
 ____Note: The flax example don't yet support features like gradient checkpoint, gradient accumulation etc, so to use flax for faster training we will need >30GB cards.___
 
+____Note: The flax example also does not yet support training a model with multiple concepts.___
 
 Before running the scripts, make sure to install the library's training dependencies:
 
@@ -316,39 +350,6 @@ python train_dreambooth_flax.py \
   --num_class_images=200 \
   --max_train_steps=800
 ```
-
-### Learning multiple concepts
-In order to have your model learn multiple concepts at once, we simply add in additional data directories and prompts to our `instance_data_dir` and `instance_prompt` (as well as `class_data_dir` and `class_prompt` if `with_prior_preservation` is specified).
-
-```bash
-export MODEL_NAME="CompVis/stable-diffusion-v1-4"
-export INSTANCE_DIR_1="path-to-instance-images-concept-1"
-export INSTANCE_DIR_2="path-to-instance-images-concept-2"
-export CLASS_DIR_1="path-to-class-images-dog"
-export CLASS_DIR_2="path-to-class-images-person"
-export OUTPUT_DIR="path-to-save-model"
-
-accelerate launch train_dreambooth.py \
-  --pretrained_model_name_or_path=$MODEL_NAME  \
-  --train_text_encoder \
-  --instance_data_dir="$INSTANCE_DIR_1,$INSTANCE_DIR_2" \
-  --class_data_dir="$CLASS_DIR_1,$CLASS_DIR_2" \
-  --output_dir=$OUTPUT_DIR \
-  --with_prior_preservation --prior_loss_weight=1.0 \
-  --instance_prompt="a photo of a sks1 dog,a photo of a sks2 person" \
-  --class_prompt="a photo of a dog,a photo of a person" \
-  --resolution=512 \
-  --train_batch_size=1 \
-  --use_8bit_adam \
-  --gradient_checkpointing \
-  --learning_rate=2e-6 \
-  --lr_scheduler="constant" \
-  --lr_warmup_steps=0 \
-  --num_class_images=200 \
-  --max_train_steps=800
-```
-
-This example shows training for 2 concepts, but the model can be trained on any number of new concepts.
 
 ### Training with xformers:
 You can enable memory efficient attention by [installing xFormers](https://github.com/facebookresearch/xformers#installing-xformers) and padding the `--enable_xformers_memory_efficient_attention` argument to the script. This is not available with the Flax/JAX implementation.

--- a/examples/dreambooth/README.md
+++ b/examples/dreambooth/README.md
@@ -318,7 +318,7 @@ python train_dreambooth_flax.py \
 ```
 
 ### Learning multiple concepts
-In order to have your model learn multiple instances at once, we simply add in additional data directories and prompts to our `instance_data_dir` and `instance_prompt` (as well as `class_data_dir` and `class_prompt` if `with_prior_preservation` is specified).
+In order to have your model learn multiple concepts at once, we simply add in additional data directories and prompts to our `instance_data_dir` and `instance_prompt` (as well as `class_data_dir` and `class_prompt` if `with_prior_preservation` is specified).
 
 ```bash
 export MODEL_NAME="CompVis/stable-diffusion-v1-4"


### PR DESCRIPTION
**Purpose of multi-prompting**
This pull request implements the ability to train a single model with multiple new concepts using dreambooth. This can be used for rendering multiple new concepts in a single generated image.

**A few things to note:**
- This implements multi-prompting for train_dreambooth.py only (not train_dreambooth_flax.py). Assuming this PR looks good, I can also implement multi-prompting for train_dreambooth_flax.py.
- This implementation does not include any unit tests, largely because I could not find any existing test for the dreambooth code. If this is not the case or there is a test suite that I should add to, please let me know.

Comments & edits are appreciated! 