### PR TITLE
Fix missing variable assign in DeepFloyd-IF-II

### DIFF
--- a/src/diffusers/pipelines/deepfloyd_if/pipeline_if_superresolution.py
+++ b/src/diffusers/pipelines/deepfloyd_if/pipeline_if_superresolution.py
@@ -667,7 +667,7 @@ class IFSuperResolutionPipeline(DiffusionPipeline):
             image = [np.array(i).astype(np.float32) / 255.0 for i in image]
 
             image = np.stack(image, axis=0)  # to np
-            torch.from_numpy(image.transpose(0, 3, 1, 2))
+            image = torch.from_numpy(image.transpose(0, 3, 1, 2))
         elif isinstance(image[0], np.ndarray):
             image = np.stack(image, axis=0)  # to np
             if image.ndim == 5:


### PR DESCRIPTION
I came across a bug when trying to send a PIL image into DeepFloyd-IF-II. It appears that when `torch.from_numpy()` is called, it doesn't get assigned. so i added that.

This PR fixes Running DeepFloyd-IF-II on a PIL image.

Without this PR, you would get `AttributeError: 'numpy.ndarray' object has no attribute 'to'`