### PR TITLE
Add UnCLIPImageVariationPipeline to dummy imports

### DIFF
--- a/src/diffusers/pipelines/unclip/__init__.py
+++ b/src/diffusers/pipelines/unclip/__init__.py
@@ -10,7 +10,7 @@ try:
     if not (is_transformers_available() and is_torch_available() and is_transformers_version(">=", "4.25.0")):
         raise OptionalDependencyNotAvailable()
 except OptionalDependencyNotAvailable:
-    from ...utils.dummy_torch_and_transformers_objects import UnCLIPPipeline
+    from ...utils.dummy_torch_and_transformers_objects import UnCLIPPipeline, UnCLIPImageVariationPipeline
 else:
     from .pipeline_unclip import UnCLIPPipeline
     from .pipeline_unclip_image_variation import UnCLIPImageVariationPipeline

--- a/src/diffusers/pipelines/unclip/__init__.py
+++ b/src/diffusers/pipelines/unclip/__init__.py
@@ -10,7 +10,7 @@ try:
     if not (is_transformers_available() and is_torch_available() and is_transformers_version(">=", "4.25.0")):
         raise OptionalDependencyNotAvailable()
 except OptionalDependencyNotAvailable:
-    from ...utils.dummy_torch_and_transformers_objects import UnCLIPPipeline, UnCLIPImageVariationPipeline
+    from ...utils.dummy_torch_and_transformers_objects import UnCLIPImageVariationPipeline, UnCLIPPipeline
 else:
     from .pipeline_unclip import UnCLIPPipeline
     from .pipeline_unclip_image_variation import UnCLIPImageVariationPipeline


### PR DESCRIPTION
This makes sure that we don't get an import error when `transformers` aren't installed and we run a script like `diffusers-cli env` or `make fix-copies`, as seen in https://github.com/huggingface/diffusers/issues/1895
```
diffusers/src/diffusers/pipelines/__init__.py", line 57, in <module>
    from .unclip import UnCLIPImageVariationPipeline, UnCLIPPipeline
ImportError: cannot import name 'UnCLIPImageVariationPipeline' from 'diffusers.pipelines.unclip' (diffusers/src/diffusers/pipelines/unclip/__init__.py)
```

cc @williamberman 