### PR TITLE
[AudioLDM] Fix dtype of returned waveform

### DIFF
--- a/src/diffusers/pipelines/audioldm/pipeline_audioldm.py
+++ b/src/diffusers/pipelines/audioldm/pipeline_audioldm.py
@@ -293,7 +293,7 @@ class AudioLDMPipeline(DiffusionPipeline):
 
         waveform = self.vocoder(mel_spectrogram)
         # we always cast to float32 as this does not cause significant overhead and is compatible with bfloat16
-        waveform = waveform.cpu()
+        waveform = waveform.cpu().float()
         return waveform
 
     # Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.StableDiffusionPipeline.prepare_extra_step_kwargs


### PR DESCRIPTION
Fixes #3091 by always upcasting float16/bfloat16 waveforms to float32, as we do in stable diffusion with the output images:
https://github.com/huggingface/diffusers/blob/3045fb276352681f6b9075956e599dd8ef571872/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L446
