### PR TITLE
fix tiled vae blend extent range

### DIFF
--- a/src/diffusers/models/autoencoder_kl.py
+++ b/src/diffusers/models/autoencoder_kl.py
@@ -196,12 +196,14 @@ class AutoencoderKL(ModelMixin, ConfigMixin):
         return DecoderOutput(sample=decoded)
 
     def blend_v(self, a, b, blend_extent):
-        for y in range(min(a.shape[2], b.shape[2], blend_extent)):
+        blend_extent = min(a.shape[2], b.shape[2], blend_extent)
+        for y in range(blend_extent):
             b[:, :, y, :] = a[:, :, -blend_extent + y, :] * (1 - y / blend_extent) + b[:, :, y, :] * (y / blend_extent)
         return b
 
     def blend_h(self, a, b, blend_extent):
-        for x in range(min(a.shape[3], b.shape[3], blend_extent)):
+        blend_extent = min(a.shape[3], b.shape[3], blend_extent)
+        for x in range(blend_extent):
             b[:, :, :, x] = a[:, :, :, -blend_extent + x] * (1 - x / blend_extent) + b[:, :, :, x] * (x / blend_extent)
         return b
 


### PR DESCRIPTION
This PR addresses bad tiled blending in the tiled vae due to the forced blend extent range from ([#2660](https://github.com/huggingface/diffusers/pull/2660)).

Although the fixed range for tiled vae blend from ([#2660](https://github.com/huggingface/diffusers/pull/2660)) prevents out-of-bounds indexing, it causes issues with bad tile blending with certain resolution, such as 768x468, as shown in the bottom of the image below:

![tiled_vae_failure_case](https://github.com/huggingface/diffusers/assets/133080491/6c1ac840-ff77-496e-acdb-9a763def5c2e)

This issue arose when the tile blend range changed to minimal tile dimension while the blend process still started from `blend_extent`.

To resolve this, this PR updates `blend_extent` to match the blend range from `min(...)`, which addresses the problem as follows:

![fixed](https://github.com/huggingface/diffusers/assets/133080491/1b18f428-1117-4afc-bb2e-51e07dbeba68)
