### PR TITLE
[scheduler] fix some scheduler dtype error

### DIFF
--- a/src/diffusers/schedulers/scheduling_k_dpm_2_ancestral_discrete.py
+++ b/src/diffusers/schedulers/scheduling_k_dpm_2_ancestral_discrete.py
@@ -201,7 +201,7 @@ class KDPM2AncestralDiscreteScheduler(SchedulerMixin, ConfigMixin):
         else:
             timesteps = torch.from_numpy(timesteps).to(device)
 
-        timesteps_interpol = self.sigma_to_t(sigmas_interpol).to(device)
+        timesteps_interpol = self.sigma_to_t(sigmas_interpol).to(device, dtype=timesteps.dtype)
         interleaved_timesteps = torch.stack((timesteps_interpol[:-2, None], timesteps[1:, None]), dim=-1).flatten()
 
         self.timesteps = torch.cat([timesteps[:1], interleaved_timesteps])

--- a/src/diffusers/schedulers/scheduling_k_dpm_2_discrete.py
+++ b/src/diffusers/schedulers/scheduling_k_dpm_2_discrete.py
@@ -190,7 +190,7 @@ class KDPM2DiscreteScheduler(SchedulerMixin, ConfigMixin):
             timesteps = torch.from_numpy(timesteps).to(device)
 
         # interpolate timesteps
-        timesteps_interpol = self.sigma_to_t(sigmas_interpol).to(device)
+        timesteps_interpol = self.sigma_to_t(sigmas_interpol).to(device, dtype=timesteps.dtype)
         interleaved_timesteps = torch.stack((timesteps_interpol[1:-1, None], timesteps[1:, None]), dim=-1).flatten()
 
         self.timesteps = torch.cat([timesteps[:1], interleaved_timesteps])


### PR DESCRIPTION
when use nvidia gpu, the dtype of timesteps is float64 and the dtype of timesteps_interpol is float32, but they will be pushed into same torch.stack. This bug will make some optimization failed. For example, when I use oneflow to mock torch, torch.stack will push timesteps_interpol and timesteps which has different dtype, and then oneflow will clash.