### PR TITLE
[Tests] Run slow matrix sequentially

### DIFF
--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -17,6 +17,7 @@ jobs:
   run_slow_tests:
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         config:
           - name: Slow PyTorch CUDA tests on Ubuntu


### PR DESCRIPTION
This is just a suspicion, feel free to close.

Both "Slow PyTorch CUDA tests on Ubuntu" and "Slow ONNXRuntime CUDA tests on Ubuntu" use the same runner (`docker-gpu`), and there is 1 machine configured to run those tests. My understanding is that the CI environment will run tests in a matrix in parallel by default, which could be the reason for the weird oom issues.

If this is actually the case, we could maybe reorganize the tests differently so that the "Slow Flax TPU tests", which use a different runner, run in parallel with any of these.