### PR TITLE
Add instance prompt to model card of lora dreambooth example

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -69,6 +69,7 @@ def save_model_card(repo_name, images=None, base_model=str, prompt=str, repo_fol
 ---
 license: creativeml-openrail-m
 base_model: {base_model}
+instance_prompt: {prompt}
 tags:
 - stable-diffusion
 - stable-diffusion-diffusers


### PR DESCRIPTION
I think it would be useful if it was possible to programmatically get what instance prompt was used in training in the case of LoRA DreamBooth example.
What do you think?