### PR TITLE
Fix panorama to support all schedulers

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_panorama.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_panorama.py
@@ -466,6 +466,13 @@ class StableDiffusionPanoramaPipeline(DiffusionPipeline, TextualInversionLoaderM
             w_end = w_start + window_size
             views.append((h_start, h_end, w_start, w_end))
         return views
+    
+    def init_views_output(self,views):
+        if hasattr(self.scheduler, "model_outputs"):
+            # init schedulers: dpmsolver, unipc
+            return [self.scheduler.model_outputs] * len(views)
+        else:
+            return None
 
     @torch.no_grad()
     @replace_example_docstring(EXAMPLE_DOC_STRING)
@@ -612,7 +619,7 @@ class StableDiffusionPanoramaPipeline(DiffusionPipeline, TextualInversionLoaderM
 
         # 6. Define panorama grid and initialize views for synthesis.
         views = self.get_views(height, width)
-        blocks_model_outputs = [None] * len(views)
+        blocks_model_outputs = self.init_views_output(views)
         count = torch.zeros_like(latents)
         value = torch.zeros_like(latents)
 
@@ -659,8 +666,7 @@ class StableDiffusionPanoramaPipeline(DiffusionPipeline, TextualInversionLoaderM
                     # compute the previous noisy sample x_t -> x_t-1
                     if hasattr(self.scheduler, "model_outputs"):
                         # rematch model_outputs in each block
-                        if i >= 1:
-                            self.scheduler.model_outputs = blocks_model_outputs[j]
+                        self.scheduler.model_outputs = blocks_model_outputs[j]
                         latents_view_denoised = self.scheduler.step(
                             noise_pred, t, latents_for_view, **extra_step_kwargs
                         ).prev_sample

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_panorama.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_panorama.py
@@ -662,7 +662,7 @@ class StableDiffusionPanoramaPipeline(DiffusionPipeline, TextualInversionLoaderM
                         noise_pred, t, latents_for_view, **extra_step_kwargs
                     ).prev_sample
 
-                    # save views scheduler status after sample 
+                    # save views scheduler status after sample
                     views_scheduler_status[j] = copy.deepcopy(self.scheduler.__dict__)
 
                     value[:, :, h_start:h_end, w_start:w_end] += latents_view_denoised

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_panorama.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_panorama.py
@@ -22,7 +22,7 @@ from transformers import CLIPImageProcessor, CLIPTextModel, CLIPTokenizer
 from ...image_processor import VaeImageProcessor
 from ...loaders import TextualInversionLoaderMixin
 from ...models import AutoencoderKL, UNet2DConditionModel
-from ...schedulers import DDIMScheduler, PNDMScheduler
+from ...schedulers import DDIMScheduler
 from ...utils import is_accelerate_available, is_accelerate_version, logging, randn_tensor, replace_example_docstring
 from ..pipeline_utils import DiffusionPipeline
 from . import StableDiffusionPipelineOutput

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py
@@ -174,15 +174,22 @@ class StableDiffusionPanoramaPipelineFastTests(PipelineLatentTesterMixin, Pipeli
     def test_stable_diffusion_panorama_pndm(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
         components = self.get_dummy_components()
-        components["scheduler"] = PNDMScheduler()
+        components["scheduler"] = PNDMScheduler(
+            beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear", skip_prk_steps = True
+        )
         sd_pipe = StableDiffusionPanoramaPipeline(**components)
         sd_pipe = sd_pipe.to(device)
         sd_pipe.set_progress_bar_config(disable=None)
 
         inputs = self.get_dummy_inputs(device)
-        # the pipeline does not expect pndm so test if it raises error.
-        with self.assertRaises(ValueError):
-            _ = sd_pipe(**inputs).images
+        image = sd_pipe(**inputs).images
+        image_slice = image[0, -3:, -3:, -1]
+
+        assert image.shape == (1, 64, 64, 3)
+
+        expected_slice =  np.array([0.6391, 0.6291, 0.4861, 0.5134, 0.5552, 0.4578, 0.5032, 0.5023, 0.4539])
+
+        assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
 
 @slow

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py
@@ -175,7 +175,7 @@ class StableDiffusionPanoramaPipelineFastTests(PipelineLatentTesterMixin, Pipeli
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
         components = self.get_dummy_components()
         components["scheduler"] = PNDMScheduler(
-            beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear", skip_prk_steps = True
+            beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear", skip_prk_steps=True
         )
         sd_pipe = StableDiffusionPanoramaPipeline(**components)
         sd_pipe = sd_pipe.to(device)
@@ -187,7 +187,7 @@ class StableDiffusionPanoramaPipelineFastTests(PipelineLatentTesterMixin, Pipeli
 
         assert image.shape == (1, 64, 64, 3)
 
-        expected_slice =  np.array([0.6391, 0.6291, 0.4861, 0.5134, 0.5552, 0.4578, 0.5032, 0.5023, 0.4539])
+        expected_slice = np.array([0.6391, 0.6291, 0.4861, 0.5134, 0.5552, 0.4578, 0.5032, 0.5023, 0.4539])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 


### PR DESCRIPTION
- Refactor some code and support all schedulers including `PNDMScheduler` for panorama pipeline.

Similar to #3499, make all schedulers sync with blocks sampling. This can solve most of the issues about failed images generation in panorama pipeline.

### Test code
```python
import torch
from diffusers import StableDiffusionPanoramaPipeline, PNDMScheduler

seed = 76
model_ckpt = "stabilityai/stable-diffusion-2-base"
prompt = "a photo of the dolomites"

pipe = StableDiffusionPanoramaPipeline.from_pretrained(model_ckpt, torch_dtype=torch.float16).to("cuda")
pipe.scheduler = PNDMScheduler.from_config(pipe.scheduler.config)
pipe.to("cuda")
generator = torch.Generator(device="cuda").manual_seed(seed)
image = pipe(prompt, generator=generator, num_inference_steps=25,width=1024,height=512).images[0]
display(image)
```
### Results
#### PNDMScheduler
![PNDM](https://github.com/huggingface/diffusers/assets/41363108/ebb6a7d3-9bf9-4bde-b39d-958084367e08)

#### UniPCMultistepScheduler
![UniPC](https://github.com/huggingface/diffusers/assets/41363108/089cfe5c-54dd-4fe7-830f-82f87248a7e7)

#### KDPM2DiscreteScheduler
![KDPM2](https://github.com/huggingface/diffusers/assets/41363108/41f444a3-73f5-42e8-b64d-57cdb71449df)

#### DEISMultistepScheduler
![DEIS](https://github.com/huggingface/diffusers/assets/41363108/086cbb8b-2665-48bb-89e6-5b4018d34b82)
