### PR TITLE
Removes the pre_norm=True line in ResnetBlock2D init function

### DIFF
--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -455,7 +455,6 @@ class ResnetBlock2D(nn.Module):
     ):
         super().__init__()
         self.pre_norm = pre_norm
-        self.pre_norm = True
         self.in_channels = in_channels
         out_channels = in_channels if out_channels is None else out_channels
         self.out_channels = out_channels


### PR DESCRIPTION
On line 427, the object's pre_norm attribute is being set using the constructor parameter, but the stored value is immediately overridden on line 428. While I don't see the pre_norm parameter being used anywhere, subtle bugs could emerge without this fix if other code started to use pre_norm=False in the ResnetBlock2D constructor and expected the value to be stored in the pre_norm attribute of the object being constructed.