### PR TITLE
[SchedulingPNDM ] reset cur_model_output after each call

### DIFF
--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -187,6 +187,7 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
 
         self.ets = []
         self.counter = 0
+        self.cur_model_output = 0
 
     def step(
         self,


### PR DESCRIPTION
Reset `cur_model_output` in `set_timesteps`. 

Thanks for spotting this @fxmarty 