### PR TITLE
Fix loaded_token reference before definition

### DIFF
--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -682,6 +682,7 @@ class TextualInversionLoaderMixin:
                 state_dict = torch.load(model_file, map_location="cpu")
 
             # 2. Load token and embedding correcly from file
+            loaded_token = None
             if isinstance(state_dict, torch.Tensor):
                 if token is None:
                     raise ValueError(


### PR DESCRIPTION
The below check fails when `token` is provided for loading textual inversion from a file (e.g. safetensors) as `loaded_token` variable is not defined.
```python
if token is not None and loaded_token != token:
    logger.info(f"The loaded token: {loaded_token} is overwritten by the passed token {token}.")
else:
    token = loaded_token
```

Fails with:
```
  File "/zzzzz", line 699, in load_textual_inversion
    if token is not None and loaded_token != token:
       │                                     └ 'zzzz'
       └ 'zzzz'

UnboundLocalError: cannot access local variable 'loaded_token' where it is not associated with a value
