### PR TITLE
add: logging to text2image.

### DIFF
--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -740,7 +740,9 @@ def main():
             images = []
             for _ in range(args.num_validation_images):
                 with torch.autocast(device_type="cuda", dtype=weight_dtype):
-                    images.append(pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0])
+                    images.append(
+                        pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0]
+                    )
 
             if accelerator.is_main_process:
                 for tracker in accelerator.trackers:

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -739,7 +739,8 @@ def main():
             generator = torch.Generator(device=accelerator.device).manual_seed(args.seed)
             images = []
             for _ in range(args.num_validation_images):
-                images.append(pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0])
+                with torch.autocast(device_type="cuda", dtype=weight_dtype):
+                    images.append(pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0])
 
             if accelerator.is_main_process:
                 for tracker in accelerator.trackers:

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -738,9 +738,7 @@ def main():
             generator = torch.Generator(device=accelerator.device).manual_seed(args.seed)
             images = []
             for _ in range(args.num_validation_images):
-                images.append(
-                    pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0]
-                )
+                images.append(pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0])
 
             if accelerator.is_main_process:
                 for tracker in accelerator.trackers:
@@ -784,9 +782,7 @@ def main():
             generator = torch.Generator(device=accelerator.device).manual_seed(args.seed)
             images = []
             for _ in range(args.num_validation_images):
-                images.append(
-                    pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0]
-                )
+                images.append(pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0])
 
             if accelerator.is_main_process:
                 for tracker in accelerator.trackers:

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -728,9 +728,9 @@ def main():
             # create pipeline
             pipeline = StableDiffusionPipeline.from_pretrained(
                 args.pretrained_model_name_or_path,
-                unet=accelerator.unwrap_model(unet),
+                unet=unet,
                 revision=args.revision,
-                torch_dtype=weight_dtype,
+                # torch_dtype=weight_dtype,
             )
             pipeline = pipeline.to(accelerator.device)
             pipeline.set_progress_bar_config(disable=True)

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -738,8 +738,8 @@ def main():
             # run inference
             generator = torch.Generator(device=accelerator.device).manual_seed(args.seed)
             images = []
-            for _ in range(args.num_validation_images):
-                with torch.autocast(device_type="cuda", dtype=weight_dtype):
+            with torch.autocast(device_type="cuda", dtype=weight_dtype):
+                for _ in range(args.num_validation_images):
                     images.append(
                         pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0]
                     )
@@ -785,8 +785,11 @@ def main():
             # run inference
             generator = torch.Generator(device=accelerator.device).manual_seed(args.seed)
             images = []
-            for _ in range(args.num_validation_images):
-                images.append(pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0])
+            with torch.autocast(device_type="cuda", dtype=weight_dtype):
+                for _ in range(args.num_validation_images):
+                    images.append(
+                        pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0]
+                    )
 
             if accelerator.is_main_process:
                 for tracker in accelerator.trackers:

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -728,9 +728,8 @@ def main():
             # create pipeline
             pipeline = StableDiffusionPipeline.from_pretrained(
                 args.pretrained_model_name_or_path,
-                unet=unet,
+                unet=accelerator.unwrap_model(unet),
                 revision=args.revision,
-                # torch_dtype=weight_dtype,
             )
             pipeline = pipeline.to(accelerator.device)
             pipeline.set_progress_bar_config(disable=True)
@@ -738,11 +737,10 @@ def main():
             # run inference
             generator = torch.Generator(device=accelerator.device).manual_seed(args.seed)
             images = []
-            with torch.autocast(device_type="cuda", dtype=weight_dtype):
-                for _ in range(args.num_validation_images):
-                    images.append(
-                        pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0]
-                    )
+            for _ in range(args.num_validation_images):
+                images.append(
+                    pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0]
+                )
 
             if accelerator.is_main_process:
                 for tracker in accelerator.trackers:
@@ -785,11 +783,10 @@ def main():
             # run inference
             generator = torch.Generator(device=accelerator.device).manual_seed(args.seed)
             images = []
