### PR TITLE
[Examples] Fix type-casting issue in the ControlNet training script

### DIFF
--- a/examples/controlnet/train_controlnet.py
+++ b/examples/controlnet/train_controlnet.py
@@ -972,8 +972,10 @@ def main(args):
                     noisy_latents,
                     timesteps,
                     encoder_hidden_states=encoder_hidden_states,
-                    down_block_additional_residuals=down_block_res_samples,
-                    mid_block_additional_residual=mid_block_res_sample,
+                    down_block_additional_residuals=[
+                        sample.to(dtype=weight_dtype) for sample in down_block_res_samples
+                    ],
+                    mid_block_additional_residual=mid_block_res_sample.to(dtype=weight_dtype),
                 ).sample
 
                 # Get the target for loss depending on the prediction type

--- a/tests/models/test_models_unet_3d_condition.py
+++ b/tests/models/test_models_unet_3d_condition.py
@@ -119,12 +119,11 @@ class UNet3DConditionModelTests(ModelTesterMixin, unittest.TestCase):
             == "XFormersAttnProcessor"
         ), "xformers is not enabled"
 
-    # Overriding because `block_out_channels` needs to be different for this model.
+    # Overriding to set `norm_num_groups` needs to be different for this model.
     def test_forward_with_norm_groups(self):
         init_dict, inputs_dict = self.prepare_init_args_and_inputs_for_common()
 
         init_dict["norm_num_groups"] = 32
-        init_dict["block_out_channels"] = (32, 64, 64, 64)
 
         model = self.model_class(**init_dict)
         model.to(torch_device)


### PR DESCRIPTION
Related issues:

* https://github.com/huggingface/diffusers/issues/2908
* https://github.com/huggingface/diffusers/issues/2991

I didn't want to use autocasting here to not mess with `accelerate`. 