### PR TITLE
stable unclip integration tests turn on memory saving

### DIFF
--- a/tests/pipelines/stable_unclip/test_stable_unclip.py
+++ b/tests/pipelines/stable_unclip/test_stable_unclip.py
@@ -189,6 +189,8 @@ class StableUnCLIPPipelineIntegrationTests(unittest.TestCase):
         pipe = StableUnCLIPPipeline.from_pretrained("fusing/stable-unclip-2-1-l", torch_dtype=torch.float16)
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
+        # stable unclip will oom when integration tests are run on a V100,
+        # so turn on memory savings
         pipe.enable_attention_slicing()
         pipe.enable_sequential_cpu_offload()
 

--- a/tests/pipelines/stable_unclip/test_stable_unclip.py
+++ b/tests/pipelines/stable_unclip/test_stable_unclip.py
@@ -189,6 +189,8 @@ class StableUnCLIPPipelineIntegrationTests(unittest.TestCase):
         pipe = StableUnCLIPPipeline.from_pretrained("fusing/stable-unclip-2-1-l", torch_dtype=torch.float16)
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
+        pipe.enable_attention_slicing()
+        pipe.enable_sequential_cpu_offload()
 
         generator = torch.Generator(device="cpu").manual_seed(0)
         output = pipe("anime turle", generator=generator, output_type="np")

--- a/tests/pipelines/stable_unclip/test_stable_unclip_img2img.py
+++ b/tests/pipelines/stable_unclip/test_stable_unclip_img2img.py
@@ -185,6 +185,8 @@ class StableUnCLIPImg2ImgPipelineIntegrationTests(unittest.TestCase):
         )
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
+        # stable unclip will oom when integration tests are run on a V100,
+        # so turn on memory savings
         pipe.enable_attention_slicing()
         pipe.enable_sequential_cpu_offload()
 
@@ -211,6 +213,8 @@ class StableUnCLIPImg2ImgPipelineIntegrationTests(unittest.TestCase):
         )
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
+        # stable unclip will oom when integration tests are run on a V100,
+        # so turn on memory savings
         pipe.enable_attention_slicing()
         pipe.enable_sequential_cpu_offload()
 

--- a/tests/pipelines/stable_unclip/test_stable_unclip_img2img.py
+++ b/tests/pipelines/stable_unclip/test_stable_unclip_img2img.py
@@ -185,6 +185,8 @@ class StableUnCLIPImg2ImgPipelineIntegrationTests(unittest.TestCase):
         )
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
+        pipe.enable_attention_slicing()
+        pipe.enable_sequential_cpu_offload()
 
         generator = torch.Generator(device="cpu").manual_seed(0)
         output = pipe("anime turle", image=input_image, generator=generator, output_type="np")
@@ -209,6 +211,8 @@ class StableUnCLIPImg2ImgPipelineIntegrationTests(unittest.TestCase):
         )
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
+        pipe.enable_attention_slicing()
+        pipe.enable_sequential_cpu_offload()
 
         generator = torch.Generator(device="cpu").manual_seed(0)
         output = pipe("anime turle", image=input_image, generator=generator, output_type="np")


### PR DESCRIPTION
Fixes integration tests oom'ing

This fixes all of the integration tests that were failing as the first test oom'ing would cause the cuda memory cache to not actually empty when calling torch.cuda.empty_cache