### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -537,7 +537,7 @@ class DiffusionPipeline(ConfigMixin):
 
                 if revision in DEPRECATED_REVISION_ARGS and version.parse(
                     version.parse(__version__).base_version
-                ) >= version.parse("0.10.0"):
+                ) >= version.parse("0.15.0"):
                     info = model_info(
                         pretrained_model_name_or_path,
                         use_auth_token=use_auth_token,


### PR DESCRIPTION
Deprecation warning should only hit at version 0.15

As explained in https://github.com/huggingface/diffusers/pull/2305 we will soon switch to using "variant" instead of "revision" to load fo16, but will only do it in the some future versions as we don't want to clutter people's cache.