### PR TITLE
include ONNX external weights when downloading from_pretrained

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -63,7 +63,7 @@ if is_transformers_available():
     from transformers.utils import SAFE_WEIGHTS_NAME as TRANSFORMERS_SAFE_WEIGHTS_NAME
     from transformers.utils import WEIGHTS_NAME as TRANSFORMERS_WEIGHTS_NAME
 
-from ..utils import FLAX_WEIGHTS_NAME, ONNX_WEIGHTS_NAME
+from ..utils import FLAX_WEIGHTS_NAME, ONNX_EXTERNAL_WEIGHTS_NAME, ONNX_WEIGHTS_NAME
 
 
 INDEX_FILE = "diffusion_pytorch_model.bin"
@@ -148,7 +148,13 @@ def is_safetensors_compatible(filenames, variant=None) -> bool:
 
 def variant_compatible_siblings(info, variant=None) -> Union[List[os.PathLike], str]:
     filenames = set(sibling.rfilename for sibling in info.siblings)
-    weight_names = [WEIGHTS_NAME, SAFETENSORS_WEIGHTS_NAME, FLAX_WEIGHTS_NAME, ONNX_WEIGHTS_NAME]
+    weight_names = [
+        WEIGHTS_NAME,
+        SAFETENSORS_WEIGHTS_NAME,
+        FLAX_WEIGHTS_NAME,
+        ONNX_WEIGHTS_NAME,
+        ONNX_EXTERNAL_WEIGHTS_NAME,
+    ]
 
     if is_transformers_available():
         weight_names += [TRANSFORMERS_WEIGHTS_NAME, TRANSFORMERS_SAFE_WEIGHTS_NAME, TRANSFORMERS_FLAX_WEIGHTS_NAME]


### PR DESCRIPTION
I'm getting an error while trying to use the ONNX `.from_pretrained` example on the latest version of `diffusers`:

```
>>> from diffusers import StableDiffusionOnnxPipeline 
>>> pipe = StableDiffusionOnnxPipeline.from_pretrained(
...     "runwayml/stable-diffusion-v1-5",
...     revision="onnx",
...     provider="CUDAExecutionProvider",
... )  

...
2023-02-25 15:40:25.146878282 [W:onnxruntime:, session_state.cc:1138 VerifyEachNodeIsAssignedToAnEp] Rerunning with verbose output on a non-minimal build will show node assignments.
2023-02-25 15:40:26.346719555 [W:onnxruntime:, session_state.cc:1136 VerifyEachNodeIsAssignedToAnEp] Some nodes were not assigned to the preferred execution providers which may or may not have 
an negative impact on performance. e.g. ORT explicitly assigns shape related ops to CPU to improve perf.                                                                                         
2023-02-25 15:40:26.346736450 [W:onnxruntime:, session_state.cc:1138 VerifyEachNodeIsAssignedToAnEp] Rerunning with verbose output on a non-minimal build will show node assignments.
Traceback (most recent call last):                                                                                                                                                               
  File "<stdin>", line 1, in <module>
  File "/tmp/ort_env/lib/python3.10/site-packages/diffusers/pipelines/pipeline_utils.py", line 872, in from_pretrained
    loaded_sub_model = load_method(os.path.join(cached_folder, name), **loading_kwargs)
  File "/tmp/ort_env/lib/python3.10/site-packages/diffusers/pipelines/onnx_utils.py", line 205, in from_pretrained
    return cls._from_pretrained(
  File "/tmp/ort_env/lib/python3.10/site-packages/diffusers/pipelines/onnx_utils.py", line 172, in _from_pretrained
    model = OnnxRuntimeModel.load_model(
  File "/tmp/ort_env/lib/python3.10/site-packages/diffusers/pipelines/onnx_utils.py", line 77, in load_model
    return ort.InferenceSession(path, providers=[provider], sess_options=sess_options)
  File "/tmp/ort_env/lib/python3.10/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 360, in __init__
    self._create_inference_session(providers, provider_options, disabled_optimizers)
  File "/tmp/ort_env/lib/python3.10/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 408, in _create_inference_session
    sess.initialize_session(providers, provider_options, disabled_optimizers)
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Deserialize tensor onnx::MatMul_9357 failed.GetFileLength for /home/ssube/.cache/huggingface/diffusers/models--
runwayml--stable-diffusion-v1-5/snapshots/eb82621657dd232b010cbecf9675d176ff82b712/unet/weights.pb failed:Invalid fd was supplied: -1
```

