### PR TITLE
Revert "[docs] Build notebooks from Markdown"

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -13,7 +13,6 @@ jobs:
     with:
       commit_sha: ${{ github.sha }}
       package: diffusers
-      notebook_folder: diffusers_doc
       languages: en ko
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}

--- a/docs/source/_config.py
+++ b/docs/source/_config.py
@@ -1,9 +1,0 @@
-# docstyle-ignore
-INSTALL_CONTENT = """
-# Diffusers installation
-! pip install diffusers transformers datasets accelerate
-# To install from source instead of the last release, comment the command above and uncomment the following one.
-# ! pip install git+https://github.com/huggingface/diffusers.git
-"""
-
-notebook_first_cells = [{"type": "code", "content": INSTALL_CONTENT}]


### PR DESCRIPTION
Reverts huggingface/diffusers#2570

@stevhliu and @yiyixuxu reverting this PR for now until the problem with Flax is solved.
Currently the docs are not updated on "main" because they can't be build. 

Both not having Flax colabs or adding Flax as a framework to the builder work for me. It might be faster to just not include Flax in the beginning.