### PR TITLE
[wip] attention refactor

### DIFF
--- a/scripts/convert_deprecated_attention_block.py
+++ b/scripts/convert_deprecated_attention_block.py
@@ -1,0 +1,223 @@
+import argparse
+
+import torch
+from torch import nn
+
+from diffusers import DiffusionPipeline
+from diffusers.models.attention import AttentionBlock, assert_no_deprecated_attention_blocks
+from diffusers.models.autoencoder_kl import AutoencoderKL
+from diffusers.models.unet_2d import UNet2DModel
+from diffusers.models.unet_2d_blocks import (
+    AttnDownBlock2D,
+    AttnDownEncoderBlock2D,
+    AttnSkipDownBlock2D,
+    AttnSkipUpBlock2D,
+    AttnUpBlock2D,
+    AttnUpDecoderBlock2D,
+    UNetMidBlock2D,
+)
+from diffusers.models.vq_model import VQModel
+from diffusers.pipelines.pipeline_utils import PipelineType
+from diffusers.utils.torch_utils import randn_tensor
+
+
+MODULES = [AutoencoderKL, VQModel, UNet2DModel]
+
+UNET_BLOCKS = [
+    UNetMidBlock2D,
+    AttnDownBlock2D,
+    AttnDownEncoderBlock2D,
+    AttnSkipDownBlock2D,
+    AttnUpBlock2D,
+    AttnUpDecoderBlock2D,
+    AttnSkipUpBlock2D,
+]
+
+
+unet_blocks_to_convert = []
+
+
+def patch_unet_block(unet_block_class):
+    orig_constructor = unet_block_class.__init__
+
+    def new_constructor(self, *args, **kwargs):
+        orig_constructor(self, *args, **kwargs)
+        unet_blocks_to_convert.append(self)
+
+    def convert_attention_blocks(self):
+        new_attentions = []
+
+        for attention_block in self.attentions:
+            if isinstance(attention_block, AttentionBlock):
+                new_attention_block = attention_block.as_cross_attention()
+            else:
+                new_attention_block = attention_block
+
+            new_attentions.append(new_attention_block)
+
+        self.attentions = nn.ModuleList(new_attentions)
+
+    unet_block_class.__init__ = new_constructor
+    unet_block_class.convert_attention_blocks = convert_attention_blocks
+
+
+for unet_block_class in UNET_BLOCKS:
+    patch_unet_block(unet_block_class)
+
+
+def default_output(pipe: DiffusionPipeline):
+    generator = torch.Generator("cpu").manual_seed(0)
+
+    # TODO
+    # height = 224
+    # width = 224
+    height = 512
+    width = 512
+
+    prompt = "a horse"
+    class_labels = [0]
+    image = randn_tensor((1, 3, height, width), generator=generator).clamp(-1, 1)
+    mask_image = torch.bernoulli(torch.full((1, 1, height, width), 0.5), generator=generator)
+
+    args = {"generator": generator, "return_dict": False, "output_type": "np"}
+
+    if pipe.pipeline_type == PipelineType.UNCONDITIONAL_IMAGE_GENERATION:
+        # No additional arguments
+        ...
+    elif pipe.pipeline_type == PipelineType.CLASS_CONDITIONAL_IMAGE_GENERATION:
+        args["class_labels"] = class_labels
+    elif pipe.pipeline_type == PipelineType.TEXT_TO_IMAGE:
+        args["prompt"] = prompt
+    elif pipe.pipeline_type == PipelineType.IMAGE_VARIATION:
+        args["image"] = image
+    elif pipe.pipeline_type == PipelineType.TEXT_GUIDED_IMAGE_VARIATION:
+        args["prompt"] = prompt
+        args["image"] = image
+    elif pipe.pipeline_type == PipelineType.INPAINTING:
+        args["image"] = image
+        args["mask_image"] = mask_image
+    elif pipe.pipeline_type == PipelineType.TEXT_GUIDED_INPAINTING:
+        args["prompt"] = prompt
+        args["image"] = image
+        args["mask_image"] = mask_image
+    elif pipe.pipeline_type == PipelineType.UNCONDITIONAL_AUDIO_GENERATION:
+        # No additional arguments
+        ...
+    elif pipe.pipeline_type == PipelineType.AUDIO_VARIATION:
+        # TODO not getting results equal
+
+        # No additional arguments
+        ...
+
+        # HACK
+        args.pop("output_type")
+    else:
+        assert False
+
+    # We want to test that the outputs are the same regardless of if or not the safety checker
+    # has a hit on the result. However, if a safety checker exists in the pipeline stored on the hub,
+    # we still want it to be a property on the loaded pipeline for when we serialize the one with
+    # converted weights.
+    #
+    # So, we temporarily remove the safety checker from the pipeline during inference and re-add it afterwards.
+
+    if hasattr(pipe, "safety_checker"):
+        safety_checker = pipe.safety_checker
+        pipe.safety_checker = None
+    else:
+        safety_checker = None
+
+    output = pipe(**args)
+
+    if pipe.pipeline_type == PipelineType.AUDIO_VARIATION:
+        # HACK
+        output = output[1][1][0]
+    else:
+        output = output[0]
+
+    if safety_checker is not None:
+        pipe.safety_checker = safety_checker
+
+    return output
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--pipeline",
+        default=None,
+        type=str,
+        required=True,
+        help="Pipeline to convert the deprecated `AttentionBlock` to `CrossAttention`",
+    )
+
+    parser.add_argument(
+        "--dump_path", default=None, type=str, required=True, help="Path to the save the converted pipeline."
+    )
+
+    parser.add_argument(
+        "--device",
+        default="cpu",
+        type=str,
+        required=False,
+        help="Device to run the pipeline on for checking output is consistent.",
+    )
+
+    args = parser.parse_args()
+
+    print(f"loading original pipeline {args.pipeline}")
+
+    pipe = DiffusionPipeline.from_pretrained(args.pipeline)
+    pipe.to(args.device)
+
+    if pipe.pipeline_type is None:
+        raise ValueError(
+            f"{pipe.__class__.__name__} must have `pipeline_type` set. We need the pipeline type to know what"
+            " parameters to pass so that we can check the conversion does not change the outputs."
+        )
+
+    print("Running original pipeline to check output against converted pipeline")
+    orig_output = default_output(pipe)
+
+    any_converted = False
+
+    for attr_name in dir(pipe):
+        attr = getattr(pipe, attr_name)
+
+        for module in MODULES:
+            if isinstance(attr, module):
+                print(
+                    f"converting `DiffusionPipeline.from_pretrained({args.pipeline}).{attr_name}.attention_block_type`"
+                )
+                attr.register_to_config(attention_block_type="CrossAttention")
+                any_converted = True
+
+    for unet_block in unet_blocks_to_convert:
+        print(f"converting {unet_block.__class__}.attentions")
+        unet_block.convert_attention_blocks()
+        any_converted = True
+
+    if not any_converted:
+        print(f"`DiffusionPipeline.from_pretrained({args.pipeline})` did not have any deprecated attention blocks")
+    else:
+        print(f"Saving converted pipeline to {args.dump_path}")
+
+        pipe.save_pretrained(args.dump_path)
+
+        print(f"Converted pipeline saved to {args.dump_path}")
+
+        print("Checking converted pipeline has no deprecated attention blocks")
+
+        with assert_no_deprecated_attention_blocks():
+            pipe = DiffusionPipeline.from_pretrained(args.dump_path)
+
+        pipe.to(args.device)
+
+        print("Running converted pipeline to check against original pipeline")
+        converted_output = default_output(pipe)
+
+        if (orig_output == converted_output).all():
+            print("output of converted pipeline matches original pipeline")
+        else:
+            raise AssertionError("converted pipeline output differs from original pipeline")

