### PR TITLE
euler discrete set_timesteps() bug fix

### DIFF
--- a/src/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_discrete.py
@@ -191,7 +191,7 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         """
         self.num_inference_steps = num_inference_steps
 
-        timesteps = np.linspace(0, self.config.num_train_timesteps - 1, num_inference_steps, dtype=float)[::-1].copy()
+        timesteps = np.linspace(self.config.num_train_timesteps - 1, 0, num_inference_steps, endpoint=False, dtype=float).copy()
         sigmas = np.array(((1 - self.alphas_cumprod) / self.alphas_cumprod) ** 0.5)
         log_sigmas = np.log(sigmas)
 


### PR DESCRIPTION
In EulerDiscreteScheduler when setting the timesteps we need to exclude the 0-th timestep. So, due to this bug during the inference the scheduler expects to receive x0 and its corresponding noise in order to denoise it which is a redundant operation because we assume that  x0 is our final result and there is no need to remove noise from it. 

After the bug fix, improvements are observed in the quality of the generated images.