### PR TITLE
[docs] Improve safetensors docstring

### DIFF
--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1205,10 +1205,10 @@ class FromCkptMixin:
                 The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
                 git-based system for storing models and other artifacts on huggingface.co, so `revision` can be any
                 identifier allowed by git.
-            use_safetensors (`bool`, *optional* ):
-                If set to `True`, the pipeline will be loaded from `safetensors` weights. If set to `None` (the
-                default). The pipeline will load using `safetensors` if the safetensors weights are available *and* if
-                `safetensors` is installed. If the to `False` the pipeline will *not* use `safetensors`.
+            use_safetensors (`bool`, *optional*, defaults to `None`):
+                If set to `None`, the pipeline will load the `safetensors` weights if they're availabe **and** if the
+                `safetensors` library is installed. If set to `True`, the pipeline will forcibly load the models from
+                `safetensors` weights. If the to `False` the pipeline will *not* use `safetensors`.
             extract_ema (`bool`, *optional*, defaults to `False`): Only relevant for
                 checkpoints that have both EMA and non-EMA weights. Whether to extract the EMA weights or not. Defaults
                 to `False`. Pass `True` to extract the EMA weights. EMA weights usually yield higher quality images for

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1208,7 +1208,7 @@ class FromCkptMixin:
             use_safetensors (`bool`, *optional*, defaults to `None`):
                 If set to `None`, the pipeline will load the `safetensors` weights if they're availabe **and** if the
                 `safetensors` library is installed. If set to `True`, the pipeline will forcibly load the models from
-                `safetensors` weights. If the to `False` the pipeline will *not* use `safetensors`.
+                `safetensors` weights. If set to `False` the pipeline will *not* use `safetensors`.
             extract_ema (`bool`, *optional*, defaults to `False`): Only relevant for
                 checkpoints that have both EMA and non-EMA weights. Whether to extract the EMA weights or not. Defaults
                 to `False`. Pass `True` to extract the EMA weights. EMA weights usually yield higher quality images for

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1206,7 +1206,7 @@ class FromCkptMixin:
                 git-based system for storing models and other artifacts on huggingface.co, so `revision` can be any
                 identifier allowed by git.
             use_safetensors (`bool`, *optional*, defaults to `None`):
-                If set to `None`, the pipeline will load the `safetensors` weights if they're availabe **and** if the
+                If set to `None`, the pipeline will load the `safetensors` weights if they're available **and** if the
                 `safetensors` library is installed. If set to `True`, the pipeline will forcibly load the models from
                 `safetensors` weights. If set to `False` the pipeline will *not* use `safetensors`.
             extract_ema (`bool`, *optional*, defaults to `False`): Only relevant for

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -407,9 +407,9 @@ class ModelMixin(torch.nn.Module):
                 If specified load weights from `variant` filename, *e.g.* pytorch_model.<variant>.bin. `variant` is
                 ignored when using `from_flax`.
             use_safetensors (`bool`, *optional*, defaults to `None`):
-                If set to `None`, the pipeline will load the `safetensors` weights if they're availabe **and** if the
-                `safetensors` library is installed. If set to `True`, the pipeline will forcibly load the models from
-                `safetensors` weights. If set to `False` the pipeline will *not* use `safetensors`.
+                If set to `None`, the `safetensors` weights will be downloaded if they're available **and** if the
+                `safetensors` library is installed. If set to `True`, the model will be forcibly loaded from
+                `safetensors` weights. If set to `False`, loading will *not* use `safetensors`.
 
         <Tip>
 

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -409,7 +409,7 @@ class ModelMixin(torch.nn.Module):
             use_safetensors (`bool`, *optional*, defaults to `None`):
                 If set to `None`, the pipeline will load the `safetensors` weights if they're availabe **and** if the
                 `safetensors` library is installed. If set to `True`, the pipeline will forcibly load the models from
