### PR TITLE
[WIP] Sample images when checkpointing.

### DIFF
--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -855,9 +855,9 @@ def main():
             # run inference
             prompt = [args.validation_prompt]
             images = []
-            for _ in range(args.num_validation_images):
-                with torch.autocast(str(accelerator.device), enabled=accelerator.mixed_precision == "fp16"):
-                    images.append(pipeline(prompt, num_images_per_prompt=args.num_validation_images).images[0])
+            with torch.autocast(str(accelerator.device), enabled=accelerator.mixed_precision == "fp16"):
+                for _ in range(args.num_validation_images):
+                    images.append(pipeline(prompt).images[0])
 
             for i, image in enumerate(images):
                 image.save(os.path.join(args.output_dir, f"test-{i}.jpg"))

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -791,7 +791,7 @@ def main():
                         if args.validation_prompt:
                             if args.use_ema:
                                 # Store the UNet parameters temporarily and load the EMA parameters to perform inference.
-                                ema_unet.store(unet.parameters()) 
+                                ema_unet.store(unet.parameters())
                                 ema_unet.copy_to(unet.parameters())
                             pipeline = StableDiffusionPipeline.from_pretrained(
                                 args.pretrained_model_name_or_path,

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -318,9 +318,7 @@ def parse_args():
         "--validation_steps",
         type=int,
         default=500,
-        help=(
-            "Sample a validation image every X updates."
-        ),
+        help="Sample a validation image every X updates.",
     )
 
     args = parser.parse_args()
@@ -805,7 +803,9 @@ def main():
                             prompt = [args.validation_prompt]
                             images = []
                             for _ in range(args.num_validation_images):
-                                with torch.autocast(str(accelerator.device), enabled=accelerator.mixed_precision == "fp16"):
+                                with torch.autocast(
+                                    str(accelerator.device), enabled=accelerator.mixed_precision == "fp16"
+                                ):
                                     images.append(pipeline(prompt).images[0])
 
                             for i, image in enumerate(images):
@@ -874,7 +874,6 @@ def main():
                             ]
                         }
                     )
-
 
         if args.push_to_hub:
             repo.push_to_hub(commit_message="End of training", blocking=False, auto_lfs_prune=True)

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -773,7 +773,7 @@ def main():
                                 args.pretrained_model_name_or_path,
                                 text_encoder=text_encoder,
                                 vae=vae,
-                                unet=accelerator.unwrap_model(unet),
+                                unet=unet,
                                 revision=args.revision,
                             )
                             pipeline = pipeline.to(accelerator.device)

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -43,7 +43,7 @@ from diffusers import AutoencoderKL, DDPMScheduler, StableDiffusionPipeline, UNe
 from diffusers.optimization import get_scheduler
 from diffusers.training_utils import EMAModel
 from diffusers.utils import check_min_version, deprecate
-from diffusers.utils.import_utils import is_xformers_available, is_wandb_available
+from diffusers.utils.import_utils import is_wandb_available, is_xformers_available
 
 
 # Will error if the minimal version of diffusers is not installed. Remove at your own risks.

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -789,7 +789,6 @@ def main():
                             del pipeline
                             torch.cuda.empty_cache()
 
-
             logs = {"step_loss": loss.detach().item(), "lr": lr_scheduler.get_last_lr()[0]}
             progress_bar.set_postfix(**logs)
 

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -372,8 +372,11 @@ def main():
 
     if args.report_to == "wandb":
         if not is_wandb_available():
-            raise ImportError("Make sure to install wandb if you want to use it for logging during training.  You can do so by doing `pip install wandb`")
-        import wandb    # Make one log on every process with the configuration for debugging.
+            raise ImportError(
+                "Make sure to install wandb if you want to use it for logging during training.  You can do so by doing"
+                " `pip install wandb`"
+            )
+        import wandb  # Make one log on every process with the configuration for debugging.
 
     logging.basicConfig(
         format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
@@ -790,7 +793,7 @@ def main():
 
                             # run inference
                             prompt = [args.validation_prompt]
-                            with torch.autocast("cuda"):                                
+                            with torch.autocast("cuda"):
                                 images = pipeline(prompt, num_images_per_prompt=args.num_validation_images).images
 
                             for i, image in enumerate(images):
@@ -807,7 +810,7 @@ def main():
                                                 for i, image in enumerate(images)
                                             ]
                                         }
