### PR TITLE
[Examples/DreamBooth] refactor save_model_card utility in dreambooth examples

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -46,6 +46,7 @@ from diffusers import (
     DDPMScheduler,
     DiffusionPipeline,
     DPMSolverMultistepScheduler,
+    StableDiffusionPipeline,
     UNet2DConditionModel,
 )
 from diffusers.optimization import get_scheduler
@@ -62,7 +63,15 @@ check_min_version("0.17.0.dev0")
 logger = get_logger(__name__)
 
 
-def save_model_card(repo_id: str, images=None, base_model=str, train_text_encoder=False, prompt=str, repo_folder=None):
+def save_model_card(
+    repo_id: str,
+    images=None,
+    base_model=str,
+    train_text_encoder=False,
+    prompt=str,
+    repo_folder=None,
+    pipeline: DiffusionPipeline = None,
+):
     img_str = ""
     for i, image in enumerate(images):
         image.save(os.path.join(repo_folder, f"image_{i}.png"))
@@ -74,8 +83,8 @@ license: creativeml-openrail-m
 base_model: {base_model}
 instance_prompt: {prompt}
 tags:
-- stable-diffusion
-- stable-diffusion-diffusers
+- {'stable-diffusion' if isinstance(pipeline, StableDiffusionPipeline) else 'if'}
+- {'stable-diffusion-diffusers' if isinstance(pipeline, StableDiffusionPipeline) else 'if-diffusers'}
 - text-to-image
 - diffusers
 - dreambooth
@@ -1297,6 +1306,7 @@ def main(args):
                 train_text_encoder=args.train_text_encoder,
                 prompt=args.instance_prompt,
                 repo_folder=args.output_dir,
+                pipeline=pipeline,
             )
             upload_folder(
                 repo_id=repo_id,


### PR DESCRIPTION
Currently, our DreamBooth PyTorch scripts (LoRA and non-LoRA) support both Stable Diffusion and IF pipelines. 

However, the `save_model_card` utility always includes `stable-diffusion` and `stable-diffusion-diffusers` tags even when the underlying pipeline is not of the `StableDiffusionPipeline` type. 

This PR fixes that. 

With this PR, the following two repositories were created:

* https://huggingface.co/sayakpaul/dreambooth-sd-dog
* https://huggingface.co/sayakpaul/dreambooth-if-dog

As one would expect, the tags are corrected:

<img width="911" alt="Screenshot 2023-05-24 at 1 54 44 PM" src="https://github.com/huggingface/diffusers/assets/22957388/3fd435c8-b9c5-4c2f-8ac5-15adcae4a28b">

<img width="743" alt="Screenshot 2023-05-24 at 1 55 00 PM" src="https://github.com/huggingface/diffusers/assets/22957388/b6afadfb-3e93-43ed-a8ff-dfb5f368f37b">


 