### PR TITLE
fix karras_ve bugs

### DIFF
--- a/src/diffusers/pipelines/stochastic_karras_ve/pipeline_stochastic_karras_ve.py
+++ b/src/diffusers/pipelines/stochastic_karras_ve/pipeline_stochastic_karras_ve.py
@@ -93,7 +93,7 @@ class KarrasVePipeline(DiffusionPipeline):
 
             # 1. Select temporarily increased noise level sigma_hat
             # 2. Add new noise to move from sample_i to sample_hat
-            sample_hat, sigma_hat = self.scheduler.add_noise_to_input(sample, sigma, generator=generator)
+            sample_hat, sigma_hat = self.scheduler.add_noise_to_input(sample, sigma, generator=generator, device=self.device)
 
             # 3. Predict the noise residual given the noise magnitude `sigma_hat`
             # The model inputs and output are adjusted by following eq. (213) in [1].

--- a/src/diffusers/pipelines/stochastic_karras_ve/pipeline_stochastic_karras_ve.py
+++ b/src/diffusers/pipelines/stochastic_karras_ve/pipeline_stochastic_karras_ve.py
@@ -93,7 +93,7 @@ class KarrasVePipeline(DiffusionPipeline):
 
             # 1. Select temporarily increased noise level sigma_hat
             # 2. Add new noise to move from sample_i to sample_hat
-            sample_hat, sigma_hat = self.scheduler.add_noise_to_input(sample, sigma, generator=generator, device=self.device)
+            sample_hat, sigma_hat = self.scheduler.add_noise_to_input(sample, sigma, generator=generator)
 
             # 3. Predict the noise residual given the noise magnitude `sigma_hat`
             # The model inputs and output are adjusted by following eq. (213) in [1].

--- a/src/diffusers/schedulers/scheduling_karras_ve.py
+++ b/src/diffusers/schedulers/scheduling_karras_ve.py
@@ -133,7 +133,7 @@ class KarrasVeScheduler(SchedulerMixin, ConfigMixin):
         self.schedule = torch.tensor(schedule, dtype=torch.float32, device=device)
 
     def add_noise_to_input(
-        self, sample: torch.FloatTensor, sigma: float, generator: Optional[torch.Generator] = None, device: Optional[torch.device] = None
+        self, sample: torch.FloatTensor, sigma: float, generator: Optional[torch.Generator] = None, 
     ) -> Tuple[torch.FloatTensor, float]:
         """
         Explicit Langevin-like "churn" step of adding noise to the sample according to a factor gamma_i ≥ 0 to reach a
@@ -147,7 +147,7 @@ class KarrasVeScheduler(SchedulerMixin, ConfigMixin):
             gamma = 0
 
         # sample eps ~ N(0, S_noise^2 * I)
-        eps = self.config.s_noise * randn_tensor(sample.shape, generator=generator, device=device).to(sample.device)
+        eps = self.config.s_noise * randn_tensor(sample.shape, generator=generator).to(sample.device)
         sigma_hat = sigma + gamma * sigma
         sample_hat = sample + ((sigma_hat**2 - sigma**2) ** 0.5 * eps)
 

--- a/src/diffusers/schedulers/scheduling_karras_ve.py
+++ b/src/diffusers/schedulers/scheduling_karras_ve.py
@@ -133,7 +133,7 @@ class KarrasVeScheduler(SchedulerMixin, ConfigMixin):
         self.schedule = torch.tensor(schedule, dtype=torch.float32, device=device)
 
     def add_noise_to_input(
-        self, sample: torch.FloatTensor, sigma: float, generator: Optional[torch.Generator] = None, 
+        self, sample: torch.FloatTensor, sigma: float, generator: Optional[torch.Generator] = None, device: Optional[torch.device] = None
     ) -> Tuple[torch.FloatTensor, float]:
         """
         Explicit Langevin-like "churn" step of adding noise to the sample according to a factor gamma_i ≥ 0 to reach a
