### PR TITLE
[WIP]add feature multi prompt validation in train_text_to_image_lora.py

### DIFF
--- a/examples/text_to_image/train_text_to_image_lora.py
+++ b/examples/text_to_image/train_text_to_image_lora.py
@@ -755,7 +755,7 @@ def main():
             if global_step >= args.max_train_steps:
                 break
         # Multi-prompt validation
-        if args.validation_prompt_path is not None and epoch % args.validation_epchs == 0:
+        if args.validation_prompt_path is not None and epoch % args.validation_epochs == 0:
             logger.info(
                 f"Running validation... \n Generating {args.num_validation_images} images with prompt:"
                 f"load from {args.validation_prompt_path}."


### PR DESCRIPTION
when start validation in train_text_to_image.py, it validation only one prompt.

I added the ability to load multiple prompts from a file address in --validation_from_path to perform multi-prompt-validation.

wandb distinguishes a separate prompt when logging, but other trackers have not implemented that feature.

it looks like these:
![image](https://user-images.githubusercontent.com/91792540/216088331-1cec5b28-8631-4745-a066-566357748907.png)

