### PR TITLE
Fix controlnet performance bugs caused by inplace operation

### DIFF
--- a/src/diffusers/models/unet_2d_condition.py
+++ b/src/diffusers/models/unet_2d_condition.py
@@ -739,8 +739,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
             for down_block_res_sample, down_block_additional_residual in zip(
                 down_block_res_samples, down_block_additional_residuals
             ):
-                down_block_res_sample = down_block_res_sample + down_block_additional_residual
-                new_down_block_res_samples += (down_block_res_sample,)
+                new_down_block_res_samples += (down_block_res_sample + down_block_additional_residual,)
 
             down_block_res_samples = new_down_block_res_samples
 


### PR DESCRIPTION
```UNet2DConditionModel``` uses the inplace operation to add the output of controlnet to the output of down blocks before the ```mid_block ``` forward.

```python
if down_block_additional_residuals is not None:
    new_down_block_res_samples = ()
    for down_block_res_sample, down_block_additional_residual in zip(
        down_block_res_samples, down_block_additional_residuals
    ):
        down_block_res_sample = down_block_res_sample + down_block_additional_residual
        new_down_block_res_samples += (down_block_res_sample,)
    down_block_res_samples = new_down_block_res_samples

# 4. mid
if self.mid_block is not None:
    sample = self.mid_block(
        sample,
        emb,
        encoder_hidden_states=encoder_hidden_states,
        attention_mask=attention_mask,
        cross_attention_kwargs=cross_attention_kwargs,
    )
```

However, the last element of ```down_block_res_sample``` and the input of ```mid_block``` are the same tensor! So the output of controlnet is also wrongly added to the ```sample``` input to ```mid_block```. The inplace operation should not be used here.