### PR TITLE
Support ControlNetMediaPipeFace model converting 

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -363,6 +363,8 @@ def convert_ldm_unet_checkpoint(checkpoint, config, path=None, extract_ema=False
             if key.startswith("model.diffusion_model"):
                 flat_ema_key = "model_ema." + "".join(key.split(".")[1:])
                 unet_state_dict[key.replace(unet_key, "")] = checkpoint.pop(flat_ema_key)
+            else:
+                unet_state_dict[key] = checkpoint.pop(key)
     else:
         if sum(k.startswith("model_ema") for k in keys) > 100:
             print(
@@ -373,7 +375,9 @@ def convert_ldm_unet_checkpoint(checkpoint, config, path=None, extract_ema=False
         for key in keys:
             if key.startswith(unet_key):
                 unet_state_dict[key.replace(unet_key, "")] = checkpoint.pop(key)
-
+            else:
+                unet_state_dict[key] = checkpoint.pop(key)
+                
     new_checkpoint = {}
 
     new_checkpoint["time_embedding.linear_1.weight"] = unet_state_dict["time_embed.0.weight"]


### PR DESCRIPTION
Block's:
```py
dict_keys(['time_embed.0.weight', 'time_embed.0.bias', 'time_embed.2.weight', 'time_embed.2.bias', 'input_blocks.0.0.weight', 'input_blocks.0.0.bias', 'input_blocks.1.0.in_layers.0.weight', 'input_blocks.1.0.in_layers.0.bias', 'input_blocks.1.0.in_layers.2.weight', 'input_blocks.1.0.in_layers.2.bias', 'input_blocks.1.0.emb_layers.1.weight', 'input_blocks.1.0.emb_layers.1.bias', 'input_blocks.1.0.out_layers.0.weight', 'input_blocks.1.0.out_layers.0.bias', 'input_blocks.1.0.out_layers.3.weight', 'input_blocks.1.0.out_layers.3.bias', 'input_blocks.1.1.norm.weight', 'input_blocks.1.1.norm.bias', 'input_blocks.1.1.proj_in.weight', 'input_blocks.1.1
...
```

Script skips that isn't start key.startswith(unet_key)
unet_key: ```control_model.```