### PR TITLE
fix KarrasVePipeline bug

### DIFF
--- a/src/diffusers/pipelines/stochastic_karras_ve/pipeline_stochastic_karras_ve.py
+++ b/src/diffusers/pipelines/stochastic_karras_ve/pipeline_stochastic_karras_ve.py
@@ -120,7 +120,7 @@ class KarrasVePipeline(DiffusionPipeline):
         sample = (sample / 2 + 0.5).clamp(0, 1)
         image = sample.cpu().permute(0, 2, 3, 1).numpy()
         if output_type == "pil":
-            image = self.numpy_to_pil(sample)
+            image = self.numpy_to_pil(image)
 
         if not return_dict:
             return (image,)


### PR DESCRIPTION
`KarrasVePipeline` crashes when `output_type="pil"`

```python
        sample = (sample / 2 + 0.5).clamp(0, 1)
        image = sample.cpu().permute(0, 2, 3, 1).numpy()
        if output_type == "pil":
            image = self.numpy_to_pil(sample)
```

should be 

```python
        sample = (sample / 2 + 0.5).clamp(0, 1)
        image = sample.cpu().permute(0, 2, 3, 1).numpy()
        if output_type == "pil":
            image = self.numpy_to_pil(image)
```