-            with torch.autocast(device_type="cuda", dtype=weight_dtype):
-                for _ in range(args.num_validation_images):
-                    images.append(
-                        pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0]
-                    )
+            for _ in range(args.num_validation_images):
+                images.append(
+                    pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0]
+                )
 
             if accelerator.is_main_process:
                 for tracker in accelerator.trackers:

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -729,7 +729,7 @@ def main():
                 )
                 # create pipeline
                 pt_safety_checker = StableDiffusionSafetyChecker.from_pretrained(
-                    args.pretrained_model_name_or_path, subfolder="safety_checker", revision=args.non_ema_version
+                    args.pretrained_model_name_or_path, subfolder="safety_checker", revision=args.non_ema_revision
                 )
                 pt_safety_checker.to(accelerator.device, dtype=weight_dtype)
                 pipeline = StableDiffusionPipeline.from_pretrained(

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -728,14 +728,14 @@ def main():
                     f" {args.validation_prompt}."
                 )
                 # create pipeline
-                pt_safety_checker = StableDiffusionSafetyChecker.from_pretrained(
+                safety_checker = StableDiffusionSafetyChecker.from_pretrained(
                     args.pretrained_model_name_or_path, subfolder="safety_checker", revision=args.non_ema_revision
                 )
-                pt_safety_checker.to(accelerator.device, dtype=weight_dtype)
+                # safety_checker.to(accelerator.device, dtype=weight_dtype)
                 pipeline = StableDiffusionPipeline.from_pretrained(
                     args.pretrained_model_name_or_path,
                     unet=accelerator.unwrap_model(unet),
-                    safety_checker=pt_safety_checker,
+                    safety_checker=safety_checker,
                     revision=args.revision,
                 )
                 pipeline = pipeline.to(accelerator.device)
@@ -762,7 +762,7 @@ def main():
                                 ]
                             }
                         )
-
+                del safety_checker
                 del pipeline
                 torch.cuda.empty_cache()
 


### PR DESCRIPTION
Context: https://github.com/huggingface/diffusers/issues/2163

Potentially closes https://github.com/huggingface/diffusers/issues/2163

Command to fire training:


```bash
export MODEL_NAME="CompVis/stable-diffusion-v1-4"
export DATASET_NAME="lambdalabs/pokemon-blip-captions"

accelerate launch --mixed_precision="fp16"  train_text_to_image.py \
  --pretrained_model_name_or_path=$MODEL_NAME \
  --dataset_name=$DATASET_NAME \
  --use_ema \
  --resolution=512 --center_crop --random_flip \
  --train_batch_size=1 \
  --gradient_accumulation_steps=4 \
  --gradient_checkpointing \
  --max_train_steps=250 \
  --learning_rate=1e-05 \
  --max_grad_norm=1 \
  --lr_scheduler="constant" --lr_warmup_steps=0 \
  --validation_prompt="cute dragon creature" \
  --seed=666 \
  --report_to="wandb" \
  --output_dir="sd-pokemon-model" 
```

Leads to:

```bash
Traceback (most recent call last):█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊      | 29/30 [00:02<00:00, 13.74it/s]
  File "train_text_to_image.py", line 813, in <module>
    main()
  File "train_text_to_image.py", line 791, in main
    pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0]
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py", line 636, in __call__
    image, has_nsfw_concept = self.run_safety_checker(image, device, prompt_embeds.dtype)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py", line 361, in run_safety_checker
    image, has_nsfw_concept = self.safety_checker(
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/diffusers/pipelines/stable_diffusion/safety_checker.py", line 52, in forward
    pooled_output = self.vision_model(clip_input)[1]  # pooled_output
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/transformers/models/clip/modeling_clip.py", line 934, in forward
    return self.vision_model(
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/transformers/models/clip/modeling_clip.py", line 859, in forward
    hidden_states = self.embeddings(pixel_values)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/transformers/models/clip/modeling_clip.py", line 195, in forward
    patch_embeds = self.patch_embedding(pixel_values)  # shape = [*, width, grid, grid]
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/torch/nn/modules/conv.py", line 463, in forward
    return self._conv_forward(input, self.weight, self.bias)
  File "/opt/conda/envs/py38/lib/python3.8/site-packages/torch/nn/modules/conv.py", line 459, in _conv_forward
    return F.conv2d(input, weight, bias, self.stride,
RuntimeError: Input type (torch.cuda.HalfTensor) and weight type (torch.FloatTensor) should be the same
```

The PR also follows this comment: https://github.com/huggingface/diffusers/issues/2163#issuecomment-1410103085

It's the safety checker that causes the problem. 