-                `safetensors` weights. If the to `False` the pipeline will *not* use `safetensors`.
+                `safetensors` weights. If set to `False` the pipeline will *not* use `safetensors`.
 
         <Tip>
 

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -406,10 +406,10 @@ class ModelMixin(torch.nn.Module):
             variant (`str`, *optional*):
                 If specified load weights from `variant` filename, *e.g.* pytorch_model.<variant>.bin. `variant` is
                 ignored when using `from_flax`.
-            use_safetensors (`bool`, *optional* ):
-                If set to `True`, the pipeline will forcibly load the models from `safetensors` weights. If set to
-                `None` (the default). The pipeline will load using `safetensors` if safetensors weights are available
-                *and* if `safetensors` is installed. If the to `False` the pipeline will *not* use `safetensors`.
+            use_safetensors (`bool`, *optional*, defaults to `None`):
+                If set to `None`, the pipeline will load the `safetensors` weights if they're availabe **and** if the
+                `safetensors` library is installed. If set to `True`, the pipeline will forcibly load the models from
+                `safetensors` weights. If the to `False` the pipeline will *not* use `safetensors`.
 
         <Tip>
 

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -817,7 +817,7 @@ class DiffusionPipeline(ConfigMixin):
             use_safetensors (`bool`, *optional*, defaults to `None`):
                 If set to `None`, the pipeline will load the `safetensors` weights if they're availabe **and** if the
                 `safetensors` library is installed. If set to `True`, the pipeline will forcibly load the models from
-                `safetensors` weights. If the to `False` the pipeline will *not* use `safetensors`.
+                `safetensors` weights. If set to `False` the pipeline will *not* use `safetensors`.
             kwargs (remaining dictionary of keyword arguments, *optional*):
                 Can be used to overwrite load - and saveable variables - *i.e.* the pipeline components - of the
                 specific pipeline class. The overwritten components are then directly passed to the pipelines

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -815,7 +815,7 @@ class DiffusionPipeline(ConfigMixin):
                 model. This is only supported when torch version >= 1.9.0. If you are using an older version of torch,
                 setting this argument to `True` will raise an error.
             use_safetensors (`bool`, *optional*, defaults to `None`):
-                If set to `None`, the pipeline will load the `safetensors` weights if they're availabe **and** if the
+                If set to `None`, the pipeline will load the `safetensors` weights if they're available **and** if the
                 `safetensors` library is installed. If set to `True`, the pipeline will forcibly load the models from
                 `safetensors` weights. If set to `False` the pipeline will *not* use `safetensors`.
             kwargs (remaining dictionary of keyword arguments, *optional*):

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -814,10 +814,10 @@ class DiffusionPipeline(ConfigMixin):
                 also tries to not use more than 1x model size in CPU memory (including peak memory) while loading the
                 model. This is only supported when torch version >= 1.9.0. If you are using an older version of torch,
                 setting this argument to `True` will raise an error.
-            use_safetensors (`bool`, *optional* ):
-                If set to `True`, the pipeline will be loaded from `safetensors` weights. If set to `None` (the
-                default). The pipeline will load using `safetensors` if the safetensors weights are available *and* if
-                `safetensors` is installed. If the to `False` the pipeline will *not* use `safetensors`.
+            use_safetensors (`bool`, *optional*, defaults to `None`):
+                If set to `None`, the pipeline will load the `safetensors` weights if they're availabe **and** if the
+                `safetensors` library is installed. If set to `True`, the pipeline will forcibly load the models from
+                `safetensors` weights. If the to `False` the pipeline will *not* use `safetensors`.
             kwargs (remaining dictionary of keyword arguments, *optional*):
                 Can be used to overwrite load - and saveable variables - *i.e.* the pipeline components - of the
                 specific pipeline class. The overwritten components are then directly passed to the pipelines


### PR DESCRIPTION
Improves the `use_safetensors` docstring to make it clearer by leading with the default (`None`) and what it means.