### PR TITLE
[Attention processor] Better warning message when shifting to `AttnProcessor2_0`

### DIFF
--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -213,6 +213,9 @@ class Attention(nn.Module):
                 )
                 processor.load_state_dict(self.processor.state_dict())
                 processor.to(self.processor.to_q_lora.up.weight.device)
+                print(
+                    f"is_lora is set to {is_lora}, type: LoRAXFormersAttnProcessor: {isinstance(processor, LoRAXFormersAttnProcessor)}"
+                )
             elif is_custom_diffusion:
                 processor = CustomDiffusionXFormersAttnProcessor(
                     train_kv=self.processor.train_kv,
@@ -250,6 +253,7 @@ class Attention(nn.Module):
                 # We use the AttnProcessor2_0 by default when torch 2.x is used which uses
                 # torch.nn.functional.scaled_dot_product_attention for native Flash/memory_efficient_attention
                 # but only if it has the default `scale` argument. TODO remove scale_qk check when we move to torch 2.1
+                print("Still defaulting to: AttnProcessor2_0 :O")
                 processor = (
                     AttnProcessor2_0()
                     if hasattr(F, "scaled_dot_product_attention") and self.scale_qk

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -191,7 +191,10 @@ class Attention(nn.Module):
             elif hasattr(F, "scaled_dot_product_attention") and self.scale_qk:
                 warnings.warn(
                     "You have specified using flash attention using xFormers but you have PyTorch 2.0 already installed. "
-                    "We will default to PyTorch's native efficient flash attention implementation provided by PyTorch 2.0."
+                    "We will default to PyTorch's native efficient flash attention implementation (`F.scaled_dot_product_attention`) "
+                    "introduced in PyTorch 2.0. In case you are using LoRA or Custom Diffusion, we will fall "
+                    "back to their respective attention processors i.e., we will NOT use the PyTorch 2.0 "
+                    "native efficient flash attention."
                 )
             else:
                 try:


### PR DESCRIPTION
Related to https://github.com/huggingface/diffusers/issues/3441. 

@wfng92, would you mind looking into this PR? 

I added specific debugging statements in the branches of `use_memory_efficient_attention_xformers()` to check if we fall back to `AttnProcessor2_0` when a user specifies to use a particular attention processor like LoRA. 

To me, it seems like we DON'T fall back to `AttnProcessor2_0` when using:

```python
pipe.unet.load_attn_procs("patrickvonplaten/lora_dreambooth_dog_example")
pipe.enable_xformers_memory_efficient_attention()
```

(The debugging statement outputs confirm that)

Here's my Colab Notebook for verification:
https://colab.research.google.com/gist/sayakpaul/57687aefcddde15bcf2f35e536b2a449/scratchpad.ipynb

I agree that the current warning message is confusing as it leads the user into thinking that Diffusers is defaulting to `AttnProcessor2_0` when using LoRA and efficient attention. So, in this PR, I improved the warning message a bit too. 

Thanks in advance. 