### PR TITLE
Fix multistep dpmsolver for cosine schedule (suitable for deepfloyd-if)

### DIFF
--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -118,6 +118,13 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
              This parameter controls whether to use Karras sigmas (Karras et al. (2022) scheme) for step sizes in the
              noise schedule during the sampling process. If True, the sigmas will be determined according to a sequence
              of noise levels {σi} as defined in Equation (5) of the paper https://arxiv.org/pdf/2206.00364.pdf.
+        lambda_min_clipped (`float`, default `-5.1`):
+            the clipping threshold for the minimum value of lambda(t) for numerical stability. This is critical for
+            cosine (squaredcos_cap_v2) noise schedule.
+        is_predicting_variance (`bool`, default `False`):
+            whether the model's output contains the predicted Gaussian variance. For example, OpenAI's guided-diffusion
+            (https://github.com/openai/guided-diffusion) predicts both mean and variance of the Gaussian distribution
+            in the model's output. DPM-Solver only needs the "mean" output because it is based on diffusion ODEs.
     """
 
     _compatibles = [e.name for e in KarrasDiffusionSchedulers]
@@ -140,6 +147,8 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
         solver_type: str = "midpoint",
         lower_order_final: bool = True,
         use_karras_sigmas: Optional[bool] = False,
+        lambda_min_clipped: float = -5.1,
+        is_predicting_variance: bool = False,
     ):
         if trained_betas is not None:
             self.betas = torch.tensor(trained_betas, dtype=torch.float32)
@@ -187,7 +196,7 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
         self.lower_order_nums = 0
         self.use_karras_sigmas = use_karras_sigmas
 
-    def set_timesteps(self, num_inference_steps: int, device: Union[str, torch.device] = None):
+    def set_timesteps(self, num_inference_steps: int = None, device: Union[str, torch.device] = None):
         """
         Sets the timesteps used for the diffusion chain. Supporting function to be run before inference.
 
@@ -197,8 +206,11 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
             device (`str` or `torch.device`, optional):
                 the device to which the timesteps should be moved to. If `None`, the timesteps are not moved.
         """
+        # Clipping the minimum of all lambda(t) for numerical stability.
+        # This is critical for cosine (squaredcos_cap_v2) noise schedule.
+        clipped_idx = torch.searchsorted(torch.flip(self.lambda_t, [0]), self.lambda_min_clipped)
         timesteps = (
-            np.linspace(0, self.config.num_train_timesteps - 1, num_inference_steps + 1)
+            np.linspace(0, self.config.num_train_timesteps - 1 - clipped_idx, num_inference_steps + 1)
             .round()[::-1][:-1]
             .copy()
             .astype(np.int64)
@@ -320,6 +332,11 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
         Returns:
             `torch.FloatTensor`: the converted model output.
         """
+
+        # DPM-Solver and DPM-Solver++ only need the "mean" output.
+        if self.is_predicting_variance:
+            model_output = model_output[:, :3]
+
         # DPM-Solver++ needs to solve an integral of the data prediction model.
         if self.config.algorithm_type == "dpmsolver++":
             if self.config.prediction_type == "epsilon":


### PR DESCRIPTION
https://github.com/deep-floyd/IF/issues/38

The cosine noise schedule has numerical issues for t near to 1000. We can just clip the lambda(t) to make dpm-solver suitable for cosine schedules (which does not affect other noise schedules).

In addition, deepfloyd-if's model output contains both mean and variance, and we only need the first three channels for ODE solvers.

In my own experience, dpm-solver can greatly reduce the inference steps of deepfloyd-if:

1. For both stage-2 and stage-3 (upscaling), I find that the 25-step DPM-Solver++ can strictly converge. And the results are quite good even for 15 steps. Overall, I recommend for 25 step for all settings.

2. For stage-1, we can apply either 100-step DDPM (the default setting) or 50-step DPM-Solver++. The average results between them are quite similar and both are very nice.

Therefore, I recommend the following setting for faster inference of deepfloyd-if with a quite excellent performance: 

1. 50-step stage1 with DPM-Solver++, 25-step stage-2 and 25-step stage-3 with DPM-Solver++.

2. 100-step stage1 with DDPM, 25-step stage-2 and 25-step stage-3 with DPM-Solver++.
