### PR TITLE
Bug fix: Reorder input image transformations.

### DIFF
--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -580,8 +580,8 @@ def main():
     # Preprocessing the datasets.
     train_transforms = transforms.Compose(
         [
-            transforms.Resize(args.resolution, interpolation=transforms.InterpolationMode.BILINEAR),
             transforms.CenterCrop(args.resolution) if args.center_crop else transforms.RandomCrop(args.resolution),
+            transforms.Resize(args.resolution, interpolation=transforms.InterpolationMode.BILINEAR), 
             transforms.RandomHorizontalFlip() if args.random_flip else transforms.Lambda(lambda x: x),
             transforms.ToTensor(),
             transforms.Normalize([0.5], [0.5]),


### PR DESCRIPTION
Currently, the input image is resized, and *then* cropped. This changes the aspect ratio of the input image.

The intent of first cropping and then resizing is expressed in the --center_crop flag description ("Whether to center crop images *before* resizing to resolution"), but the code doesn't currently reflect that.

Before (deformed image):
---
![image](https://user-images.githubusercontent.com/6214514/211411311-3668154e-8f39-4c08-85c2-75d54062822f.png)

After (correct aspect ratio):
---
![image](https://user-images.githubusercontent.com/6214514/211411278-5068d0f8-d512-4d24-8577-fee625191c0f.png)