### PR TITLE
[dreambooth] fix multi on gpu.

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -716,11 +716,16 @@ def main(args):
         " doing mixed precision training. copy of the weights should still be float32."
     )
 
-    if unet.dtype != torch.float32:
-        raise ValueError(f"Unet loaded as datatype {unet.dtype}. {low_precision_error_string}")
+    if accelerator.unwrap_model(unet).dtype != torch.float32:
+        raise ValueError(
+            f"Unet loaded as datatype {accelerator.unwrap_model(unet).dtype}. {low_precision_error_string}"
+        )
 
-    if args.train_text_encoder and text_encoder.dtype != torch.float32:
-        raise ValueError(f"Text encoder loaded as datatype {text_encoder.dtype}. {low_precision_error_string}")
+    if args.train_text_encoder and accelerator.unwrap_model(text_encoder).dtype != torch.float32:
+        raise ValueError(
+            f"Text encoder loaded as datatype {accelerator.unwrap_model(text_encoder).dtype}."
+            f" {low_precision_error_string}"
+        )
 
     # We need to recalculate our total training steps as the size of the training dataloader may have changed.
     num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)


### PR DESCRIPTION
When using multi GPU, the `model` becomes an instance of `DistributedDataParallel`, and we need to unwrap the model to access any property/methods of the model. This PR unwraps the model before accessing `dtype` arg. 
cc @williamberman 