### PR TITLE
Add output type = latent for inpainting pipeline

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -870,15 +870,24 @@ class StableDiffusionInpaintPipeline(DiffusionPipeline):
                     if callback is not None and i % callback_steps == 0:
                         callback(i, t, latents)
 
-        # 11. Post-processing
-        image = self.decode_latents(latents)
+        if output_type == "latent":
+            image = latents
+            has_nsfw_concept = None
+        elif output_type == "pil":
+            # 11. Post-processing
+            image = self.decode_latents(latents)
 
-        # 12. Run safety checker
-        image, has_nsfw_concept = self.run_safety_checker(image, device, prompt_embeds.dtype)
+            # 12. Run safety checker
+            image, has_nsfw_concept = self.run_safety_checker(image, device, prompt_embeds.dtype)
 
-        # 13. Convert to PIL
-        if output_type == "pil":
+            # 13. Convert to PIL
             image = self.numpy_to_pil(image)
+        else:
+            # 11. Post-processing
+            image = self.decode_latents(latents)
+
+            # 12. Run safety checker
+            image, has_nsfw_concept = self.run_safety_checker(image, device, prompt_embeds.dtype)
 
         # Offload last model to CPU
         if hasattr(self, "final_offload_hook") and self.final_offload_hook is not None:


### PR DESCRIPTION
Closes #2768.

**Context:**
The output type "latent" is not handled correctly in the inpainting pipeline, the pipeline returned the decoded latents instead of the latents.
It may cause unexpected behaviours, for instance adapting the code in the [huggingface documentation](https://huggingface.co/stabilityai/sd-x2-latent-upscaler) for the inpainting pipeline is not working.

**Next steps to go further**:
- Create a method that handles the postprocessing according to the output type and add it to all SD pipelines
- Add unit tests for the newly created method