### PR TITLE
[controlnet training] resize and same channels all logged images before `np.stack`

### DIFF
--- a/examples/controlnet/train_controlnet.py
+++ b/examples/controlnet/train_controlnet.py
@@ -139,12 +139,22 @@ def log_validation(vae, text_encoder, tokenizer, unet, controlnet, args, acceler
                 validation_prompt = log["validation_prompt"]
                 validation_image = log["validation_image"]
 
+                # incase there are minor discrepancies in the dimensions of the conditioning
+                # image and the generated images, resize the conditioning images.
+                height = validation_image.height
+                width = validation_image.width
+
                 formatted_images = []
 
-                formatted_images.append(np.asarray(validation_image))
+                validation_image = validation_image.convert("RGB")
+                validation_image = np.asarray(validation_image)
+                formatted_images.append(validation_image)
 
                 for image in images:
-                    formatted_images.append(np.asarray(image))
+                    image = image.convert("RGB")
+                    image = image.resize((height, width))
+                    image = np.asarray(image)
+                    formatted_images.append(image)
 
                 formatted_images = np.stack(formatted_images)
 


### PR DESCRIPTION
re: https://github.com/huggingface/diffusers/issues/2695

In all honesty, I'm not sure _how_ the outputs end up being differently sized that the input conditioning. I guess it is possible given that the conditioning has a separate encoder than the vae which can result in slightly different dimensions of the outputs. 

This is small enough that I think we should just resize the outputs to the size of the conditioning

Note: also added the channel conversion which makes more sense as to why np.stack would throw