### PR TITLE
Ensure validation image RGB not RGBA

### DIFF
--- a/examples/controlnet/train_controlnet.py
+++ b/examples/controlnet/train_controlnet.py
@@ -106,7 +106,7 @@ def log_validation(vae, text_encoder, tokenizer, unet, controlnet, args, acceler
     image_logs = []
 
     for validation_prompt, validation_image in zip(validation_prompts, validation_images):
-        validation_image = Image.open(validation_image)
+        validation_image = Image.open(validation_image).convert('RGB')
 
         images = []
 

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -110,7 +110,7 @@ def log_validation(controlnet, controlnet_params, tokenizer, args, rng, weight_d
         prompt_ids = pipeline.prepare_text_inputs(prompts)
         prompt_ids = shard(prompt_ids)
 
-        validation_image = Image.open(validation_image)
+        validation_image = Image.open(validation_image).convert('RGB')
         processed_image = pipeline.prepare_image_inputs(num_samples * [validation_image])
         processed_image = shard(processed_image)
         images = pipeline(


### PR DESCRIPTION
When working with the provided example PNG images, which have 4 channel (RGBA), the images cause problems when we stack the input and generated images during logging to tensorboard
https://github.com/huggingface/diffusers/blob/8c530fc2f6a76a2aefb6b285dce6df1675092ac6/examples/controlnet/train_controlnet.py#L139