@@ -147,7 +147,7 @@ class KarrasVeScheduler(SchedulerMixin, ConfigMixin):
             gamma = 0
 
         # sample eps ~ N(0, S_noise^2 * I)
-        eps = self.config.s_noise * randn_tensor(sample.shape, generator=generator).to(sample.device)
+        eps = self.config.s_noise * randn_tensor(sample.shape, generator=generator, device=device).to(sample.device)
         sigma_hat = sigma + gamma * sigma
         sample_hat = sample + ((sigma_hat**2 - sigma**2) ** 0.5 * eps)
 

--- a/src/diffusers/schedulers/scheduling_karras_ve.py
+++ b/src/diffusers/schedulers/scheduling_karras_ve.py
@@ -133,7 +133,7 @@ class KarrasVeScheduler(SchedulerMixin, ConfigMixin):
         self.schedule = torch.tensor(schedule, dtype=torch.float32, device=device)
 
     def add_noise_to_input(
-        self, sample: torch.FloatTensor, sigma: float, generator: Optional[torch.Generator] = None
+        self, sample: torch.FloatTensor, sigma: float, generator: Optional[torch.Generator] = None, device: Optional[torch.device] = None
     ) -> Tuple[torch.FloatTensor, float]:
         """
         Explicit Langevin-like "churn" step of adding noise to the sample according to a factor gamma_i ≥ 0 to reach a
@@ -147,7 +147,7 @@ class KarrasVeScheduler(SchedulerMixin, ConfigMixin):
             gamma = 0
 
         # sample eps ~ N(0, S_noise^2 * I)
-        eps = self.config.s_noise * randn_tensor(sample.shape, generator=generator).to(sample.device)
+        eps = self.config.s_noise * randn_tensor(sample.shape, generator=generator, device=device).to(sample.device)
         sigma_hat = sigma + gamma * sigma
         sample_hat = sample + ((sigma_hat**2 - sigma**2) ** 0.5 * eps)
 


### PR DESCRIPTION
A solution for solving the KarrasVePipeline error in GPU environment.

An error occurs when executing the following code:
```
import numpy as np
import torch

from diffusers import KarrasVePipeline, KarrasVeScheduler, UNet2DModel
from diffusers.utils.testing_utils import torch_device

model_id = "google/ncsnpp-celebahq-256"
model = UNet2DModel.from_pretrained(model_id)
scheduler = KarrasVeScheduler()

pipe = KarrasVePipeline(unet=model, scheduler=scheduler)
pipe.to(torch_device)
pipe.set_progress_bar_config(disable=None)

generator = torch.Generator(device="cuda").manual_seed(0)
image = pipe(num_inference_steps=20, generator=generator, output_type="numpy").images
```


'''
Traceback (most recent call last):
  File "test.py", line 18, in <module>
    image = pipe(num_inference_steps=20, generator=generator, output_type="numpy").images
  File "/root/miniconda3/envs/paddle112/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/root/project/paddlenlp/ppdiffusers_0.13.1/diffusers_bug_fix/base/diffusers/src/diffusers/pipelines/stochastic_karras_ve/pipeline_stochastic_karras_ve.py", line 96, in __call__
    sample_hat, sigma_hat = self.scheduler.add_noise_to_input(sample, sigma, generator=generator)
  File "/root/project/paddlenlp/ppdiffusers_0.13.1/diffusers_bug_fix/base/diffusers/src/diffusers/schedulers/scheduling_karras_ve.py", line 150, in add_noise_to_input
    eps = self.config.s_noise * randn_tensor(sample.shape, generator=generator).to(sample.device)
  File "/root/project/paddlenlp/ppdiffusers_0.13.1/diffusers_bug_fix/base/diffusers/src/diffusers/utils/torch_utils.py", line 58, in randn_tensor
    raise ValueError(f"Cannot generate a {device} tensor from a generator of type {gen_device_type}.")
ValueError: Cannot generate a cpu tensor from a generator of type cuda.
'''          