### PR TITLE
[Pix2Pix Zero] Fix slow tests

### DIFF
--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -264,12 +264,8 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
         image = pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1].flatten()
 
-        image_slice_list = [round(x, 4) for x in image_slice.tolist()]
-        print("Default:")
-        print(", ".join([str(x) for x in image_slice_list]))
-
         assert image.shape == (1, 512, 512, 3)
-        expected_slice = np.array([0.4705, 0.4771, 0.4832, 0.4783, 0.4495, 0.447, 0.4658, 0.4568, 0.438])
+        expected_slice = np.array([0.5742, 0.5757, 0.5747, 0.5781, 0.5688, 0.5713, 0.5742, 0.5664, 0.5747])
 
         assert np.abs(expected_slice - image_slice).max() < 1e-3
 
@@ -286,12 +282,8 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
         image = pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1].flatten()
 
-        image_slice_list = [round(x, 4) for x in image_slice.tolist()]
-        print("LMS:")
-        print(", ".join([str(x) for x in image_slice_list]))
-
         assert image.shape == (1, 512, 512, 3)
-        expected_slice = np.array([0.6514, 0.5571, 0.5244, 0.5591, 0.4998, 0.4834, 0.502, 0.468, 0.4663])
+        expected_slice = np.array([0.6367, 0.5459, 0.5146, 0.5479, 0.4905, 0.4753, 0.4961, 0.4629, 0.4624])
 
         assert np.abs(expected_slice - image_slice).max() < 1e-3
 
@@ -310,19 +302,11 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                     [-0.5176, 0.0669, -0.1963, -0.1653, -0.7856, -0.2871, -0.5562, -0.0096, -0.012]
                 )
 
-                latent_slice_list = [round(x, 4) for x in expected_slice.flatten().tolist()]
-                print(f"Step: {step}:")
-                print(", ".join([str(x) for x in latent_slice_list]))
-
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2
             elif step == 2:
                 latents = latents.detach().cpu().numpy()
                 assert latents.shape == (1, 4, 64, 64)
                 latents_slice = latents[0, -3:, -3:, -1]
-
-                latent_slice_list = [round(x, 4) for x in expected_slice.flatten().tolist()]
-                print(f"Step: {step}:")
-                print(", ".join([str(x) for x in latent_slice_list]))
                 expected_slice = np.array(
                     [-0.5127, 0.0613, -0.1937, -0.1622, -0.7856, -0.2849, -0.5601, -0.0111, -0.0137]
                 )

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -301,11 +301,6 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                 expected_slice = np.array(
                     [0.1345, 0.268, 0.1539, 0.0726, 0.0959, 0.2261, -0.2673, 0.0277, -0.2062]
                 )
-                # print(f"Step: {step}")
-                # latents_slice_list = [str(round(x, 4)) for x in latents_slice.flatten().tolist()]
-                # print(", ".join(latents_slice_list))
-                # print(f"expected_slice: {expected_slice}")
-                print(f"Max absolute difference: {np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2}")
 
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2
             elif step == 2:
@@ -315,6 +310,10 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                 expected_slice = np.array(
                     [-0.5127, 0.0613, -0.1937, -0.1622, -0.7856, -0.2849, -0.5601, -0.0111, -0.0137]
                 )
+                print(f"Step: {step}")
+                latents_slice_list = [str(round(x, 4)) for x in latents_slice.flatten().tolist()]
+                print(", ".join(latents_slice_list))
+                print(f"expected_slice: {expected_slice}")
 
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2
 

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -302,7 +302,7 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                     [0.1345, 0.268, 0.1539, 0.0726, 0.0959, 0.2261, -0.2673, 0.0277, -0.2062]
                 )
                 print(f"Step: {step}")
-                latents_slice_list = [round(x, 4) for x in latents_slice.flatten().tolist()]
+                latents_slice_list = [str(round(x, 4)) for x in latents_slice.flatten().tolist()]
                 print(", ".join(latents_slice_list))
                 print(f"latents_slice: {latents_slice}")
                 print(f"expected_slice: {expected_slice}")

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -236,8 +236,8 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
         for url in [src_emb_url, tgt_emb_url]:
             download_from_url(url, url.split("/")[-1])
 
