### PR TITLE
[docs] Add AttnProcessor to docs

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -128,6 +128,8 @@
   - sections:
     - local: api/models
       title: Models
+    - local: api/attnprocessor
+      title: Attention Processor
     - local: api/diffusion_pipeline
       title: Diffusion Pipeline
     - local: api/logging

--- a/docs/source/en/api/attnprocessor.mdx
+++ b/docs/source/en/api/attnprocessor.mdx
@@ -29,7 +29,7 @@ An attention processor is a class for applying different types of attention mech
 ## LoRAXFormersAttnProcessor
 [[autodoc]] models.attention_processor.LoRAXFormersAttnProcessor
 
-## CustomDiffusionXFormerAttnProcessor
+## CustomDiffusionXFormersAttnProcessor
 [[autodoc]] models.attention_processor.CustomDiffusionXFormerAttnProcessor
 
 ## SlicedAttnProcessor

--- a/docs/source/en/api/attnprocessor.mdx
+++ b/docs/source/en/api/attnprocessor.mdx
@@ -30,7 +30,7 @@ An attention processor is a class for applying different types of attention mech
 [[autodoc]] models.attention_processor.LoRAXFormersAttnProcessor
 
 ## CustomDiffusionXFormersAttnProcessor
-[[autodoc]] models.attention_processor.CustomDiffusionXFormerAttnProcessor
+[[autodoc]] models.attention_processor.CustomDiffusionXFormersAttnProcessor
 
 ## SlicedAttnProcessor
 [[autodoc]] models.attention_processor.SlicedAttnProcessor

--- a/docs/source/en/api/attnprocessor.mdx
+++ b/docs/source/en/api/attnprocessor.mdx
@@ -1,0 +1,39 @@
+# Attention Processor
+
+An attention processor is a class for applying different types of attention mechanisms.
+
+## AttnProcessor
+[[autodoc]] models.attention_processor.AttnProcessor
+
+## AttnProcessor2_0
+[[autodoc]] models.attention_processor.AttnProcessor2_0
+
+## LoRAAttnProcessor
+[[autodoc]] models.attention_processor.LoRAAttnProcessor
+
+## CustomDiffusionAttnProcessor
+[[autodoc]] models.attention_processor.CustomDiffusionAttnProcessor
+
+## AttnAddedKVProcessor
+[[autodoc]] models.attention_processor.AttnAddedKVProcessor
+
+## AttnAddedKVProcessor2_0
+[[autodoc]] models.attention_processor.AttnAddedKVProcessor2_0
+
+## LoRAAttnAddedKVProcessor
+[[autodoc]] models.attention_processor.LoRAAttnAddedKVProcessor
+
+## XFormersAttnProcessor
+[[autodoc]] models.attention_processor.XFormersAttnProcessor
+
+## LoRAXFormersAttnProcessor
+[[autodoc]] models.attention_processor.LoRAXFormersAttnProcessor
+
+## CustomDiffusionXFormerAttnProcessor
+[[autodoc]] models.attention_processor.CustomDiffusionXFormerAttnProcessor
+
+## SlicedAttnProcessor
+[[autodoc]] models.attention_processor.SlicedAttnProcessor
+
+## SlicedAttnAddedKVProcessor
+[[autodoc]] models.attention_processor.SlicedAttnAddedKVProcessor

--- a/docs/source/en/api/models.mdx
+++ b/docs/source/en/api/models.mdx
@@ -19,12 +19,6 @@ The models are built on the base class ['ModelMixin'] that is a `torch.nn.module
 ## ModelMixin
 [[autodoc]] ModelMixin
 
-## AttnProcessor
-[[autodoc]] models.attention_processor.AttnProcessor
-
-## AttnProcessor2_0
-[[autodoc]] models.attention_processor.AttnProcessor2_0
-
 ## UNet2DOutput
 [[autodoc]] models.unet_2d.UNet2DOutput
 

--- a/docs/source/en/api/models.mdx
+++ b/docs/source/en/api/models.mdx
@@ -20,10 +20,10 @@ The models are built on the base class ['ModelMixin'] that is a `torch.nn.module
 [[autodoc]] ModelMixin
 
 ## AttnProcessor
-[[autodoc]] AttnProcessor
+[[autodoc]] models.attention_processor.AttnProcessor
 
 ## AttnProcessor2_0
