### PR TITLE
Adds profiling flags, computes train metrics average.

### DIFF
--- a/examples/controlnet/README.md
+++ b/examples/controlnet/README.md
@@ -393,7 +393,7 @@ python3 train_controlnet_flax.py \
 	--train_batch_size=1 \
 	--revision="flax" \
 	--report_to="wandb" \
-  --tracker_project_name=$HUB_MODEL_ID
+	--tracker_project_name=$HUB_MODEL_ID
 ```
 
 Note, however, that the performance of the TPUs might get bottlenecked as streaming with `datasets` is not optimized for images. For ensuring maximum throughput, we encourage you to explore the following options:

--- a/examples/controlnet/README.md
+++ b/examples/controlnet/README.md
@@ -372,7 +372,7 @@ python3 train_controlnet_flax.py \
 
 Since we passed the `--push_to_hub` flag, it will automatically create a model repo under your huggingface account based on `$HUB_MODEL_ID`. By the end of training, the final checkpoint will be automatically stored on the hub. You can find an example model repo [here](https://huggingface.co/YiYiXu/fill-circle-controlnet).
 
-Our training script also provides limited support for streaming large datasets from the Hugging Face Hub. In order to enable streaming, one must also set `--max_train_samples`.  Here is an example command (from [this Blog article](https://huggingface.co/blog/train-your-controlnet)):
+Our training script also provides limited support for streaming large datasets from the Hugging Face Hub. In order to enable streaming, one must also set `--max_train_samples`.  Here is an example command (from [this blog article](https://huggingface.co/blog/train-your-controlnet)):
 
 ```bash
 export MODEL_DIR="runwayml/stable-diffusion-v1-5"

