### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ input = noise
 for t in scheduler.timesteps:
     with torch.no_grad():
         noisy_residual = model(input, t).sample
-        previous_noisy_sample = scheduler.step(noisy_residual, t, input).prev_sample
+        prev_noisy_sample = scheduler.step(noisy_residual, t, input).prev_sample
+        input = prev_noisy_sample
 
 image = (input / 2 + 0.5).clamp(0, 1)
 image = image.cpu().permute(0, 2, 3, 1).numpy()[0]

--- a/README.md
+++ b/README.md
@@ -84,13 +84,11 @@ input = noise
 for t in scheduler.timesteps:
     with torch.no_grad():
         noisy_residual = model(input, t).sample
-
-previous_noisy_sample = scheduler.step(noisy_residual, t, input).prev_sample
-input = previous_noisy_sample
+        previous_noisy_sample = scheduler.step(noisy_residual, t, input).prev_sample
 
 image = (input / 2 + 0.5).clamp(0, 1)
 image = image.cpu().permute(0, 2, 3, 1).numpy()[0]
-image = Image.fromarray((image * 255)).round().astype("uint8")
+image = Image.fromarray((image * 255).round().astype("uint8"))
 image
 ```
 


### PR DESCRIPTION
fix 2 bugs in "models and schedulers toolbox" Quickstart example codes: (1) "previous_noisy_sample" should be in the FOR loop in line 88; (2) converting image to INT should be before "Image.fromarray" in line 93