I've tried deleting my model cache directory and downloading again a few times, but it appears to be consistent.

Listing the repo info does show the `weights.pb` file in siblings:

```
>>> import huggingface_hub                                                                                                                                                                       >>> api = huggingface_hub.HfApi()                                                                                                                                                                
>>> api.model_info("runwayml/stable-diffusion-v1-5", revision="onnx").siblings                                                                                                                   
[RepoFile(rfilename='.gitattributes', size='None', blob_id='None', lfs='None'), RepoFile(rfilename='README.md', size='None', blob_id='None', lfs='None'), RepoFile(rfilename='feature_extractor/preprocessor_config.json', size='None', blob_id='None', lfs='None'), RepoFile(rfilename='model_index.json', size='None', blob_id='None', lfs='None'), RepoFile(rfilename='safety_checker/model.onn
x', size='None', blob_id='None', lfs='None'), RepoFile(rfilename='scheduler/scheduler_config.json', size='None', blob_id='None', lfs='None'), RepoFile(rfilename='text_encoder/model.onnx', size=
'None', blob_id='None', lfs='None'), RepoFile(rfilename='tokenizer/merges.txt', size='None', blob_id='None', lfs='None'), RepoFile(rfilename='tokenizer/special_tokens_map.json', size='None', blob_id='None', lfs='None'), RepoFile(rfilename='tokenizer/tokenizer_config.json', size='None', blob_id='None', lfs='None'), RepoFile(rfilename='tokenizer/vocab.json', size='None', blob_id='None'
, lfs='None'), RepoFile(rfilename='unet/model.onnx', size='None', blob_id='None', lfs='None'), RepoFile(rfilename='unet/weights.pb', size='None', blob_id='None', lfs='None'), RepoFile(rfilename
='vae_decoder/model.onnx', size='None', blob_id='None', lfs='None'), RepoFile(rfilename='vae_encoder/model.onnx', size='None', blob_id='None', lfs='None')]   
```

I added some logging around https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/pipeline_utils.py#L526, which does not show the `weights.pb` file:

```
diffusers folder names: ['feature_extractor', 'safety_checker', 'scheduler', 'text_encoder', 'tokenizer', 'unet', 'vae_decoder', 'vae_encoder']
{'unet/model.onnx', 'vae_decoder/model.onnx', 'vae_encoder/model.onnx', 'text_encoder/model.onnx', 'safety_checker/model.onnx'} set() {'vae_encoder', 'text_encoder', 'vae_decoder', 'safety_checker', 'unet'}  
```

I don't see any references to `ONNX_EXTERNAL_WEIGHTS_NAME` in or around the download code, it appears to only be used in the `._save_pretrained` code:

```
> grep -I ONNX_EXTERNAL_WEIGHTS_NAME -r * 
src/diffusers/utils/constants.py:ONNX_EXTERNAL_WEIGHTS_NAME = "weights.pb"
src/diffusers/utils/__init__.py:    ONNX_EXTERNAL_WEIGHTS_NAME,
src/diffusers/pipelines/onnx_utils.py:from ..utils import ONNX_EXTERNAL_WEIGHTS_NAME, ONNX_WEIGHTS_NAME, is_onnx_available, logging
src/diffusers/pipelines/onnx_utils.py:        src_path = self.model_save_dir.joinpath(ONNX_EXTERNAL_WEIGHTS_NAME)
src/diffusers/pipelines/onnx_utils.py:            dst_path = Path(save_directory).joinpath(ONNX_EXTERNAL_WEIGHTS_NAME)
```

The list of allowed `weight_names` at https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/pipeline_utils.py#L151 includes `ONNX_WEIGHTS_NAME` but not `ONNX_EXTERNAL_WEIGHTS_NAME`. Adding that seems to resolve the issue.