-                                    )                            
+                                    )
                             del pipeline
                             torch.cuda.empty_cache()
 

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -793,8 +793,10 @@ def main():
 
                             # run inference
                             prompt = [args.validation_prompt]
-                            with torch.autocast("cuda"):
-                                images = pipeline(prompt, num_images_per_prompt=args.num_validation_images).images
+                            images = []
+                            for _ in range(args.num_validation_images):
+                                with torch.autocast(str(accelerator.device), enabled=accelerator.mixed_precision == "fp16"):
+                                    images.append(pipeline(prompt).images[0])
 
                             for i, image in enumerate(images):
                                 image.save(os.path.join(args.output_dir, f"sample-{global_step}-{i}.jpg"))

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -775,14 +775,14 @@ def main():
                                 vae=vae,
                                 unet=accelerator.unwrap_model(unet),
                                 revision=args.revision,
-                                torch_dtype=weight_dtype,
                             )
                             pipeline = pipeline.to(accelerator.device)
                             pipeline.set_progress_bar_config(disable=True)
 
                             # run inference
                             prompt = [args.validation_prompt]
-                            images = pipeline(prompt, num_images_per_prompt=args.num_validation_images).images
+                            with torch.autocast("cuda"):                                
+                                images = pipeline(prompt, num_images_per_prompt=args.num_validation_images).images
 
                             for i, image in enumerate(images):
                                 image.save(os.path.join(args.output_dir, f"sample-{global_step}-{i}.jpg"))

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -43,7 +43,7 @@ from diffusers import AutoencoderKL, DDPMScheduler, StableDiffusionPipeline, UNe
 from diffusers.optimization import get_scheduler
 from diffusers.training_utils import EMAModel
 from diffusers.utils import check_min_version, deprecate
-from diffusers.utils.import_utils import is_xformers_available
+from diffusers.utils.import_utils import is_xformers_available, is_wandb_available
 
 
 # Will error if the minimal version of diffusers is not installed. Remove at your own risks.

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -789,6 +789,10 @@ def main():
                 if global_step % args.validation_steps == 0:
                     if accelerator.is_main_process:
                         if args.validation_prompt:
+                            if args.use_ema:
+                                # Store the UNet parameters temporarily and load the EMA parameters to perform inference.
+                                ema_unet.store(unet.parameters()) 
+                                ema_unet.copy_to(unet.parameters())
                             pipeline = StableDiffusionPipeline.from_pretrained(
                                 args.pretrained_model_name_or_path,
                                 text_encoder=text_encoder,
@@ -823,6 +827,9 @@ def main():
                                             ]
                                         }
                                     )
+                            if args.use_ema:
+                                # Switch back to the original UNet parameters.
+                                ema_unet.restore(unet.parameters())
                             del pipeline
                             torch.cuda.empty_cache()
 

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -32,11 +32,6 @@ from accelerate import Accelerator
 from accelerate.logging import get_logger
 from accelerate.utils import ProjectConfiguration, set_seed
 from datasets import load_dataset
-from diffusers import AutoencoderKL, DDPMScheduler, StableDiffusionPipeline, UNet2DConditionModel
-from diffusers.optimization import get_scheduler
-from diffusers.training_utils import EMAModel
-from diffusers.utils import check_min_version, is_wandb_available
-from diffusers.utils.import_utils import is_xformers_available
 from huggingface_hub import HfFolder, Repository, create_repo, whoami
 from packaging import version
 from torchvision import transforms

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -314,6 +314,14 @@ def parse_args():
         default=4,
         help="Number of images that should be generated during validation with `validation_prompt`.",
     )
