### PR TITLE
Update onnxruntime package candidates

### DIFF
--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -156,6 +156,8 @@ if _onnx_available:
         "onnxruntime-directml",
         "onnxruntime-openvino",
         "ort_nightly_directml",
+        "onnxruntime-rocm",
+        "onnxruntime-training",
     )
     _onnxruntime_version = None
     # For the metadata, we have to look for both onnxruntime and onnxruntime-gpu

--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -153,6 +153,7 @@ if _onnx_available:
     candidates = (
         "onnxruntime",
         "onnxruntime-gpu",
+        "ort_nightly_gpu",
         "onnxruntime-directml",
         "onnxruntime-openvino",
         "ort_nightly_directml",


### PR DESCRIPTION
For onnxruntime ROCm EP, two python package will be used.
1. The official python package is training package(`onnxruntime-training`). 
2. Build from souce and generate inference package(`onnxruntime-rocm`). 

For onnxruntime Cuda EP, `ort_nightly_gpu` is needed for inference nightly python package.