### PR TITLE
Funky spacing issue

### DIFF
--- a/docs/source/en/conceptual/ethical_guidelines.mdx
+++ b/docs/source/en/conceptual/ethical_guidelines.mdx
@@ -9,10 +9,14 @@ Given its real case applications in the world and potential negative impacts on 
 The risks associated with using this technology are still being examined, but to name a few: copyrights issues for artists; deep-fake exploitation; sexual content generation in inappropriate contexts; non-consensual impersonation; harmful social biases perpetuating the oppression of marginalized groups.
 We will keep tracking risks and adapt the following guidelines based on the community's responsiveness and valuable feedback.
 
+
 ## Scope
+
 The Diffusers community will apply the following ethical guidelines to the project’s development and help coordinate how the community will integrate the contributions, especially concerning sensitive topics related to ethical concerns.
 
+
 ## Ethical guidelines
+
 The following ethical guidelines apply generally, but we will primarily implement them when dealing with ethically sensitive issues while making a technical choice. Furthermore, we commit to adapting those ethical principles over time following emerging harms related to the state of the art of the technology in question.
 
 - **Transparency**: we are committed to being transparent in managing PRs, explaining our choices to users, and making technical decisions.
@@ -27,7 +31,9 @@ The following ethical guidelines apply generally, but we will primarily implemen
 
 - **Responsibility**: as a community and through teamwork, we hold a collective responsibility to our users by anticipating and mitigating this technology's potential risks and dangers.
 
+
 ## Examples of implementations: Safety features and Mechanisms
+
 The team works daily to make the technical and non-technical tools available to deal with the potential ethical and social risks associated with diffusion technology. Moreover, the community's input is invaluable in ensuring these features' implementation and raising awareness with us. 
 
 - [**Community tab**](https://huggingface.co/docs/hub/repositories-pull-requests-discussions): it enables the community to discuss and better collaborate on a project.


### PR DESCRIPTION
There isn't a space between the "Scope" paragraph and "Ethical Guidelines", here: https://huggingface.co/docs/diffusers/main/en/conceptual/ethical_guidelines , yet I can't see that in the preview. In this PR, I'm simply adding some spaces in the hopes that it resolves the issue.....