-        src_embeds = torch.load(src_emb_url.split("/1")[-1])
-        target_embeds = torch.load(tgt_emb_url.split("/1")[-1])
+        src_embeds = torch.load(src_emb_url.split("/")[-1])
+        target_embeds = torch.load(tgt_emb_url.split("/")[-1])
 
         inputs = {
             "prompt": "turn him into a cyborg",

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -305,7 +305,7 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                 latents_slice_list = [str(round(x, 4)) for x in latents_slice.flatten().tolist()]
                 print(", ".join(latents_slice_list))
                 print(f"expected_slice: {expected_slice}")
-                print(f"Max absolute difference: {np.abs(latents_slice.flatten() - expected_slice).max()}")
+                print(f"Max absolute difference: {np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2}")
 
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2
             elif step == 2:

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -298,18 +298,14 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                 latents = latents.detach().cpu().numpy()
                 assert latents.shape == (1, 4, 64, 64)
                 latents_slice = latents[0, -3:, -3:, -1]
-                expected_slice = np.array(
-                    [0.1345, 0.268, 0.1539, 0.0726, 0.0959, 0.2261, -0.2673, 0.0277, -0.2062]
-                )
+                expected_slice = np.array([0.1345, 0.268, 0.1539, 0.0726, 0.0959, 0.2261, -0.2673, 0.0277, -0.2062])
 
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2
             elif step == 2:
                 latents = latents.detach().cpu().numpy()
                 assert latents.shape == (1, 4, 64, 64)
                 latents_slice = latents[0, -3:, -3:, -1]
-                expected_slice = np.array(
-                    [0.1393, 0.2637, 0.1617, 0.0724, 0.0987, 0.2271, -0.2666, 0.0299, -0.2104]
-                )
+                expected_slice = np.array([0.1393, 0.2637, 0.1617, 0.0724, 0.0987, 0.2271, -0.2666, 0.0299, -0.2104])
 
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2
 

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -304,8 +304,8 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                 print(f"Step: {step}")
                 latents_slice_list = [str(round(x, 4)) for x in latents_slice.flatten().tolist()]
                 print(", ".join(latents_slice_list))
-                print(f"latents_slice: {latents_slice}")
                 print(f"expected_slice: {expected_slice}")
+                print(f"Difference: {latents_slice.flatten() - expected_slice}")
 
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2
             elif step == 2:

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -302,6 +302,8 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                     [0.1345, 0.268, 0.1539, 0.0726, 0.0959, 0.2261, -0.2673, 0.0277, -0.2062]
                 )
                 print(f"Step: {step}")
+                latents_slice_list = [round(x, 4) for x in latents_slice.flatten().tolist()]
+                print(", ".join(latents_slice_list))
                 print(f"latents_slice: {latents_slice}")
                 print(f"expected_slice: {expected_slice}")
 

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -305,7 +305,7 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                 latents_slice_list = [str(round(x, 4)) for x in latents_slice.flatten().tolist()]
                 print(", ".join(latents_slice_list))
                 print(f"expected_slice: {expected_slice}")
-                print(f"Difference: {latents_slice.flatten() - expected_slice}")
+                print(f"Max absolute difference: {np.abs(latents_slice.flatten() - expected_slice).max()}")
 
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2
             elif step == 2:

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -264,6 +264,10 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
         image = pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1].flatten()
 
+        image_slice_list = [round(x, 4) for x in image_slice.tolist()]
+        print("Default:")
+        print(", ".join([str(x) for x in image_slice_list]))
+
         assert image.shape == (1, 512, 512, 3)
         expected_slice = np.array([0.4705, 0.4771, 0.4832, 0.4783, 0.4495, 0.447, 0.4658, 0.4568, 0.438])
 
@@ -281,6 +285,10 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
         inputs = self.get_inputs()
         image = pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1].flatten()
+
+        image_slice_list = [round(x, 4) for x in image_slice.tolist()]
+        print("LMS:")
+        print(", ".join([str(x) for x in image_slice_list]))
 
         assert image.shape == (1, 512, 512, 3)
         expected_slice = np.array([0.6514, 0.5571, 0.5244, 0.5591, 0.4998, 0.4834, 0.502, 0.468, 0.4663])