--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -11,15 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import math
+from contextlib import ContextDecorator
 from typing import Callable, Optional
 
 import torch
 import torch.nn.functional as F
 from torch import nn
 
+from ..utils import deprecate
 from ..utils.import_utils import is_xformers_available
-from .cross_attention import CrossAttention
+from .cross_attention import CrossAttention, SpatialAttnProcessor, XFormersSpatialAttnProcessor
 from .embeddings import CombinedTimestepLabelEmbeddings
 
 
@@ -57,6 +58,20 @@ class AttentionBlock(nn.Module):
         eps: float = 1e-5,
     ):
         super().__init__()
+
+        if _assert_no_deprecated_attention_blocks > 0:
+            raise AssertionError(
+                "Deprecated `AttentionBlock` created while `assert_no_deprecated_attention_blocks` context manager"
+                " active."
+            )
+
+        deprecation_message = (
+            "AttentionBlock has been deprecated and will be replaced with CrossAttention. TODO add upgrade"
+            " instructions"
+        )
+
+        deprecate("AttentionBlock", "1.0.0", deprecation_message, standard_warn=True)
+
         self.channels = channels
 
         self.num_heads = channels // num_head_channels if num_head_channels is not None else 1
@@ -73,20 +88,6 @@ class AttentionBlock(nn.Module):
 
         self._use_memory_efficient_attention_xformers = False
         self._attention_op = None
