### PR TITLE
[Safetensors] Make sure metadata is saved

### DIFF
--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -291,9 +291,6 @@ class ModelMixin(torch.nn.Module):
             logger.error(f"Provided path ({save_directory}) should be a directory, not a file")
             return
 
-        if save_function is None:
-            save_function = safetensors.torch.save_file if safe_serialization else torch.save
-
         os.makedirs(save_directory, exist_ok=True)
 
         model_to_save = self
@@ -310,7 +307,10 @@ class ModelMixin(torch.nn.Module):
         weights_name = _add_variant(weights_name, variant)
 
         # Save the model
-        save_function(state_dict, os.path.join(save_directory, weights_name))
+        if safe_serialization:
+            safetensors.torch.save_file(state_dict, os.path.join(save_directory, weights_name), metadata={"format": "pt"})
+        else:
+            torch.save(state_dict, os.path.join(save_directory, weights_name))
 
         logger.info(f"Model weights saved in {os.path.join(save_directory, weights_name)}")
 

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -308,7 +308,9 @@ class ModelMixin(torch.nn.Module):
 
         # Save the model
         if safe_serialization:
-            safetensors.torch.save_file(state_dict, os.path.join(save_directory, weights_name), metadata={"format": "pt"})
+            safetensors.torch.save_file(
+                state_dict, os.path.join(save_directory, weights_name), metadata={"format": "pt"}
+            )
         else:
             torch.save(state_dict, os.path.join(save_directory, weights_name))
 


### PR DESCRIPTION
When loading devices with `device_map="auto"` and safetensors, accelerate expects that the safetensors weights have a "pytorch" format, see: https://github.com/huggingface/accelerate/blob/907a86d145cc62521ea0281eb24465f537480e2d/src/accelerate/utils/modeling.py#L670

Let's make sure we save this format when saving with `safe_serialization`.