### PR TITLE
fix index out of bounds error when strength is 0

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -502,6 +502,8 @@ class StableDiffusionImg2ImgPipeline(DiffusionPipeline):
         init_timestep = min(int(num_inference_steps * strength), num_inference_steps)
 
         t_start = max(num_inference_steps - init_timestep, 0)
+        if strength==0:
+            t_start=0
         timesteps = self.scheduler.timesteps[t_start:]
 
         return timesteps, num_inference_steps - t_start


### PR DESCRIPTION
When trying to do a strength=0 img2img an error is thrown. this is because no inference time steps run which then means the diffused image array stays uninitialized, which is not the intention of strength=0