### PR TITLE
Fix slow tests

### DIFF
--- a/src/diffusers/pipelines/stochastic_karras_ve/pipeline_stochastic_karras_ve.py
+++ b/src/diffusers/pipelines/stochastic_karras_ve/pipeline_stochastic_karras_ve.py
@@ -82,7 +82,7 @@ class KarrasVePipeline(DiffusionPipeline):
         model = self.unet
 
         # sample x_0 ~ N(0, sigma_0^2 * I)
-        sample = randn_tensor(shape, device=self.device) * self.scheduler.init_noise_sigma
+        sample = randn_tensor(shape, generator=generator, device=self.device) * self.scheduler.init_noise_sigma
 
         self.scheduler.set_timesteps(num_inference_steps)
 

--- a/tests/pipelines/karras_ve/test_karras_ve.py
+++ b/tests/pipelines/karras_ve/test_karras_ve.py
@@ -80,6 +80,5 @@ class KarrasVePipelineIntegrationTests(unittest.TestCase):
 
         image_slice = image[0, -3:, -3:, -1]
         assert image.shape == (1, 256, 256, 3)
-        print(torch.from_numpy(image_slice).flatten())
         expected_slice = np.array([0.578, 0.5811, 0.5924, 0.5809, 0.587, 0.5886, 0.5861, 0.5802, 0.586])
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2

--- a/tests/pipelines/karras_ve/test_karras_ve.py
+++ b/tests/pipelines/karras_ve/test_karras_ve.py
@@ -25,6 +25,44 @@ from diffusers.utils.testing_utils import require_torch, slow, torch_device
 torch.backends.cuda.matmul.allow_tf32 = False
 
 