+    parser.add_argument(
+        "--validation_steps",
+        type=int,
+        default=500,
+        help=(
+            "Sample a validation image every X updates."
+        ),
+    )
 
     args = parser.parse_args()
     env_local_rank = int(os.environ.get("LOCAL_RANK", -1))
@@ -780,6 +788,8 @@ def main():
                         accelerator.save_state(save_path)
                         logger.info(f"Saved state to {save_path}")
 
+                if global_step % args.validation_steps == 0:
+                    if accelerator.is_main_process:
                         if args.validation_prompt:
                             pipeline = StableDiffusionPipeline.from_pretrained(
                                 args.pretrained_model_name_or_path,

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -802,10 +802,10 @@ def main():
                             # run inference
                             prompt = [args.validation_prompt]
                             images = []
-                            for _ in range(args.num_validation_images):
-                                with torch.autocast(
-                                    str(accelerator.device), enabled=accelerator.mixed_precision == "fp16"
-                                ):
+                            with torch.autocast(
+                                str(accelerator.device), enabled=accelerator.mixed_precision == "fp16"
+                            ):
+                                for _ in range(args.num_validation_images):
                                     images.append(pipeline(prompt).images[0])
 
                             for i, image in enumerate(images):


### PR DESCRIPTION
I based this on the in progress sampling in https://github.com/huggingface/diffusers/blob/main/examples/dreambooth/train_dreambooth_lora.py due to the suggestion on https://github.com/huggingface/diffusers/pull/2030 that that was a good example to follow.

Unfortunately, this code doesn't work at present and I'm not sure why.  I get the error `RuntimeError: Input type (c10::Half) and bias type (float) should be the same`, full stack trace:

```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /mnt/c/Users/lucas/Development/diffusers/examples/text_to_image/train_text_to_image.py:757 in    │
│ <module>                                                                                         │
│                                                                                                  │
│   754                                                                                            │
│   755                                                                                            │
│   756 if __name__ == "__main__":                                                                 │
│ ❱ 757 │   main()                                                                                 │
│   758                                                                                            │
│                                                                                                  │
│ /mnt/c/Users/lucas/Development/diffusers/examples/text_to_image/train_text_to_image.py:720 in    │
│ main                                                                                             │
│                                                                                                  │
│   717 │   │   │   │   │   │   │                                                                  │
│   718 │   │   │   │   │   │   │   # run inference                                                │
│   719 │   │   │   │   │   │   │   prompt = [args.validation_prompt]                              │
│ ❱ 720 │   │   │   │   │   │   │   images = pipeline(prompt, num_images_per_prompt=args.num_val   │
│   721 │   │   │   │   │   │   │                                                                  │
│   722 │   │   │   │   │   │   │   for i, image in enumerate(images):                             │
│   723 │   │   │   │   │   │   │   │   image.save(os.path.join(args.output_dir, f"sample-{globa   │
│                                                                                                  │
│ /home/lucas/.local/lib/python3.8/site-packages/torch/utils/_contextlib.py:115 in                 │
│ decorate_context                                                                                 │
│                                                                                                  │
│   112 │   @functools.wraps(func)                                                                 │
│   113 │   def decorate_context(*args, **kwargs):                                                 │
│   114 │   │   with ctx_factory():                                                                │
│ ❱ 115 │   │   │   return func(*args, **kwargs)                                                   │
│   116 │                                                                                          │
│   117 │   return decorate_context                                                                │
│   118                                                                                            │
│                                                                                                  │
│ /home/lucas/.local/lib/python3.8/site-packages/diffusers/pipelines/stable_diffusion/pipeline_sta │
│ ble_diffusion.py:611 in __call__                                                                 │
│                                                                                                  │
│   608 │   │   │   │   latent_model_input = self.scheduler.scale_model_input(latent_model_input   │
│   609 │   │   │   │                                                                              │
│   610 │   │   │   │   # predict the noise residual                                               │
│ ❱ 611 │   │   │   │   noise_pred = self.unet(                                                    │
│   612 │   │   │   │   │   latent_model_input,                                                    │
│   613 │   │   │   │   │   t,                                                                     │
│   614 │   │   │   │   │   encoder_hidden_states=prompt_embeds,                                   │
│                                                                                                  │
│ /home/lucas/.local/lib/python3.8/site-packages/torch/nn/modules/module.py:1488 in _call_impl     │
│                                                                                                  │
│   1485 │   │   if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks   │
│   1486 │   │   │   │   or _global_backward_pre_hooks or _global_backward_hooks                   │
│   1487 │   │   │   │   or _global_forward_hooks or _global_forward_pre_hooks):                   │
│ ❱ 1488 │   │   │   return forward_call(*args, **kwargs)                                          │
│   1489 │   │   # Do not call functions when jit is used                                          │
│   1490 │   │   full_backward_hooks, non_full_backward_hooks = [], []                             │
│   1491 │   │   backward_pre_hooks = []                                                           │
│                                                                                                  │
│ /home/lucas/.local/lib/python3.8/site-packages/diffusers/models/unet_2d_condition.py:482 in      │
│ forward                                                                                          │
│                                                                                                  │
│   479 │   │   │   emb = emb + class_emb                                                          │
│   480 │   │                                                                                      │
│   481 │   │   # 2. pre-process                                                                   │
│ ❱ 482 │   │   sample = self.conv_in(sample)                                                      │
│   483 │   │                                                                                      │
│   484 │   │   # 3. down                                                                          │
│   485 │   │   down_block_res_samples = (sample,)                                                 │
│                                                                                                  │
│ /home/lucas/.local/lib/python3.8/site-packages/torch/nn/modules/module.py:1488 in _call_impl     │
│                                                                                                  │
│   1485 │   │   if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks   │
│   1486 │   │   │   │   or _global_backward_pre_hooks or _global_backward_hooks                   │
│   1487 │   │   │   │   or _global_forward_hooks or _global_forward_pre_hooks):                   │
│ ❱ 1488 │   │   │   return forward_call(*args, **kwargs)                                          │
│   1489 │   │   # Do not call functions when jit is used                                          │
│   1490 │   │   full_backward_hooks, non_full_backward_hooks = [], []                             │
│   1491 │   │   backward_pre_hooks = []                                                           │
│                                                                                                  │
│ /home/lucas/.local/lib/python3.8/site-packages/torch/nn/modules/conv.py:463 in forward           │
│                                                                                                  │
│    460 │   │   │   │   │   │   self.padding, self.dilation, self.groups)                         │
│    461 │                                                                                         │
│    462 │   def forward(self, input: Tensor) -> Tensor:                                           │
│ ❱  463 │   │   return self._conv_forward(input, self.weight, self.bias)                          │
│    464                                                                                           │
│    465 class Conv3d(_ConvNd):                                                                    │
│    466 │   __doc__ = r"""Applies a 3D convolution over an input signal composed of several inpu  │
│                                                                                                  │
│ /home/lucas/.local/lib/python3.8/site-packages/torch/nn/modules/conv.py:459 in _conv_forward     │
│                                                                                                  │
│    456 │   │   │   return F.conv2d(F.pad(input, self._reversed_padding_repeated_twice, mode=sel  │
│    457 │   │   │   │   │   │   │   weight, bias, self.stride,                                    │
│    458 │   │   │   │   │   │   │   _pair(0), self.dilation, self.groups)                         │
│ ❱  459 │   │   return F.conv2d(input, weight, bias, self.stride,                                 │
│    460 │   │   │   │   │   │   self.padding, self.dilation, self.groups)                         │
│    461 │                                                                                         │
│    462 │   def forward(self, input: Tensor) -> Tensor:                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
RuntimeError: Input type (c10::Half) and bias type (float) should be the same
```

I tried to fix it on line 713 by setting `torch_dtype=weight_dtype` on the StableDiffusionPipeline, but that didn't work.