### PR TITLE
Hotfix textual inv logging

### DIFF
--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -783,6 +783,7 @@ def main():
             pipeline = DiffusionPipeline.from_pretrained(
                 args.pretrained_model_name_or_path,
                 text_encoder=accelerator.unwrap_model(text_encoder),
+                tokenizer=tokenizer,
                 revision=args.revision,
             )
             pipeline.scheduler = DPMSolverMultistepScheduler.from_config(pipeline.scheduler.config)


### PR DESCRIPTION
Fixed the bug I mentioned [here[(https://github.com/huggingface/diffusers/issues/2182) where textual inversion logging wasn't using the tokenizer with placeholder token. So, the logging displays the wrong images.