### PR TITLE
[2905]: Add Karras pattern to discrete euler

### DIFF
--- a/src/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_discrete.py
@@ -103,6 +103,10 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         interpolation_type (`str`, default `"linear"`, optional):
             interpolation type to compute intermediate sigmas for the scheduler denoising steps. Should be one of
             [`"linear"`, `"log_linear"`].
+        use_karras_sigmas (`bool`, *optional*, defaults to `False`):
+            Use karras sigmas. For example, specifying `sample_dpmpp_2m` to `set_scheduler` will be equivalent to
+            `DPM++2M` in stable-diffusion-webui. On top of that, setting this option to True will make it `DPM++2M
+            Karras`.
     """
 
     _compatibles = [e.name for e in KarrasDiffusionSchedulers]
@@ -118,6 +122,7 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         trained_betas: Optional[Union[np.ndarray, List[float]]] = None,
         prediction_type: str = "epsilon",
         interpolation_type: str = "linear",
+        use_karras_sigmas: Optional[bool] = False,
     ):
         if trained_betas is not None:
             self.betas = torch.tensor(trained_betas, dtype=torch.float32)
@@ -149,6 +154,7 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         timesteps = np.linspace(0, num_train_timesteps - 1, num_train_timesteps, dtype=float)[::-1].copy()
         self.timesteps = torch.from_numpy(timesteps)
         self.is_scale_input_called = False
+        self.use_karras_sigmas = use_karras_sigmas
 
     def scale_model_input(
         self, sample: torch.FloatTensor, timestep: Union[float, torch.FloatTensor]
@@ -187,6 +193,7 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
 
         timesteps = np.linspace(0, self.config.num_train_timesteps - 1, num_inference_steps, dtype=float)[::-1].copy()
         sigmas = np.array(((1 - self.alphas_cumprod) / self.alphas_cumprod) ** 0.5)
+        log_sigmas = np.log(sigmas)
 
         if self.config.interpolation_type == "linear":
             sigmas = np.interp(timesteps, np.arange(0, len(sigmas)), sigmas)
@@ -198,6 +205,10 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
                 " 'linear' or 'log_linear'"
             )
 
+        if self.use_karras_sigmas:
+            sigmas = self._convert_to_karras(in_sigmas=sigmas)
+            timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
+
         sigmas = np.concatenate([sigmas, [0.0]]).astype(np.float32)
         self.sigmas = torch.from_numpy(sigmas).to(device=device)
         if str(device).startswith("mps"):
@@ -205,6 +216,45 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             self.timesteps = torch.from_numpy(timesteps).to(device, dtype=torch.float32)
         else:
             self.timesteps = torch.from_numpy(timesteps).to(device=device)
+
+    def _sigma_to_t(self, sigma, log_sigmas):
+        # get log sigma
+        log_sigma = np.log(sigma)
+
+        # get distribution
+        dists = log_sigma - log_sigmas[:, np.newaxis]
+
+        # get sigmas range
+        low_idx = np.cumsum((dists >= 0), axis=0).argmax(axis=0).clip(max=log_sigmas.shape[0] - 2)
+        high_idx = low_idx + 1
+
+        low = log_sigmas[low_idx]
+        high = log_sigmas[high_idx]
+
+        # interpolate sigmas
+        w = (low - log_sigma) / (low - high)
+        w = np.clip(w, 0, 1)
+
+        # transform interpolation to time range
+        t = (1 - w) * low_idx + w * high_idx
+        t = t.reshape(sigma.shape)
+        return t
+
+    # Copied from https://github.com/crowsonkb/k-diffusion/blob/686dbad0f39640ea25c8a8c6a6e56bb40eacefa2/k_diffusion/sampling.py#L17
+    def _convert_to_karras(self, in_sigmas: torch.FloatTensor) -> torch.FloatTensor:
+        """Constructs the noise schedule of Karras et al. (2022)."""
+
+        sigma_min: float = in_sigmas[-1].item()
+        sigma_max: float = in_sigmas[0].item()
+        print(sigma_min, sigma_max)
+
+        rho = 7.0
+        # ramp = torch.linspace(0, 1, self.num_inference_steps)
+        ramp = np.linspace(0, 1, self.num_inference_steps)
+        min_inv_rho = sigma_min ** (1 / rho)
+        max_inv_rho = sigma_max ** (1 / rho)
+        sigmas = (max_inv_rho + ramp * (min_inv_rho - max_inv_rho)) ** rho
+        return sigmas
 
     def step(
         self,

--- a/src/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_discrete.py
@@ -18,6 +18,7 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import torch
+from k_diffusion.sampling import get_sigmas_karras
 
 from ..configuration_utils import ConfigMixin, register_to_config
 from ..utils import BaseOutput, logging, randn_tensor
@@ -206,7 +207,8 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             )
 
         if self.use_karras_sigmas:
-            sigmas = self._convert_to_karras(in_sigmas=sigmas)
+            # get_sigmas_karras also append 0.0 to the end of the list, so chopping the last element
+            sigmas = get_sigmas_karras(n=num_inference_steps, sigma_min=sigmas.min(), sigma_max=sigmas.max())[:-1]
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
 
         sigmas = np.concatenate([sigmas, [0.0]]).astype(np.float32)
@@ -216,45 +218,6 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             self.timesteps = torch.from_numpy(timesteps).to(device, dtype=torch.float32)
         else:
             self.timesteps = torch.from_numpy(timesteps).to(device=device)
-
-    def _sigma_to_t(self, sigma, log_sigmas):
-        # get log sigma
-        log_sigma = np.log(sigma)
-
-        # get distribution
-        dists = log_sigma - log_sigmas[:, np.newaxis]
-
-        # get sigmas range
-        low_idx = np.cumsum((dists >= 0), axis=0).argmax(axis=0).clip(max=log_sigmas.shape[0] - 2)
-        high_idx = low_idx + 1
-
-        low = log_sigmas[low_idx]
-        high = log_sigmas[high_idx]
-
-        # interpolate sigmas
-        w = (low - log_sigma) / (low - high)
-        w = np.clip(w, 0, 1)
-
-        # transform interpolation to time range
-        t = (1 - w) * low_idx + w * high_idx
-        t = t.reshape(sigma.shape)
-        return t
-
-    # Copied from https://github.com/crowsonkb/k-diffusion/blob/686dbad0f39640ea25c8a8c6a6e56bb40eacefa2/k_diffusion/sampling.py#L17
-    def _convert_to_karras(self, in_sigmas: torch.FloatTensor) -> torch.FloatTensor:
-        """Constructs the noise schedule of Karras et al. (2022)."""
-
-        sigma_min: float = in_sigmas[-1].item()
-        sigma_max: float = in_sigmas[0].item()
-        print(sigma_min, sigma_max)
-
-        rho = 7.0
-        # ramp = torch.linspace(0, 1, self.num_inference_steps)
-        ramp = np.linspace(0, 1, self.num_inference_steps)
-        min_inv_rho = sigma_min ** (1 / rho)
-        max_inv_rho = sigma_max ** (1 / rho)
-        sigmas = (max_inv_rho + ramp * (min_inv_rho - max_inv_rho)) ** rho
-        return sigmas
 
     def step(
         self,

--- a/src/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_discrete.py
@@ -107,7 +107,7 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         use_karras_sigmas (`bool`, *optional*, defaults to `False`):
             Use karras sigmas. For example, specifying `sample_dpmpp_2m` to `set_scheduler` will be equivalent to
             `DPM++2M` in stable-diffusion-webui. On top of that, setting this option to True will make it `DPM++2M
-            Karras`.
+            Karras`. Please see equation (5) https://arxiv.org/pdf/2206.00364.pdf for more details.
     """
 
     _compatibles = [e.name for e in KarrasDiffusionSchedulers]

