### PR TITLE
Flax dreambooth train example - multiply by no. devices to fix reshape issue.

### DIFF
--- a/examples/dreambooth/train_dreambooth_flax.py
+++ b/examples/dreambooth/train_dreambooth_flax.py
@@ -370,7 +370,8 @@ def main():
             for example in tqdm(
                 sample_dataloader, desc="Generating class images", disable=not jax.process_index() == 0
             ):
-                prompt_ids = pipeline.prepare_inputs(example["prompt"])
+                prompt = example["prompt"] * jax.device_count()
+                prompt_ids = pipeline.prepare_inputs(prompt)
                 prompt_ids = shard(prompt_ids)
                 p_params = jax_utils.replicate(params)
                 rng = jax.random.split(rng)[0]


### PR DESCRIPTION
This fixes an issue I encountered trying to run `train_dreambooth_flax.py` where the instance class prompt is not being duplicated for the number of devices, resulting in an reshaping error. This was tested with a TPUv4.