### PR TITLE
fix wrong parameter name for accelerate

### DIFF
--- a/examples/research_projects/dreambooth_inpaint/train_dreambooth_inpaint_lora.py
+++ b/examples/research_projects/dreambooth_inpaint/train_dreambooth_inpaint_lora.py
@@ -411,7 +411,7 @@ def main():
         mixed_precision=args.mixed_precision,
         log_with="tensorboard",
         logging_dir=logging_dir,
-        accelerator_project_config=accelerator_project_config,
+        project_config=accelerator_project_config,
     )
 
     # Currently, it's not possible to do gradient accumulation when training two models with accelerate.accumulate

--- a/examples/research_projects/onnxruntime/text_to_image/train_text_to_image.py
+++ b/examples/research_projects/onnxruntime/text_to_image/train_text_to_image.py
@@ -328,7 +328,7 @@ def main():
         mixed_precision=args.mixed_precision,
         log_with=args.report_to,
         logging_dir=logging_dir,
-        accelerator_project_config=accelerator_project_config,
+        project_config=accelerator_project_config,
     )
 
     # Make one log on every process with the configuration for debugging.


### PR DESCRIPTION
ref https://github.com/huggingface/diffusers/blob/dcfa6e1d20d9dc14f2dd652010bf251150aca843/examples/research_projects/dreambooth_inpaint/train_dreambooth_inpaint.py#L415

Wrong parameter name will raise error : `TypeError: __init__() got an unexpected keyword argument 'accelerator_project_config'`