### PR TITLE
Fix monkey-patch for text_encoder LoRA

### DIFF
--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -943,14 +943,16 @@ class LoraLoaderMixin:
                 module = self.text_encoder.get_submodule(name)
                 # Construct a new function that performs the LoRA merging. We will monkey patch
                 # this forward pass.
-                lora_layer = getattr(attn_processors[name], self._get_lora_layer_attribute(name))
-                old_forward = module.forward
 
-                def new_forward(x):
-                    return old_forward(x) + lora_layer(x)
+                if name in attn_processors:
+                    module.lora_layer = getattr(attn_processors[name], self._get_lora_layer_attribute(name))
+                    module.old_forward = module.forward
 
-                # Monkey-patch.
-                module.forward = new_forward
+                    def new_forward(self, x):
+                        return self.old_forward(x) + self.lora_layer(x)
+
+                    # Monkey-patch.
+                    module.forward = new_forward.__get__(module)
 
     def _get_lora_layer_attribute(self, name: str) -> str:
         if "q_proj" in name:

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -946,6 +946,7 @@ class LoraLoaderMixin:
                 lora_layer = getattr(attn_processors[name], self._get_lora_layer_attribute(name))
                 old_forward = module.forward
 
+                # create a new scope that locks in the old_forward, lora_layer value for each new_forward function
                 def make_new_forward(old_forward, lora_layer):
                     def new_forward(x):
                         return old_forward(x) + lora_layer(x)

--- a/tests/models/test_lora_layers.py
+++ b/tests/models/test_lora_layers.py
@@ -23,7 +23,7 @@ from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
 from diffusers import AutoencoderKL, DDIMScheduler, StableDiffusionPipeline, UNet2DConditionModel
 from diffusers.loaders import AttnProcsLayers, LoraLoaderMixin
-from diffusers.models.attention_processor import LoRAAttnProcessor, LoRALinearLayer
+from diffusers.models.attention_processor import LoRAAttnProcessor
 from diffusers.utils import TEXT_ENCODER_TARGET_MODULES, floats_tensor, torch_device
 
 
@@ -218,14 +218,31 @@ class LoraLoaderMixinTests(unittest.TestCase):
     def get_dummy_tokens(self):
         max_seq_length = 77
 
-        inputs = torch.randint(2, 56, size=(1, max_seq_length), generator=torch.manual_seed(0)).to("cuda")
+        inputs = torch.randint(2, 56, size=(1, max_seq_length), generator=torch.manual_seed(0))
 
         prepared_inputs = {}
         prepared_inputs["input_ids"] = inputs
         return prepared_inputs
 
+    def get_text_lora_attn_procs(self, text_encoder: nn.Module, randn_weight=False):
+        text_lora_attn_procs = {}
+        for name, module in text_encoder.named_modules():
+            if any(x in name for x in TEXT_ENCODER_TARGET_MODULES):
+                attn_proc = LoRAAttnProcessor(hidden_size=module.out_features, cross_attention_dim=None)
+                # set up.weights
+                for layer_name, layer_module in attn_proc.named_modules():
+                    if layer_name.endswith("_lora"):
+                        weight = (
+                            torch.randn_like(layer_module.up.weight)
+                            if randn_weight
+                            else torch.zeros_like(layer_module.up.weight)
+                        )
+                        layer_module.up.weight = torch.nn.Parameter(weight)
+                text_lora_attn_procs[name] = attn_proc
+        return text_lora_attn_procs
+
     def test_text_encoder_lora_monkey_patch(self):
-        pipe = StableDiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5").to("cuda")
+        pipe = StableDiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5")
 
         dummy_tokens = self.get_dummy_tokens()
 
@@ -234,19 +251,7 @@ class LoraLoaderMixinTests(unittest.TestCase):
         assert outputs_without_lora.shape == (1, 77, 768)
 
         # create lora_attn_procs with zeroed out up.weights
-        text_lora_attn_procs = {}
-        for name, module in pipe.text_encoder.named_modules():
-            if any(x in name for x in TEXT_ENCODER_TARGET_MODULES):
-                attn_proc = LoRAAttnProcessor(hidden_size=module.out_features, cross_attention_dim=None).to("cuda")
-
-                # make sure that the up.weights are zeroed out
-                for layer_name, layer_module in attn_proc.named_modules():
-                    if layer_name.endswith("_lora"):
-                        assert torch.allclose(
-                            layer_module.up.weight, torch.zeros_like(layer_module.up.weight)
-                        ), "lora_up_weight should be zeroed out"
-
-                text_lora_attn_procs[name] = attn_proc
+        text_lora_attn_procs = self.get_text_lora_attn_procs(pipe.text_encoder, randn_weight=False)
 
         # monkey patch
         pipe._modify_text_encoder(text_lora_attn_procs)
@@ -263,13 +268,15 @@ class LoraLoaderMixinTests(unittest.TestCase):
             outputs_without_lora, outputs_with_lora
         ), "lora_up_weight are all zero, so the lora outputs should be the same to without lora outputs"
 
-        # set randn to lora_up.weights
-        for name, _ in pipe.text_encoder.named_modules():
-            if any(name.endswith(x) for x in TEXT_ENCODER_TARGET_MODULES):
-                module = pipe.text_encoder.get_submodule(name)
-                assert hasattr(module, "lora_layer"), "lora_layer should be added"
-                assert isinstance(module.lora_layer, LoRALinearLayer), "lora_layer should be LoRALinearLayer"
-                module.lora_layer.up.weight = torch.nn.Parameter(torch.randn_like(module.lora_layer.up.weight))
+        # create lora_attn_procs with randn up.weights
+        text_lora_attn_procs = self.get_text_lora_attn_procs(pipe.text_encoder, randn_weight=True)
+
+        # monkey patch
+        pipe._modify_text_encoder(text_lora_attn_procs)
+
+        # verify that it's okay to release the text_lora_attn_procs which holds the LoRAAttnProcessor.
+        del text_lora_attn_procs
+        gc.collect()
 
         # inference with lora
         outputs_with_lora = pipe.text_encoder(**dummy_tokens)[0]


### PR DESCRIPTION
Related Issue #3445. and PR #3437. See https://github.com/huggingface/diffusers/pull/3437#discussion_r1196667667
>This change, which I believe should not be necessary in principle, is one that I would like to revert once I understand the underlying cause and confirm that it's not a problem.
>
>When I investigated the cause of the severe output distortion when enabling LoRA for the text_encoder, I found that the output was still distorted even when I removed the + lora_layer(x) part. Therefore, I concluded that this monkey-patch itself was the cause. As a countermeasure, I tried making it an instance method, and for some reason it worked, although I'm not entirely sure why it was fixed.
>
>I compared the original code equivalent with the method of making it an instance method in simplified test code, but both of these tests pass without any problems.
https://gist.github.com/takuma104/1263383cdab8f54bb14f389facdbe960
>
>I suspect that it might be a memory-related issue with Python or PyTorch garbage collection, but I'm not sure yet. I'm thinking of adjusting the test a bit closer to the current situation and investigating.

## Workflow plan:
https://github.com/huggingface/diffusers/pull/3437#issuecomment-1553911767
> - Monkey-patch fix (looks like it's fixed now)
> - Revisit the tests for that (I will take care of that)
> - Qualitative testing (we both can do this)
> - DreamBooth LoRA with text encoder test (qualitative)
