### PR TITLE
[docs] Build Jax notebooks for real

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -13,6 +13,7 @@ jobs:
     with:
       commit_sha: ${{ github.sha }}
       package: diffusers
+      notebook_folder: diffusers_doc
       languages: en ko
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}

--- a/docs/source/_config.py
+++ b/docs/source/_config.py
@@ -1,0 +1,9 @@
+# docstyle-ignore
+INSTALL_CONTENT = """
+# Diffusers installation
+! pip install diffusers transformers datasets accelerate
+# To install from source instead of the last release, comment the command above and uncomment the following one.
+# ! pip install git+https://github.com/huggingface/diffusers.git
+"""
+
+notebook_first_cells = [{"type": "code", "content": INSTALL_CONTENT}]


### PR DESCRIPTION
`doc-builder` supports building Jax notebooks (enabled in https://github.com/huggingface/doc-builder/pull/359) so I think we can add back building notebooks to Diffusers!