### PR TITLE
fix typo in imagic_stable_diffusion.py

### DIFF
--- a/examples/community/imagic_stable_diffusion.py
+++ b/examples/community/imagic_stable_diffusion.py
@@ -229,7 +229,7 @@ class ImagicStableDiffusionPipeline(DiffusionPipeline):
             prompt,
             padding="max_length",
             max_length=self.tokenizer.model_max_length,
-            truncaton=True,
+            truncation=True,
             return_tensors="pt",
         )
         text_embeddings = torch.nn.Parameter(


### PR DESCRIPTION
changed named arg to `self.tokenizer` from `truncaton` to `truncation` according to Tokenizer docs (https://huggingface.co/docs/tokenizers/api/tokenizer#tokenizers.Tokenizer.truncation)