### PR TITLE
Fixed Documentation Bug

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddpm.py
+++ b/src/diffusers/schedulers/scheduling_ddpm.py
@@ -237,8 +237,7 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
         Args:
             model_output (`torch.FloatTensor`): direct output from learned diffusion model.
             timestep (`int`): current discrete timestep in the diffusion chain.
-            sample (`torch.FloatTensor`):
-                current instance of sample being created by diffusion process.
+            sample (`torch.FloatTensor`): current instance of sample being created by diffusion process.
             generator: random number generator.
             return_dict (`bool`): option for returning tuple rather than DDPMSchedulerOutput class
 


### PR DESCRIPTION
In the documentation on https://huggingface.co/docs/diffusers/main/en/api/schedulers/ddpm#diffusers.DDPMScheduler.step.sample "generator" is on the same line as "sample" I think this will fix it but I don't know.