### PR TITLE
Fix scheduler type mismatch

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_flax_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_flax_stable_diffusion.py
@@ -245,6 +245,9 @@ class FlaxStableDiffusionPipeline(FlaxDiffusionPipeline):
         negative_prompt_embeds = self.text_encoder(uncond_input, params=params["text_encoder"])[0]
         context = jnp.concatenate([negative_prompt_embeds, prompt_embeds])
 
+        # Ensure model output will be `float32` before going into the scheduler
+        guidance_scale = jnp.array([guidance_scale], dtype=jnp.float32)
+
         latents_shape = (
             batch_size,
             self.unet.in_channels,


### PR DESCRIPTION
When doing generation manually instead of using `__call__`, and using guidance_scale as a static argument.

See #3039 for a discussion.
