### PR TITLE
`AttentionProcessor.group_norm` num_channels should be `query_dim`

### DIFF
--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -81,7 +81,7 @@ class Attention(nn.Module):
         self.added_kv_proj_dim = added_kv_proj_dim
 
         if norm_num_groups is not None:
-            self.group_norm = nn.GroupNorm(num_channels=inner_dim, num_groups=norm_num_groups, eps=1e-5, affine=True)
+            self.group_norm = nn.GroupNorm(num_channels=query_dim, num_groups=norm_num_groups, eps=1e-5, affine=True)
         else:
             self.group_norm = None
 


### PR DESCRIPTION
The group_norm on the attention processor should really norm the number of channels in the query _not_ the inner dim. This wasn't caught before because the group_norm is only used by the added kv attention processors and the added kv attention processors are only used by the karlo models which are configured such that the inner dim is the same as the query dim.


I separately ran the integration tests on the unclip/karlo models to confirm they all still pass. 


See here that hidden states is normed _before_ the projection to inner dim https://github.com/huggingface/diffusers/blob/67c3518f68d9129a1c429fd45659c7896c44e08e/src/diffusers/models/attention_processor.py#L406