### PR TITLE
Fix unused upcast_attn flag in convert_original_stable_diffusion_to_diffusers script

### DIFF
--- a/scripts/convert_original_stable_diffusion_to_diffusers.py
+++ b/scripts/convert_original_stable_diffusion_to_diffusers.py
@@ -839,7 +839,7 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
-        "--upcast_attn",
+        "--upcast_attention",
         default=False,
         type=bool,
         help=(
@@ -870,7 +870,7 @@ if __name__ == "__main__":
     if "state_dict" in checkpoint:
         checkpoint = checkpoint["state_dict"]
 
-    upcast_attention = False
+    upcast_attention = args.upcast_attention
     if args.original_config_file is None:
         key_name = "model.diffusion_model.input_blocks.2.1.transformer_blocks.0.attn2.to_k.weight"
 


### PR DESCRIPTION
`upcast_attn` flag was introduced in this PR https://github.com/huggingface/diffusers/pull/1559/files#diff-575959cae6329573c802ceca78d9a160b9d25948817a9ff37feb37585f819b05R842, however the flag is actually not used.

This PR:
* fixes it by setting `upcast_attention` to what's specified by the flag.
* rename the flag to make it consistent with the rest of the code.