### PR TITLE
Fix textual inversion loading

### DIFF
--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -555,7 +555,7 @@ class TextualInversionLoaderMixin:
             embeddings = [e for e in embedding]  # noqa: C416
         else:
             tokens = [token]
-            embeddings = [embedding] if len(embedding.shape) > 1 else [embedding[0]]
+            embeddings = [embedding[0]] if len(embedding.shape) > 1 else [embedding]
 
         # add tokens and get ids
         self.tokenizer.add_tokens(tokens)


### PR DESCRIPTION
Textual inversion doesn’t produce expected results, I tried [commenting on the PR](https://github.com/huggingface/diffusers/pull/2009#discussion_r1152398766) but it got merged without the fix.

Basically it looks like when the embedding’s shape has more than one dimension we take the full embedding but if it has only one we take the first value of it, resulting in a tensor of a single value. This ends up not changing the images generated at all.

For example:
 - Embedding shape is [3, 768]: embedding is considered multi vector and 3 embeddings of shape [768] are added.
 - Embedding shape is [1, 768]: At the moment the full tensor is being loaded, we should load a single embedding of shape [768].
 - Embedding shape is [768]: At the moment the first value of the tensor is being loaded, we should load the full embedding.