### PR TITLE
[{Up,Down}sample1d] explicit view kernel size as number elements in flattened indices

### DIFF
--- a/src/diffusers/models/unet_1d_blocks.py
+++ b/src/diffusers/models/unet_1d_blocks.py
@@ -300,7 +300,8 @@ class Downsample1d(nn.Module):
         hidden_states = F.pad(hidden_states, (self.pad,) * 2, self.pad_mode)
         weight = hidden_states.new_zeros([hidden_states.shape[1], hidden_states.shape[1], self.kernel.shape[0]])
         indices = torch.arange(hidden_states.shape[1], device=hidden_states.device)
-        weight[indices, indices] = self.kernel.to(weight)
+        kernel = self.kernel.to(weight)[None, :].expand(hidden_states.shape[1], -1)
+        weight[indices, indices] = kernel
         return F.conv1d(hidden_states, weight, stride=2)
 
 
@@ -316,7 +317,8 @@ class Upsample1d(nn.Module):
         hidden_states = F.pad(hidden_states, ((self.pad + 1) // 2,) * 2, self.pad_mode)
         weight = hidden_states.new_zeros([hidden_states.shape[1], hidden_states.shape[1], self.kernel.shape[0]])
         indices = torch.arange(hidden_states.shape[1], device=hidden_states.device)
-        weight[indices, indices] = self.kernel.to(weight)
+        kernel = self.kernel.to(weight)[None, :].expand(hidden_states.shape[1], -1)
+        weight[indices, indices] = kernel
         return F.conv_transpose1d(hidden_states, weight, stride=2, padding=self.pad * 2 + 1)
 
 


### PR DESCRIPTION
To fix this error in the integration tests:
```
FAILED tests/pipelines/dance_diffusion/test_dance_diffusion.py::DanceDiffusionPipelineFastTests::test_dict_tuple_outputs_equivalent - RuntimeError: linearIndex.numel()*sliceSize*nElemBefore == expandedValue.numel() INTERNAL ASSERT FAILED at "../aten/src/ATen/native/cuda/Indexing.cu":389, please report a bug to PyTorch. number of flattened indices did not match number of elements in the value tensor: 256 vs 8
```

Someone who knows this block better, please double check this logic :) 

My understanding is that the assignment requires[^1]  the highest dim in kernel to match the number of flattened indices, and the indices are flattened pair wise (i.e. arr[[1,2,3], [4,5,6]] -> 3 number of flattened indices, not 9). So we can just unsqueeze the additional dimension and view it the appropriate number of times.

[^1]: Only requires this explicit casting sometimes? Note that this is error is only thrown sometimes (even when this block is using tensors of the same shape -- idk maybe it's a memory layout issue?) and only when determinism is turned on.