### PR TITLE
Fix k_dpm_2 & k_dpm_2_a on MPS

### DIFF
--- a/src/diffusers/schedulers/scheduling_k_dpm_2_ancestral_discrete.py
+++ b/src/diffusers/schedulers/scheduling_k_dpm_2_ancestral_discrete.py
@@ -161,16 +161,16 @@ class KDPM2AncestralDiscreteScheduler(SchedulerMixin, ConfigMixin):
         # standard deviation of the initial noise distribution
         self.init_noise_sigma = self.sigmas.max()
 
-        timesteps = torch.from_numpy(timesteps).to(device)
-        timesteps_interpol = self.sigma_to_t(sigmas_interpol).to(device)
-        interleaved_timesteps = torch.stack((timesteps_interpol[:-2, None], timesteps[1:, None]), dim=-1).flatten()
-        timesteps = torch.cat([timesteps[:1], interleaved_timesteps])
-
         if str(device).startswith("mps"):
             # mps does not support float64
-            self.timesteps = timesteps.to(device, dtype=torch.float32)
+            timesteps = torch.from_numpy(timesteps).to(device, dtype=torch.float32)
         else:
-            self.timesteps = timesteps
+            timesteps = torch.from_numpy(timesteps).to(device)
+
+        timesteps_interpol = self.sigma_to_t(sigmas_interpol).to(device)
+        interleaved_timesteps = torch.stack((timesteps_interpol[:-2, None], timesteps[1:, None]), dim=-1).flatten()
+
+        self.timesteps = torch.cat([timesteps[:1], interleaved_timesteps])
 
         self.sample = None
 


### PR DESCRIPTION
Needed to convert `timesteps` to `float32` a bit sooner.

Fixes #1537

Thanks @keturn for identifying the solution.

`make test` reports failures, but they are the same failures as on `main` - not sure what this means:
```
======================================================================================= short test summary info =======================================================================================
FAILED tests/pipelines/ddim/test_ddim.py::DDIMPipelineFastTests::test_save_load_local - AssertionError: 0.45593053 not less than 0.0001
FAILED tests/pipelines/ddim/test_ddim.py::DDIMPipelineFastTests::test_save_load_optional_components - AssertionError: 0.45593053 not less than 0.0001
FAILED tests/pipelines/paint_by_example/test_paint_by_example.py::PaintByExamplePipelineFastTests::test_num_inference_steps_consistent - AssertionError: False is not true
FAILED tests/pipelines/stable_diffusion/test_stable_diffusion_inpaint.py::StableDiffusionInpaintPipelineFastTests::test_num_inference_steps_consistent - AssertionError: False is not true
================================================================ 4 failed, 755 passed, 408 skipped, 302 warnings in 122.09s (0:02:02) =================================================================
make: *** [test] Error 1
```