--- a/src/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_discrete.py
@@ -104,9 +104,9 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             interpolation type to compute intermediate sigmas for the scheduler denoising steps. Should be one of
             [`"linear"`, `"log_linear"`].
         use_karras_sigmas (`bool`, *optional*, defaults to `False`):
-            Use karras sigmas. For example, specifying `sample_dpmpp_2m` to `set_scheduler` will be equivalent to
-            `DPM++2M` in stable-diffusion-webui. On top of that, setting this option to True will make it `DPM++2M
-            Karras`. Please see equation (5) https://arxiv.org/pdf/2206.00364.pdf for more details.
+             This parameter controls whether to use Karras sigmas (Karras et al. (2022) scheme) for step sizes in the
+             noise schedule during the sampling process. If True, the sigmas will be determined according to a sequence
+             of noise levels {σi} as defined in Equation (5) of the paper https://arxiv.org/pdf/2206.00364.pdf.
     """
 
     _compatibles = [e.name for e in KarrasDiffusionSchedulers]

--- a/src/diffusers/schedulers/scheduling_utils.py
+++ b/src/diffusers/schedulers/scheduling_utils.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Union
 
-import numpy as np
 import torch
 
 from ..utils import BaseOutput
@@ -175,27 +174,3 @@ class SchedulerMixin:
             getattr(diffusers_library, c) for c in compatible_classes_str if hasattr(diffusers_library, c)
         ]
         return compatible_classes
-
-    @classmethod
-    def _sigma_to_t(self, sigma, log_sigmas):
-        # get log sigma
-        log_sigma = np.log(sigma)
-
-        # get distribution
-        dists = log_sigma - log_sigmas[:, np.newaxis]
-
-        # get sigmas range
-        low_idx = np.cumsum((dists >= 0), axis=0).argmax(axis=0).clip(max=log_sigmas.shape[0] - 2)
-        high_idx = low_idx + 1
-
-        low = log_sigmas[low_idx]
-        high = log_sigmas[high_idx]
-
-        # interpolate sigmas
-        w = (low - log_sigma) / (low - high)
-        w = np.clip(w, 0, 1)
-
-        # transform interpolation to time range
-        t = (1 - w) * low_idx + w * high_idx
-        t = t.reshape(sigma.shape)
-        return t

--- a/src/diffusers/schedulers/scheduling_utils.py
+++ b/src/diffusers/schedulers/scheduling_utils.py
@@ -17,8 +17,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Union
 
-import torch
 import numpy as np
+import torch
 
 from ..utils import BaseOutput
 
@@ -175,6 +175,7 @@ class SchedulerMixin:
             getattr(diffusers_library, c) for c in compatible_classes_str if hasattr(diffusers_library, c)
         ]
         return compatible_classes
+
     @classmethod
     def _sigma_to_t(self, sigma, log_sigmas):
         # get log sigma

--- a/tests/schedulers/test_scheduler_euler.py
+++ b/tests/schedulers/test_scheduler_euler.py
@@ -117,3 +117,30 @@ class EulerDiscreteSchedulerTest(SchedulerCommonTest):
 
         assert abs(result_sum.item() - 10.0807) < 1e-2
         assert abs(result_mean.item() - 0.0131) < 1e-3
+
+    def test_full_loop_device_karras_sigmas(self):
+        scheduler_class = self.scheduler_classes[0]
+        scheduler_config = self.get_scheduler_config()
+        scheduler = scheduler_class(**scheduler_config, use_karras_sigmas=True)
+
+        scheduler.set_timesteps(self.num_inference_steps, device=torch_device)
+
+        generator = torch.manual_seed(0)
+
+        model = self.dummy_model()
+        sample = self.dummy_sample_deter * scheduler.init_noise_sigma
+        sample = sample.to(torch_device)
+
+        for t in scheduler.timesteps:
+            sample = scheduler.scale_model_input(sample, t)
+
+            model_output = model(sample, t)
+
+            output = scheduler.step(model_output, t, sample, generator=generator)
+            sample = output.prev_sample
+
+        result_sum = torch.sum(torch.abs(sample))
+        result_mean = torch.mean(torch.abs(sample))
+        print(result_sum.item(), result_mean.item())
+        assert abs(result_sum.item() - 124.52299499511719) < 1e-2
+        assert abs(result_mean.item() - 0.16213932633399963) < 1e-3

--- a/tests/schedulers/test_scheduler_euler.py
+++ b/tests/schedulers/test_scheduler_euler.py
@@ -141,6 +141,6 @@ class EulerDiscreteSchedulerTest(SchedulerCommonTest):
 
         result_sum = torch.sum(torch.abs(sample))
         result_mean = torch.mean(torch.abs(sample))
-        print(result_sum.item(), result_mean.item())
+
         assert abs(result_sum.item() - 124.52299499511719) < 1e-2
         assert abs(result_mean.item() - 0.16213932633399963) < 1e-3


### PR DESCRIPTION
Discussion: #2905, #2064

This pull request allows for the utilization of karras_sigmas in the Euler Discrete scheduler. Additionally, happy to get feedback as we refine a set of guidelines as we expand this functionality to all the schedulers. This update introduces two key components:

- The inclusion of karras-based sigma.
- The mapping of sigmas to the timestamp, which will be used as input for UNET.

Also, I apologize if I overstepped any boundaries, as I was working on #2064, I realized to better setup the guidelines with a simpler scheduler.

**Euler Discrete Test**
```
from diffusers import StableDiffusionPipeline, EulerDiscreteScheduler
import torch 

seed = 33

pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4")
pipe = pipe.to("mps")
pipe.scheduler = EulerDiscreteScheduler.from_config(pipe.scheduler.config, use_karras_sigmas=True)

prompt = "an astronaut riding a horse on mars"

generator = torch.Generator(device="mps").manual_seed(seed)
image = pipe(prompt, generator=generator, num_inference_steps=20).images[0]

display(image)
```
![image](https://user-images.githubusercontent.com/6430864/229621572-c9e8737b-d433-4a2e-be77-eaf0c91021c4.png)

**Compared with KDiffusion - sample_euler**
```
import torch
from diffusers import StableDiffusionKDiffusionPipeline

seed = 33

pipe = StableDiffusionKDiffusionPipeline.from_pretrained('CompVis/stable-diffusion-v1-4').to('mps')
pipe.set_scheduler('sample_euler')

prompt = "an astronaut riding a horse on mars"

generator = torch.Generator(device="mps").manual_seed(seed)
image = pipe(prompt, generator=generator, num_inference_steps=20, use_karras_sigmas=True).images[0]

display(image)
```
![image](https://user-images.githubusercontent.com/6430864/229621657-4294b34f-872e-4fdd-9877-675d0b4a0edb.png)

Tensor Comparison

EulerDiscreteScheduler - Sigmas
```
14.6146, 11.7254,  9.3402,  7.3836,  5.7894,  4.4998,  3.4648,  2.6408, 1.9909,  1.4832,  1.0908,  0.7909,  0.5647,  0.3964,  0.2730,  0.1842, 0.1213,  0.0779,  0.0485,  0.0292,  0.0000
```
EulerDiscreteScheduler - Timestep to UNET
```
999.0000, 961.7328, 921.0421, 876.3138, 826.7906, 771.5520, 709.5297, 639.6147, 560.9754, 473.7489, 380.1317, 285.3175, 197.0806, 123.3951, 69.2569,  34.6974,  15.4816,   5.9918,   1.7830,   0.0000
```

sample_euler - Sigmas
```
14.6146, 11.7254, 9.3402, 7.3836, 5.7894, 4.4998, 3.4648, 2.6408, 1.9909, 1.4832, 1.0908, 0.7909, 0.5647, 0.3964, 0.2730, 0.1842, 0.1213, 0.0779, 0.0485, 0.0292, 0.0000
```

sample_euler - Timestep to UNET
```
998.9999, 961.7327, 921.0419, 876.3136, 826.7905, 771.5519, 709.5297, 639.6146, 560.9752, 473.7487, 380.1315, 285.3175, 197.0805, 123.3950, 69.2569, 34.6974, 15.4816, 5.9918, 1.7829, 0.0, 0.0
```