### PR TITLE
Update modeling_utils.py

### DIFF
--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -564,9 +564,14 @@ class ModelMixin(torch.nn.Module):
                             " `low_cpu_mem_usage=False` and `device_map=None` if you want to randomly initialize"
                             " those weights or else make sure your checkpoint file is correct."
                         )
-
+                    
+                    unexpected_keys = set(state_dict.keys()) - set(model.state_dict().keys())
                     empty_state_dict = model.state_dict()
                     for param_name, param in state_dict.items():
+                        
+                        if param_name in unexpected_keys:
+                            continue
+                        
                         accepts_dtype = "dtype" in set(
                             inspect.signature(set_module_tensor_to_device).parameters.keys()
                         )

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -564,14 +564,14 @@ class ModelMixin(torch.nn.Module):
                             " `low_cpu_mem_usage=False` and `device_map=None` if you want to randomly initialize"
                             " those weights or else make sure your checkpoint file is correct."
                         )
-                    
+
                     unexpected_keys = set(state_dict.keys()) - set(model.state_dict().keys())
                     empty_state_dict = model.state_dict()
                     for param_name, param in state_dict.items():
-                        
+
                         if param_name in unexpected_keys:
                             continue
-                        
+
                         accepts_dtype = "dtype" in set(
                             inspect.signature(set_module_tensor_to_device).parameters.keys()
                         )


### PR DESCRIPTION
This PR fixes https://github.com/huggingface/diffusers/issues/2900.

The demo usage is as below, where we assume the UNet and its LoRA layers both get trained. For now, the new added LoRA weight is within UNet, so it cannot directly load via from_pretrained.

```
unet = accelerator.unwrap_model(unet)
pipeline = DiffusionPipeline.from_pretrained(
                    args.pretrained_model_name_or_path,
                    unet=unet
                    revision=args.revision,
                    torch_dtype=weight_dtype,
                )

unet.save_attn_procs(lora_path)
pipe.save_pretrained(base_path)

pipe = DiffusionPipeline.from_pretrained(base_path, torch_dtype=torch.float16)
pipe.unet.load_attn_procs(lora_path)
```