### PR TITLE
[Loading] Better error message on missing keys

### DIFF
--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -541,6 +541,10 @@ class ModelMixin(torch.nn.Module):
                     param_device = "cpu"
                     state_dict = load_state_dict(model_file)
                     # move the params from meta device to cpu
+                    missing_keys = set(model.state_dict().keys()) - set(state_dict.keys())
+                    if len(missing_keys) > 0:
+                        raise ValueError(f"Cannot load {cls} from {pretrained_model_name_or_path} because the following keys are missing: \n {', '.join(missing_keys)}. \n Please make sure to pass `low_cpu_mem_usage=False` and `device_map=None` if you want to randomely initialize those weights or else make sure your checkpoint file is correct.")
+
                     for param_name, param in state_dict.items():
                         accepts_dtype = "dtype" in set(
                             inspect.signature(set_module_tensor_to_device).parameters.keys()

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -543,7 +543,12 @@ class ModelMixin(torch.nn.Module):
                     # move the params from meta device to cpu
                     missing_keys = set(model.state_dict().keys()) - set(state_dict.keys())
                     if len(missing_keys) > 0:
-                        raise ValueError(f"Cannot load {cls} from {pretrained_model_name_or_path} because the following keys are missing: \n {', '.join(missing_keys)}. \n Please make sure to pass `low_cpu_mem_usage=False` and `device_map=None` if you want to randomely initialize those weights or else make sure your checkpoint file is correct.")
+                        raise ValueError(
+                            f"Cannot load {cls} from {pretrained_model_name_or_path} because the following keys are"
+                            f" missing: \n {', '.join(missing_keys)}. \n Please make sure to pass"
+                            " `low_cpu_mem_usage=False` and `device_map=None` if you want to randomely initialize"
+                            " those weights or else make sure your checkpoint file is correct."
+                        )
 
                     for param_name, param in state_dict.items():
                         accepts_dtype = "dtype" in set(

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -31,8 +31,8 @@ class ModelUtilsTest(unittest.TestCase):
         with self.assertRaises(ValueError) as error_context:
             UNet2DConditionModel.from_pretrained("hf-internal-testing/stable-diffusion-broken", subfolder="unet")
 
-        import ipdb; ipdb.set_trace()
-        assert True
+        # make sure that error message states what keys are missing
+        assert "conv_out.bias" in str(error_context.exception)
 
 
 class ModelTesterMixin:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -21,9 +21,18 @@ from typing import Dict, List, Tuple
 import numpy as np
 import torch
 
-from diffusers.models import ModelMixin
+from diffusers.models import ModelMixin, UNet2DConditionModel
 from diffusers.training_utils import EMAModel
 from diffusers.utils import torch_device
+
+
+class ModelUtilsTest(unittest.TestCase):
+    def test_accelerate_loading_error_message(self):
+        with self.assertRaises(ValueError) as error_context:
+            UNet2DConditionModel.from_pretrained("hf-internal-testing/stable-diffusion-broken", subfolder="unet")
+
+        import ipdb; ipdb.set_trace()
+        assert True
 
 
 class ModelTesterMixin:


### PR DESCRIPTION
diffusers uses accelerate loading by default which means that when weights are missing the error messages aren't great. 

This PR improves the error messages when running into cases as mentioned here: https://github.com/huggingface/diffusers/pull/2059#issuecomment-1411131741

cc @yiyixuxu 