### PR TITLE
Fix imports for composable_stable_diffusion pipeline

### DIFF
--- a/examples/community/composable_stable_diffusion.py
+++ b/examples/community/composable_stable_diffusion.py
@@ -30,11 +30,11 @@ from diffusers.schedulers import (
     LMSDiscreteScheduler,
     PNDMScheduler,
 )
-from diffusers.utils import is_accelerate_available
+from diffusers.utils import is_accelerate_available, deprecate, logging
 
-from ...utils import deprecate, logging
-from . import StableDiffusionPipelineOutput
-from .safety_checker import StableDiffusionSafetyChecker
+from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import StableDiffusionPipelineOutput
+from diffusers.pipelines.stable_diffusion.safety_checker import StableDiffusionSafetyChecker
+
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name

--- a/examples/community/composable_stable_diffusion.py
+++ b/examples/community/composable_stable_diffusion.py
@@ -36,7 +36,6 @@ from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import Stabl
 from diffusers.pipelines.stable_diffusion.safety_checker import StableDiffusionSafetyChecker
 
 
-
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
 
@@ -580,3 +579,4 @@ class ComposableStableDiffusionPipeline(DiffusionPipeline):
             return (image, has_nsfw_concept)
 
         return StableDiffusionPipelineOutput(images=image, nsfw_content_detected=has_nsfw_concept)
+

--- a/examples/community/composable_stable_diffusion.py
+++ b/examples/community/composable_stable_diffusion.py
@@ -579,4 +579,4 @@ class ComposableStableDiffusionPipeline(DiffusionPipeline):
             return (image, has_nsfw_concept)
 
         return StableDiffusionPipelineOutput(images=image, nsfw_content_detected=has_nsfw_concept)
-
+        


### PR DESCRIPTION
Fixes #2703

Relative imports were breaking the pipeline

This pipeline also only works as composable diffusion with a narrow use case (num_images_per_prompt=1, prompt as a string). I was unable to figure out how to make it work with num_images_per_prompt > 1.