-
-    def reshape_heads_to_batch_dim(self, tensor):
-        batch_size, seq_len, dim = tensor.shape
-        head_size = self.num_heads
-        tensor = tensor.reshape(batch_size, seq_len, head_size, dim // head_size)
-        tensor = tensor.permute(0, 2, 1, 3).reshape(batch_size * head_size, seq_len, dim // head_size)
-        return tensor
-
-    def reshape_batch_dim_to_heads(self, tensor):
-        batch_size, seq_len, dim = tensor.shape
-        head_size = self.num_heads
-        tensor = tensor.reshape(batch_size // head_size, head_size, seq_len, dim)
-        tensor = tensor.permute(0, 2, 1, 3).reshape(batch_size // head_size, seq_len, dim * head_size)
-        return tensor
 
     def set_use_memory_efficient_attention_xformers(
         self, use_memory_efficient_attention_xformers: bool, attention_op: Optional[Callable] = None
@@ -119,59 +120,43 @@ class AttentionBlock(nn.Module):
         self._attention_op = attention_op
 
     def forward(self, hidden_states):
-        residual = hidden_states
-        batch, channel, height, width = hidden_states.shape
+        attn = self.as_cross_attention()
+        hidden_states = attn(hidden_states)
 
-        # norm
-        hidden_states = self.group_norm(hidden_states)
-
-        hidden_states = hidden_states.view(batch, channel, height * width).transpose(1, 2)
-
-        # proj to q, k, v
-        query_proj = self.query(hidden_states)
-        key_proj = self.key(hidden_states)
-        value_proj = self.value(hidden_states)
-
-        scale = 1 / math.sqrt(self.channels / self.num_heads)
-
-        query_proj = self.reshape_heads_to_batch_dim(query_proj)
-        key_proj = self.reshape_heads_to_batch_dim(key_proj)
-        value_proj = self.reshape_heads_to_batch_dim(value_proj)
-
-        if self._use_memory_efficient_attention_xformers:
-            # Memory efficient attention
-            hidden_states = xformers.ops.memory_efficient_attention(
-                query_proj, key_proj, value_proj, attn_bias=None, op=self._attention_op
-            )
-            hidden_states = hidden_states.to(query_proj.dtype)
-        else:
-            attention_scores = torch.baddbmm(
-                torch.empty(
-                    query_proj.shape[0],
-                    query_proj.shape[1],
-                    key_proj.shape[1],
-                    dtype=query_proj.dtype,
-                    device=query_proj.device,
-                ),
-                query_proj,
-                key_proj.transpose(-1, -2),
-                beta=0,
-                alpha=scale,
-            )
-            attention_probs = torch.softmax(attention_scores.float(), dim=-1).type(attention_scores.dtype)
-            hidden_states = torch.bmm(attention_probs, value_proj)
-
-        # reshape hidden_states
-        hidden_states = self.reshape_batch_dim_to_heads(hidden_states)
-
-        # compute next hidden_states
-        hidden_states = self.proj_attn(hidden_states)
-
-        hidden_states = hidden_states.transpose(-1, -2).reshape(batch, channel, height, width)
-
-        # res connect and rescale
-        hidden_states = (hidden_states + residual) / self.rescale_output_factor
         return hidden_states
+
+    def as_cross_attention(self):
+        if self._attention_op is None:
+            processor = SpatialAttnProcessor()
+        else:
+            processor = XFormersSpatialAttnProcessor(self._attention_op)
+
+        if self.num_head_size is None:
+            # When `self.num_head_size` is None, there is a single attention head
+            # of all the channels
+            dim_head = self.channels
+        else:
+            dim_head = self.num_head_size
+
+        attn = CrossAttention(
+            self.channels,
+            heads=self.num_heads,
+            dim_head=dim_head,
+            bias=True,
+            upcast_softmax=True,
+            norm_num_groups=self.group_norm.num_groups,
+            processor=processor,
+            eps=self.group_norm.eps,
+            rescale_output_factor=self.rescale_output_factor,
+        )
+
+        attn.group_norm = self.group_norm
+        attn.to_q = self.query
+        attn.to_k = self.key
+        attn.to_v = self.value
+        attn.to_out[0] = self.proj_attn
+
+        return attn
 
 
 class BasicTransformerBlock(nn.Module):
@@ -480,3 +465,18 @@ class AdaLayerNormZero(nn.Module):
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = emb.chunk(6, dim=1)
         x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
         return x, gate_msa, shift_mlp, scale_mlp, gate_mlp
+
+
+# tracks the number of `assert_no_deprecated_attention_blocks` decorators
+_assert_no_deprecated_attention_blocks = 0
+
+
+class assert_no_deprecated_attention_blocks(ContextDecorator):
+    def __enter__(self):
+        global _assert_no_deprecated_attention_blocks
+        _assert_no_deprecated_attention_blocks += 1
+        return self
+
+    def __exit__(self, *args):
+        global _assert_no_deprecated_attention_blocks
+        _assert_no_deprecated_attention_blocks -= 1

--- a/src/diffusers/models/autoencoder_kl.py
+++ b/src/diffusers/models/autoencoder_kl.py
@@ -79,6 +79,7 @@ class AutoencoderKL(ModelMixin, ConfigMixin):
         norm_num_groups: int = 32,
         sample_size: int = 32,
         scaling_factor: float = 0.18215,
+        attention_block_type: str = "AttentionBlock",
     ):
         super().__init__()
 
@@ -92,6 +93,7 @@ class AutoencoderKL(ModelMixin, ConfigMixin):
             act_fn=act_fn,
             norm_num_groups=norm_num_groups,
             double_z=True,
+            attention_block_type=attention_block_type,
         )
 
         # pass init params to Decoder
@@ -103,6 +105,7 @@ class AutoencoderKL(ModelMixin, ConfigMixin):
             layers_per_block=layers_per_block,
             norm_num_groups=norm_num_groups,
             act_fn=act_fn,
+            attention_block_type=attention_block_type,
         )
 
         self.quant_conv = nn.Conv2d(2 * latent_channels, 2 * latent_channels, 1)

--- a/src/diffusers/models/unet_2d.py
+++ b/src/diffusers/models/unet_2d.py
@@ -101,6 +101,7 @@ class UNet2DModel(ModelMixin, ConfigMixin):
         add_attention: bool = True,
         class_embed_type: Optional[str] = None,
         num_class_embeds: Optional[int] = None,
+        attention_block_type="AttentionBlock",
     ):
         super().__init__()
 
@@ -154,6 +155,7 @@ class UNet2DModel(ModelMixin, ConfigMixin):
                 attn_num_head_channels=attention_head_dim,
                 downsample_padding=downsample_padding,
                 resnet_time_scale_shift=resnet_time_scale_shift,
+                attention_block_type=attention_block_type,
             )
             self.down_blocks.append(down_block)
 
@@ -168,6 +170,7 @@ class UNet2DModel(ModelMixin, ConfigMixin):
             attn_num_head_channels=attention_head_dim,
             resnet_groups=norm_num_groups,
             add_attention=add_attention,
+            attention_block_type=attention_block_type,
         )
 
         # up
@@ -193,6 +196,7 @@ class UNet2DModel(ModelMixin, ConfigMixin):
                 resnet_groups=norm_num_groups,
                 attn_num_head_channels=attention_head_dim,
                 resnet_time_scale_shift=resnet_time_scale_shift,
+                attention_block_type=attention_block_type,
             )
             self.up_blocks.append(up_block)
             prev_output_channel = output_channel

--- a/src/diffusers/models/vae.py
+++ b/src/diffusers/models/vae.py
@@ -46,6 +46,7 @@ class Encoder(nn.Module):
         norm_num_groups=32,
         act_fn="silu",
         double_z=True,
+        attention_block_type: str = "AttentionBlock",
     ):
         super().__init__()
         self.layers_per_block = layers_per_block
@@ -74,6 +75,7 @@ class Encoder(nn.Module):
                 resnet_groups=norm_num_groups,
                 attn_num_head_channels=None,
                 temb_channels=None,
+                attention_block_type=attention_block_type,
             )
             self.down_blocks.append(down_block)
 
@@ -87,6 +89,7 @@ class Encoder(nn.Module):
             attn_num_head_channels=None,
             resnet_groups=norm_num_groups,
             temb_channels=None,
+            attention_block_type=attention_block_type,
         )
 
         # out
@@ -125,6 +128,7 @@ class Decoder(nn.Module):
         layers_per_block=2,
         norm_num_groups=32,
         act_fn="silu",
