### PR TITLE
[dreambooth] low precision guard

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -676,7 +676,7 @@ def main(args):
         " copy of the weights should still be float32."
     )
 
-    if unet.dtype != torch.float32 or (args.train_text_encoder and text_encoder.dtype != torch.float32):
+    if unet.dtype != torch.float32:
         raise ValueError(f"Unet loaded as datatype {unet.dtype}. {low_precision_error_string}")
 
     if args.train_text_encoder and text_encoder.dtype != torch.float32:

--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -671,6 +671,17 @@ def main(args):
     if not args.train_text_encoder:
         text_encoder.to(accelerator.device, dtype=weight_dtype)
 
+    low_precision_error_string = (
+        "Training on low precision datatypes is not supported. Even When doing mixed precision training, the master"
+        " copy of the weights should still be float32."
+    )
+
+    if unet.dtype != torch.float32 or (args.train_text_encoder and text_encoder.dtype != torch.float32):
+        raise ValueError(f"Unet loaded as datatype {unet.dtype}. {low_precision_error_string}")
+
+    if args.train_text_encoder and text_encoder.dtype != torch.float32:
+        raise ValueError(f"Text encoder loaded as datatype {text_encoder.dtype}. {low_precision_error_string}")
+
     # We need to recalculate our total training steps as the size of the training dataloader may have changed.
     num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
     if overrode_max_train_steps:

--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -70,7 +70,10 @@ def parse_args(input_args=None):
         type=str,
         default=None,
         required=False,
-        help="Revision of pretrained model identifier from huggingface.co/models.",
+        help=(
+            "Revision of pretrained model identifier from huggingface.co/models. Trainable model components should be"
+            " float32 precision."
+        ),
     )
     parser.add_argument(
         "--tokenizer_name",
@@ -140,7 +143,11 @@ def parse_args(input_args=None):
     parser.add_argument(
         "--center_crop", action="store_true", help="Whether to center crop images before resizing to resolution"
     )
-    parser.add_argument("--train_text_encoder", action="store_true", help="Whether to train the text encoder")
+    parser.add_argument(
+        "--train_text_encoder",
+        action="store_true",
+        help="Whether to train the text encoder. If set, the text encoder should be float32 precision.",
+    )
     parser.add_argument(
         "--train_batch_size", type=int, default=4, help="Batch size (per device) for the training dataloader."
     )

--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -679,8 +679,8 @@ def main(args):
         text_encoder.to(accelerator.device, dtype=weight_dtype)
 
     low_precision_error_string = (
-        "Please make sure to always have all model weights in full float32 precision when starting training - even if doing mixed precision training."
-        " copy of the weights should still be float32."
+        "Please make sure to always have all model weights in full float32 precision when starting training - even if"
+        " doing mixed precision training. copy of the weights should still be float32."
     )
 
     if unet.dtype != torch.float32:

--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -679,7 +679,7 @@ def main(args):
         text_encoder.to(accelerator.device, dtype=weight_dtype)
 
     low_precision_error_string = (
-        "Training on low precision datatypes is not supported. Even When doing mixed precision training, the master"
+        "Please make sure to always have all model weights in full float32 precision when starting training - even if doing mixed precision training."
         " copy of the weights should still be float32."
     )
 


### PR DESCRIPTION
re: https://github.com/huggingface/diffusers/issues/1246

training/fine tuning shouldn't be done with fp16 weights[^1], fp16 inputs are ok with amp + gradient scaling. fp16 weights throw an error when used with amp + gradient scaling. We should check the dtype of the loaded model and throw an informative error before training begins.

We add a guard checking the datatype of the unet. We also add a guard checking the datatype of the text encoder if we are training the text encoder.

[^1]: precision issues when adding small gradient updates to fp16 weights. Reason why training with amp [recommends](https://developer.nvidia.com/blog/mixed-precision-training-deep-neural-networks/#:~:text=Training%C2%A0paper.-,FP32%20Master%C2%A0Copy%20of%20Weights,-Each%20iteration%20of) to keep weights as fp32 for gradient updates and makes a copy in half precision for forward and backward passes.