### PR TITLE
Change PNDMPipeline to use PNDMScheduler

### DIFF
--- a/src/diffusers/pipelines/pndm/pipeline_pndm.py
+++ b/src/diffusers/pipelines/pndm/pipeline_pndm.py
@@ -39,6 +39,9 @@ class PNDMPipeline(DiffusionPipeline):
 
     def __init__(self, unet: UNet2DModel, scheduler: PNDMScheduler):
         super().__init__()
+
+        scheduler = PNDMScheduler.from_config(scheduler.config)
+        
         self.register_modules(unet=unet, scheduler=scheduler)
 
     @torch.no_grad()

--- a/src/diffusers/pipelines/pndm/pipeline_pndm.py
+++ b/src/diffusers/pipelines/pndm/pipeline_pndm.py
@@ -41,7 +41,7 @@ class PNDMPipeline(DiffusionPipeline):
         super().__init__()
 
         scheduler = PNDMScheduler.from_config(scheduler.config)
-        
+
         self.register_modules(unet=unet, scheduler=scheduler)
 
     @torch.no_grad()


### PR DESCRIPTION
Fixes #1918. 

Loading DDPMs in a `PNDMPipeline` (shown in the code below) will produce noisy results as the scheduler is not a `PNDMScheduler`.

```python
from diffusers import PNDMPipeline
model_id = "google/ddpm-cifar10-32"
pndm = PNDMPipeline.from_pretrained(model_id)
images = pndm(num_inference_steps=50, batch_size=3).images
```
![image](https://user-images.githubusercontent.com/21955567/212650403-8911f38b-cf14-4d7e-be24-9d86ac497a22.png)

Changing the scheduler after creating the pipeline will give the expected results.
```python
from diffusers import PNDMPipeline, PNDMScheduler
model_id = "google/ddpm-cifar10-32"
pndm = PNDMPipeline.from_pretrained(model_id)
pndm.scheduler = PNDMScheduler.from_config(pndm.scheduler.config)
images = pndm(num_inference_steps=50, batch_size=3).images
```
![image](https://user-images.githubusercontent.com/21955567/212650889-efe9d5ac-2667-4bae-9223-36fa199e4717.png)

The fix is similar to #1932, where the scheduler is manually set in the constructor of the pipeline. 