### PR TITLE
flax from_pretrained: allow passing in rng key

### DIFF
--- a/src/diffusers/models/modeling_flax_utils.py
+++ b/src/diffusers/models/modeling_flax_utils.py
@@ -197,6 +197,7 @@ class FlaxModelMixin:
         cls,
         pretrained_model_name_or_path: Union[str, os.PathLike],
         dtype: jnp.dtype = jnp.float32,
+        rng: jax.random.KeyArray = jax.random.PRNGKey(0),
         *model_args,
         **kwargs,
     ):
@@ -432,7 +433,7 @@ class FlaxModelMixin:
         # flatten dicts
         state = flatten_dict(state)
 
-        params_shape_tree = jax.eval_shape(model.init_weights, rng=jax.random.PRNGKey(0))
+        params_shape_tree = jax.eval_shape(model.init_weights, rng=rng)
         required_params = set(flatten_dict(unfreeze(params_shape_tree)).keys())
 
         shape_state = flatten_dict(unfreeze(params_shape_tree))


### PR DESCRIPTION
This allows users to set the random seed for initializing model weights when loading models that do not include weights for every layer.

This is necessary for determinism when expanding existing models to run downstream fine tuning or transfer learning.

The alternative would be replicating large parts of code in `from_pretrained` in user code.