### PR TITLE
[lora] Allow finetuning text encoder with lora

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1037,7 +1037,9 @@ def main(args):
         # Final inference
         # Load previous pipeline
         pipeline = DiffusionPipeline.from_pretrained(
-            args.pretrained_model_name_or_path, revision=args.revision, torch_dtype=weight_dtype
+            args.pretrained_model_name_or_path,
+            revision=args.revision,
+            torch_dtype=weight_dtype if not args.train_text_encoder else torch.float32,
         )
         pipeline.scheduler = DPMSolverMultistepScheduler.from_config(pipeline.scheduler.config)
         pipeline = pipeline.to(accelerator.device)

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -51,7 +51,7 @@ from huggingface_hub import HfFolder, Repository, create_repo, whoami
 from PIL import Image
 from torchvision import transforms
 from tqdm.auto import tqdm
-from transformers import AutoTokenizer, PretrainedConfig, CLIPTextModel
+from transformers import AutoTokenizer, CLIPTextModel, PretrainedConfig
 
 
 # Will error if the minimal version of diffusers is not installed. Remove at your own risks.

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1101,7 +1101,6 @@ def inject_lora_text_encoder_params(
     ancestors = [module for module in text_encoder.modules() if module.__class__.__name__ == "CLIPAttention"]
     for i, ancestor in enumerate(ancestors):
         for fullname, module in ancestor.named_modules():
-
             if any([isinstance(module, _class) for _class in [torch.nn.Linear]]):
                 # Find the direct parent if this is a descendant, not a child, of target
                 *path, name = fullname.split(".")


### PR DESCRIPTION
Fine-tuning `text_encoder` along with `unet` can bring us much more fidelity in the results when training Dreambooth. With LoRA, my personal experiments have shown that this conclusion holds true. Hence this PR: 
- Passing `--train_text_encoder` to fine-tune model's `text_encoder` entirely
- Passing both `--train_text_encoder` and `--lora_text_encoder_only` only trains injected text encoder lora layers

For inference:
```python
pipe = DiffusionPipeline.from_pretrained(
    "runwayml/stable-diffusion-v1-5",
    text_encoder=CLIPTextModel.from_pretrained("path-to-output/text_encoder"),
    torch_dtype=torch.float16,
)
```

OR lora layers only:
```python
from train_dreambooth_lora import inject_lora_text_encoder_params

inject_lora_text_encoder_params(pipe.text_encoder, "path-to-output/pytorch_lora.text_encoder_weights.bin")
```

I do have a few noob questions left, and it would be appreciated if anyone can explain anything to me:
- I saw in [train_dreambooth.py](https://github.com/huggingface/diffusers/blob/main/examples/dreambooth/train_dreambooth.py) that when training `text_encoder` should be always in full-precision. Why? Although in this PR I implemented it in full-precision to make it work, but I don't really understand what's going on to be honest.
- Currently I wrote everything in [train_dreambooth_lora.py](https://github.com/huggingface/diffusers/blob/main/examples/dreambooth/train_dreambooth_lora.py) but it is not as beautiful as the `CrossAttnProcessor`. But to implement something like that, I would need to change library `transformers`... Is there a better way for this, or is current implementation alright (as an example)?
