### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/actions/setup-miniconda/action.yml
+++ b/.github/actions/setup-miniconda/action.yml
@@ -27,7 +27,7 @@ runs:
       - name: Get date
         id: get-date
         shell: bash
-        run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')d"
+        run: echo "today=$(/bin/date -u '+%Y%m%d')d" >> $GITHUB_OUTPUT
       - name: Setup miniconda cache
         id: miniconda-cache
         uses: actions/cache@v2


### PR DESCRIPTION
## Description

Resolve  #3408 

Update `.github/actions/setup-miniconda/action.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')d"
```

**TO-BE**

```yml
run: echo "today=$(/bin/date -u '+%Y%m%d')d" >> $GITHUB_OUTPUT
```