### PR TITLE
Migrate blog content to docs

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -23,7 +23,7 @@
     title: Loading & Hub
   - sections:
     - local: using-diffusers/write_own_pipeline
-      title: Write your own inference pipeline
+      title: Understanding models and schedulers
     - local: using-diffusers/unconditional_image_generation
       title: Unconditional Image Generation
     - local: using-diffusers/conditional_image_generation

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -22,6 +22,8 @@
       title: Using KerasCV Stable Diffusion Checkpoints in Diffusers
     title: Loading & Hub
   - sections:
+    - local: using-diffusers/write_own_pipeline
+      title: Write your own inference pipeline
     - local: using-diffusers/unconditional_image_generation
       title: Unconditional Image Generation
     - local: using-diffusers/conditional_image_generation

--- a/docs/source/en/using-diffusers/write_own_pipeline.mdx
+++ b/docs/source/en/using-diffusers/write_own_pipeline.mdx
@@ -10,36 +10,97 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# Understanding models and schedulers
+# Understanding pipelines, models and schedulers
 
 [[open-in-colab]]
 
-A diffusion model consists of two main components, the model and the scheduler. The model's primary function is to denoise noisy input samples. The scheduler handles all the details of the denoising process, such as the number of denoising steps and the amount of noise to add. Depending on the context, the scheduler does slightly different things:
+🧨 Diffusers is designed to be a user-friendly and flexible toolbox for building diffusion systems tailored to your use-case. At the core of the toolbox are models and schedulers. While the [`DiffusionPipeline`] bundles these components together for convenience, you can also unbundle the pipeline and use the models and schedulers separately to create new diffusion systems. 
 
-* During *inference*, the scheduler defines how to update a noisy image to generate a denoised image.
-* During *training*, the scheduler defines the amount of noise added to the inputs for the model to train on.
+In this tutorial, you'll learn how to use models and schedulers to assemble a diffusion system for inference, starting with a basic pipeline and then progressing to the Stable Diffusion pipeline.
 
-To make things easier, these components are bundled together into the [`DiffusionPipeline`]. However, you can also use them separately to create your own custom diffusion system, as 🧨 Diffusers is designed to be a modular toolbox.
+## Deconstruct a basic pipeline
 
-This tutorial will focus on understanding the model and scheduler and teach you how to use these components to recreate a Stable Diffusion pipeline (but with a twist!) so you can learn how to combine them for other tasks.
+A pipeline is a quick and easy way to run a model for inference, requiring no more than four lines of code to generate an image:
 
-## Load models and scheduler
+```py
+>>> from diffusers import DDPMPipeline
 
-The pretrained [`runwayml/stable-diffusion-v1-5`](https://huggingface.co/runwayml/stable-diffusion-v1-5) checkpoint includes all the necessary components of a diffusion model, and they're stored in the following folders:
+>>> ddpm = DDPMPipeline.from_pretrained("google/ddpm-cat-256").to("cuda")
+>>> image = ddpm(num_inference_steps=25).images[0]
+>>> image
+```
 
-* `text_encoder`: the model used to generate the text embeddings from the input.
-* `tokenizer`: the tokenizer used to tokenize the text prompt; it must match the one used by the `text_encoder` model.
-* `scheduler`: the scheduling algorithm used to generate a denoised image.
-* `unet`: the model used to generate the latent representation of the input. A UNet model has ResNet blocks in its encoder and decoder. The encoder compresses an image representation into a lower resolution image, and the decoder decodes it back to the original higher resolution image with less noise. 
-* `vae`: the autoencoder module you'll use to decode latent representations into real images. For inference, you'll only need the VAE decoder to convert the denoised latents back into images.
+That was super easy, but how did the pipeline do that? Let's breakdown the pipeline and take a look at what's happening under the hood.
 
-Load these components individually with the [`~ModelMixin.from_pretrained.subfolder`] parameter in the [`~ModelMixin.from_pretrained`] method:
+In the example above, the pipeline contains a UNet model and a DDPM scheduler. The pipeline denoises an image by taking random noise the size of the desired output and passing it through the model several times. At each timestep, the model predicts the *noise residual* and the scheduler uses it to predict a less noisy image. The pipeline repeats this process until it reaches the end of the specified number of inference steps. 
+
+To recreate the pipeline with the model and scheduler separately, let's write our own denoising process.
+
+1. Load the model and scheduler:
+
+    ```py
+    >>> from diffusers import DDPMScheduler, UNet2DModel
+
+    >>> scheduler = DDPMScheduler.from_pretrained("google/ddpm-cat-256")
+    >>> model = UNet2DModel.from_pretrained("google/ddpm-cat-256").to("cuda")
+    ```
+
+2. Set the number of timesteps to run the denoising process for:
+
+    ```py
+    >>> scheduler.set_timesteps(50)
+    ```
+
+3. Create some random noise with the same shape as the desired output:
+
+    ```py
+    >>> import torch
+
+    >>> sample_size = model.config.sample_size
+    >>> noise = torch.randn((1, 3, sample_size, sample_size)).to("cuda")
+    ```
+
+4. Now write a loop to iterate over the number of timesteps. At each timestep, the model does a [~`UNet2DModel.forward`] pass and returns the noisy residual. The scheduler's [`~DDPMScheduler.step`] method takes the noisy residual, timestep, and input and it predicts the image at the previous timestep. This output becomes the next input to the model in the denoising loop, and it'll repeat until it reaches the end of the `set_timesteps`.
+
+    ```py
+    >>> input = noise
+
+    >>> for t in scheduler.timesteps:
+    ...     with torch.no_grad():
+    ...         noisy_residual = model(input, t).sample
+    >>> previous_noisy_sample = scheduler.step(noisy_residual, t, input).prev_sample
+    >>> input = previous_noisy_sample
+    ```
+
+    This is the entire denoising process, and you can use this same pattern to write any diffusion system.
+
+5. The last step is to convert the denoised output into an image:
+
+    ```py
+    >>> from PIL import Image
+    >>> import numpy as np
+
+    >>> image = (input / 2 + 0.5).clamp(0, 1)
+    >>> image = image.cpu().permute(0, 2, 3, 1).numpy()[0]
+    >>> image = Image.fromarray((image * 255)).round().astype("uint8")
+    >>> image
+    ```
+
+In the next section, you'll put your skills to the test and breakdown the more complex Stable Diffusion pipeline, but it's still built from the same components and follows the same denoising pattern.
+
+## Deconstruct the Stable Diffusion pipeline
+
+Stable Diffusion is a text-to-image *latent diffusion* model. It is called a latent diffusion model because it works with a lower-dimensional representation of the image instead of the actual pixel space, which makes it more memory efficient. The encoder compresses the image into a smaller representation, and a decoder to convert the compressed representation back into an image. For text-to-image models, you'll need a tokenizer and an encoder to generate text embeddings. From the previous example, you already know you need a UNet model and a scheduler.
+
+As you can see, this is already more complex than the DDPM pipeline which only contains a UNet model. The Stable Diffusion model has three separate pretrained models.
 
 <Tip>
 
