### PR TITLE
Fix link to LoRA training guide in DreamBooth training guide

### DIFF
--- a/docs/source/en/training/dreambooth.mdx
+++ b/docs/source/en/training/dreambooth.mdx
@@ -237,7 +237,7 @@ python train_dreambooth_flax.py \
 
 ## Finetuning with LoRA
 
-You can also use Low-Rank Adaptation of Large Language Models (LoRA), a fine-tuning technique for accelerating training large models, on DreamBooth. For more details, take a look at the [LoRA training](training/lora#dreambooth) guide.
+You can also use Low-Rank Adaptation of Large Language Models (LoRA), a fine-tuning technique for accelerating training large models, on DreamBooth. For more details, take a look at the [LoRA training](./lora#dreambooth) guide.
 
 ## Saving checkpoints while training
 


### PR DESCRIPTION
The previous link leads to https://huggingface.co/docs/diffusers/main/en/training/training/lora#dreambooth, which returns 404.