### PR TITLE
Add `last_epoch` argument to `optimization.get_scheduler`

### DIFF
--- a/src/diffusers/optimization.py
+++ b/src/diffusers/optimization.py
@@ -242,6 +242,7 @@ def get_scheduler(
     num_training_steps: Optional[int] = None,
     num_cycles: int = 1,
     power: float = 1.0,
+    last_epoch: int = -1,
 ):
     """
     Unified API to get any scheduler from its name.
@@ -267,14 +268,14 @@ def get_scheduler(
     name = SchedulerType(name)
     schedule_func = TYPE_TO_SCHEDULER_FUNCTION[name]
     if name == SchedulerType.CONSTANT:
-        return schedule_func(optimizer)
+        return schedule_func(optimizer, last_epoch=last_epoch)
 
     # All other schedulers require `num_warmup_steps`
     if num_warmup_steps is None:
         raise ValueError(f"{name} requires `num_warmup_steps`, please provide that argument.")
 
     if name == SchedulerType.CONSTANT_WITH_WARMUP:
-        return schedule_func(optimizer, num_warmup_steps=num_warmup_steps)
+        return schedule_func(optimizer, num_warmup_steps=num_warmup_steps, last_epoch=last_epoch)
 
     # All other schedulers require `num_training_steps`
     if num_training_steps is None:
@@ -282,12 +283,22 @@ def get_scheduler(
 
     if name == SchedulerType.COSINE_WITH_RESTARTS:
         return schedule_func(
-            optimizer, num_warmup_steps=num_warmup_steps, num_training_steps=num_training_steps, num_cycles=num_cycles
+            optimizer,
+            num_warmup_steps=num_warmup_steps,
+            num_training_steps=num_training_steps,
+            num_cycles=num_cycles,
+            last_epoch=last_epoch,
         )
 
     if name == SchedulerType.POLYNOMIAL:
         return schedule_func(
-            optimizer, num_warmup_steps=num_warmup_steps, num_training_steps=num_training_steps, power=power
+            optimizer,
+            num_warmup_steps=num_warmup_steps,
+            num_training_steps=num_training_steps,
+            power=power,
+            last_epoch=last_epoch,
         )
 
-    return schedule_func(optimizer, num_warmup_steps=num_warmup_steps, num_training_steps=num_training_steps)
+    return schedule_func(
+        optimizer, num_warmup_steps=num_warmup_steps, num_training_steps=num_training_steps, last_epoch=last_epoch
+    )


### PR DESCRIPTION
All learning rate schedulers in the `optimization` module support the argument `last_epoch` which allows specifying the index of the last epoch when resuming training.

Currently, `optimization.get_scheduler` (as a unified API to the schedulers) does not support this. However, the docstring for the argument was already added which seems like an oversight.

This PR adds the argument `last_epoch` to `get_scheduler` according to the pre-existing docstring and passes it along when calling a factory method for a learning rate scheduler.