### PR TITLE
fix: deepseepd_plugin retrieval from accelerate state

### DIFF
--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -471,7 +471,7 @@ def main():
         """
         returns either a context list that includes one that will disable zero.Init or an empty context list
         """
-        deepspeed_plugin = AcceleratorState() if accelerate.state.is_initialized() else None
+        deepspeed_plugin = AcceleratorState().deepspeed_plugin if accelerate.state.is_initialized() else None
         if deepspeed_plugin is None:
             return []
 


### PR DESCRIPTION
Fixes:

```bash
AttributeError: 'AcceleratorState' object has no attribute 'zero3_init_context_manager'
```

from our [CI](https://github.com/huggingface/diffusers/actions/runs/4955138459/jobs/8864271403?pr=3397). 