+        attention_block_type: str = "AttentionBlock",
     ):
         super().__init__()
         self.layers_per_block = layers_per_block
@@ -144,6 +148,7 @@ class Decoder(nn.Module):
             attn_num_head_channels=None,
             resnet_groups=norm_num_groups,
             temb_channels=None,
+            attention_block_type=attention_block_type,
         )
 
         # up
@@ -167,6 +172,7 @@ class Decoder(nn.Module):
                 resnet_groups=norm_num_groups,
                 attn_num_head_channels=None,
                 temb_channels=None,
+                attention_block_type=attention_block_type,
             )
             self.up_blocks.append(up_block)
             prev_output_channel = output_channel

--- a/src/diffusers/models/vq_model.py
+++ b/src/diffusers/models/vq_model.py
@@ -82,6 +82,7 @@ class VQModel(ModelMixin, ConfigMixin):
         norm_num_groups: int = 32,
         vq_embed_dim: Optional[int] = None,
         scaling_factor: float = 0.18215,
+        attention_block_type: str = "AttentionBlock",
     ):
         super().__init__()
 
@@ -95,6 +96,7 @@ class VQModel(ModelMixin, ConfigMixin):
             act_fn=act_fn,
             norm_num_groups=norm_num_groups,
             double_z=False,
+            attention_block_type=attention_block_type,
         )
 
         vq_embed_dim = vq_embed_dim if vq_embed_dim is not None else latent_channels
@@ -112,6 +114,7 @@ class VQModel(ModelMixin, ConfigMixin):
             layers_per_block=layers_per_block,
             act_fn=act_fn,
             norm_num_groups=norm_num_groups,
+            attention_block_type=attention_block_type,
         )
 
     def encode(self, x: torch.FloatTensor, return_dict: bool = True) -> VQEncoderOutput:

--- a/src/diffusers/pipelines/alt_diffusion/pipeline_alt_diffusion.py
+++ b/src/diffusers/pipelines/alt_diffusion/pipeline_alt_diffusion.py
@@ -25,7 +25,7 @@ from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import deprecate, logging, randn_tensor, replace_example_docstring
-from ..pipeline_utils import DiffusionPipeline
+from ..pipeline_utils import DiffusionPipeline, PipelineType
 from ..stable_diffusion.safety_checker import StableDiffusionSafetyChecker
 from . import AltDiffusionPipelineOutput, RobertaSeriesModelWithTransformation
 
@@ -77,6 +77,7 @@ class AltDiffusionPipeline(DiffusionPipeline):
             Model that extracts features from generated images to be used as inputs for the `safety_checker`.
     """
     _optional_components = ["safety_checker", "feature_extractor"]
+    pipeline_type = PipelineType.TEXT_TO_IMAGE
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/alt_diffusion/pipeline_alt_diffusion_img2img.py
+++ b/src/diffusers/pipelines/alt_diffusion/pipeline_alt_diffusion_img2img.py
@@ -27,7 +27,7 @@ from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import PIL_INTERPOLATION, deprecate, logging, randn_tensor, replace_example_docstring
-from ..pipeline_utils import DiffusionPipeline
+from ..pipeline_utils import DiffusionPipeline, PipelineType
 from ..stable_diffusion.safety_checker import StableDiffusionSafetyChecker
 from . import AltDiffusionPipelineOutput, RobertaSeriesModelWithTransformation
 
@@ -115,6 +115,7 @@ class AltDiffusionImg2ImgPipeline(DiffusionPipeline):
             Model that extracts features from generated images to be used as inputs for the `safety_checker`.
     """
     _optional_components = ["safety_checker", "feature_extractor"]
+    pipeline_type = PipelineType.TEXT_GUIDED_IMAGE_VARIATION
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/audio_diffusion/mel.py
+++ b/src/diffusers/pipelines/audio_diffusion/mel.py
@@ -13,15 +13,10 @@
 # limitations under the License.
 
 
-import warnings
+import numpy as np  # noqa: E402
 
 from ...configuration_utils import ConfigMixin, register_to_config
 from ...schedulers.scheduling_utils import SchedulerMixin
-
-
-warnings.filterwarnings("ignore")
-
-import numpy as np  # noqa: E402
 
 
 try:

--- a/src/diffusers/pipelines/audio_diffusion/pipeline_audio_diffusion.py
+++ b/src/diffusers/pipelines/audio_diffusion/pipeline_audio_diffusion.py
@@ -24,7 +24,7 @@ from PIL import Image
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import DDIMScheduler, DDPMScheduler
 from ...utils import randn_tensor
-from ..pipeline_utils import AudioPipelineOutput, BaseOutput, DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import AudioPipelineOutput, BaseOutput, DiffusionPipeline, ImagePipelineOutput, PipelineType
 from .mel import Mel
 
 
@@ -41,6 +41,7 @@ class AudioDiffusionPipeline(DiffusionPipeline):
     """
 
     _optional_components = ["vqvae"]
+    pipeline_type = PipelineType.AUDIO_VARIATION
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/dance_diffusion/pipeline_dance_diffusion.py
+++ b/src/diffusers/pipelines/dance_diffusion/pipeline_dance_diffusion.py
@@ -18,7 +18,7 @@ from typing import List, Optional, Tuple, Union
 import torch
 
 from ...utils import logging, randn_tensor
-from ..pipeline_utils import AudioPipelineOutput, DiffusionPipeline
+from ..pipeline_utils import AudioPipelineOutput, DiffusionPipeline, PipelineType
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -36,6 +36,8 @@ class DanceDiffusionPipeline(DiffusionPipeline):
             [`IPNDMScheduler`].
     """
 
+    pipeline_type = PipelineType.UNCONDITIONAL_AUDIO_GENERATION
+
     def __init__(self, unet, scheduler):
         super().__init__()
         self.register_modules(unet=unet, scheduler=scheduler)
