### PR TITLE
Fix stable diffusion onnx pipeline error when  batch_size > 1

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_onnx_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_onnx_stable_diffusion.py
@@ -303,9 +303,6 @@ class OnnxStableDiffusionPipeline(DiffusionPipeline):
                 self.numpy_to_pil(image), return_tensors="np"
             ).pixel_values.astype(image.dtype)
 
-            image, has_nsfw_concepts = self.safety_checker(clip_input=safety_checker_input, images=image)
-
-            # There will throw an error if use safety_checker batchsize>1
             images, has_nsfw_concept = [], []
             for i in range(image.shape[0]):
                 image_i, has_nsfw_concept_i = self.safety_checker(


### PR DESCRIPTION
onnx pipeline will throw error when batch size > 1. 

There is one line shall be removed. It tried to call safety checker on all images (but the exported safety checker only supports batch_size == 1).  Code below this line calls safety checker on each image so this line is not needed any more.

Note that a better solution is to update onnx export script to allow safety checker onnx model support batch_size >1. That could achieve better performance.