### PR TITLE
apply_forward_hook simply returns if no accelerate

### DIFF
--- a/src/diffusers/utils/accelerate_utils.py
+++ b/src/diffusers/utils/accelerate_utils.py
@@ -34,6 +34,8 @@ def apply_forward_hook(method):
 
     :param method: The method to decorate. This method should be a method of a PyTorch module.
     """
+    if not is_accelerate_available():
+        return method
     accelerate_version = version.parse(accelerate.__version__).base_version
     if version.parse(accelerate_version) < version.parse("0.17.0"):
         return method


### PR DESCRIPTION
We should not parse `accelerate.__version__` if accelerate is not available :)