-💡 Read the [How does Stable Diffusion work?](https://huggingface.co/blog/stable_diffusion#how-does-stable-diffusion-work) blog for more information about the UNet and VAE models work.
+💡 Read the [How does Stable Diffusion work?](https://huggingface.co/blog/stable_diffusion#how-does-stable-diffusion-work) blog for more details about how the VAE, UNet, and text encoder models.
 
 </Tip>
+
+Now that you know what you need for the Stable Diffusion pipeline, load all these components with the [`~ModelMixin.from_pretrained`] method. You can find them in the pretrained [`runwayml/stable-diffusion-v1-5`](https://huggingface.co/runwayml/stable-diffusion-v1-5) checkpoint, and each component is stored in a separate subfolder:
 
 ```py
 >>> from PIL import Image
@@ -53,7 +114,7 @@ Load these components individually with the [`~ModelMixin.from_pretrained.subfol
 >>> unet = UNet2DConditionModel.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="unet")
 ```
 
-Ready for the twist we mentioned earlier? Instead of loading the default [`PNDMScheduler`], you'll load the [`LMSDiscreteScheduler`] to see how you can plug a different scheduler in:
+Instead of the default [`PNDMScheduler`], exchange it for the [`LMSDiscreteScheduler`] to see how easy it is to plug a different scheduler in:
 
 ```py
 >>> from diffusers import LMSDiscreteScheduler
@@ -63,7 +124,7 @@ Ready for the twist we mentioned earlier? Instead of loading the default [`PNDMS
 ... )
 ```
 
-To speed up inference, move the models to a GPU since they have trainable weights, unlike the scheduler:
+To speed up inference, move the models to a GPU since, unlike the scheduler, they have trainable weights:
 
 ```py
 >>> torch_device = "cuda"
@@ -72,9 +133,9 @@ To speed up inference, move the models to a GPU since they have trainable weight
 >>> unet.to(torch_device)
 ```
 
-## Create text embeddings
+### Create text embeddings
 
-The model generates an image from a text prompt, so the next step is to tokenize the text to generate embeddings. The text is used to condition the UNet model and steer the diffusion process towards something that resembles the input prompt. 
+The next step is to tokenize the text to generate embeddings. The text is used to condition the UNet model and steer the diffusion process towards something that resembles the input prompt. 
 
 <Tip>
 
@@ -94,7 +155,7 @@ Feel free to choose any prompt you like if you want to generate something else!
 >>> batch_size = len(prompt)
 ```
 
-First, tokenize the text and generate the text embeddings from the prompt:
+Tokenize the text and generate the embeddings from the prompt:
 
 ```py
 >>> text_input = tokenizer(
@@ -118,7 +179,7 @@ For unconditional image generation, you typically do two forward passes, one for
 >>> text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
 ```
 
-## Create random noise
+### Create random noise
 
 Next, generate some initial random noise as a starting point for the diffusion process. This is the latent representation of the image, and it'll be gradually denoised. At this point, the `latent` image is smaller than the final image size but that's okay though because the model will transform it into the final 512x512 image dimensions later.
 
@@ -130,18 +191,20 @@ Next, generate some initial random noise as a starting point for the diffusion p
 >>> latents = latents.to(torch_device)
 ```
 
-## Denoise the image
+### Denoise the image
 
-One of the last steps is to create the denoising loop that'll progressively transform the pure noise in `latents` to an image described by your prompt. 
-
-Initialize the scheduler with the `num_inference_steps` to compute the `sigmas` (the noise scale value) and exact timestep values to use during denoising. You'll also need to scale the input by the inital noise distribution:
+Start by scaling the input with the initial noise distribution, *sigma*, the noise scale value:
 
 ```py
 >>> scheduler.set_timesteps(num_inference_steps)
 >>> latents = latents * scheduler.init_noise_sigma
 ```
 
-Finally, write a denoising loop that'll turn the noise into an image!
+The last step is to create the denoising loop that'll progressively transform the pure noise in `latents` to an image described by your prompt. Remember, the denoising loop needs to do three things:
+
+1. Set the scheduler's timesteps to use during denoising.
+2. Iterate over the timesteps.
+3. At each timestep, call the UNet model to predict the noise residual and pass it to the scheduler to compute the previous noisy sample.
 
 ```py
 >>> from tqdm.auto import tqdm
@@ -166,9 +229,9 @@ Finally, write a denoising loop that'll turn the noise into an image!
 ...     latents = scheduler.step(noise_pred, t, latents).prev_sample
 ```
 
-## Decode the image
+### Decode the image
 
-The final step is to use the `vae` to decode the latent representation into an image with the [`DecoderOutput.sample`] method:
+The final step is to use the `vae` to decode the latent representation into an image and get the decoded output with `sample`:
 
 ```py
 # scale and decode the image latents with vae
@@ -193,7 +256,11 @@ Lastly, convert the image to a `PIL.Image` to see your generated image!
 
 ## Next steps
 
-Now that you understand how models and schedulers work, you might be interested in:
+From basic to complex pipelines, you've seen that all you really need to write your own diffusion system is a denoising loop. The loop should set the scheduler's timesteps, iterate over them, and alternate between calling the UNet model to predict the noise residual and passing it to the scheduler to compute the previous noisy sample. 
 
-* How to [exchange compatible schedulers](using-diffusers/schedulers#changing-the-scheduler) and compare their results.
-* A more in-depth [guide](using-diffusers/loading#loading-models) to loading models and schedulers.`
+This is really what 🧨 Diffusers is designed for: to make it intuitive and easy to write your own diffusion system using models and schedulers.
+
+For your next steps, feel free to:
+
+* Learn how to [build and contribute a pipeline](using-diffusers/#contribute_pipeline) to 🧨 Diffusers. We can't wait and see what you'll come up with!
+* Explore [existing pipelines](./api/pipelines/overview) in the library, and see if you can deconstruct and build a pipeline from scratch using the models and schedulers separately.

--- a/docs/source/en/using-diffusers/write_own_pipeline.mdx
+++ b/docs/source/en/using-diffusers/write_own_pipeline.mdx
@@ -30,6 +30,10 @@ A pipeline is a quick and easy way to run a model for inference, requiring no mo
 >>> image
 ```
 
+<div class="flex justify-center">
+    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/ddpm-cat.png" alt="Image of cat created from DDPMPipeline"/>
+</div>
+
 That was super easy, but how did the pipeline do that? Let's breakdown the pipeline and take a look at what's happening under the hood.
 
 In the example above, the pipeline contains a UNet model and a DDPM scheduler. The pipeline denoises an image by taking random noise the size of the desired output and passing it through the model several times. At each timestep, the model predicts the *noise residual* and the scheduler uses it to predict a less noisy image. The pipeline repeats this process until it reaches the end of the specified number of inference steps. 
@@ -51,7 +55,17 @@ To recreate the pipeline with the model and scheduler separately, let's write ou
     >>> scheduler.set_timesteps(50)
     ```
 
-3. Create some random noise with the same shape as the desired output:
+3. Setting the scheduler timesteps creates a tensor with evenly spaced elements in it, 50 in this example. Each element corresponds to a timestep at which the model denoises an image. When you create the denoising loop later, you'll iterate over this tensor to denoise an image:
+
+    ```py
+    >>> scheduler.timesteps
+    tensor([980, 960, 940, 920, 900, 880, 860, 840, 820, 800, 780, 760, 740, 720,
+        700, 680, 660, 640, 620, 600, 580, 560, 540, 520, 500, 480, 460, 440,
+        420, 400, 380, 360, 340, 320, 300, 280, 260, 240, 220, 200, 180, 160,
+        140, 120, 100,  80,  60,  40,  20,   0])
+    ```
+
+4. Create some random noise with the same shape as the desired output:
 
     ```py
     >>> import torch
@@ -60,7 +74,7 @@ To recreate the pipeline with the model and scheduler separately, let's write ou
     >>> noise = torch.randn((1, 3, sample_size, sample_size)).to("cuda")
     ```
 
-4. Now write a loop to iterate over the number of timesteps. At each timestep, the model does a [~`UNet2DModel.forward`] pass and returns the noisy residual. The scheduler's [`~DDPMScheduler.step`] method takes the noisy residual, timestep, and input and it predicts the image at the previous timestep. This output becomes the next input to the model in the denoising loop, and it'll repeat until it reaches the end of the `set_timesteps`.
+4. Now write a loop to iterate over the timesteps. At each timestep, the model does a [`UNet2DModel.forward`] pass and returns the noisy residual. The scheduler's [`~DDPMScheduler.step`] method takes the noisy residual, timestep, and input and it predicts the image at the previous timestep. This output becomes the next input to the model in the denoising loop, and it'll repeat until it reaches the end of the `timesteps` array.
 
     ```py
     >>> input = noise
@@ -86,7 +100,9 @@ To recreate the pipeline with the model and scheduler separately, let's write ou
     >>> image
     ```
 
-In the next section, you'll put your skills to the test and breakdown the more complex Stable Diffusion pipeline, but it's still built from the same components and follows the same denoising pattern.
+In the next section, you'll put your skills to the test and breakdown the more complex Stable Diffusion pipeline. The steps are more or less the same. You'll initialize the necessary components, and set the number of timesteps to create a `timestep` array. The `timestep` array is used in the denoising loop, and for each element in this array, the model predicts a less noisy image. The denoising loop iterates over the `timestep`'s, and at each timestep, it outputs a noisy residual and the scheduler uses it to predict a less noisy image at the previous timestep. This process is repeated until you reach the end of the `timestep` array.
+
+Let's try it out!
 
 ## Deconstruct the Stable Diffusion pipeline
 
@@ -109,19 +125,17 @@ Now that you know what you need for the Stable Diffusion pipeline, load all thes
 >>> from diffusers import AutoencoderKL, UNet2DConditionModel, PNDMScheduler
 
 >>> vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
->>> tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")
->>> text_encoder = CLIPTextModel.from_pretrained("openai/clip-vit-large-patch14")
+>>> tokenizer = CLIPTokenizer.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="tokenizer")
+>>> text_encoder = CLIPTextModel.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="text_encoder")
 >>> unet = UNet2DConditionModel.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="unet")
 ```
 
-Instead of the default [`PNDMScheduler`], exchange it for the [`LMSDiscreteScheduler`] to see how easy it is to plug a different scheduler in:
+Instead of the default [`PNDMScheduler`], exchange it for the [`UniPCMultistepScheduler`] to see how easy it is to plug a different scheduler in:
 
 ```py
->>> from diffusers import LMSDiscreteScheduler
+>>> from diffusers import UniPCMultistepScheduler
 
->>> scheduler = LMSDiscreteScheduler(
-...     beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear", num_train_timesteps=1000
-... )
+>>> scheduler = UniPCMultistepScheduler.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="scheduler")
 ```
 
 To speed up inference, move the models to a GPU since, unlike the scheduler, they have trainable weights:
@@ -149,7 +163,7 @@ Feel free to choose any prompt you like if you want to generate something else!
 >>> prompt = ["a photograph of an astronaut riding a horse"]
 >>> height = 512  # default height of Stable Diffusion
 >>> width = 512  # default width of Stable Diffusion
->>> num_inference_steps = 100  # Number of denoising steps
+>>> num_inference_steps = 25  # Number of denoising steps
 >>> guidance_scale = 7.5  # Scale for classifier-free guidance
 >>> generator = torch.manual_seed(0)  # Seed generator to create the inital latent noise
 >>> batch_size = len(prompt)
@@ -162,7 +176,8 @@ Tokenize the text and generate the embeddings from the prompt:
 ...     prompt, padding="max_length", max_length=tokenizer.model_max_length, truncation=True, return_tensors="pt"
 ... )
 
->>> text_embeddings = text_encoder(text_input.input_ids.to(torch_device))[0]
+>>> with torch.no_grad():
+...     text_embeddings = text_encoder(text_input.input_ids.to(torch_device))[0]
 ```
 
 You'll also need to generate the *unconditional text embeddings* which are the embeddings for the padding token. These need to have the same shape (`batch_size` and `seq_length`) as the conditional `text_embeddings`:
@@ -173,7 +188,7 @@ You'll also need to generate the *unconditional text embeddings* which are the e
 >>> uncond_embeddings = text_encoder(uncond_input.input_ids.to(torch_device))[0]
 ```
 
-For unconditional image generation, you typically do two forward passes, one for each of the embeddings. But in practice, it is better to concatenate the embeddings into a single batch to avoid doing two forward passes:
+Let's concatenate the conditional and unconditional embeddings into a batch to avoid doing two forward passes:
 
 ```py
 >>> text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
@@ -182,6 +197,16 @@ For unconditional image generation, you typically do two forward passes, one for
 ### Create random noise
 
 Next, generate some initial random noise as a starting point for the diffusion process. This is the latent representation of the image, and it'll be gradually denoised. At this point, the `latent` image is smaller than the final image size but that's okay though because the model will transform it into the final 512x512 image dimensions later.
+
+<Tip>
+
+💡 The height and width are divided by 8 because the `vae` model has 3 down-sampling layers. You can check by running the following:
+
+```py
+2 ** (len(vae.config.block_out_channels) - 1) == 8
+```
+
+</Tip>
 
 ```py
 >>> latents = torch.randn(
@@ -193,10 +218,9 @@ Next, generate some initial random noise as a starting point for the diffusion p
 
 ### Denoise the image
 
-Start by scaling the input with the initial noise distribution, *sigma*, the noise scale value:
+Start by scaling the input with the initial noise distribution, *sigma*, the noise scale value, which is required for improved schedulers like [`UniPCMultistepScheduler`]:
 
 ```py
->>> scheduler.set_timesteps(num_inference_steps)
 >>> latents = latents * scheduler.init_noise_sigma
 ```
 

--- a/docs/source/en/using-diffusers/write_own_pipeline.mdx
+++ b/docs/source/en/using-diffusers/write_own_pipeline.mdx
@@ -10,27 +10,34 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# Write your own inference pipeline
+# Understanding models and schedulers
 
 [[open-in-colab]]
 
-🧨 Diffusers allows you to freely exchange models and schedulers in the pipeline to create your own custom pipeline for inference. This guide will show you how to create a custom Stable Diffusion pipeline for inference with the [`LMSDiscreteScheduler`] instead of the default [`PNDMScheduler`].
+A diffusion model consists of two main components, the model and the scheduler. The model's primary function is to denoise noisy input samples. The scheduler handles all the details of the denoising process, such as the number of denoising steps and the amount of noise to add. Depending on the context, the scheduler does slightly different things:
 
-## Load pipeline components
+* During *inference*, the scheduler defines how to update a noisy image to generate a denoised image.
+* During *training*, the scheduler defines the amount of noise added to the inputs for the model to train on.
 
-The pretrained [`stable-diffusion-v1-4`](https://huggingface.co/CompVis/stable-diffusion-v1-4/tree/main) checkpoint includes all the components required to setup a complete diffusion pipeline. These components are stored in the following folders:
+To make things easier, these components are bundled together into the [`DiffusionPipeline`]. However, you can also use them separately to create your own custom diffusion system, as 🧨 Diffusers is designed to be a modular toolbox.
 
-* text_encoder: the model used to generate the text representation of the input. Stable Diffusion uses CLIP, but other diffusion models may use other encoders such as BERT.
-* tokenizer: it must match the one used by the `text_encoder` model.
-* scheduler: the scheduling algorithm used to progressively add noise to the image during training.
-* unet: the model used to generate the latent representation of the input.
-* vae: the autoencoder module you'll use to decode latent representations into real images.
+This tutorial will focus on understanding the model and scheduler and teach you how to use these components to recreate a Stable Diffusion pipeline (but with a twist!) so you can learn how to combine them for other tasks.
+
+## Load models and scheduler
+
+The pretrained [`runwayml/stable-diffusion-v1-5`](https://huggingface.co/runwayml/stable-diffusion-v1-5) checkpoint includes all the necessary components of a diffusion model, and they're stored in the following folders:
+
+* `text_encoder`: the model used to generate the text embeddings from the input.
+* `tokenizer`: the tokenizer used to tokenize the text prompt; it must match the one used by the `text_encoder` model.
+* `scheduler`: the scheduling algorithm used to generate a denoised image.
+* `unet`: the model used to generate the latent representation of the input. A UNet model has ResNet blocks in its encoder and decoder. The encoder compresses an image representation into a lower resolution image, and the decoder decodes it back to the original higher resolution image with less noise. 
+* `vae`: the autoencoder module you'll use to decode latent representations into real images. For inference, you'll only need the VAE decoder to convert the denoised latents back into images.
 
 Load these components individually with the [`~ModelMixin.from_pretrained.subfolder`] parameter in the [`~ModelMixin.from_pretrained`] method:
 
 <Tip>
 
-💡 While you can load the entire checkpoint and all its components by calling the [`StableDiffusionPipeline`] with the [`~DiffusionPipeline.from_pretrained`] method, the goal of this guide is to show how you can pick and choose the individual models and scheduler you want to use to create a custom inference system.
+💡 Read the [How does Stable Diffusion work?](https://huggingface.co/blog/stable_diffusion#how-does-stable-diffusion-work) blog for more information about the UNet and VAE models work.
 
 </Tip>
 
@@ -39,19 +46,14 @@ Load these components individually with the [`~ModelMixin.from_pretrained.subfol
 >>> import torch
 >>> from transformers import CLIPTextModel, CLIPTokenizer
 >>> from diffusers import AutoencoderKL, UNet2DConditionModel, PNDMScheduler
-# 1. Load the autoencoder model which will be used to decode the latents into image space.
 
 >>> vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
-# 2. Load the tokenizer and text encoder to tokenize and encode the text.
-
 >>> tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")
 >>> text_encoder = CLIPTextModel.from_pretrained("openai/clip-vit-large-patch14")
-# 3. The UNet model for generating the latents.
-
 >>> unet = UNet2DConditionModel.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="unet")
 ```
 
-Instead of loading the default [`PNDMScheduler`], load the [`LMSDiscreteScheduler`] and feel free to configure some of the parameters:
+Ready for the twist we mentioned earlier? Instead of loading the default [`PNDMScheduler`], you'll load the [`LMSDiscreteScheduler`] to see how you can plug a different scheduler in:
 
 ```py
 >>> from diffusers import LMSDiscreteScheduler
