### PR TITLE
Fix typo in textual inversion JAX training script

### DIFF
--- a/docs/source/en/training/text_inversion.mdx
+++ b/docs/source/en/training/text_inversion.mdx
@@ -220,7 +220,7 @@ from flax.training.common_utils import shard
 from diffusers import FlaxStableDiffusionPipeline
 
 model_path = "path-to-your-trained-model"
-pipe, params = FlaxStableDiffusionPipeline.from_pretrained(model_path, dtype=jax.numpy.bfloat16)
+pipeline, params = FlaxStableDiffusionPipeline.from_pretrained(model_path, dtype=jax.numpy.bfloat16)
 
 prompt = "A <cat-toy> backpack"
 prng_seed = jax.random.PRNGKey(0)


### PR DESCRIPTION
The pipeline is built as `pipe` but then used as `pipeline`.