### PR TITLE
[lora] Fix bug with training without validation

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -984,19 +984,19 @@ def main(args):
             prompt = args.num_validation_images * [args.validation_prompt]
             images = pipeline(prompt, num_inference_steps=25, generator=generator).images
 
-        for tracker in accelerator.trackers:
-            if tracker.name == "tensorboard":
-                np_images = np.stack([np.asarray(img) for img in images])
-                tracker.writer.add_images("test", np_images, epoch, dataformats="NHWC")
-            if tracker.name == "wandb":
-                tracker.log(
-                    {
-                        "test": [
-                            wandb.Image(image, caption=f"{i}: {args.validation_prompt}")
-                            for i, image in enumerate(images)
-                        ]
-                    }
-                )
+            for tracker in accelerator.trackers:
+                if tracker.name == "tensorboard":
+                    np_images = np.stack([np.asarray(img) for img in images])
+                    tracker.writer.add_images("test", np_images, epoch, dataformats="NHWC")
+                if tracker.name == "wandb":
+                    tracker.log(
+                        {
+                            "test": [
+                                wandb.Image(image, caption=f"{i}: {args.validation_prompt}")
+                                for i, image in enumerate(images)
+                            ]
+                        }
+                    )
 
         if args.push_to_hub:
             save_model_card(


### PR DESCRIPTION
Currenctly due to an indentation mistake, training Lora without validation (to be able to run at 6.5GB VRAM as mentioned [here](https://github.com/huggingface/diffusers/pull/1884#issuecomment-1387426047)) throws `UnboundLocalError: local variable 'images' referenced before assignment`.

This should be fixed by this PR.