-[[autodoc]] AttnProcessor2_0
+[[autodoc]] models.attention_processor.AttnProcessor2_0
 
 ## UNet2DOutput
 [[autodoc]] models.unet_2d.UNet2DOutput

--- a/docs/source/en/api/models.mdx
+++ b/docs/source/en/api/models.mdx
@@ -19,6 +19,12 @@ The models are built on the base class ['ModelMixin'] that is a `torch.nn.module
 ## ModelMixin
 [[autodoc]] ModelMixin
 
+## AttnProcessor
+[[autodoc]] AttnProcessor
+
+## AttnProcessor2_0
+[[autodoc]] AttnProcessor2_0
+
 ## UNet2DOutput
 [[autodoc]] models.unet_2d.UNet2DOutput
 

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -414,7 +414,7 @@ class Attention(nn.Module):
 
 class AttnProcessor:
     r"""
-    Processor for implementing the basic attention mechanism.
+    Default processor for performing attention-related computations.
     """
 
     def __call__(
@@ -579,9 +579,9 @@ class CustomDiffusionAttnProcessor(nn.Module):
 
     Args:
         train_kv (`bool`, defaults to `True`):
-            Whether to train the text features.
+            Whether to newly train the key and value matrices corresponding to the text features.
         train_q_out (`bool`, defaults to `True`):
-            Whether to train the latent image features.
+            Whether to newly train query matrices corresponding to the latent image features.
         hidden_size (`int`, *optional*, defaults to `None`):
             The hidden size of the attention layer.
         cross_attention_dim (`int`, *optional*, defaults to `None`):
@@ -670,6 +670,11 @@ class CustomDiffusionAttnProcessor(nn.Module):
 
 
 class AttnAddedKVProcessor:
+    r"""
+    Processor for performing attention-related computations with extra learnable key and value matrices for the text
+    encoder.
+    """
+
     def __call__(self, attn: Attention, hidden_states, encoder_hidden_states=None, attention_mask=None):
         residual = hidden_states
         hidden_states = hidden_states.view(hidden_states.shape[0], hidden_states.shape[1], -1).transpose(1, 2)
@@ -719,6 +724,11 @@ class AttnAddedKVProcessor:
 
 
 class AttnAddedKVProcessor2_0:
+    r"""
+    Processor for performing scaled dot product attention (enabled by default if you're using PyTorch 2.0) with extra
+    learnable key and value matrices for the text encoder.
+    """
+
     def __init__(self):
         if not hasattr(F, "scaled_dot_product_attention"):
             raise ImportError(
@@ -778,6 +788,9 @@ class AttnAddedKVProcessor2_0:
 
 class LoRAAttnAddedKVProcessor(nn.Module):
     r"""
+    Processor for implementing the LoRA attention mechanism with extra learnable key and value matrices for the text
+    encoder.
+
     Args:
         hidden_size (`int`, *optional*):
             The hidden size of the attention layer.
@@ -855,7 +868,7 @@ class LoRAAttnAddedKVProcessor(nn.Module):
 
 class XFormersAttnProcessor:
     r"""
-    Processor for implementing memory efficient attention.
+    Processor for implementing memory efficient attention using xFormers.
 
     Args:
         attention_op (`Callable`, *optional*, defaults to `None`):
@@ -996,7 +1009,7 @@ class AttnProcessor2_0:
 
 class LoRAXFormersAttnProcessor(nn.Module):
     r"""
-    Processor for implementing memory efficient attention with LoRA.
+    Processor for implementing the LoRA attention mechanism with memory efficient attention using xFormers.
 
     Args:
         hidden_size (`int`, *optional*):
@@ -1079,13 +1092,13 @@ class LoRAXFormersAttnProcessor(nn.Module):
 
 class CustomDiffusionXFormersAttnProcessor(nn.Module):
     r"""
-    Processor for implementing memory efficient attention for the Custom Diffusion method.
+    Processor for implementing memory efficient attention using xFormers for the Custom Diffusion method.
 
     Args:
     train_kv (`bool`, defaults to `True`):
-            Whether to train the text features.
+        Whether to newly train the key and value matrices corresponding to the text features.
     train_q_out (`bool`, defaults to `True`):
-        Whether to train the latent image features.
+        Whether to newly train query matrices corresponding to the latent image features.
     hidden_size (`int`, *optional*, defaults to `None`):
         The hidden size of the attention layer.
     cross_attention_dim (`int`, *optional*, defaults to `None`):
@@ -1095,10 +1108,9 @@ class CustomDiffusionXFormersAttnProcessor(nn.Module):
     dropout (`float`, *optional*, defaults to 0.0):
         The dropout probability to use.
     attention_op (`Callable`, *optional*, defaults to `None`):
-            The base
-            [operator](https://facebookresearch.github.io/xformers/components/ops.html#xformers.ops.AttentionOpBase) to
-            use as the attention operator. It is recommended to set to `None`, and allow xFormers to choose the best
-            operator.
+        The base
+        [operator](https://facebookresearch.github.io/xformers/components/ops.html#xformers.ops.AttentionOpBase) to use
+        as the attention operator. It is recommended to set to `None`, and allow xFormers to choose the best operator.
     """
 
     def __init__(
@@ -1268,6 +1280,8 @@ class SlicedAttnProcessor:
 
 class SlicedAttnAddedKVProcessor:
     r"""
+    Processor for implementing sliced attention with extra learnable key and value matrices for the text encoder.
+
     Args:
         slice_size (`int`, *optional*):
             The number of steps to compute attention. Uses as many slices as `attention_head_dim // slice_size`, and

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -413,6 +413,10 @@ class Attention(nn.Module):
 
 
 class AttnProcessor:
