### PR TITLE
[WIP] Check UNet shapes in StableDiffusionInpaintPipeline __init__

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -243,6 +243,14 @@ class StableDiffusionInpaintPipeline(DiffusionPipeline):
             new_config = dict(unet.config)
             new_config["sample_size"] = 64
             unet._internal_dict = FrozenDict(new_config)
+        # Check shapes, assume num_channels_latents == 4, num_channels_mask == 1, num_channels_masked == 4
+        if unet.config.in_channels != 9:
+            logger.warning(
+                f"You have loaded a UNet with {unet.config.in_channels} input channels, whereas by default,"
+                f" {self.__class__} assumes that `pipeline.unet` has 9 input channels: 4 for `num_channels_latents`,"
+                " 1 for `num_channels_mask`, and 4 for `num_channels_masked_image`. If you did not intend to modify"
+                " this behavior, please check whether you have loaded the right checkpoint."
+            )
 
         self.register_modules(
             vae=vae,


### PR DESCRIPTION
This PR adds a warning in `StableDiffusionInpaintPipeline`'s `__init__` method if the user initializes the pipeline with a UNet with `unet.config.in_channels` other than 9. This follows up on #2799 .

This is because a Stable Diffusion inpainting model typically has 9 input channels: 4 for the latent (encoded) base image (`num_channels_latents`), 1 for the inpainting mask (`num_channels_mask`), and 4 for the latent masked image (`num_channels_masked_image`). However, a valid SD inpainting model could have a different number of input channels, which is why we raise a warning instead of an exception; the precise condition that must be satisfied is that `num_channels_latents + num_channels_mask + num_channels_masked_image == self.unet.config.in_channels`, which is checked in the `__call__` method. See #2799 for more details.