### PR TITLE
Skip inconsistent tests for MPS in test_unet_2d_blocks

### DIFF
--- a/tests/test_unet_2d_blocks.py
+++ b/tests/test_unet_2d_blocks.py
@@ -254,11 +254,9 @@ class SimpleCrossAttnUpBlock2DTests(UNetBlockTesterMixin, unittest.TestCase):
         init_dict["cross_attention_dim"] = 32
         return init_dict, inputs_dict
 
+    @unittest.skipIf(torch_device == "mps", "MPS result is not consistent")
     def test_output(self):
-        if torch_device == "mps":
-            expected_slice = [0.4327, 0.5538, 0.3919, 0.5682, 0.2704, 0.1573, -0.8768, -0.4615, -0.4146]
-        else:
-            expected_slice = [0.2645, 0.1480, 0.0909, 0.8044, -0.9758, -0.9083, 0.0994, -1.1453, -0.7402]
+        expected_slice = [0.2645, 0.1480, 0.0909, 0.8044, -0.9758, -0.9083, 0.0994, -1.1453, -0.7402]
         super().test_output(expected_slice)
 
 
@@ -335,9 +333,7 @@ class AttnUpDecoderBlock2DTests(UNetBlockTesterMixin, unittest.TestCase):
         inputs_dict = self.dummy_input
         return init_dict, inputs_dict
 
+    @unittest.skipIf(torch_device == "mps", "MPS result is not consistent")
     def test_output(self):
-        if torch_device == "mps":
-            expected_slice = [-0.3669, -0.3387, 0.1029, -0.6564, 0.2728, -0.3233, 0.5977, -0.1784, 0.5482]
-        else:
-            expected_slice = [0.6738, 0.4491, 0.1055, 1.0710, 0.7316, 0.3339, 0.3352, 0.1023, 0.3568]
+        expected_slice = [0.6738, 0.4491, 0.1055, 1.0710, 0.7316, 0.3339, 0.3352, 0.1023, 0.3568]
         super().test_output(expected_slice)


### PR DESCRIPTION
All recent PRs validations failed because two `test_unet_2d_blocks.py` tests give inconsistent result on Mac (MPS device)

```
FAILED tests/test_unet_2d_blocks.py::SimpleCrossAttnUpBlock2DTests::test_output - AssertionError: Max diff is absolute 1.2456624507904053. Diff tensor is tensor([0.1679, 0.4054, 0.3008, 0.2366, 1.2457, 1.0652, 0.9767, 0.6834, 0.3251],
       device='mps:0').
FAILED tests/test_unet_2d_blocks.py::AttnUpDecoderBlock2DTests::test_output - AssertionError: Max diff is absolute 1.7274205684661865. Diff tensor is tensor([1.0407, 0.7878, 0.0026, 1.7274, 0.4588, 0.6572, 0.2625, 0.2807, 0.1914],
       device='mps:0').
```

I tried to run these tests on Mac

`SimpleCrossAttnUpBlock2DTests` randomly gives the following two outputs:
```
[ 0.5771,  0.5599,  0.1788,  0.2298, -0.1610, -0.6679, -0.3543, -0.2655, 0.1562]
[ 0.1935,  0.2100,  0.1523,  0.3923, -0.0860, -0.0189, -0.3123, -0.2552, 0.1499]
```

`AttnUpDecoderBlock2DTests` randomly gives the following two outputs:
```
[-0.0069,  0.1846, -0.1053,  0.0273,  0.0236,  0.0067,  0.0031,  0.1628, 0.0043]
[0.0422, 0.0423, 0.0418, 0.0422, 0.0422, 0.0420, 0.0423, 0.0424, 0.0419]
```

Two other tests in this file are already skipped if device is mps - `SimpleCrossAttnDownBlock2DTests` and `AttnUpBlock2DTests`

We can skip skip `SimpleCrossAttnUpBlock2DTests` and `AttnUpDecoderBlock2DTests` on mps device too.