@@ -61,7 +63,7 @@ Instead of loading the default [`PNDMScheduler`], load the [`LMSDiscreteSchedule
 ... )
 ```
 
-Move the models to a GPU to speed up inference:
+To speed up inference, move the models to a GPU since they have trainable weights, unlike the scheduler:
 
 ```py
 >>> torch_device = "cuda"
@@ -72,7 +74,7 @@ Move the models to a GPU to speed up inference:
 
 ## Create text embeddings
 
-The pipeline generates an image from a text prompt, so the next step is to tokenize the text to generate embeddings to condition the UNet model and steer the diffusion process towards something that resembles the input prompt. 
+The model generates an image from a text prompt, so the next step is to tokenize the text to generate embeddings. The text is used to condition the UNet model and steer the diffusion process towards something that resembles the input prompt. 
 
 <Tip>
 
@@ -80,7 +82,7 @@ The pipeline generates an image from a text prompt, so the next step is to token
 
 </Tip>
 
-Feel free to choose any prompt you'd like!
+Feel free to choose any prompt you like if you want to generate something else!
 
 ```py
 >>> prompt = ["a photograph of an astronaut riding a horse"]
@@ -166,7 +168,7 @@ Finally, write a denoising loop that'll turn the noise into an image!
 
 ## Decode the image
 
-The final step is to use the `vae` to decode the latent representation into an image with the [`~diffusers.models.vae.DecoderOutput.sample`] method:
+The final step is to use the `vae` to decode the latent representation into an image with the [`DecoderOutput.sample`] method:
 
 ```py
 # scale and decode the image latents with vae
@@ -189,11 +191,9 @@ Lastly, convert the image to a `PIL.Image` to see your generated image!
     <img src="https://huggingface.co/blog/assets/98_stable_diffusion/stable_diffusion_k_lms.png"/>
 </div>
 
-## Summary
+## Next steps
 
-In this guide you learned how to:
+Now that you understand how models and schedulers work, you might be interested in:
 
-* individually load the components of a Stable Diffusion model and replace the default scheduler with another one
-* create text embeddings from the prompt to guide the UNet model
-* write a denoising loop with the [`LMSDiscreteScheduler`] to generate an image
-* decode and display the generated image
+* How to [exchange compatible schedulers](using-diffusers/schedulers#changing-the-scheduler) and compare their results.
+* A more in-depth [guide](using-diffusers/loading#loading-models) to loading models and schedulers.`

--- a/docs/source/en/using-diffusers/write_own_pipeline.mdx
+++ b/docs/source/en/using-diffusers/write_own_pipeline.mdx
@@ -26,7 +26,13 @@ The pretrained [`stable-diffusion-v1-4`](https://huggingface.co/CompVis/stable-d
 * unet: the model used to generate the latent representation of the input.
 * vae: the autoencoder module you'll use to decode latent representations into real images.
 
-Load these components with the [`~ModelMixin.from_pretrained.subfolder`] parameter in the [`~ModelMixin.from_pretrained`] method:
+Load these components individually with the [`~ModelMixin.from_pretrained.subfolder`] parameter in the [`~ModelMixin.from_pretrained`] method:
+
+<Tip>
+
+💡 While you can load the entire checkpoint and all its components by calling the [`StableDiffusionPipeline`] with the [`~DiffusionPipeline.from_pretrained`] method, the goal of this guide is to show how you can pick and choose the individual models and scheduler you want to use to create a custom inference system.
+
+</Tip>
 
 ```py
 >>> from PIL import Image
@@ -102,7 +108,7 @@ You'll also need to generate the *unconditional text embeddings* which are the e
 >>> uncond_embeddings = text_encoder(uncond_input.input_ids.to(torch_device))[0]
 ```
 
-Concatenate the embeddings into a single batch to get it ready for the forward pass:
+For unconditional image generation, you typically do two forward passes, one for each of the embeddings. But in practice, it is better to concatenate the embeddings into a single batch to avoid doing two forward passes:
 
 ```py
 >>> text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
@@ -110,7 +116,7 @@ Concatenate the embeddings into a single batch to get it ready for the forward p
 
 ## Create random noise
 
-Next, generate some initial random noise as a starting point for the diffusion process. This is the latent representation of the image, and it'll be gradually denoised by the model and scheduler. At this point, the `latent` image is smaller than the final image size. That's okay though because the model will transform it into the final 512x512 image dimensions later.
+Next, generate some initial random noise as a starting point for the diffusion process. This is the latent representation of the image, and it'll be gradually denoised. At this point, the `latent` image is smaller than the final image size but that's okay though because the model will transform it into the final 512x512 image dimensions later.
 
 ```py
 >>> latents = torch.randn(
@@ -189,5 +195,3 @@ In this guide you learned how to:
 * create text embeddings from the prompt to guide the UNet model
 * write a denoising loop with the [`LMSDiscreteScheduler`] to generate an image
 * decode and display the generated image
-
-If you're interested in writing your own pipeline for other tasks like text-guided image-to-image generation or text-guide image-inpainting, controlling generation, and how to contribute a new pipeline to the library, take a look at the Pipelines for Inference section.

--- a/docs/source/en/using-diffusers/write_own_pipeline.mdx
+++ b/docs/source/en/using-diffusers/write_own_pipeline.mdx
@@ -1,0 +1,193 @@
+<!--Copyright 2023 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# Write your own inference pipeline
+
+[[open-in-colab]]
+
+🧨 Diffusers allows you to freely exchange models and schedulers in the pipeline to create your own custom pipeline for inference. This guide will show you how to create a custom Stable Diffusion pipeline for inference with the [`LMSDiscreteScheduler`] instead of the default [`PNDMScheduler`].
+
+## Load pipeline components
+
+The pretrained [`stable-diffusion-v1-4`](https://huggingface.co/CompVis/stable-diffusion-v1-4/tree/main) checkpoint includes all the components required to setup a complete diffusion pipeline. These components are stored in the following folders:
+
+* text_encoder: the model used to generate the text representation of the input. Stable Diffusion uses CLIP, but other diffusion models may use other encoders such as BERT.
+* tokenizer: it must match the one used by the `text_encoder` model.
+* scheduler: the scheduling algorithm used to progressively add noise to the image during training.
+* unet: the model used to generate the latent representation of the input.
+* vae: the autoencoder module you'll use to decode latent representations into real images.
+
+Load these components with the [`~ModelMixin.from_pretrained.subfolder`] parameter in the [`~ModelMixin.from_pretrained`] method:
+
+```py
+>>> from PIL import Image
+>>> import torch
+>>> from transformers import CLIPTextModel, CLIPTokenizer
+>>> from diffusers import AutoencoderKL, UNet2DConditionModel, PNDMScheduler
+
+# 1. Load the autoencoder model which will be used to decode the latents into image space. 
+>>> vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+
+# 2. Load the tokenizer and text encoder to tokenize and encode the text. 
+>>> tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")
+>>> text_encoder = CLIPTextModel.from_pretrained("openai/clip-vit-large-patch14")
+
+# 3. The UNet model for generating the latents.
+>>> unet = UNet2DConditionModel.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="unet")
+```
+
+Instead of loading the default [`PNDMScheduler`], load the [`LMSDiscreteScheduler`] and feel free to configure some of the parameters:
+
+```py
+>>> from diffusers import LMSDiscreteScheduler
+
+>>> scheduler = LMSDiscreteScheduler(beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear", num_train_timesteps=1000)
+```
+
+Move the models to a GPU to speed up inference:
+
+```py
+>>> torch_device = "cuda"
+>>> vae.to(torch_device)
+>>> text_encoder.to(torch_device)
+>>> unet.to(torch_device)
+```
+
+## Create text embeddings
+
+The pipeline generates an image from a text prompt, so the next step is to tokenize the text to generate embeddings to condition the UNet model and steer the diffusion process towards something that resembles the input prompt. 
+
+<Tip>
+
+💡 The `guidance_scale` parameter determines how much weight should be given to the prompt when generating an image.
+
+</Tip>
+
+Feel free to choose any prompt you'd like!
+
+```py
+>>> prompt = ["a photograph of an astronaut riding a horse"]
+>>> height = 512                        # default height of Stable Diffusion
+>>> width = 512                         # default width of Stable Diffusion
+>>> num_inference_steps = 100           # Number of denoising steps
+>>> guidance_scale = 7.5                # Scale for classifier-free guidance
+>>> generator = torch.manual_seed(0)    # Seed generator to create the inital latent noise
+>>> batch_size = len(prompt)
+```
+
+First, tokenize the text and generate the text embeddings from the prompt:
+
+```py
+>>> text_input = tokenizer(prompt, padding="max_length", max_length=tokenizer.model_max_length, truncation=True, return_tensors="pt")
+
+>>> text_embeddings = text_encoder(text_input.input_ids.to(torch_device))[0]
+```
+
+You'll also need to generate the *unconditional text embeddings* which are the embeddings for the padding token. These need to have the same shape (`batch_size` and `seq_length`) as the conditional `text_embeddings`:
+
+```py
+>>> max_length = text_input.input_ids.shape[-1]
+>>> uncond_input = tokenizer(
+...     [""] * batch_size, padding="max_length", max_length=max_length, return_tensors="pt"
+... )
+>>> uncond_embeddings = text_encoder(uncond_input.input_ids.to(torch_device))[0]
+```
+
+Concatenate the embeddings into a single batch to get it ready for the forward pass:
+
+```py
+>>> text_embeddings = torch.cat([uncond_embeddings, text_embeddings])
+```
+
+## Create random noise
+
+Next, generate some initial random noise as a starting point for the diffusion process. This is the latent representation of the image, and it'll be gradually denoised by the model and scheduler. At this point, the `latent` image is smaller than the final image size. That's okay though because the model will transform it into the final 512x512 image dimensions later.
+
+```py
+>>> latents = torch.randn(
+...     (batch_size, unet.in_channels, height // 8, width // 8),
+...     generator=generator,
+... )
+>>> latents = latents.to(torch_device)
+```
+
+## Denoise the image
+
+One of the last steps is to create the denoising loop that'll progressively transform the pure noise in `latents` to an image described by your prompt. 
+
+Initialize the scheduler with the `num_inference_steps` to compute the `sigmas` (the noise scale value) and exact timestep values to use during denoising. You'll also need to scale the input by the inital noise distribution:
+
+```py
+>>> scheduler.set_timesteps(num_inference_steps)
+>>> latents = latents * scheduler.init_noise_sigma
+```
+
+Finally, write a denoising loop that'll turn the noise into an image!
+
+```py
+>>> from tqdm.auto import tqdm
+
+>>> scheduler.set_timesteps(num_inference_steps)
+
+>>> for t in tqdm(scheduler.timesteps):
+...     # expand the latents if we are doing classifier-free guidance to avoid doing two forward passes.
+...     latent_model_input = torch.cat([latents] * 2)
+... 
+...     latent_model_input = scheduler.scale_model_input(latent_model_input, timestep=t)
+... 
+...     # predict the noise residual
+...     with torch.no_grad():
+...         noise_pred = unet(latent_model_input, t, encoder_hidden_states=text_embeddings).sample
+... 
+...     # perform guidance
+...     noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+...     noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+... 
+...     # compute the previous noisy sample x_t -> x_t-1
+...     latents = scheduler.step(noise_pred, t, latents).prev_sample
+```
+
+## Decode the image
+
+The final step is to use the `vae` to decode the latent representation into an image with the [`~diffusers.models.vae.DecoderOutput.sample`] method:
+
+```py
+# scale and decode the image latents with vae
+>>> latents = 1 / 0.18215 * latents
+>>> with torch.no_grad():
+...     image = vae.decode(latents).sample
+```
+
+Lastly, convert the image to a `PIL.Image` to see your generated image!
+
+```py
+>>> image = (image / 2 + 0.5).clamp(0, 1)
+>>> image = image.detach().cpu().permute(0, 2, 3, 1).numpy()
+>>> images = (image * 255).round().astype("uint8")
+>>> pil_images = [Image.fromarray(image) for image in images]
+>>> pil_images[0]
+```
+
+<div class="flex justify-center">
+    <img src="https://huggingface.co/blog/assets/98_stable_diffusion/stable_diffusion_k_lms.png"/>
+</div>
+
+## Summary
+
+In this guide you learned how to:
+
+* individually load the components of a Stable Diffusion model and replace the default scheduler with another one
+* create text embeddings from the prompt to guide the UNet model
+* write a denoising loop with the [`LMSDiscreteScheduler`] to generate an image
+* decode and display the generated image
+
+If you're interested in writing your own pipeline for other tasks like text-guided image-to-image generation or text-guide image-inpainting, controlling generation, and how to contribute a new pipeline to the library, take a look at the Pipelines for Inference section.

--- a/docs/source/en/using-diffusers/write_own_pipeline.mdx
+++ b/docs/source/en/using-diffusers/write_own_pipeline.mdx
@@ -39,15 +39,15 @@ Load these components individually with the [`~ModelMixin.from_pretrained.subfol
 >>> import torch
 >>> from transformers import CLIPTextModel, CLIPTokenizer
 >>> from diffusers import AutoencoderKL, UNet2DConditionModel, PNDMScheduler
+# 1. Load the autoencoder model which will be used to decode the latents into image space.
 
-# 1. Load the autoencoder model which will be used to decode the latents into image space. 
 >>> vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+# 2. Load the tokenizer and text encoder to tokenize and encode the text.
 
-# 2. Load the tokenizer and text encoder to tokenize and encode the text. 
 >>> tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")
 >>> text_encoder = CLIPTextModel.from_pretrained("openai/clip-vit-large-patch14")
-
 # 3. The UNet model for generating the latents.
+
 >>> unet = UNet2DConditionModel.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="unet")
 ```
 
@@ -56,7 +56,9 @@ Instead of loading the default [`PNDMScheduler`], load the [`LMSDiscreteSchedule
 ```py
 >>> from diffusers import LMSDiscreteScheduler
 
->>> scheduler = LMSDiscreteScheduler(beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear", num_train_timesteps=1000)
+>>> scheduler = LMSDiscreteScheduler(
+...     beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear", num_train_timesteps=1000
+... )
 ```
 
 Move the models to a GPU to speed up inference:
@@ -82,18 +84,20 @@ Feel free to choose any prompt you'd like!
 
 ```py
 >>> prompt = ["a photograph of an astronaut riding a horse"]
->>> height = 512                        # default height of Stable Diffusion
->>> width = 512                         # default width of Stable Diffusion
->>> num_inference_steps = 100           # Number of denoising steps
->>> guidance_scale = 7.5                # Scale for classifier-free guidance
->>> generator = torch.manual_seed(0)    # Seed generator to create the inital latent noise
+>>> height = 512  # default height of Stable Diffusion
+>>> width = 512  # default width of Stable Diffusion
+>>> num_inference_steps = 100  # Number of denoising steps
+>>> guidance_scale = 7.5  # Scale for classifier-free guidance
+>>> generator = torch.manual_seed(0)  # Seed generator to create the inital latent noise
 >>> batch_size = len(prompt)
 ```
 
 First, tokenize the text and generate the text embeddings from the prompt:
 
 ```py
->>> text_input = tokenizer(prompt, padding="max_length", max_length=tokenizer.model_max_length, truncation=True, return_tensors="pt")
+>>> text_input = tokenizer(
+...     prompt, padding="max_length", max_length=tokenizer.model_max_length, truncation=True, return_tensors="pt"
+... )
 
 >>> text_embeddings = text_encoder(text_input.input_ids.to(torch_device))[0]
 ```
@@ -102,9 +106,7 @@ You'll also need to generate the *unconditional text embeddings* which are the e
 
 ```py
 >>> max_length = text_input.input_ids.shape[-1]
->>> uncond_input = tokenizer(
-...     [""] * batch_size, padding="max_length", max_length=max_length, return_tensors="pt"
-... )
+>>> uncond_input = tokenizer([""] * batch_size, padding="max_length", max_length=max_length, return_tensors="pt")
 >>> uncond_embeddings = text_encoder(uncond_input.input_ids.to(torch_device))[0]
 ```
 
@@ -147,17 +149,17 @@ Finally, write a denoising loop that'll turn the noise into an image!
 >>> for t in tqdm(scheduler.timesteps):
 ...     # expand the latents if we are doing classifier-free guidance to avoid doing two forward passes.
 ...     latent_model_input = torch.cat([latents] * 2)
-... 
+
 ...     latent_model_input = scheduler.scale_model_input(latent_model_input, timestep=t)
-... 
+
 ...     # predict the noise residual
 ...     with torch.no_grad():
 ...         noise_pred = unet(latent_model_input, t, encoder_hidden_states=text_embeddings).sample
-... 
+
 ...     # perform guidance
 ...     noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
 ...     noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
-... 
+
 ...     # compute the previous noisy sample x_t -> x_t-1
 ...     latents = scheduler.step(noise_pred, t, latents).prev_sample
 ```
@@ -168,9 +170,9 @@ The final step is to use the `vae` to decode the latent representation into an i
 
 ```py
 # scale and decode the image latents with vae
->>> latents = 1 / 0.18215 * latents
->>> with torch.no_grad():
-...     image = vae.decode(latents).sample
+latents = 1 / 0.18215 * latents
+with torch.no_grad():
+    image = vae.decode(latents).sample
 ```
 
 Lastly, convert the image to a `PIL.Image` to see your generated image!


### PR DESCRIPTION
This PR migrates the [Writing your own inference pipeline](https://huggingface.co/blog/stable_diffusion#writing-your-own-inference-pipeline) to the docs as part of the efforts to consolidate our docs sources. I added some light edits here and there for clarification and included section headers to give it structure.

The biggest thing here for me is how we use the term `pipeline` which I think can be a little ambiguous. To me, the pipeline has a very specific connotation (the `DiffusionPipeline` and all the pipeline classes that inherit from it). Here, we're showing how to use models and a scheduler to replicate what a pipeline does, but we don't actually use the `DiffusionPipeline` class. Maybe we can clarify that when we're talking about a `pipeline` here, we're talking about a complete diffusion system or something like that? Eager to hear what you think! ❤️