@@ -47,6 +49,7 @@ class DanceDiffusionPipeline(DiffusionPipeline):
         num_inference_steps: int = 100,
         generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
         audio_length_in_s: Optional[float] = None,
+        output_type: str = "np",
         return_dict: bool = True,
     ) -> Union[AudioPipelineOutput, Tuple]:
         r"""
@@ -62,6 +65,8 @@ class DanceDiffusionPipeline(DiffusionPipeline):
             audio_length_in_s (`float`, *optional*, defaults to `self.unet.config.sample_size/self.unet.config.sample_rate`):
                 The length of the generated audio sample in seconds. Note that the output of the pipeline, *i.e.*
                 `sample_size`, will be `audio_length_in_s` * `self.unet.sample_rate`.
+            output_type (`str`, *optional*, defaults to `"np"`):
+                The output format of the generated auto. Only supports `np.array`.
             return_dict (`bool`, *optional*, defaults to `True`):
                 Whether or not to return a [`~pipelines.AudioPipelineOutput`] instead of a plain tuple.
 

--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -18,7 +18,7 @@ import torch
 
 from ...schedulers import DDIMScheduler
 from ...utils import randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 class DDIMPipeline(DiffusionPipeline):
@@ -32,6 +32,7 @@ class DDIMPipeline(DiffusionPipeline):
             A scheduler to be used in combination with `unet` to denoise the encoded image. Can be one of
             [`DDPMScheduler`], or [`DDIMScheduler`].
     """
+    pipeline_type = PipelineType.UNCONDITIONAL_IMAGE_GENERATION
 
     def __init__(self, unet, scheduler):
         super().__init__()

--- a/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
+++ b/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
@@ -18,7 +18,7 @@ from typing import List, Optional, Tuple, Union
 import torch
 
 from ...utils import randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 class DDPMPipeline(DiffusionPipeline):
@@ -32,6 +32,7 @@ class DDPMPipeline(DiffusionPipeline):
             A scheduler to be used in combination with `unet` to denoise the encoded image. Can be one of
             [`DDPMScheduler`], or [`DDIMScheduler`].
     """
+    pipeline_type = PipelineType.UNCONDITIONAL_IMAGE_GENERATION
 
     def __init__(self, unet, scheduler):
         super().__init__()

--- a/src/diffusers/pipelines/dit/pipeline_dit.py
+++ b/src/diffusers/pipelines/dit/pipeline_dit.py
@@ -25,7 +25,7 @@ import torch
 from ...models import AutoencoderKL, Transformer2DModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 class DiTPipeline(DiffusionPipeline):
@@ -41,6 +41,7 @@ class DiTPipeline(DiffusionPipeline):
         scheduler ([`DDIMScheduler`]):
             A scheduler to be used in combination with `dit` to denoise the encoded image latents.
     """
+    pipeline_type = PipelineType.CLASS_CONDITIONAL_IMAGE_GENERATION
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
+++ b/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion.py
@@ -27,7 +27,7 @@ from transformers.utils import logging
 from ...models import AutoencoderKL, UNet2DConditionModel, UNet2DModel, VQModel
 from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
 from ...utils import randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 class LDMTextToImagePipeline(DiffusionPipeline):
@@ -48,6 +48,7 @@ class LDMTextToImagePipeline(DiffusionPipeline):
             A scheduler to be used in combination with `unet` to denoise the encoded image latents. Can be one of
             [`DDIMScheduler`], [`LMSDiscreteScheduler`], or [`PNDMScheduler`].
     """
+    pipeline_type = PipelineType.TEXT_TO_IMAGE
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion_superresolution.py
+++ b/src/diffusers/pipelines/latent_diffusion/pipeline_latent_diffusion_superresolution.py
@@ -17,7 +17,7 @@ from ...schedulers import (
     PNDMScheduler,
 )
 from ...utils import PIL_INTERPOLATION, deprecate, randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 def preprocess(image):
@@ -46,6 +46,7 @@ class LDMSuperResolutionPipeline(DiffusionPipeline):
             [`DDIMScheduler`], [`LMSDiscreteScheduler`], [`EulerDiscreteScheduler`],
             [`EulerAncestralDiscreteScheduler`], [`DPMSolverMultistepScheduler`], or [`PNDMScheduler`].
     """
+    pipeline_type = PipelineType.IMAGE_VARIATION
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
+++ b/src/diffusers/pipelines/latent_diffusion_uncond/pipeline_latent_diffusion_uncond.py
@@ -20,7 +20,7 @@ import torch
 from ...models import UNet2DModel, VQModel
 from ...schedulers import DDIMScheduler
 from ...utils import randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 class LDMPipeline(DiffusionPipeline):
