### PR TITLE
fix mixed precision training on train_dreambooth_inpaint_lora

### DIFF
--- a/examples/research_projects/dreambooth_inpaint/train_dreambooth_inpaint_lora.py
+++ b/examples/research_projects/dreambooth_inpaint/train_dreambooth_inpaint_lora.py
@@ -735,7 +735,7 @@ def main():
                         torch.nn.functional.interpolate(mask, size=(args.resolution // 8, args.resolution // 8))
                         for mask in masks
                     ]
-                )
+                ).to(dtype=weight_dtype)
                 mask = mask.reshape(-1, 1, args.resolution // 8, args.resolution // 8)
 
                 # Sample noise that we'll add to the latents


### PR DESCRIPTION
at the moment, If we select --mixed_precision on this script we get an error of mixing floats and half.
This cast fixes it