### PR TITLE
Don't copy when unwrapping model

### DIFF
--- a/examples/unconditional_image_generation/train_unconditional.py
+++ b/examples/unconditional_image_generation/train_unconditional.py
@@ -1,5 +1,4 @@
 import argparse
-import copy
 import inspect
 import logging
 import math

--- a/examples/unconditional_image_generation/train_unconditional.py
+++ b/examples/unconditional_image_generation/train_unconditional.py
@@ -530,7 +530,7 @@ def main(args):
         # Generate sample images for visual inspection
         if accelerator.is_main_process:
             if epoch % args.save_images_epochs == 0 or epoch == args.num_epochs - 1:
-                unet = copy.deepcopy(accelerator.unwrap_model(model))
+                unet = accelerator.unwrap_model(model)
                 if args.use_ema:
                     ema_model.copy_to(unet.parameters())
                 pipeline = DDPMPipeline(


### PR DESCRIPTION
Otherwise an exception is raised when using fp16.

Seen while testing #2048. `train_text_to_image` doesn't have it either.