@@ -302,11 +310,19 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                     [-0.5176, 0.0669, -0.1963, -0.1653, -0.7856, -0.2871, -0.5562, -0.0096, -0.012]
                 )
 
+                latent_slice_list = [round(x, 4) for x in expected_slice.flatten().tolist()]
+                print(f"Step: {step}:")
+                print(", ".join([str(x) for x in latent_slice_list]))
+
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2
             elif step == 2:
                 latents = latents.detach().cpu().numpy()
                 assert latents.shape == (1, 4, 64, 64)
                 latents_slice = latents[0, -3:, -3:, -1]
+
+                latent_slice_list = [round(x, 4) for x in expected_slice.flatten().tolist()]
+                print(f"Step: {step}:")
+                print(", ".join([str(x) for x in latent_slice_list]))
                 expected_slice = np.array(
                     [-0.5127, 0.0613, -0.1937, -0.1622, -0.7856, -0.2849, -0.5601, -0.0111, -0.0137]
                 )

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -301,6 +301,9 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                 expected_slice = np.array(
                     [-0.5176, 0.0669, -0.1963, -0.1653, -0.7856, -0.2871, -0.5562, -0.0096, -0.012]
                 )
+                print("Step: {step}")
+                print(f"latents_slice: {latents_slice}")
+                print(f"expected_slice: {expected_slice}")
 
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2
             elif step == 2:

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -299,7 +299,7 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                 assert latents.shape == (1, 4, 64, 64)
                 latents_slice = latents[0, -3:, -3:, -1]
                 expected_slice = np.array(
-                    [-0.5176, 0.0669, -0.1963, -0.1653, -0.7856, -0.2871, -0.5562, -0.0096, -0.012]
+                    [0.1345, 0.268, 0.1539, 0.0726, 0.0959, 0.2261, -0.2673, 0.0277, -0.2062]
                 )
                 print(f"Step: {step}")
                 print(f"latents_slice: {latents_slice}")

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -308,12 +308,8 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                 assert latents.shape == (1, 4, 64, 64)
                 latents_slice = latents[0, -3:, -3:, -1]
                 expected_slice = np.array(
-                    [-0.5127, 0.0613, -0.1937, -0.1622, -0.7856, -0.2849, -0.5601, -0.0111, -0.0137]
+                    [0.1393, 0.2637, 0.1617, 0.0724, 0.0987, 0.2271, -0.2666, 0.0299, -0.2104]
                 )
-                print(f"Step: {step}")
-                latents_slice_list = [str(round(x, 4)) for x in latents_slice.flatten().tolist()]
-                print(", ".join(latents_slice_list))
-                print(f"expected_slice: {expected_slice}")
 
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2
 

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -301,7 +301,7 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                 expected_slice = np.array(
                     [-0.5176, 0.0669, -0.1963, -0.1653, -0.7856, -0.2871, -0.5562, -0.0096, -0.012]
                 )
-                print("Step: {step}")
+                print(f"Step: {step}")
                 print(f"latents_slice: {latents_slice}")
                 print(f"expected_slice: {expected_slice}")
 

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py
@@ -301,10 +301,10 @@ class StableDiffusionPix2PixZeroPipelineSlowTests(unittest.TestCase):
                 expected_slice = np.array(
                     [0.1345, 0.268, 0.1539, 0.0726, 0.0959, 0.2261, -0.2673, 0.0277, -0.2062]
                 )
-                print(f"Step: {step}")
-                latents_slice_list = [str(round(x, 4)) for x in latents_slice.flatten().tolist()]
-                print(", ".join(latents_slice_list))
-                print(f"expected_slice: {expected_slice}")
+                # print(f"Step: {step}")
+                # latents_slice_list = [str(round(x, 4)) for x in latents_slice.flatten().tolist()]
+                # print(", ".join(latents_slice_list))
+                # print(f"expected_slice: {expected_slice}")
                 print(f"Max absolute difference: {np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2}")
 
                 assert np.abs(latents_slice.flatten() - expected_slice).max() < 5e-2


### PR DESCRIPTION
Lesson learned:

Always run append `RUN_SLOW=1` when running an individual test. 