### PR TITLE
Reduce peak VRAM by releasing large attention tensors (as soon as they're unnecessary)

### DIFF
--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -344,11 +344,14 @@ class Attention(nn.Module):
             beta=beta,
             alpha=self.scale,
         )
+        del baddbmm_input
 
         if self.upcast_softmax:
             attention_scores = attention_scores.float()
 
         attention_probs = attention_scores.softmax(dim=-1)
+        del attention_scores
+
         attention_probs = attention_probs.to(dtype)
 
         return attention_probs


### PR DESCRIPTION
Hi,

The change is quite simple, but it results in a big reduction in peak VRAM usage in pre-torch 2.0 installations. Especially for larger images.

For e.g. it reduces peak VRAM usage by 2 GB for a 1024x1024 image, even with attention slicing. And the savings scale up quickly with larger images.

`baddbmm_input`, `attention_scores` and `attention_probs` are 2 GB *each* for a 1024x1024 image (with attention slices == 4). And they're 4x bigger without attention slicing.

Keeping a reference to `baddbmm_input` (till the end of the function) means `attention_probs` will allocate an additional 2 GB of VRAM, which increases the peak VRAM usage. This reference is unnecessary, and freeing it up means `attention_probs` does not allocate an additional 2 GB of VRAM.

This allows larger images to be generated, without hitting VRAM limits.

This change has been running on Easy Diffusion's beta branch for the past few days (via monkey-patching), and users have confirmed that they're able to make bigger images. No issues have been reported.

Please let me know if this needs any changes, or isn't the right approach.

Thanks!