+class KarrasVePipelineFastTests(unittest.TestCase):
+    @property
+    def dummy_uncond_unet(self):
+        torch.manual_seed(0)
+        model = UNet2DModel(
+            block_out_channels=(32, 64),
+            layers_per_block=2,
+            sample_size=32,
+            in_channels=3,
+            out_channels=3,
+            down_block_types=("DownBlock2D", "AttnDownBlock2D"),
+            up_block_types=("AttnUpBlock2D", "UpBlock2D"),
+        )
+        return model
+
+    def test_inference(self):
+        unet = self.dummy_uncond_unet
+        scheduler = KarrasVeScheduler()
+
+        pipe = KarrasVePipeline(unet=unet, scheduler=scheduler)
+        pipe.to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
+
+        generator = torch.manual_seed(0)
+        image = pipe(num_inference_steps=2, generator=generator, output_type="numpy").images
+
+        generator = torch.manual_seed(0)
+        image_from_tuple = pipe(num_inference_steps=2, generator=generator, output_type="numpy", return_dict=False)[0]
+
+        image_slice = image[0, -3:, -3:, -1]
+        image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
+
+        assert image.shape == (1, 32, 32, 3)
+        expected_slice = np.array([0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+        assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
+        assert np.abs(image_from_tuple_slice.flatten() - expected_slice).max() < 1e-2
+
+
 @slow
 @require_torch
 class KarrasVePipelineIntegrationTests(unittest.TestCase):
@@ -42,5 +80,6 @@ class KarrasVePipelineIntegrationTests(unittest.TestCase):
 
         image_slice = image[0, -3:, -3:, -1]
         assert image.shape == (1, 256, 256, 3)
+        print(torch.from_numpy(image_slice).flatten())
         expected_slice = np.array([0.578, 0.5811, 0.5924, 0.5809, 0.587, 0.5886, 0.5861, 0.5802, 0.586])
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -742,10 +742,10 @@ class PipelineSlowTests(unittest.TestCase):
             new_ddpm.to(torch_device)
 
         generator = torch.Generator(device=torch_device).manual_seed(0)
-        image = ddpm(generator=generator, output_type="numpy").images
+        image = ddpm(generator=generator, num_inference_steps=5, output_type="numpy").images
 
         generator = generator.manual_seed(0)
-        new_image = new_ddpm(generator=generator, output_type="numpy").images
+        new_image = new_ddpm(generator=generator, num_inference_steps=5, output_type="numpy").images
 
         assert np.abs(image - new_image).sum() < 1e-5, "Models don't give the same forward pass"
 
@@ -763,10 +763,10 @@ class PipelineSlowTests(unittest.TestCase):
         ddpm_from_hub.set_progress_bar_config(disable=None)
 
         generator = torch.Generator(device=torch_device).manual_seed(0)
-        image = ddpm(generator=generator, output_type="numpy").images
+        image = ddpm(generator=generator, num_inference_steps=5, output_type="numpy").images
 
         generator = generator.manual_seed(0)
-        new_image = ddpm_from_hub(generator=generator, output_type="numpy").images
+        new_image = ddpm_from_hub(generator=generator, num_inference_steps=5, output_type="numpy").images
 
         assert np.abs(image - new_image).sum() < 1e-5, "Models don't give the same forward pass"
 
@@ -786,10 +786,10 @@ class PipelineSlowTests(unittest.TestCase):
         ddpm_from_hub_custom_model.set_progress_bar_config(disable=None)
 
         generator = torch.Generator(device=torch_device).manual_seed(0)
-        image = ddpm_from_hub_custom_model(generator=generator, output_type="numpy").images
+        image = ddpm_from_hub_custom_model(generator=generator, num_inference_steps=5, output_type="numpy").images
 
         generator = generator.manual_seed(0)
-        new_image = ddpm_from_hub(generator=generator, output_type="numpy").images
+        new_image = ddpm_from_hub(generator=generator, num_inference_steps=5, output_type="numpy").images
 
         assert np.abs(image - new_image).sum() < 1e-5, "Models don't give the same forward pass"
 


### PR DESCRIPTION
Fix currently failing slow tests:

```
FAILED tests/test_pipelines.py::PipelineSlowTests::test_from_pretrained_hub - ValueError: `num_inference_steps`: 1000 cannot be larger than `self.config.train_timesteps`: 10 as the unet model trained with this scheduler can only handle maximal 10 timesteps.
FAILED tests/test_pipelines.py::PipelineSlowTests::test_from_pretrained_hub_pass_model - ValueError: `num_inference_steps`: 1000 cannot be larger than `self.config.train_timesteps`: 10 as the unet model trained with this scheduler can only handle maximal 10 timesteps.
FAILED tests/test_pipelines.py::PipelineSlowTests::test_from_save_pretrained - ValueError: `num_inference_steps`: 1000 cannot be larger than `self.config.train_timesteps`: 10 as the unet model trained with this scheduler can only handle maximal 10 timesteps.
FAILED tests/pipelines/karras_ve/test_karras_ve.py::KarrasVePipelineIntegrationTests::test_inference - AssertionError: assert 0.2973653168678284 < 0.01
 +  where 0.2973653168678284 = <built-in method max of numpy.ndarray object at 0x7f005a1b4ab0>()
 +    where <built-in method max of numpy.ndarray object at 0x7f005a1b4ab0> = array([0.29736532, 0.29216324, 0.27975966, 0.29056747, 0.28537269,\n       0.27839474, 0.28657929, 0.29181643, 0.27639702]).max
 +      where array([0.29736532, 0.29216324, 0.27975966, 0.29056747, 0.28537269,\n       0.27839474, 0.28657929, 0.29181643, 0.27639702]) = <ufunc 'absolute'>((array([0.8753653 , 0.87326324, 0.87215966, 0.8714675 , 0.8723727 ,\n       0.86699474, 0.8726793 , 0.87201643, 0.862397  ], dtype=float32) - array([0.578 , 0.5811, 0.5924, 0.5809, 0.587 , 0.5886, 0.5861, 0.5802,\n       0.586 ])))
 +        where <ufunc 'absolute'> = np.abs
 +        and   array([0.8753653 , 0.87326324, 0.87215966, 0.8714675 , 0.8723727 ,\n       0.86699474, 0.8726793 , 0.87201643, 0.862397  ], dtype=float32) = <built-in method flatten of numpy.ndarray object at 0x7f005a1b4e70>()
 +          where <built-in method flatten of numpy.ndarray object at 0x7f005a1b4e70> = array([[0.8753653 , 0.87326324, 0.87215966],\n       [0.8714675 , 0.8723727 , 0.86699474],\n       [0.8726793 , 0.87201643, 0.862397  ]], dtype=float32).flatten
```