### PR TITLE
Fix prompt_embeds inference in img2img

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -428,9 +428,6 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
     def check_inputs(
         self, prompt, strength, callback_steps, negative_prompt=None, prompt_embeds=None, negative_prompt_embeds=None
     ):
-        if not isinstance(prompt, str) and not isinstance(prompt, list):
-            raise ValueError(f"`prompt` has to be of type `str` or `list` but is {type(prompt)}")
-
         if strength < 0 or strength > 1:
             raise ValueError(f"The value of strength should in [0.0, 1.0] but is {strength}")
 
@@ -623,7 +620,13 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
         self.check_inputs(prompt, strength, callback_steps, negative_prompt, prompt_embeds, negative_prompt_embeds)
 
         # 2. Define call parameters
-        batch_size = 1 if isinstance(prompt, str) else len(prompt)
+        if prompt is not None and isinstance(prompt, str):
+            batch_size = 1
+        elif prompt is not None and isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            batch_size = prompt_embeds.shape[0]
+
         device = self._execution_device
         # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
         # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`


### PR DESCRIPTION
Fix check inputs issue with StableDiffusionImg2ImgPipeline. In the event where `prompt_embeds` is given without `prompt`, it will cause Value error due to the check at 

https://github.com/huggingface/diffusers/blob/374ec161707c5a6a6abdaa6a87117fba0e8d58d4/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py#L431-L432

and `TypeError: object of type 'NoneType' has no len()` due to the following code (since `prompt` is None)

https://github.com/huggingface/diffusers/blob/374ec161707c5a6a6abdaa6a87117fba0e8d58d4/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py#L626

This implementation is based on the same code in `pipeline_stable_diffusion.py`.
