### PR TITLE
allow Attend-and-excite pipeline work with different image sizes

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_attend_and_excite.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_attend_and_excite.py
@@ -691,6 +691,7 @@ class StableDiffusionAttendAndExcitePipeline(DiffusionPipeline):
         max_iter_to_alter: int = 25,
         thresholds: dict = {0: 0.05, 10: 0.5, 20: 0.8},
         scale_factor: int = 20,
+        attn_res: int = 16,
     ):
         r"""
         Function invoked when calling the pipeline for generation.
@@ -762,6 +763,8 @@ class StableDiffusionAttendAndExcitePipeline(DiffusionPipeline):
                 Dictionary defining the iterations and desired thresholds to apply iterative latent refinement in.
             scale_factor (`int`, *optional*, default to 20):
                 Scale factor that controls the step size of each Attend and Excite update.
+            attn_res (`int`, *optional*, default to 16):
+                The resolution of most semantic attention map.
 
         Examples:
 
@@ -834,7 +837,7 @@ class StableDiffusionAttendAndExcitePipeline(DiffusionPipeline):
         # 6. Prepare extra step kwargs. TODO: Logic should ideally just be moved out of the pipeline
         extra_step_kwargs = self.prepare_extra_step_kwargs(generator, eta)
 
-        self.attention_store = AttentionStore()
+        self.attention_store = AttentionStore(attn_res=attn_res)
         self.register_attention_control()
 
         # default config for step size from original repo


### PR DESCRIPTION
fix for https://github.com/huggingface/diffusers/issues/2471

This PR add `attn_res` variable to `StableDiffusionAttendAndExcitePipeline.__call__`  so the user can adjust the resolution for attention maps based on the input image size 

It now works with image sizes other than `512 x 512`, however the generated image quality seems worse based on my quick experiment 

```python
import torch

from diffusers import StableDiffusionAttendAndExcitePipeline


pipe = StableDiffusionAttendAndExcitePipeline.from_pretrained(
    "CompVis/stable-diffusion-v1-4",
    torch_dtype=torch.float16,
).to("cuda")

prompt = "a cat and a frog"
indices = [2, 5]
seed = 6141
g = torch.Generator("cuda").manual_seed(seed)

images = pipe(
    prompt=prompt,
    token_indices=indices,
    guidance_scale=7.5,
    generator=g,
    num_inference_steps=50,
    max_iter_to_alter=25,
    width=576
    height=576,
    attn_res=18,
).images

images[0]
```

![test223_tf16_a cat and a frog_6141_576x576_18](https://user-images.githubusercontent.com/12631849/221063314-046e92e0-0b9d-4e5f-852d-67bac7836b9d.png)