@@ -35,6 +35,7 @@ class LDMPipeline(DiffusionPipeline):
         scheduler ([`SchedulerMixin`]):
             [`DDIMScheduler`] is to be used in combination with `unet` to denoise the encoded image latents.
     """
+    pipeline_type = PipelineType.UNCONDITIONAL_IMAGE_GENERATION
 
     def __init__(self, vqvae: VQModel, unet: UNet2DModel, scheduler: DDIMScheduler):
         super().__init__()

--- a/src/diffusers/pipelines/paint_by_example/pipeline_paint_by_example.py
+++ b/src/diffusers/pipelines/paint_by_example/pipeline_paint_by_example.py
@@ -25,7 +25,7 @@ from transformers import CLIPFeatureExtractor
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler
 from ...utils import logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline
+from ..pipeline_utils import DiffusionPipeline, PipelineType
 from ..stable_diffusion import StableDiffusionPipelineOutput
 from ..stable_diffusion.safety_checker import StableDiffusionSafetyChecker
 from .image_encoder import PaintByExampleImageEncoder
@@ -164,6 +164,7 @@ class PaintByExamplePipeline(DiffusionPipeline):
     # TODO: feature_extractor is required to encode initial images (if they are in PIL format),
     # we should give a descriptive message if the pipeline doesn't have one.
     _optional_components = ["safety_checker"]
+    pipeline_type = PipelineType.TEXT_GUIDED_INPAINTING
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -18,6 +18,7 @@ import importlib
 import inspect
 import os
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -92,6 +93,21 @@ for library in LOADABLE_CLASSES:
     ALL_IMPORTABLE_CLASSES.update(LOADABLE_CLASSES[library])
 
 
+class PipelineType(Enum):
+    UNCONDITIONAL_IMAGE_GENERATION = "UNCONDITIONAL_IMAGE_GENERATION"
+    CLASS_CONDITIONAL_IMAGE_GENERATION = "CLASS_CONDITIONAL_IMAGE_GENERATION"
+    TEXT_TO_IMAGE = "TEXT_TO_IMAGE"
+
+    IMAGE_VARIATION = "IMAGE_VARIATION"
+    TEXT_GUIDED_IMAGE_VARIATION = "TEXT_GUIDED_IMAGE_VARIATION"
+
+    INPAINTING = "INPAINTING"
+    TEXT_GUIDED_INPAINTING = "TEXT_GUIDED_INPAINTING"
+
+    UNCONDITIONAL_AUDIO_GENERATION = "UNCONDITIONAL_AUDIO_GENERATION"
+    AUDIO_VARIATION = "AUDIO_VARIATION"
+
+
 @dataclass
 class ImagePipelineOutput(BaseOutput):
     """
@@ -153,9 +169,12 @@ class DiffusionPipeline(ConfigMixin):
           components of the diffusion pipeline.
         - **_optional_components** (List[`str`]) -- list of all components that are optional so they don't have to be
           passed for the pipeline to function (should be overridden by subclasses).
+        - **pipeline_type** (`PipelineType`, *optional*) -- Optional field for specifying the type of the pipeline.
+          I.e. text to image, image variation, text guided image variation, etc...
     """
     config_name = "model_index.json"
     _optional_components = []
+    pipeline_type = None
 
     def register_modules(self, **kwargs):
         # import it here to avoid circular import

--- a/src/diffusers/pipelines/pndm/pipeline_pndm.py
+++ b/src/diffusers/pipelines/pndm/pipeline_pndm.py
@@ -20,7 +20,7 @@ import torch
 from ...models import UNet2DModel
 from ...schedulers import PNDMScheduler
 from ...utils import randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 class PNDMPipeline(DiffusionPipeline):
@@ -33,6 +33,7 @@ class PNDMPipeline(DiffusionPipeline):
         scheduler ([`SchedulerMixin`]):
             The `PNDMScheduler` to be used in combination with `unet` to denoise the encoded image.
     """
+    pipeline_type = PipelineType.UNCONDITIONAL_IMAGE_GENERATION
 
     unet: UNet2DModel
     scheduler: PNDMScheduler

--- a/src/diffusers/pipelines/repaint/pipeline_repaint.py
+++ b/src/diffusers/pipelines/repaint/pipeline_repaint.py
@@ -23,7 +23,7 @@ import PIL
 from ...models import UNet2DModel
 from ...schedulers import RePaintScheduler
 from ...utils import PIL_INTERPOLATION, deprecate, logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -74,6 +74,8 @@ def _preprocess_mask(mask: Union[List, PIL.Image.Image, torch.Tensor]):
 class RePaintPipeline(DiffusionPipeline):
     unet: UNet2DModel
     scheduler: RePaintScheduler
+
+    pipeline_type = PipelineType.INPAINTING
 
     def __init__(self, unet, scheduler):
         super().__init__()

--- a/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
+++ b/src/diffusers/pipelines/score_sde_ve/pipeline_score_sde_ve.py
@@ -19,7 +19,7 @@ import torch
 from ...models import UNet2DModel
 from ...schedulers import ScoreSdeVeScheduler
 from ...utils import randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 class ScoreSdeVePipeline(DiffusionPipeline):
@@ -32,6 +32,8 @@ class ScoreSdeVePipeline(DiffusionPipeline):
     """
     unet: UNet2DModel
     scheduler: ScoreSdeVeScheduler
+
+    pipeline_type = PipelineType.UNCONDITIONAL_IMAGE_GENERATION
 
     def __init__(self, unet: UNet2DModel, scheduler: DiffusionPipeline):
         super().__init__()

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_cycle_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_cycle_diffusion.py
@@ -27,7 +27,7 @@ from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import DDIMScheduler
 from ...utils import PIL_INTERPOLATION, deprecate, logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline
+from ..pipeline_utils import DiffusionPipeline, PipelineType
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
 
@@ -146,6 +146,7 @@ class CycleDiffusionPipeline(DiffusionPipeline):
             Model that extracts features from generated images to be used as inputs for the `safety_checker`.
     """
     _optional_components = ["safety_checker", "feature_extractor"]
+    pipeline_type = PipelineType.TEXT_GUIDED_IMAGE_VARIATION
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -24,7 +24,7 @@ from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import deprecate, is_accelerate_available, logging, randn_tensor, replace_example_docstring
-from ..pipeline_utils import DiffusionPipeline
+from ..pipeline_utils import DiffusionPipeline, PipelineType
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
 
@@ -74,6 +74,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
             Model that extracts features from generated images to be used as inputs for the `safety_checker`.
     """
     _optional_components = ["safety_checker", "feature_extractor"]
+    pipeline_type = PipelineType.TEXT_TO_IMAGE
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_image_variation.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_image_variation.py
@@ -25,7 +25,7 @@ from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import deprecate, is_accelerate_available, logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline
+from ..pipeline_utils import DiffusionPipeline, PipelineType
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
 
@@ -60,6 +60,7 @@ class StableDiffusionImageVariationPipeline(DiffusionPipeline):
     # TODO: feature_extractor is required to encode images (if they are in PIL format),
     # we should give a descriptive message if the pipeline doesn't have one.
     _optional_components = ["safety_checker"]
+    pipeline_type = PipelineType.IMAGE_VARIATION
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -33,7 +33,7 @@ from ...utils import (
     randn_tensor,
     replace_example_docstring,
 )
-from ..pipeline_utils import DiffusionPipeline
+from ..pipeline_utils import DiffusionPipeline, PipelineType
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
 
@@ -118,6 +118,7 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
             Model that extracts features from generated images to be used as inputs for the `safety_checker`.
     """
     _optional_components = ["safety_checker", "feature_extractor"]
