### PR TITLE
adapt attention.py to torch 2.0

### DIFF
--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -144,6 +144,9 @@ class AttentionBlock(nn.Module):
                 query_proj, key_proj, value_proj, attn_bias=None, op=self._attention_op
             )
             hidden_states = hidden_states.to(query_proj.dtype)
+        elif hasattr(F, "scaled_dot_product_attention"):
+            # torch.nn.functional.scaled_dot_product_attention when torch2.x is used
+            hidden_states = F.scaled_dot_product_attention(query_proj, key_proj, value_proj)
         else:
             attention_scores = torch.baddbmm(
                 torch.empty(


### PR DESCRIPTION
The [AttentionBlock](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention.py#L147) is not adapted to the torch 2.0. When using StableDiffusionLatentUpscalePipeline with 768x768 images, it will raise OOM on 16GB GPU. This PR use F.scaled_dot_product_attention to decrease the memory usage. I tested on Colab this PR can fix the issue. https://colab.research.google.com/drive/1qMwzjweWSUHsYeG932OCECAeA-qkyUjb?usp=sharing . 