### PR TITLE
[Breaking change] fix legacy inpaint noise and resize mask tensor

### DIFF
--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_inpaint_legacy.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_inpaint_legacy.py
@@ -212,8 +212,8 @@ class StableDiffusionInpaintLegacyPipelineFastTests(unittest.TestCase):
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
 
         assert image.shape == (1, 32, 32, 3)
-        expected_slice = np.array([0.4731, 0.5346, 0.4531, 0.6251, 0.5446, 0.4057, 0.5527, 0.5896, 0.5153])
-
+        expected_slice = np.array([0.4941, 0.5396, 0.4689, 0.6338, 0.5392, 0.4094, 0.5477, 0.5904, 0.5165])
+        
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
         assert np.abs(image_from_tuple_slice.flatten() - expected_slice).max() < 1e-2
 
@@ -260,7 +260,7 @@ class StableDiffusionInpaintLegacyPipelineFastTests(unittest.TestCase):
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 32, 32, 3)
-        expected_slice = np.array([0.4765, 0.5339, 0.4541, 0.6240, 0.5439, 0.4055, 0.5503, 0.5891, 0.5150])
+        expected_slice = np.array([0.4941, 0.5396, 0.4689, 0.6338, 0.5392, 0.4094, 0.5477, 0.5904, 0.5165])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 


### PR DESCRIPTION
Follow up to https://github.com/huggingface/diffusers/pull/2096

PR addresses the following issues in the stable diffusion legacy inpaint pipeline:

When passing the inpainting mask as a tensor, the pipeline does not scale the mask to the latent size, causing a shape mismatch during the denoising loop.
Fix: Modified the `preprocess_mask` function to resize the mask tensor to the latent size with torch interpolate. Expected mask tensor shapes are `(B, H, W, C)` or `(B, C, H, W)`, where C is 1 or 3 (in which case channel dimension is reduced to 1 by averaging)

Noise is added to the unmasked latents after the denoising loop, causing noticeable image corruption with certain schedulers/low inference steps
Fix: Restore original latents corresponding to unmasked portions of the image after denoising loop.

[from @patrickvonplaten]:
🚨🚨🚨 **Breaking change** 🚨🚨🚨

This PR corrects the non-official `StableDiffusionInpaintPipelineLegacy` pipeline by forcing the masked part of the image to not be changed. IMO it's a bit questionable whether this is a clear improvement as it could mean that the border of the mask and newly generated image become less smooth, but let's see what the community gives in terms of feedback.