### PR TITLE
Improve deprecation warnings

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -201,24 +201,24 @@ def variant_compatible_siblings(filenames, variant=None) -> Union[List[os.PathLi
     # .bin, .safetensors, ...
     weight_suffixs = [w.split(".")[-1] for w in weight_names]
     # -00001-of-00002
-    transformers_index_format = "\d{5}-of-\d{5}"
+    transformers_index_format = r"\d{5}-of-\d{5}"
 
     if variant is not None:
         # `diffusion_pytorch_model.fp16.bin` as well as `model.fp16-00001-of-00002.safetenstors`
         variant_file_re = re.compile(
-            f"({'|'.join(weight_prefixes)})\.({variant}|{variant}-{transformers_index_format})\.({'|'.join(weight_suffixs)})$"
+            rf"({'|'.join(weight_prefixes)})\.({variant}|{variant}-{transformers_index_format})\.({'|'.join(weight_suffixs)})$"
         )
         # `text_encoder/pytorch_model.bin.index.fp16.json`
         variant_index_re = re.compile(
-            f"({'|'.join(weight_prefixes)})\.({'|'.join(weight_suffixs)})\.index\.{variant}\.json$"
+            rf"({'|'.join(weight_prefixes)})\.({'|'.join(weight_suffixs)})\.index\.{variant}\.json$"
         )
 
     # `diffusion_pytorch_model.bin` as well as `model-00001-of-00002.safetenstors`
     non_variant_file_re = re.compile(
-        f"({'|'.join(weight_prefixes)})(-{transformers_index_format})?\.({'|'.join(weight_suffixs)})$"
+        rf"({'|'.join(weight_prefixes)})(-{transformers_index_format})?\.({'|'.join(weight_suffixs)})$"
     )
     # `text_encoder/pytorch_model.bin.index.json`
-    non_variant_index_re = re.compile(f"({'|'.join(weight_prefixes)})\.({'|'.join(weight_suffixs)})\.index\.json")
+    non_variant_index_re = re.compile(rf"({'|'.join(weight_prefixes)})\.({'|'.join(weight_suffixs)})\.index\.json")
 
     if variant is not None:
         variant_weights = {f for f in filenames if variant_file_re.match(f.split("/")[-1]) is not None}

--- a/tests/models/test_lora_layers.py
+++ b/tests/models/test_lora_layers.py
@@ -71,6 +71,7 @@ class LoraLoaderMixinTests(unittest.TestCase):
             beta_schedule="scaled_linear",
             clip_sample=False,
             set_alpha_to_one=False,
+            steps_offset=1,
         )
         torch.manual_seed(0)
         vae = AutoencoderKL(


### PR DESCRIPTION
Fixing the following deprecation warnings:

```
                                                                                                                                        
src/diffusers/pipelines/pipeline_utils.py:204                                                                                          
  /home/patrick/diffusers/src/diffusers/pipelines/pipeline_utils.py:204: DeprecationWarning: invalid escape sequence '\d'               
    transformers_index_format = "\d{5}-of-\d{5}"                                                                                                                                                                                                                                
                                                                                                                                       
src/diffusers/pipelines/pipeline_utils.py:209                                                                                          
src/diffusers/pipelines/pipeline_utils.py:209                                                                                          
  /home/patrick/diffusers/src/diffusers/pipelines/pipeline_utils.py:209: DeprecationWarning: invalid escape sequence '\.'               
    f"({'|'.join(weight_prefixes)})\.({variant}|{variant}-{transformers_index_format})\.({'|'.join(weight_suffixs)})$"                  
                                                                                                                                                                                                                                                                                
src/diffusers/pipelines/pipeline_utils.py:213                                                                                          
src/diffusers/pipelines/pipeline_utils.py:213                      
src/diffusers/pipelines/pipeline_utils.py:213                                                                                          
  /home/patrick/diffusers/src/diffusers/pipelines/pipeline_utils.py:213: DeprecationWarning: invalid escape sequence '\.'                                                                                                                                                       
    f"({'|'.join(weight_prefixes)})\.({'|'.join(weight_suffixs)})\.index\.{variant}\.json$"                                            
                                                                                                                                       
src/diffusers/pipelines/pipeline_utils.py:218                       
  /home/patrick/diffusers/src/diffusers/pipelines/pipeline_utils.py:218: DeprecationWarning: invalid escape sequence '\.'              
    f"({'|'.join(weight_prefixes)})(-{transformers_index_format})?\.({'|'.join(weight_suffixs)})$"                                     
                                                                                                                                       
src/diffusers/pipelines/pipeline_utils.py:221                                                                                                                                                                                                                                   
src/diffusers/pipelines/pipeline_utils.py:221                                                                                           
  /home/patrick/diffusers/src/diffusers/pipelines/pipeline_utils.py:221: DeprecationWarning: invalid escape sequence '\.'               
    non_variant_index_re = re.compile(f"({'|'.join(weight_prefixes)})\.({'|'.join(weight_suffixs)})\.index\.json")  
```