### PR TITLE
Update pipeline_flax_stable_diffusion_controlnet.py

### DIFF
--- a/src/diffusers/pipelines/controlnet/pipeline_flax_controlnet.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_flax_controlnet.py
@@ -464,7 +464,7 @@ class FlaxStableDiffusionControlNetPipeline(FlaxDiffusionPipeline):
 
             images_uint8_casted = np.asarray(images_uint8_casted).reshape(num_devices * batch_size, height, width, 3)
             images_uint8_casted, has_nsfw_concept = self._run_safety_checker(images_uint8_casted, safety_params, jit)
-            images = np.asarray(images)
+            images = np.array(images)
 
             # block images
             if any(has_nsfw_concept):


### PR DESCRIPTION
np.asarray makes a read-only copy of a jax array. This then breaks at line 473 if a nsfw image is detected