### PR TITLE
Textual inv save log memory

### DIFF
--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -90,6 +90,12 @@ def save_progress(text_encoder, placeholder_token_id, accelerator, args, save_pa
 def parse_args():
     parser = argparse.ArgumentParser(description="Simple example of a training script.")
     parser.add_argument(
+        "--reuse_model_for_logging",
+        action="store_true",
+        default=False,
+        help="Reuse models used for training for the logging pipeline.",
+    )
+    parser.add_argument(
         "--save_steps",
         type=int,
         default=500,
@@ -780,11 +786,23 @@ def main():
                 f" {args.validation_prompt}."
             )
             # create pipeline (note: unet and vae are loaded again in float32)
-            pipeline = DiffusionPipeline.from_pretrained(
-                args.pretrained_model_name_or_path,
-                text_encoder=accelerator.unwrap_model(text_encoder),
-                revision=args.revision,
-            )
+            if args.reuse_model_for_logging:
+                pipeline = DiffusionPipeline.from_pretrained(
+                    args.pretrained_model_name_or_path,
+                    text_encoder=accelerator.unwrap_model(text_encoder),
+                    tokenizer=tokenizer,
+                    unet=unet,
+                    vae=vae,
+                    revision=args.revision,
+                    torch_dtype=weight_dtype,
+                )
+            else:
+                pipeline = DiffusionPipeline.from_pretrained(
+                    args.pretrained_model_name_or_path,
+                    text_encoder=accelerator.unwrap_model(text_encoder),
+                    revision=args.revision,
+                    torch_dtype=weight_dtype,
+                )
             pipeline.scheduler = DPMSolverMultistepScheduler.from_config(pipeline.scheduler.config)
             pipeline = pipeline.to(accelerator.device)
             pipeline.set_progress_bar_config(disable=True)

--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -800,6 +800,7 @@ def main():
                 pipeline = DiffusionPipeline.from_pretrained(
                     args.pretrained_model_name_or_path,
                     text_encoder=accelerator.unwrap_model(text_encoder),
+                    tokenizer=tokenizer,
                     revision=args.revision,
                     torch_dtype=weight_dtype,
                 )

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -577,7 +577,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
             negative_prompt,
             prompt_embeds=prompt_embeds,
             negative_prompt_embeds=negative_prompt_embeds,
-        )
+        ).to(dtype=self.unet.dtype)
 
         # 4. Prepare timesteps
         self.scheduler.set_timesteps(num_inference_steps, device=device)
@@ -594,7 +594,7 @@ class StableDiffusionPipeline(DiffusionPipeline):
             device,
             generator,
             latents,
-        )
+        ).to(dtype=self.unet.dtype)
 
         # 6. Prepare extra step kwargs. TODO: Logic should ideally just be moved out of the pipeline
         extra_step_kwargs = self.prepare_extra_step_kwargs(generator, eta)


### PR DESCRIPTION
Saving memory in textual inversion by 
1. Reusing models used in training
2. Allowing mixed precision logging by converting the intermediate tensors to unet's dtype