### PR TITLE
Add `Karras sigmas` to HeunDiscreteScheduler

### DIFF
--- a/tests/schedulers/test_scheduler_heun.py
+++ b/tests/schedulers/test_scheduler_heun.py
@@ -129,3 +129,28 @@ class HeunDiscreteSchedulerTest(SchedulerCommonTest):
             # CUDA
             assert abs(result_sum.item() - 0.1233) < 1e-2
             assert abs(result_mean.item() - 0.0002) < 1e-3
+
+    def test_full_loop_device_karras_sigmas(self):
+        scheduler_class = self.scheduler_classes[0]
+        scheduler_config = self.get_scheduler_config()
+        scheduler = scheduler_class(**scheduler_config, use_karras_sigmas=True)
+
+        scheduler.set_timesteps(self.num_inference_steps, device=torch_device)
+
+        model = self.dummy_model()
+        sample = self.dummy_sample_deter * scheduler.init_noise_sigma
+        sample = sample.to(torch_device)
+
+        for t in scheduler.timesteps:
+            sample = scheduler.scale_model_input(sample, t)
+
+            model_output = model(sample, t)
+
+            output = scheduler.step(model_output, t, sample)
+            sample = output.prev_sample
+
+        result_sum = torch.sum(torch.abs(sample))
+        result_mean = torch.mean(torch.abs(sample))
+
+        assert abs(result_sum.item() - 0.00015) < 1e-2
+        assert abs(result_mean.item() - 1.9869554535034695e-07) < 1e-2

--- a/tests/schedulers/test_scheduler_heun.py
+++ b/tests/schedulers/test_scheduler_heun.py
@@ -138,7 +138,7 @@ class HeunDiscreteSchedulerTest(SchedulerCommonTest):
         scheduler.set_timesteps(self.num_inference_steps, device=torch_device)
 
         model = self.dummy_model()
-        sample = self.dummy_sample_deter * scheduler.init_noise_sigma
+        sample = self.dummy_sample_deter.to(torch_device) * scheduler.init_noise_sigma
         sample = sample.to(torch_device)
 
         for t in scheduler.timesteps:


### PR DESCRIPTION
Discussion: #2905 #2064 

This pull request allows for the utilization of karras_sigmas in the Heun Discrete scheduler and builds upon the valuable contributions made in PR #2956. This update introduces two key components:

- The inclusion of karras-based sigma.
- The mapping of sigmas to the timestamp, which will be used as input for UNET.

**Heun Discrete Test**

```python
from diffusers import StableDiffusionPipeline, HeunDiscreteScheduler
import torch 

seed = 33

pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4")
pipe = pipe.to("cpu")
pipe.scheduler = HeunDiscreteScheduler.from_config(pipe.scheduler.config, use_karras_sigmas=True)

prompt = "an astronaut riding a horse on mars"

generator = torch.Generator(device="cpu").manual_seed(seed)
image = pipe(prompt, generator=generator, num_inference_steps=20).images[0]

display(image)
```

![without_k](https://user-images.githubusercontent.com/104783077/233239683-fcecc263-56c5-4dac-a9fb-2a34b2d9735e.png)

**Compared with KDiffusion - sample_heun**

```python
import torch
from diffusers import StableDiffusionKDiffusionPipeline

seed = 33

pipe = StableDiffusionKDiffusionPipeline.from_pretrained('CompVis/stable-diffusion-v1-4').to('cpu')
pipe.set_scheduler('sample_heun')

prompt = "an astronaut riding a horse on mars"

generator = torch.Generator(device="cpu").manual_seed(seed)
image = pipe(prompt, generator=generator, num_inference_steps=20, use_karras_sigmas=True).images[0]

display(image)
```

![with_k](https://user-images.githubusercontent.com/104783077/233239642-e7c9df50-bca8-42ac-98bb-a4845a60ca59.png)