--- a/examples/controlnet/README.md
+++ b/examples/controlnet/README.md
@@ -418,3 +418,22 @@ You can then start your training from this saved checkpoint with
 We support training with the Min-SNR weighting strategy proposed in [Efficient Diffusion Training via Min-SNR Weighting Strategy](https://arxiv.org/abs/2303.09556) which helps to achieve faster convergence by rebalancing the loss. To use it, one needs to set the `--snr_gamma` argument. The recommended value when using it is `5.0`.
 
 We also support gradient accumulation - it is a technique that lets you use a bigger batch size than your machine would normally be able to fit into memory. You can use `gradient_accumulation_steps` argument to set gradient accumulation steps. The ControlNet author recommends using gradient accumulation to achieve better convergence. Read more [here](https://github.com/lllyasviel/ControlNet/blob/main/docs/train.md#more-consideration-sudden-converge-phenomenon-and-gradient-accumulation).
+
+You can **profile your code** with:
+
+```bash
+  --profile_steps==5
+```
+
+Refer to the [JAX documentation on profiling](https://jax.readthedocs.io/en/latest/profiling.html). To inspect the profile trace, you'll have to install and start Tensorboard with the profile plugin:
+
+```bash
+pip install tensorflow tensorboard-plugin-profile
+tensorboard --logdir runs/fill-circle-100steps-20230411_165612/
+```
+
+The profile can then be inspected at http://localhost:6006/#profile
+
+Sometimes you'll get version conflicts (error messages like `Duplicate plugins for name projector`), which means that you have to uninstall and reinstall all versions of Tensorflow/Tensorboard (e.g. with `pip uninstall tensorflow tf-nightly tensorboard tb-nightly tensorboard-plugin-profile && pip install tf-nightly tbp-nightly tensorboard-plugin-profile`).
+
+Note that the debugging functionality of the Tensorboard `profile` plugin is still under active development. Not all views are fully functional, and for example the `trace_viewer` cuts off events after 1M (which can result in all your device traces getting lost if you for example profile the compilation step by accident).

--- a/examples/controlnet/README.md
+++ b/examples/controlnet/README.md
@@ -340,13 +340,12 @@ We encourage you to store or share your model with the community. To use hugging
 huggingface-cli login
 ```
 
-Make sure you have the `MODEL_DIR`,`OUTPUT_DIR` and `HUB_MODEL_ID` environment variables set. The `OUTPUT_DIR` and `HUB_MODEL_ID` variables specify where to save the model to on the Hub. The `TRACKER_PROJECT_NAME` variable sets the project name in `wandb`.
+Make sure you have the `MODEL_DIR`,`OUTPUT_DIR` and `HUB_MODEL_ID` environment variables set. The `OUTPUT_DIR` and `HUB_MODEL_ID` variables specify where to save the model to on the Hub:
 
 ```bash
 export MODEL_DIR="runwayml/stable-diffusion-v1-5"
 export OUTPUT_DIR="runs/fill-circle-{timestamp}"
 export HUB_MODEL_ID="controlnet-fill-circle"
-export TRACKER_PROJECT_NAME='controlnet_fill50k'
 ```
 
 And finally start the training
@@ -356,7 +355,6 @@ python3 train_controlnet_flax.py \
  --pretrained_model_name_or_path=$MODEL_DIR \
  --output_dir=$OUTPUT_DIR \
  --dataset_name=fusing/fill50k \
- --tracker_project_name="$TRACKER_PROJECT_NAME" \
  --resolution=512 \
  --learning_rate=1e-5 \
  --validation_image "./conditioning_image_1.png" "./conditioning_image_2.png" \
@@ -366,6 +364,7 @@ python3 train_controlnet_flax.py \
  --revision="non-ema" \
  --from_pt \
  --report_to="wandb" \
+ --tracker_project_name=$HUB_MODEL_ID \
  --num_train_epochs=11 \
  --push_to_hub \
  --hub_model_id=$HUB_MODEL_ID
@@ -373,9 +372,13 @@ python3 train_controlnet_flax.py \
 
 Since we passed the `--push_to_hub` flag, it will automatically create a model repo under your huggingface account based on `$HUB_MODEL_ID`. By the end of training, the final checkpoint will be automatically stored on the hub. You can find an example model repo [here](https://huggingface.co/YiYiXu/fill-circle-controlnet).
 
-Our training script also provides limited support for streaming large datasets from the Hugging Face Hub. In order to enable streaming, one must also set `--max_train_samples`.  Here is an example command:
+Our training script also provides limited support for streaming large datasets from the Hugging Face Hub. In order to enable streaming, one must also set `--max_train_samples`.  Here is an example command (from [this Blog article](https://huggingface.co/blog/train-your-controlnet)):
 
 ```bash
+export MODEL_DIR="runwayml/stable-diffusion-v1-5"
+export OUTPUT_DIR="runs/uncanny-faces-{timestamp}"
+export HUB_MODEL_ID="controlnet-uncanny-faces"
+
 python3 train_controlnet_flax.py \
 	--pretrained_model_name_or_path=$MODEL_DIR \
 	--output_dir=$OUTPUT_DIR \
@@ -385,13 +388,12 @@ python3 train_controlnet_flax.py \
 	--image_column=image \
 	--caption_column=image_caption \
 	--resolution=512 \
-	--max_train_samples 50 \
-	--max_train_steps 5 \
+	--max_train_samples 100000 \
 	--learning_rate=1e-5 \
-	--validation_steps=2 \
 	--train_batch_size=1 \
 	--revision="flax" \
-	--report_to="wandb"
+	--report_to="wandb" \
+  --tracker_project_name=$HUB_MODEL_ID
 ```
 
 Note, however, that the performance of the TPUs might get bottlenecked as streaming with `datasets` is not optimized for images. For ensuring maximum throughput, we encourage you to explore the following options:

--- a/examples/controlnet/README.md
+++ b/examples/controlnet/README.md
@@ -284,9 +284,9 @@ TPU_TYPE=v4-8
 VM_NAME=hg_flax
 
 gcloud alpha compute tpus tpu-vm create $VM_NAME \
-    --zone $ZONE \
-    --accelerator-type $TPU_TYPE \
-    --version  tpu-vm-v4-base
+ --zone $ZONE \
+ --accelerator-type $TPU_TYPE \
+ --version  tpu-vm-v4-base
 
 gcloud alpha compute tpus tpu-vm ssh $VM_NAME --zone $ZONE -- \
 ```
@@ -380,20 +380,20 @@ export OUTPUT_DIR="runs/uncanny-faces-{timestamp}"
 export HUB_MODEL_ID="controlnet-uncanny-faces"
 
 python3 train_controlnet_flax.py \
-	--pretrained_model_name_or_path=$MODEL_DIR \
-	--output_dir=$OUTPUT_DIR \
-	--dataset_name=multimodalart/facesyntheticsspigacaptioned \
-	--streaming \
-	--conditioning_image_column=spiga_seg \
-	--image_column=image \
-	--caption_column=image_caption \
-	--resolution=512 \
-	--max_train_samples 100000 \
-	--learning_rate=1e-5 \
-	--train_batch_size=1 \
-	--revision="flax" \
-	--report_to="wandb" \
-	--tracker_project_name=$HUB_MODEL_ID
+ --pretrained_model_name_or_path=$MODEL_DIR \
+ --output_dir=$OUTPUT_DIR \
+ --dataset_name=multimodalart/facesyntheticsspigacaptioned \
+ --streaming \
+ --conditioning_image_column=spiga_seg \
+ --image_column=image \
+ --caption_column=image_caption \
+ --resolution=512 \
+ --max_train_samples 100000 \
+ --learning_rate=1e-5 \
+ --train_batch_size=1 \
+ --revision="flax" \
+ --report_to="wandb" \
+ --tracker_project_name=$HUB_MODEL_ID
 ```
 
 Note, however, that the performance of the TPUs might get bottlenecked as streaming with `datasets` is not optimized for images. For ensuring maximum throughput, we encourage you to explore the following options:
@@ -405,14 +405,14 @@ Note, however, that the performance of the TPUs might get bottlenecked as stream
 When work with a larger dataset, you may need to run training process for a long time and it’s useful to save regular checkpoints during the process. You can use the following argument to enable intermediate checkpointing:
 
 ```bash
-  --checkpointing_steps=500
+ --checkpointing_steps=500
 ```
 This will save the trained model in subfolders of your output_dir. Subfolder names is the number of steps performed so far; for example: a checkpoint saved after 500 training steps would be saved in a subfolder named 500 
 
 You can then start your training from this saved checkpoint with 
 
 ```bash
-   --controlnet_model_name_or_path="./control_out/500" 
+ --controlnet_model_name_or_path="./control_out/500" 
 ```
 
 We support training with the Min-SNR weighting strategy proposed in [Efficient Diffusion Training via Min-SNR Weighting Strategy](https://arxiv.org/abs/2303.09556) which helps to achieve faster convergence by rebalancing the loss. To use it, one needs to set the `--snr_gamma` argument. The recommended value when using it is `5.0`.
@@ -422,7 +422,7 @@ We also support gradient accumulation - it is a technique that lets you use a bi
 You can **profile your code** with:
 
 ```bash
-  --profile_steps==5
+ --profile_steps==5
 ```
 
 Refer to the [JAX documentation on profiling](https://jax.readthedocs.io/en/latest/profiling.html). To inspect the profile trace, you'll have to install and start Tensorboard with the profile plugin:

--- a/examples/controlnet/README.md
+++ b/examples/controlnet/README.md
@@ -326,6 +326,7 @@ If you want to use Weights and Biases logging, you should also install `wandb` n
 pip install wandb
 ```
 
+
 Now let's downloading two conditioning images that we will use to run validation during the training in order to track our progress
 
 ```

--- a/examples/controlnet/README.md
+++ b/examples/controlnet/README.md
@@ -340,12 +340,13 @@ We encourage you to store or share your model with the community. To use hugging
 huggingface-cli login
 ```
 
-Make sure you have the `MODEL_DIR`,`OUTPUT_DIR` and `HUB_MODEL_ID` environment variables set. The `OUTPUT_DIR` and `HUB_MODEL_ID` variables specify where to save the model to on the Hub:
+Make sure you have the `MODEL_DIR`,`OUTPUT_DIR` and `HUB_MODEL_ID` environment variables set. The `OUTPUT_DIR` and `HUB_MODEL_ID` variables specify where to save the model to on the Hub. The `TRACKER_PROJECT_NAME` variable sets the project name in `wandb`.
 
 ```bash
 export MODEL_DIR="runwayml/stable-diffusion-v1-5"
 export OUTPUT_DIR="runs/fill-circle-{timestamp}"
 export HUB_MODEL_ID="controlnet-fill-circle"
+export TRACKER_PROJECT_NAME='controlnet_fill50k'
 ```
 
 And finally start the training
@@ -355,6 +356,7 @@ python3 train_controlnet_flax.py \
  --pretrained_model_name_or_path=$MODEL_DIR \
  --output_dir=$OUTPUT_DIR \
  --dataset_name=fusing/fill50k \
+ --tracker_project_name="$TRACKER_PROJECT_NAME" \
  --resolution=512 \
  --learning_rate=1e-5 \
  --validation_image "./conditioning_image_1.png" "./conditioning_image_2.png" \

--- a/examples/controlnet/README.md
+++ b/examples/controlnet/README.md
@@ -363,7 +363,7 @@ python3 train_controlnet_flax.py \
  --revision="non-ema" \
  --from_pt \
  --report_to="wandb" \
- --max_train_steps=10000 \
+ --num_train_epochs=11 \
  --push_to_hub \
  --hub_model_id=$HUB_MODEL_ID
  ```

--- a/examples/controlnet/README.md
+++ b/examples/controlnet/README.md
@@ -343,8 +343,8 @@ Make sure you have the `MODEL_DIR`,`OUTPUT_DIR` and `HUB_MODEL_ID` environment v
 
 ```bash
 export MODEL_DIR="runwayml/stable-diffusion-v1-5"
-export OUTPUT_DIR="control_out"
-export HUB_MODEL_ID="fill-circle-controlnet"
+export OUTPUT_DIR="runs/fill-circle-{timestamp}"
+export HUB_MODEL_ID="controlnet-fill-circle"
 ```
 
 And finally start the training

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -1032,6 +1032,7 @@ def main():
         # ======================== Training ================================
 
         train_metrics = []
+        train_metric = None
 
         steps_per_epoch = (
             args.max_train_samples // total_train_batch_size
@@ -1047,12 +1048,11 @@ def main():
         )
         # train
         for batch in train_dataloader:
-
             if args.profile_steps and global_step == 1:
-                train_metric['loss'].block_until_ready()
+                train_metric["loss"].block_until_ready()
                 jax.profiler.start_trace(args.output_dir)
             if args.profile_steps and global_step == 1 + args.profile_steps:
-                train_metric['loss'].block_until_ready()
+                train_metric["loss"].block_until_ready()
                 jax.profiler.stop_trace()
 
             batch = shard(batch)

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -251,8 +251,9 @@ def parse_args():
     parser.add_argument(
         "--output_dir",
         type=str,
-        default="controlnet-model",
-        help="The output directory where the model predictions and checkpoints will be written.",
+        default="runs/{timestamp}",
+        help="The output directory where the model predictions and checkpoints will be written. "
+        "Can contain placeholders: {timestamp}.",
     )
     parser.add_argument(
         "--cache_dir",
@@ -467,6 +468,10 @@ def parse_args():
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
 
     args = parser.parse_args()
+    args.output_dir = args.output_dir.replace(
+        '{timestamp}', time.strftime('%Y%m%d_%H%M%S')
+    )
+
     env_local_rank = int(os.environ.get("LOCAL_RANK", -1))
     if env_local_rank != -1 and env_local_rank != args.local_rank:
         args.local_rank = env_local_rank

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -22,7 +22,6 @@ import time
 from pathlib import Path
 
 import jax
-import jax.experimental.compilation_cache.compilation_cache as cc
 import jax.numpy as jnp
 import numpy as np
 import optax
@@ -1027,9 +1026,6 @@ def main():
                 "controlnet_params": sum(np.prod(x.shape) for x in jax.tree_util.tree_leaves(state.params)),
             }
         )
-
-    if args.ccache:
-        cc.initialize_cache(args.ccache)
 
     global_step = step0 = 0
     epochs = tqdm(

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -320,15 +320,6 @@ def parse_args():
         help="The name of the repository to keep in sync with the local `output_dir`.",
     )
     parser.add_argument(
-        "--logging_dir",
-        type=str,
-        default="logs",
-        help=(
-            "[TensorBoard](https://www.tensorflow.org/tensorboard) log directory. Will default to"
-            " *output_dir/runs/**CURRENT_DATETIME_HOSTNAME***."
-        ),
-    )
-    parser.add_argument(
         "--logging_steps",
         type=int,
         default=100,

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -1064,7 +1064,7 @@ def main():
         for step, batch in enumerate(train_dataloader):
             if args.profile_steps and step == 0:
                 jax.profiler.start_trace(args.output_dir)
-            elif args.profile_steps == step:
+            if args.profile_steps and args.profile_steps == step:
                 jax.profiler.stop_trace()
 
             batch = shard(batch)

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -217,6 +217,17 @@ def parse_args():
         help="Load the pretrained model from a PyTorch checkpoint.",
     )
     parser.add_argument(
+        "--controlnet_revision",
+        type=str,
+        default=None,
+        help="Revision of controlnet model identifier from huggingface.co/models.",
+    )
+    parser.add_argument(
+        "--controlnet_from_pt",
+        action="store_true",
+        help="Load the controlnet model from a PyTorch checkpoint.",
+    )
+    parser.add_argument(
         "--profile_steps",
         type=int,
         default=0,

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -1086,6 +1086,8 @@ def main():
                 ignore_patterns=["step_*", "epoch_*"],
             )
 
+    logger.info("Finished training.")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -1042,6 +1042,7 @@ def main():
     )
     if args.profile_memory:
         jax.profiler.save_device_memory_profile(os.path.join(args.output_dir, "memory_initial.prof"))
+    t00 = time.monotonic()
     for epoch in epochs:
         # ======================== Training ================================
 
@@ -1092,6 +1093,7 @@ def main():
                     train_metrics = jax.tree_util.tree_map(lambda *m: jnp.array(m).mean(), *train_metrics)
                     wandb.log(
                         {
+                            "walltime": time.monotonic() - t00,
                             "train/step": global_step,
                             "train/epoch": epoch + (step + 1) / dataset_length,
                             "train/steps_per_sec": (step - step0) / (time.monotonic() - t0),

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -222,11 +222,6 @@ def parse_args():
         help="Revision of controlnet model identifier from huggingface.co/models.",
     )
     parser.add_argument(
-        "--controlnet_from_pt",
-        action="store_true",
-        help="Load the controlnet model from a PyTorch checkpoint.",
-    )
-    parser.add_argument(
         "--profile_steps",
         type=int,
         default=0,
@@ -247,12 +242,6 @@ def parse_args():
         type=str,
         default=None,
         help="Enables compilation cache.",
-    )
-    parser.add_argument(
-        "--controlnet_revision",
-        type=str,
-        default=None,
-        help="Revision of controlnet model identifier from huggingface.co/models.",
     )
     parser.add_argument(
         "--controlnet_from_pt",

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import time
 
 import jax
+import jax.experimental.compilation_cache.compilation_cache as cc
 import jax.numpy as jnp
 import numpy as np
 import optax
@@ -230,6 +231,12 @@ def parse_args():
         "--profile_memory",
         action="store_true",
         help="Whether to dump an initial (before training loop) and a final (at program end) memory profile.",
+    )
+    parser.add_argument(
+        "--ccache",
+        type=str,
+        default=None,
+        help="Enables compilation cache.",
     )
     parser.add_argument(
         "--controlnet_revision",
@@ -1011,6 +1018,9 @@ def main():
                 "controlnet_params": sum(np.prod(x.shape) for x in jax.tree_util.tree_leaves(state.params)),
             }
         )
+
+    if args.ccache:
+        cc.initialize_cache(args.ccache)
 
     global_step = 0
     epochs = tqdm(

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -18,8 +18,8 @@ import logging
 import math
 import os
 import random
-from pathlib import Path
 import time
+from pathlib import Path
 
 import jax
 import jax.experimental.compilation_cache.compilation_cache as cc
@@ -486,9 +486,7 @@ def parse_args():
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
 
     args = parser.parse_args()
-    args.output_dir = args.output_dir.replace(
-        '{timestamp}', time.strftime('%Y%m%d_%H%M%S')
-    )
+    args.output_dir = args.output_dir.replace("{timestamp}", time.strftime("%Y%m%d_%H%M%S"))
 
     env_local_rank = int(os.environ.get("LOCAL_RANK", -1))
     if env_local_rank != -1 and env_local_rank != args.local_rank:
@@ -982,8 +980,8 @@ def main():
 
         metrics = {"loss": loss}
         metrics = jax.lax.pmean(metrics, axis_name="batch")
-        l2 = lambda xs: jnp.sqrt(sum([
-            jnp.vdot(x, x) for x in jax.tree_util.tree_leaves(xs)]))
+        def l2(xs):
+            return jnp.sqrt(sum([jnp.vdot(x, x) for x in jax.tree_util.tree_leaves(xs)]))
         metrics["l2_grads"] = l2(jax.tree_util.tree_leaves(grad))
 
         return new_state, metrics, new_train_rng

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -1047,9 +1047,12 @@ def main():
         )
         # train
         for batch in train_dataloader:
-            if args.profile_steps and global_step == 0:
+
+            if args.profile_steps and global_step == 1:
+                train_metric['loss'].block_until_ready()
                 jax.profiler.start_trace(args.output_dir)
-            if args.profile_steps and args.profile_steps == global_step:
+            if args.profile_steps and global_step == 1 + args.profile_steps:
+                train_metric['loss'].block_until_ready()
                 jax.profiler.stop_trace()
 
             batch = shard(batch)

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -1093,7 +1093,7 @@ def main():
                     wandb.log(
                         {
                             "train/step": global_step,
-                            "train/epoch": epoch,
+                            "train/epoch": epoch + (step + 1) / dataset_length,
                             "train/steps_per_sec": (step - step0) / (time.monotonic() - t0),
                             **{f"train/{k}": v for k, v in train_metrics.items()},
                         }

--- a/examples/controlnet/train_controlnet_flax.py
+++ b/examples/controlnet/train_controlnet_flax.py
@@ -979,8 +979,10 @@ def main():
 
         metrics = {"loss": loss}
         metrics = jax.lax.pmean(metrics, axis_name="batch")
+
         def l2(xs):
             return jnp.sqrt(sum([jnp.vdot(x, x) for x in jax.tree_util.tree_leaves(xs)]))
+
         metrics["l2_grads"] = l2(jax.tree_util.tree_leaves(grad))
 
         return new_state, metrics, new_train_rng


### PR DESCRIPTION
List of small changes accumulated over the weekend:

1. Added profiling flags `--profile_steps`, `--profile_validation`, and `--profile_memory`, removed unused `--logging_dir`. Updated `--output_dir` to default to `runs/{timestamp}`.
1. Updated commands in README to store model in `runs/` subdirectory with timestamp, so they ignored by Git (`runs/` is in `.gitignore`), and multiple runs land automatically in different directories. Also setting `--tracker_project_name=$HUB_MODEL_ID`, and mention dataset for both commands to avoid mixing up different dataset runs in the same `wandb` project.
1. Changed `--num_train_epochs=11` for the `fusing/fill50k` dataset, since I noticed that models don't actually converge before this many epochs (see runs with different number of epochs here: https://wandb.ai/andsteing/controlnet-fill-circle ). Also set `--max_train_samples 100000` for the second commands, since that's what is recommended in the linked Blog article https://huggingface.co/blog/train-your-controlnet
1. Added `l2_grads` metric for logging the L2 norm of gradients.
1. The `train/step` metric, which is used as the X coordinate for other metrics, now uses the added (relative) `walltime` metric as its X coordinate. This allows to quickly read out the run time in the metric view of `wandb`.
1. Added `train/steps_per_sec` metric.
1. Bugfix computation `train_metrics`: Before this PR, the latest `train_metric` was reported, which resulted in a very high variance in e.g. the reported `loss`. Now, the average of the `train_metrics` since the last logging is reported.
1. The metric `epoch` is now fractional. This allows e.g. for plotting of metrics when experimenting with different batch sizes.

Latest runs:

- `--dataset_name=fusing/fill50k`: https://wandb.ai/andsteing/controlnet-fill-circle_bs
- `--dataset_name=multimodalart/facesyntheticsspigacaptioned`: https://wandb.ai/andsteing/controlnet-uncanny-faces