### PR TITLE
Run same number of DDPM steps in inference as training

### DIFF
--- a/examples/research_projects/onnxruntime/unconditional_image_generation/train_unconditional.py
+++ b/examples/research_projects/onnxruntime/unconditional_image_generation/train_unconditional.py
@@ -552,6 +552,7 @@ def main(args):
                     generator=generator,
                     batch_size=args.eval_batch_size,
                     output_type="numpy",
+                    num_inference_steps=args.ddpm_num_steps,
                 ).images
 
                 # denormalize the images and save to tensorboard

--- a/examples/unconditional_image_generation/train_unconditional.py
+++ b/examples/unconditional_image_generation/train_unconditional.py
@@ -587,6 +587,7 @@ def main(args):
                     generator=generator,
                     batch_size=args.eval_batch_size,
                     output_type="numpy",
+                    num_inference_steps=args.ddpm_num_steps,
                 ).images
 
                 # denormalize the images and save to tensorboard


### PR DESCRIPTION
Resolves ValueError: `num_inference_steps`: 1000 cannot be larger than `self.config.train_timesteps`: 50 as the unet model trained with this scheduler can only handle maximal 50 timesteps.

Triggered when running with --ddpm_num_steps set to less than 1000.