### PR TITLE
Remove required from tracker_project_name

### DIFF
--- a/examples/controlnet/train_controlnet.py
+++ b/examples/controlnet/train_controlnet.py
@@ -536,7 +536,6 @@ def parse_args(input_args=None):
         "--tracker_project_name",
         type=str,
         default="train_controlnet",
-        required=True,
         help=(
             "The `project_name` argument passed to Accelerator.init_trackers for"
             " more information see https://huggingface.co/docs/accelerate/v0.17.0/en/package_reference/accelerator#accelerate.Accelerator"


### PR DESCRIPTION
A small thing, but as observed by @off99555 in https://github.com/huggingface/diffusers/issues/2695#issuecomment-1470755050, that argument already has a default value. I experienced the same thing when testing controlnet and it was mildly annoying.