### PR TITLE
[nit] torch_dtype used twice in doc string

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -356,7 +356,6 @@ class DiffusionPipeline(ConfigMixin):
                 Adding Custom
                 Pipelines](https://huggingface.co/docs/diffusers/using-diffusers/custom_pipeline_overview)
 
-            torch_dtype (`str` or `torch.dtype`, *optional*):
             force_download (`bool`, *optional*, defaults to `False`):
                 Whether or not to force the (re-)download of the model weights and configuration files, overriding the
                 cached versions if they exist.


### PR DESCRIPTION
see actual docstring here: https://github.com/huggingface/diffusers/blob/048d4d35b4a061871b3bce6776d0ebf4f7823566/src/diffusers/pipelines/pipeline_utils.py#L311