### PR TITLE
fix dit doc header

### DIFF
--- a/docs/source/en/api/pipelines/dit.mdx
+++ b/docs/source/en/api/pipelines/dit.mdx
@@ -10,7 +10,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# [Scalable Diffusion Models with Transformers](https://www.wpeebles.com/DiT) (DiT)
+# Scalable Diffusion Models with Transformers (DiT)
 
 ## Overview
 


### PR DESCRIPTION
The link in the main heading needs to be rendered on the doc page. It displays the text as is. cc @kashif 