### PR TITLE
[from_pretrained] only load config one time

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -531,8 +531,7 @@ class DiffusionPipeline(ConfigMixin):
             )
         else:
             cached_folder = pretrained_model_name_or_path
-
-        config_dict = cls.load_config(cached_folder)
+            config_dict = cls.load_config(cached_folder)
 
         # 2. Load the pipeline class, if using custom module then load it from the hub
         # if we load from explicit class, let's use it


### PR DESCRIPTION
In the path where we remotely load from the hub, we've already loaded the config here

https://github.com/huggingface/diffusers/blob/a89576925eec43963fa8694ba45863cd12f3297c/src/diffusers/pipelines/pipeline_utils.py#L461


Checked with, from diffusers root:

```bash
cd ..
git lfs clone https://huggingface.co/runwayml/stable-diffusion-v1-5
cd diffusers
```

```py
from diffusers import StableDiffusionPipeline
import torch

pipe = StableDiffusionPipeline.from_pretrained('runwayml/stable-diffusion-v1-5', torch_dtype=torch.float16)
pipe.to('cuda')

images = pipe('a horse riding inside a rocketship', num_images_per_prompt=4).images

for idx, image in enumerate(images):
    image.save(f"./image-{idx}.png")


pipe = StableDiffusionPipeline.from_pretrained('../stable-diffusion-v1-5', torch_dtype=torch.float16)
pipe.to('cuda')

images = pipe('a horse riding inside a rocketship', num_images_per_prompt=4).images

for idx, image in enumerate(images):
    image.save(f"./image-local-{idx}.png")
```