+    r"""
+    Processor for implementing the basic attention mechanism.
+    """
+
     def __call__(
         self,
         attn: Attention,
@@ -494,6 +498,18 @@ class LoRALinearLayer(nn.Module):
 
 
 class LoRAAttnProcessor(nn.Module):
+    r"""
+    Processor for implementing the LoRA attention mechanism.
+
+    Args:
+        hidden_size (`int`, *optional*):
+            The hidden size of the attention layer.
+        cross_attention_dim (`int`, *optional*):
+            The number of channels in the `encoder_hidden_states`.
+        rank (`int`, defaults to 4):
+            The dimension of the LoRA update matrices.
+    """
+
     def __init__(self, hidden_size, cross_attention_dim=None, rank=4):
         super().__init__()
 
@@ -558,6 +574,24 @@ class LoRAAttnProcessor(nn.Module):
 
 
 class CustomDiffusionAttnProcessor(nn.Module):
+    r"""
+    Processor for implementing attention for the Custom Diffusion method.
+
+    Args:
+        train_kv (`bool`, defaults to `True`):
+            Whether to train the text features.
+        train_q_out (`bool`, defaults to `True`):
+            Whether to train the latent image features.
+        hidden_size (`int`, *optional*, defaults to `None`):
+            The hidden size of the attention layer.
+        cross_attention_dim (`int`, *optional*, defaults to `None`):
+            The number of channels in the `encoder_hidden_states`.
+        out_bias (`bool`, defaults to `True`):
+            Whether to include the bias parameter in `train_q_out`.
+        dropout (`float`, *optional*, defaults to 0.0):
+            The dropout probability to use.
+    """
+
     def __init__(
         self,
         train_kv=True,
@@ -743,6 +777,16 @@ class AttnAddedKVProcessor2_0:
 
 
 class LoRAAttnAddedKVProcessor(nn.Module):
+    r"""
+    Args:
+        hidden_size (`int`, *optional*):
+            The hidden size of the attention layer.
+        cross_attention_dim (`int`, *optional*, defaults to `None`):
+            The number of channels in the `encoder_hidden_states`.
+        rank (`int`, defaults to 4):
+            The dimension of the LoRA update matrices.
+    """
+
     def __init__(self, hidden_size, cross_attention_dim=None, rank=4):
         super().__init__()
 
@@ -810,6 +854,17 @@ class LoRAAttnAddedKVProcessor(nn.Module):
 
 
 class XFormersAttnProcessor:
+    r"""
+    Processor for implementing memory efficient attention.
+
+    Args:
+        attention_op (`Callable`, *optional*, defaults to `None`):
+            The base
+            [operator](https://facebookresearch.github.io/xformers/components/ops.html#xformers.ops.AttentionOpBase) to
+            use as the attention operator. It is recommended to set to `None`, and allow xFormers to choose the best
+            operator.
+    """
+
     def __init__(self, attention_op: Optional[Callable] = None):
         self.attention_op = attention_op
 
@@ -868,6 +923,10 @@ class XFormersAttnProcessor:
 
 
 class AttnProcessor2_0:
+    r"""
+    Processor for implementing scaled dot product attention (enabled by default if you're using PyTorch 2.0).
+    """
+
     def __init__(self):
         if not hasattr(F, "scaled_dot_product_attention"):
             raise ImportError("AttnProcessor2_0 requires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.")
@@ -936,6 +995,23 @@ class AttnProcessor2_0:
 
 
 class LoRAXFormersAttnProcessor(nn.Module):
+    r"""
+    Processor for implementing memory efficient attention with LoRA.
+
+    Args:
+        hidden_size (`int`, *optional*):
+            The hidden size of the attention layer.
+        cross_attention_dim (`int`, *optional*):
+            The number of channels in the `encoder_hidden_states`.
+        rank (`int`, defaults to 4):
+            The dimension of the LoRA update matrices.
+        attention_op (`Callable`, *optional*, defaults to `None`):
+            The base
+            [operator](https://facebookresearch.github.io/xformers/components/ops.html#xformers.ops.AttentionOpBase) to
+            use as the attention operator. It is recommended to set to `None`, and allow xFormers to choose the best
+            operator.
+    """
+
     def __init__(self, hidden_size, cross_attention_dim, rank=4, attention_op: Optional[Callable] = None):
         super().__init__()
 
@@ -1002,6 +1078,29 @@ class LoRAXFormersAttnProcessor(nn.Module):
 
 
 class CustomDiffusionXFormersAttnProcessor(nn.Module):
+    r"""
+    Processor for implementing memory efficient attention for the Custom Diffusion method.
+
+    Args:
+    train_kv (`bool`, defaults to `True`):
+            Whether to train the text features.
+    train_q_out (`bool`, defaults to `True`):
+        Whether to train the latent image features.
+    hidden_size (`int`, *optional*, defaults to `None`):
+        The hidden size of the attention layer.
+    cross_attention_dim (`int`, *optional*, defaults to `None`):
+        The number of channels in the `encoder_hidden_states`.
+    out_bias (`bool`, defaults to `True`):
+        Whether to include the bias parameter in `train_q_out`.
+    dropout (`float`, *optional*, defaults to 0.0):
+        The dropout probability to use.
+    attention_op (`Callable`, *optional*, defaults to `None`):
+            The base
+            [operator](https://facebookresearch.github.io/xformers/components/ops.html#xformers.ops.AttentionOpBase) to
+            use as the attention operator. It is recommended to set to `None`, and allow xFormers to choose the best
+            operator.
+    """
+
     def __init__(
         self,
         train_kv=True,
@@ -1087,6 +1186,15 @@ class CustomDiffusionXFormersAttnProcessor(nn.Module):
 
 
 class SlicedAttnProcessor:
+    r"""
+    Processor for implementing sliced attention.
+
+    Args:
+        slice_size (`int`, *optional*):
+            The number of steps to compute attention. Uses as many slices as `attention_head_dim // slice_size`, and
+            `attention_head_dim` must be a multiple of the `slice_size`.
+    """
+
     def __init__(self, slice_size):
         self.slice_size = slice_size
 
@@ -1159,6 +1267,13 @@ class SlicedAttnProcessor:
 
 
 class SlicedAttnAddedKVProcessor:
+    r"""
+    Args:
+        slice_size (`int`, *optional*):
+            The number of steps to compute attention. Uses as many slices as `attention_head_dim // slice_size`, and
+            `attention_head_dim` must be a multiple of the `slice_size`.
+    """
+
     def __init__(self, slice_size):
         self.slice_size = slice_size
 

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -725,7 +725,7 @@ class AttnAddedKVProcessor:
 
 class AttnAddedKVProcessor2_0:
     r"""
-    Processor for performing scaled dot product attention (enabled by default if you're using PyTorch 2.0) with extra
+    Processor for performing scaled dot-product attention (enabled by default if you're using PyTorch 2.0), with extra
     learnable key and value matrices for the text encoder.
     """
 
@@ -937,7 +937,7 @@ class XFormersAttnProcessor:
 
 class AttnProcessor2_0:
     r"""
-    Processor for implementing scaled dot product attention (enabled by default if you're using PyTorch 2.0).
+    Processor for implementing scaled dot-product attention (enabled by default if you're using PyTorch 2.0).
     """
 
     def __init__(self):


### PR DESCRIPTION
Adds the `AttnProcessor` and `AttnProcessor2_0` to the API docs.