+    pipeline_type = PipelineType.TEXT_GUIDED_IMAGE_VARIATION
 
     # Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.StableDiffusionPipeline.__init__
     def __init__(

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -26,7 +26,7 @@ from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import deprecate, is_accelerate_available, logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline
+from ..pipeline_utils import DiffusionPipeline, PipelineType
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
 
@@ -166,6 +166,7 @@ class StableDiffusionInpaintPipeline(DiffusionPipeline):
             Model that extracts features from generated images to be used as inputs for the `safety_checker`.
     """
     _optional_components = ["safety_checker", "feature_extractor"]
+    pipeline_type = PipelineType.TEXT_GUIDED_INPAINTING
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint_legacy.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint_legacy.py
@@ -26,7 +26,7 @@ from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import PIL_INTERPOLATION, deprecate, is_accelerate_available, logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline
+from ..pipeline_utils import DiffusionPipeline, PipelineType
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
 
@@ -103,6 +103,7 @@ class StableDiffusionInpaintPipelineLegacy(DiffusionPipeline):
             Model that extracts features from generated images to be used as inputs for the `safety_checker`.
     """
     _optional_components = ["feature_extractor"]
+    pipeline_type = PipelineType.TEXT_GUIDED_INPAINTING
 
     # Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.StableDiffusionPipeline.__init__
     def __init__(

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_instruct_pix2pix.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_instruct_pix2pix.py
@@ -24,7 +24,7 @@ from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import PIL_INTERPOLATION, deprecate, is_accelerate_available, logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline
+from ..pipeline_utils import DiffusionPipeline, PipelineType
 from . import StableDiffusionPipelineOutput
 from .safety_checker import StableDiffusionSafetyChecker
 
@@ -82,6 +82,7 @@ class StableDiffusionInstructPix2PixPipeline(DiffusionPipeline):
             Model that extracts features from generated images to be used as inputs for the `safety_checker`.
     """
     _optional_components = ["safety_checker", "feature_extractor"]
+    pipeline_type = PipelineType.TEXT_GUIDED_IMAGE_VARIATION
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_k_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_k_diffusion.py
@@ -22,6 +22,7 @@ from k_diffusion.external import CompVisDenoiser, CompVisVDenoiser
 from ...pipelines import DiffusionPipeline
 from ...schedulers import LMSDiscreteScheduler
 from ...utils import is_accelerate_available, logging, randn_tensor
+from ..pipeline_utils import PipelineType
 from . import StableDiffusionPipelineOutput
 
 
@@ -76,6 +77,7 @@ class StableDiffusionKDiffusionPipeline(DiffusionPipeline):
             Model that extracts features from generated images to be used as inputs for the `safety_checker`.
     """
     _optional_components = ["safety_checker", "feature_extractor"]
+    pipeline_type = PipelineType.TEXT_TO_IMAGE
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_upscale.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_upscale.py
@@ -24,7 +24,7 @@ from transformers import CLIPTextModel, CLIPTokenizer
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import DDPMScheduler, KarrasDiffusionSchedulers
 from ...utils import deprecate, is_accelerate_available, logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -76,6 +76,7 @@ class StableDiffusionUpscalePipeline(DiffusionPipeline):
             A scheduler to be used in combination with `unet` to denoise the encoded image latents. Can be one of
             [`DDIMScheduler`], [`LMSDiscreteScheduler`], or [`PNDMScheduler`].
     """
+    pipeline_type = PipelineType.TEXT_GUIDED_IMAGE_VARIATION
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/stable_diffusion_safe/pipeline_stable_diffusion_safe.py
+++ b/src/diffusers/pipelines/stable_diffusion_safe/pipeline_stable_diffusion_safe.py
@@ -12,7 +12,7 @@ from ...configuration_utils import FrozenDict
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import deprecate, is_accelerate_available, logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline
+from ..pipeline_utils import DiffusionPipeline, PipelineType
 from . import StableDiffusionSafePipelineOutput
 from .safety_checker import SafeStableDiffusionSafetyChecker
 
@@ -51,6 +51,7 @@ class StableDiffusionPipelineSafe(DiffusionPipeline):
     """
 
     _optional_components = ["safety_checker", "feature_extractor"]
+    pipeline_type = PipelineType.TEXT_TO_IMAGE
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/stochastic_karras_ve/pipeline_stochastic_karras_ve.py
+++ b/src/diffusers/pipelines/stochastic_karras_ve/pipeline_stochastic_karras_ve.py
@@ -19,7 +19,7 @@ import torch
 from ...models import UNet2DModel
 from ...schedulers import KarrasVeScheduler
 from ...utils import randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 class KarrasVePipeline(DiffusionPipeline):
@@ -36,6 +36,8 @@ class KarrasVePipeline(DiffusionPipeline):
         scheduler ([`KarrasVeScheduler`]):
             Scheduler for the diffusion process to be used in combination with `unet` to denoise the encoded image.
     """
+
+    pipeline_type = PipelineType.UNCONDITIONAL_IMAGE_GENERATION
 
     # add type hints for linting
     unet: UNet2DModel

--- a/src/diffusers/pipelines/unclip/pipeline_unclip.py
+++ b/src/diffusers/pipelines/unclip/pipeline_unclip.py
@@ -23,7 +23,7 @@ from transformers.models.clip.modeling_clip import CLIPTextModelOutput
 
 from ...models import PriorTransformer, UNet2DConditionModel, UNet2DModel
 from ...pipelines import DiffusionPipeline
-from ...pipelines.pipeline_utils import ImagePipelineOutput
+from ...pipelines.pipeline_utils import ImagePipelineOutput, PipelineType
 from ...schedulers import UnCLIPScheduler
 from ...utils import is_accelerate_available, logging, randn_tensor
 from .text_proj import UnCLIPTextProjModel
@@ -75,6 +75,8 @@ class UnCLIPPipeline(DiffusionPipeline):
     prior_scheduler: UnCLIPScheduler
     decoder_scheduler: UnCLIPScheduler
     super_res_scheduler: UnCLIPScheduler
+
+    pipeline_type = PipelineType.TEXT_TO_IMAGE
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/unclip/pipeline_unclip_image_variation.py
+++ b/src/diffusers/pipelines/unclip/pipeline_unclip_image_variation.py
@@ -30,6 +30,7 @@ from ...models import UNet2DConditionModel, UNet2DModel
 from ...pipelines import DiffusionPipeline, ImagePipelineOutput
 from ...schedulers import UnCLIPScheduler
 from ...utils import is_accelerate_available, logging, randn_tensor
+from ..pipeline_utils import PipelineType
 from .text_proj import UnCLIPTextProjModel
 
 
@@ -81,6 +82,8 @@ class UnCLIPImageVariationPipeline(DiffusionPipeline):
 
     decoder_scheduler: UnCLIPScheduler
     super_res_scheduler: UnCLIPScheduler
+
+    pipeline_type = PipelineType.IMAGE_VARIATION
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/versatile_diffusion/pipeline_versatile_diffusion.py
+++ b/src/diffusers/pipelines/versatile_diffusion/pipeline_versatile_diffusion.py
@@ -20,7 +20,8 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
 class VersatileDiffusionPipeline(DiffusionPipeline):
     r"""
-    Pipeline for text-to-image generation using Stable Diffusion.
+    Wrapper pipeline for unconditional image variation, text guided image variation, and text to image versatile
+    diffusion pipelines.
 
     This model inherits from [`DiffusionPipeline`]. Check the superclass documentation for the generic methods the
     library implements for all the pipelines (such as downloading or saving, running on a particular device, etc.)

--- a/src/diffusers/pipelines/versatile_diffusion/pipeline_versatile_diffusion_dual_guided.py
+++ b/src/diffusers/pipelines/versatile_diffusion/pipeline_versatile_diffusion_dual_guided.py
@@ -30,7 +30,7 @@ from transformers import (
 from ...models import AutoencoderKL, DualTransformer2DModel, Transformer2DModel, UNet2DConditionModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import is_accelerate_available, logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 from .modeling_text_unet import UNetFlatConditionModel
 
 
@@ -65,6 +65,7 @@ class VersatileDiffusionDualGuidedPipeline(DiffusionPipeline):
     scheduler: KarrasDiffusionSchedulers
 
     _optional_components = ["text_unet"]
+    pipeline_type = PipelineType.TEXT_GUIDED_IMAGE_VARIATION
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/versatile_diffusion/pipeline_versatile_diffusion_image_variation.py
+++ b/src/diffusers/pipelines/versatile_diffusion/pipeline_versatile_diffusion_image_variation.py
@@ -25,7 +25,7 @@ from transformers import CLIPFeatureExtractor, CLIPVisionModelWithProjection
 from ...models import AutoencoderKL, UNet2DConditionModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import is_accelerate_available, logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -54,6 +54,8 @@ class VersatileDiffusionImageVariationPipeline(DiffusionPipeline):
     image_unet: UNet2DConditionModel
     vae: AutoencoderKL
     scheduler: KarrasDiffusionSchedulers
+
+    pipeline_type = PipelineType.IMAGE_VARIATION
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/versatile_diffusion/pipeline_versatile_diffusion_text_to_image.py
+++ b/src/diffusers/pipelines/versatile_diffusion/pipeline_versatile_diffusion_text_to_image.py
@@ -23,7 +23,7 @@ from transformers import CLIPFeatureExtractor, CLIPTextModelWithProjection, CLIP
 from ...models import AutoencoderKL, Transformer2DModel, UNet2DConditionModel
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import is_accelerate_available, logging, randn_tensor
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 from .modeling_text_unet import UNetFlatConditionModel
 
 
@@ -57,6 +57,7 @@ class VersatileDiffusionTextToImagePipeline(DiffusionPipeline):
     scheduler: KarrasDiffusionSchedulers
 
     _optional_components = ["text_unet"]
+    pipeline_type = PipelineType.TEXT_TO_IMAGE
 
     def __init__(
         self,

--- a/src/diffusers/pipelines/vq_diffusion/pipeline_vq_diffusion.py
+++ b/src/diffusers/pipelines/vq_diffusion/pipeline_vq_diffusion.py
@@ -22,7 +22,7 @@ from ...configuration_utils import ConfigMixin, register_to_config
 from ...models import ModelMixin, Transformer2DModel, VQModel
 from ...schedulers import VQDiffusionScheduler
 from ...utils import logging
-from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput, PipelineType
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -80,6 +80,8 @@ class VQDiffusionPipeline(DiffusionPipeline):
     transformer: Transformer2DModel
     learned_classifier_free_sampling_embeddings: LearnedClassifierFreeSamplingEmbeddings
     scheduler: VQDiffusionScheduler
+
+    pipeline_type = PipelineType.TEXT_TO_IMAGE
 
     def __init__(
         self,


### PR DESCRIPTION
re: https://github.com/huggingface/diffusers/issues/1880

1. When `AttentionBlock`'s forward is called, dynamically create a `CrossAttention` module with the same parameters and call its forward method instead.
2. If an AttentionBlock is constructed, We will log a deprecation warning and instructions for converting the model. We can use a context manager that manages a one off logging method in attention.py to de-dup deprecation messages.