### PR TITLE
smooth spatially instead of along heads

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_attend_and_excite.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_attend_and_excite.py
@@ -551,9 +551,11 @@ class StableDiffusionAttendAndExcitePipeline(DiffusionPipeline):
         max_indices_list = []
         for i in indices:
             image = attention_for_text[:, :, i]
+            head, total_pixel = image.shape
+            image = image.reshape(head, int(total_pixel**0.5), int(total_pixel**0.5))
             smoothing = GaussianSmoothing().to(attention_maps.device)
-            input = F.pad(image.unsqueeze(0).unsqueeze(0), (1, 1, 1, 1), mode="reflect")
-            image = smoothing(input).squeeze(0).squeeze(0)
+            input = F.pad(image.unsqueeze(0), (1, 1, 1, 1), mode="reflect")
+            image = smoothing(input).squeeze(0)
             max_indices_list.append(image.max())
         return max_indices_list
 


### PR DESCRIPTION
original paper mentions blurring the reshaped spatial maps. Currently it blurs the maps such that the convolution considers 'heads' as height and 'total pixels' as width. 8x4096 for a 512x512 image at the highest res layer for attn. doing it this way will cause scores of one head to bleed into another and I do not think this is intended.

the explanation in that paper suggests that this should be first transformed into (8x64x64) and then smoothed.

BTW, the current change i made will cause inaccuracies if user specifies a resolution that is not 1:1, to fix this extra parameters will be need to be passed to several functions which I would be happy to help with :)

https://attendandexcite.github.io/Attend-and-Excite/