### PR TITLE
[Don't merge] Discussions on why IF DreamBooth LoRA is spurious

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1287,7 +1287,7 @@ def main(args):
         pipeline = DiffusionPipeline.from_pretrained(
             args.pretrained_model_name_or_path, revision=args.revision, torch_dtype=weight_dtype
         )
-        pipeline.unet = unet
+        pipeline.unet = unet.to(weight_dtype)
 
         # We train on the simplified learning objective. If we were previously predicting a variance, we need the scheduler to ignore it
         scheduler_args = {}

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -830,7 +830,7 @@ def main(args):
 
     unet.set_attn_processor(unet_lora_attn_procs)
     unet_lora_layers = AttnProcsLayers(unet.attn_processors)
-    initial_state_dict = unet_lora_layers().state_dict()
+    initial_state_dict = unet_lora_layers.state_dict()
 
     # The text encoder comes from 🤗 transformers, so we cannot directly modify it.
     # So, instead, we monkey-patch the forward calls of its attention-blocks. For this,

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1270,7 +1270,7 @@ def main(args):
         for k in trained_state_dict:
             trained_param = trained_state_dict[k]
             initial_param = initial_state_dict[k]
-            logger.info(torch.allclose(trained_param, initial_param))
+            logger.info(torch.allclose(trained_param.cpu(), initial_param))
 
         if text_encoder is not None:
             text_encoder = text_encoder.to(torch.float32)

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1270,7 +1270,7 @@ def main(args):
         for k in trained_state_dict:
             trained_param = trained_state_dict[k]
             initial_param = initial_state_dict[k]
-            logger.info(torch.all_close(trained_param, initial_param))
+            logger.info(torch.allclose(trained_param, initial_param))
 
         if text_encoder is not None:
             text_encoder = text_encoder.to(torch.float32)

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1289,7 +1289,8 @@ def main(args):
         print(f"Text encoder layers: {text_encoder_lora_layers}")
         LoraLoaderMixin.save_lora_weights(
             save_directory=args.output_dir,
-            unet_lora_layers=unet_lora_layers,
+            unet_lora_layers=AttnProcsLayers(unet.attn_processors),
+            # unet_lora_layers=unet_lora_layers,
             text_encoder_lora_layers=text_encoder_lora_layers,
         )
 

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1270,7 +1270,7 @@ def main(args):
         for k in trained_state_dict:
             trained_param = trained_state_dict[k]
             initial_param = initial_state_dict[k]
-            logger.info(torch.allclose(trained_param.cpu(), initial_param))
+            logger.info((trained_param.cpu() - initial_param).max())
 
         if text_encoder is not None:
             text_encoder = text_encoder.to(torch.float32)

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1282,6 +1282,12 @@ def main(args):
                     f"{k} {list(trained_state_dict[k].shape)} mean={torch.mean(trained_state_dict[k]):.3g} std={torch.std(trained_state_dict[k]):.3g}"
                 )
 
+        unet_attn_proc_state_dict = AttnProcsLayers(unet.attn_processors).state_dict()
+        for k in unet_attn_proc_state_dict:
+            from_unet = unet_attn_proc_state_dict[k]
+            orig = trained_state_dict[k]
+            print(f"Assertion: {torch.allclose(from_unet, orig)}")
+
         if text_encoder is not None:
             text_encoder = text_encoder.to(torch.float32)
             text_encoder_lora_layers = accelerator.unwrap_model(text_encoder_lora_layers)

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -847,65 +847,65 @@ def main(args):
         text_encoder = temp_pipeline.text_encoder
         del temp_pipeline
 
-    # create custom saving & loading hooks so that `accelerator.save_state(...)` serializes in a nice format
-    def save_model_hook(models, weights, output_dir):
-        # there are only two options here. Either are just the unet attn processor layers
-        # or there are the unet and text encoder atten layers
-        unet_lora_layers_to_save = None
-        text_encoder_lora_layers_to_save = None
+    # # create custom saving & loading hooks so that `accelerator.save_state(...)` serializes in a nice format
+    # def save_model_hook(models, weights, output_dir):
+    #     # there are only two options here. Either are just the unet attn processor layers
+    #     # or there are the unet and text encoder atten layers
+    #     unet_lora_layers_to_save = None
+    #     text_encoder_lora_layers_to_save = None
 
-        if args.train_text_encoder:
-            text_encoder_keys = accelerator.unwrap_model(text_encoder_lora_layers).state_dict().keys()
-        unet_keys = accelerator.unwrap_model(unet_lora_layers).state_dict().keys()
+    #     if args.train_text_encoder:
+    #         text_encoder_keys = accelerator.unwrap_model(text_encoder_lora_layers).state_dict().keys()
+    #     unet_keys = accelerator.unwrap_model(unet_lora_layers).state_dict().keys()
 
-        for model in models:
-            state_dict = model.state_dict()
+    #     for model in models:
+    #         state_dict = model.state_dict()
 
-            if (
-                text_encoder_lora_layers is not None
-                and text_encoder_keys is not None
-                and state_dict.keys() == text_encoder_keys
-            ):
-                # text encoder
-                text_encoder_lora_layers_to_save = state_dict
-            elif state_dict.keys() == unet_keys:
-                # unet
-                unet_lora_layers_to_save = state_dict
+    #         if (
+    #             text_encoder_lora_layers is not None
+    #             and text_encoder_keys is not None
+    #             and state_dict.keys() == text_encoder_keys
+    #         ):
+    #             # text encoder
+    #             text_encoder_lora_layers_to_save = state_dict
+    #         elif state_dict.keys() == unet_keys:
+    #             # unet
+    #             unet_lora_layers_to_save = state_dict
 
-            # make sure to pop weight so that corresponding model is not saved again
-            weights.pop()
+    #         # make sure to pop weight so that corresponding model is not saved again
+    #         weights.pop()
 
-        LoraLoaderMixin.save_lora_weights(
-            output_dir,
-            unet_lora_layers=unet_lora_layers_to_save,
-            text_encoder_lora_layers=text_encoder_lora_layers_to_save,
-        )
+    #     LoraLoaderMixin.save_lora_weights(
+    #         output_dir,
+    #         unet_lora_layers=unet_lora_layers_to_save,
+    #         text_encoder_lora_layers=text_encoder_lora_layers_to_save,
+    #     )
 
-    def load_model_hook(models, input_dir):
-        # Note we DON'T pass the unet and text encoder here an purpose
-        # so that the we don't accidentally override the LoRA layers of
-        # unet_lora_layers and text_encoder_lora_layers which are stored in `models`
-        # with new torch.nn.Modules / weights. We simply use the pipeline class as
-        # an easy way to load the lora checkpoints
-        temp_pipeline = DiffusionPipeline.from_pretrained(
-            args.pretrained_model_name_or_path,
-            revision=args.revision,
-            torch_dtype=weight_dtype,
-        )
-        temp_pipeline.load_lora_weights(input_dir)
+    # def load_model_hook(models, input_dir):
+    #     # Note we DON'T pass the unet and text encoder here an purpose
+    #     # so that the we don't accidentally override the LoRA layers of
+    #     # unet_lora_layers and text_encoder_lora_layers which are stored in `models`
+    #     # with new torch.nn.Modules / weights. We simply use the pipeline class as
+    #     # an easy way to load the lora checkpoints
+    #     temp_pipeline = DiffusionPipeline.from_pretrained(
+    #         args.pretrained_model_name_or_path,
+    #         revision=args.revision,
+    #         torch_dtype=weight_dtype,
+    #     )
+    #     temp_pipeline.load_lora_weights(input_dir)
 
-        # load lora weights into models
-        models[0].load_state_dict(AttnProcsLayers(temp_pipeline.unet.attn_processors).state_dict())
-        if len(models) > 1:
-            models[1].load_state_dict(AttnProcsLayers(temp_pipeline.text_encoder_lora_attn_procs).state_dict())
+    #     # load lora weights into models
+    #     models[0].load_state_dict(AttnProcsLayers(temp_pipeline.unet.attn_processors).state_dict())
+    #     if len(models) > 1:
+    #         models[1].load_state_dict(AttnProcsLayers(temp_pipeline.text_encoder_lora_attn_procs).state_dict())
 
-        # delete temporary pipeline and pop models
-        del temp_pipeline
-        for _ in range(len(models)):
-            models.pop()
+    #     # delete temporary pipeline and pop models
+    #     del temp_pipeline
+    #     for _ in range(len(models)):
+    #         models.pop()
 
-    accelerator.register_save_state_pre_hook(save_model_hook)
-    accelerator.register_load_state_pre_hook(load_model_hook)
+    # accelerator.register_save_state_pre_hook(save_model_hook)
+    # accelerator.register_load_state_pre_hook(load_model_hook)
 
     # Enable TF32 for faster training on Ampere GPUs,
     # cf https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1328,7 +1328,7 @@ def main(args):
         for k in unet_attn_proc_state_dict:
             from_unet = unet_attn_proc_state_dict[k]
             orig = trained_state_dict[k]
-            print(f"Assertion: {torch.allclose(from_unet, orig)}")
+            print(f"Assertion: {torch.allclose(from_unet, orig.to(from_unet.dtype))}")
 
         # run inference
         images = []

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1264,29 +1264,8 @@ def main(args):
     # Save the lora layers
     accelerator.wait_for_everyone()
     if accelerator.is_main_process:
-        # unet = unet.to(torch.float32)
+        unet = unet.to(torch.float32)
         unet_lora_layers = accelerator.unwrap_model(unet_lora_layers)
-
-        # print("*****************Initial state dict*****************")
-        # for k in sorted(initial_state_dict.keys()):
-        #     if isinstance(initial_state_dict[k], torch.Tensor):
-        #         print(
-        #             f"{k} {list(initial_state_dict[k].shape)} mean={torch.mean(initial_state_dict[k]):.3g} std={torch.std(initial_state_dict[k]):.3g}"
-        #         )
-
-        # trained_state_dict = unet_lora_layers.state_dict()
-        # print("*****************Trained state dict*****************")
-        # for k in sorted(trained_state_dict.keys()):
-        #     if isinstance(trained_state_dict[k], torch.Tensor):
-        #         print(
-        #             f"{k} {list(trained_state_dict[k].shape)} mean={torch.mean(trained_state_dict[k]):.3g} std={torch.std(trained_state_dict[k]):.3g}"
-        #         )
-
-        # unet_attn_proc_state_dict = AttnProcsLayers(unet.attn_processors).state_dict()
-        # for k in unet_attn_proc_state_dict:
-        #     from_unet = unet_attn_proc_state_dict[k]
-        #     orig = trained_state_dict[k]
-        #     print(f"Assertion: {torch.allclose(from_unet, orig)}")
 
         if text_encoder is not None:
             text_encoder = text_encoder.to(torch.float32)

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -827,7 +827,6 @@ def main(args):
 
     unet.set_attn_processor(unet_lora_attn_procs)
     unet_lora_layers = AttnProcsLayers(unet.attn_processors)
-    initial_unet_lora_layers = copy.deepcopy(unet_lora_layers)
 
     # The text encoder comes from 🤗 transformers, so we cannot directly modify it.
     # So, instead, we monkey-patch the forward calls of its attention-blocks. For this,
@@ -1264,23 +1263,24 @@ def main(args):
         unet = unet.to(torch.float32)
         unet_lora_layers = accelerator.unwrap_model(unet_lora_layers)
 
-        initial_state_dict = initial_unet_lora_layers.state_dict()
-        trained_state_dict = unet_lora_layers.state_dict()
-        logger.info("Checking between initial state dict and trained state dict.")
-        for k in trained_state_dict:
-            trained_param = trained_state_dict[k]
-            initial_param = initial_state_dict[k]
-            logger.info((trained_param.cpu() - initial_param).max())
+        # initial_state_dict = initial_unet_lora_layers.state_dict()
+        # trained_state_dict = unet_lora_layers.state_dict()
+        # logger.info("Checking between initial state dict and trained state dict.")
+        # for k in trained_state_dict:
+        #     trained_param = trained_state_dict[k]
+        #     initial_param = initial_state_dict[k]
+        #     logger.info((trained_param.cpu() - initial_param).max())
 
         if text_encoder is not None:
             text_encoder = text_encoder.to(torch.float32)
             text_encoder_lora_layers = accelerator.unwrap_model(text_encoder_lora_layers)
 
-        LoraLoaderMixin.save_lora_weights(
-            save_directory=args.output_dir,
-            unet_lora_layers=unet_lora_layers,
-            text_encoder_lora_layers=text_encoder_lora_layers,
-        )
+        # LoraLoaderMixin.save_lora_weights(
+        #     save_directory=args.output_dir,
+        #     unet_lora_layers=unet_lora_layers,
+        #     text_encoder_lora_layers=text_encoder_lora_layers,
+        # )
+        unet.save_attn_procs(save_directory=args.output_dir,)
 
         # Final inference
         # Load previous pipeline

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1267,26 +1267,26 @@ def main(args):
         # unet = unet.to(torch.float32)
         unet_lora_layers = accelerator.unwrap_model(unet_lora_layers)
 
-        print("*****************Initial state dict*****************")
-        for k in sorted(initial_state_dict.keys()):
-            if isinstance(initial_state_dict[k], torch.Tensor):
-                print(
-                    f"{k} {list(initial_state_dict[k].shape)} mean={torch.mean(initial_state_dict[k]):.3g} std={torch.std(initial_state_dict[k]):.3g}"
-                )
+        # print("*****************Initial state dict*****************")
+        # for k in sorted(initial_state_dict.keys()):
+        #     if isinstance(initial_state_dict[k], torch.Tensor):
+        #         print(
+        #             f"{k} {list(initial_state_dict[k].shape)} mean={torch.mean(initial_state_dict[k]):.3g} std={torch.std(initial_state_dict[k]):.3g}"
+        #         )
 
-        trained_state_dict = unet_lora_layers.state_dict()
-        print("*****************Trained state dict*****************")
-        for k in sorted(trained_state_dict.keys()):
-            if isinstance(trained_state_dict[k], torch.Tensor):
-                print(
-                    f"{k} {list(trained_state_dict[k].shape)} mean={torch.mean(trained_state_dict[k]):.3g} std={torch.std(trained_state_dict[k]):.3g}"
-                )
+        # trained_state_dict = unet_lora_layers.state_dict()
+        # print("*****************Trained state dict*****************")
+        # for k in sorted(trained_state_dict.keys()):
+        #     if isinstance(trained_state_dict[k], torch.Tensor):
+        #         print(
+        #             f"{k} {list(trained_state_dict[k].shape)} mean={torch.mean(trained_state_dict[k]):.3g} std={torch.std(trained_state_dict[k]):.3g}"
+        #         )
 
-        unet_attn_proc_state_dict = AttnProcsLayers(unet.attn_processors).state_dict()
-        for k in unet_attn_proc_state_dict:
-            from_unet = unet_attn_proc_state_dict[k]
-            orig = trained_state_dict[k]
-            print(f"Assertion: {torch.allclose(from_unet, orig)}")
+        # unet_attn_proc_state_dict = AttnProcsLayers(unet.attn_processors).state_dict()
+        # for k in unet_attn_proc_state_dict:
+        #     from_unet = unet_attn_proc_state_dict[k]
+        #     orig = trained_state_dict[k]
+        #     print(f"Assertion: {torch.allclose(from_unet, orig)}")
 
         if text_encoder is not None:
             text_encoder = text_encoder.to(torch.float32)
@@ -1295,8 +1295,8 @@ def main(args):
         print(f"Text encoder layers: {text_encoder_lora_layers}")
         LoraLoaderMixin.save_lora_weights(
             save_directory=args.output_dir,
-            unet_lora_layers=AttnProcsLayers(unet.attn_processors),
-            # unet_lora_layers=unet_lora_layers,
+            # unet_lora_layers=AttnProcsLayers(unet.attn_processors),
+            unet_lora_layers=unet_lora_layers,
             text_encoder_lora_layers=text_encoder_lora_layers,
         )
 
@@ -1323,6 +1323,12 @@ def main(args):
 
         # load attention processors
         pipeline.load_lora_weights(args.output_dir)
+        trained_state_dict = unet_lora_layers.state_dict()
+        unet_attn_proc_state_dict = AttnProcsLayers(pipeline.unet.attn_processors).state_dict()
+        for k in unet_attn_proc_state_dict:
+            from_unet = unet_attn_proc_state_dict[k]
+            orig = trained_state_dict[k]
+            print(f"Assertion: {torch.allclose(from_unet, orig)}")
 
         # run inference
         images = []

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -847,65 +847,65 @@ def main(args):
         text_encoder = temp_pipeline.text_encoder
         del temp_pipeline
 
-    # # create custom saving & loading hooks so that `accelerator.save_state(...)` serializes in a nice format
-    # def save_model_hook(models, weights, output_dir):
-    #     # there are only two options here. Either are just the unet attn processor layers
-    #     # or there are the unet and text encoder atten layers
-    #     unet_lora_layers_to_save = None
-    #     text_encoder_lora_layers_to_save = None
+    # create custom saving & loading hooks so that `accelerator.save_state(...)` serializes in a nice format
+    def save_model_hook(models, weights, output_dir):
+        # there are only two options here. Either are just the unet attn processor layers
+        # or there are the unet and text encoder atten layers
+        unet_lora_layers_to_save = None
+        text_encoder_lora_layers_to_save = None
 
-    #     if args.train_text_encoder:
-    #         text_encoder_keys = accelerator.unwrap_model(text_encoder_lora_layers).state_dict().keys()
-    #     unet_keys = accelerator.unwrap_model(unet_lora_layers).state_dict().keys()
+        if args.train_text_encoder:
+            text_encoder_keys = accelerator.unwrap_model(text_encoder_lora_layers).state_dict().keys()
+        unet_keys = accelerator.unwrap_model(unet_lora_layers).state_dict().keys()
 
-    #     for model in models:
-    #         state_dict = model.state_dict()
+        for model in models:
+            state_dict = model.state_dict()
 
-    #         if (
-    #             text_encoder_lora_layers is not None
-    #             and text_encoder_keys is not None
-    #             and state_dict.keys() == text_encoder_keys
-    #         ):
-    #             # text encoder
-    #             text_encoder_lora_layers_to_save = state_dict
-    #         elif state_dict.keys() == unet_keys:
-    #             # unet
-    #             unet_lora_layers_to_save = state_dict
+            if (
+                text_encoder_lora_layers is not None
+                and text_encoder_keys is not None
+                and state_dict.keys() == text_encoder_keys
+            ):
+                # text encoder
+                text_encoder_lora_layers_to_save = state_dict
+            elif state_dict.keys() == unet_keys:
+                # unet
+                unet_lora_layers_to_save = state_dict
 
-    #         # make sure to pop weight so that corresponding model is not saved again
-    #         weights.pop()
+            # make sure to pop weight so that corresponding model is not saved again
+            weights.pop()
 
-    #     LoraLoaderMixin.save_lora_weights(
-    #         output_dir,
-    #         unet_lora_layers=unet_lora_layers_to_save,
-    #         text_encoder_lora_layers=text_encoder_lora_layers_to_save,
-    #     )
+        LoraLoaderMixin.save_lora_weights(
+            output_dir,
+            unet_lora_layers=unet_lora_layers_to_save,
+            text_encoder_lora_layers=text_encoder_lora_layers_to_save,
+        )
 
-    # def load_model_hook(models, input_dir):
-    #     # Note we DON'T pass the unet and text encoder here an purpose
-    #     # so that the we don't accidentally override the LoRA layers of
-    #     # unet_lora_layers and text_encoder_lora_layers which are stored in `models`
-    #     # with new torch.nn.Modules / weights. We simply use the pipeline class as
-    #     # an easy way to load the lora checkpoints
-    #     temp_pipeline = DiffusionPipeline.from_pretrained(
-    #         args.pretrained_model_name_or_path,
-    #         revision=args.revision,
-    #         torch_dtype=weight_dtype,
-    #     )
-    #     temp_pipeline.load_lora_weights(input_dir)
+    def load_model_hook(models, input_dir):
+        # Note we DON'T pass the unet and text encoder here an purpose
+        # so that the we don't accidentally override the LoRA layers of
+        # unet_lora_layers and text_encoder_lora_layers which are stored in `models`
+        # with new torch.nn.Modules / weights. We simply use the pipeline class as
+        # an easy way to load the lora checkpoints
+        temp_pipeline = DiffusionPipeline.from_pretrained(
+            args.pretrained_model_name_or_path,
+            revision=args.revision,
+            torch_dtype=weight_dtype,
+        )
+        temp_pipeline.load_lora_weights(input_dir)
 
-    #     # load lora weights into models
-    #     models[0].load_state_dict(AttnProcsLayers(temp_pipeline.unet.attn_processors).state_dict())
-    #     if len(models) > 1:
-    #         models[1].load_state_dict(AttnProcsLayers(temp_pipeline.text_encoder_lora_attn_procs).state_dict())
+        # load lora weights into models
+        models[0].load_state_dict(AttnProcsLayers(temp_pipeline.unet.attn_processors).state_dict())
+        if len(models) > 1:
+            models[1].load_state_dict(AttnProcsLayers(temp_pipeline.text_encoder_lora_attn_procs).state_dict())
 
-    #     # delete temporary pipeline and pop models
-    #     del temp_pipeline
-    #     for _ in range(len(models)):
-    #         models.pop()
+        # delete temporary pipeline and pop models
+        del temp_pipeline
+        for _ in range(len(models)):
+            models.pop()
 
-    # accelerator.register_save_state_pre_hook(save_model_hook)
-    # accelerator.register_load_state_pre_hook(load_model_hook)
+    accelerator.register_save_state_pre_hook(save_model_hook)
+    accelerator.register_load_state_pre_hook(load_model_hook)
 
     # Enable TF32 for faster training on Ampere GPUs,
     # cf https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices
@@ -1275,19 +1275,19 @@ def main(args):
             text_encoder = text_encoder.to(torch.float32)
             text_encoder_lora_layers = accelerator.unwrap_model(text_encoder_lora_layers)
 
-        # LoraLoaderMixin.save_lora_weights(
-        #     save_directory=args.output_dir,
-        #     unet_lora_layers=unet_lora_layers,
-        #     text_encoder_lora_layers=text_encoder_lora_layers,
-        # )
-        unet.save_attn_procs(save_directory=args.output_dir,)
+        LoraLoaderMixin.save_lora_weights(
+            save_directory=args.output_dir,
+            unet_lora_layers=unet_lora_layers,
+            text_encoder_lora_layers=text_encoder_lora_layers,
+        )
+        # unet.save_attn_procs(save_directory=args.output_dir,)
 
         # Final inference
         # Load previous pipeline
         pipeline = DiffusionPipeline.from_pretrained(
             args.pretrained_model_name_or_path, revision=args.revision, torch_dtype=weight_dtype
         )
-        pipeline.unet = unet.to(weight_dtype)
+        # pipeline.unet = unet.to(weight_dtype)
 
         # We train on the simplified learning objective. If we were previously predicting a variance, we need the scheduler to ignore it
         scheduler_args = {}
@@ -1305,14 +1305,14 @@ def main(args):
         pipeline = pipeline.to(accelerator.device)
 
         # load attention processors
-        # pipeline.load_lora_weights(args.output_dir)
+        pipeline.load_lora_weights(args.output_dir)
 
         # run inference
         images = []
         if args.validation_prompt and args.num_validation_images > 0:
             generator = torch.Generator(device=accelerator.device).manual_seed(args.seed) if args.seed else None
             images = [
-                pipeline(args.validation_prompt, num_inference_steps=25, generator=generator).images[0]
+                pipeline(args.validation_prompt, generator=generator).images[0]
                 for _ in range(args.num_validation_images)
             ]
 

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1287,6 +1287,7 @@ def main(args):
         pipeline = DiffusionPipeline.from_pretrained(
             args.pretrained_model_name_or_path, revision=args.revision, torch_dtype=weight_dtype
         )
+        pipeline.unet = unet
 
         # We train on the simplified learning objective. If we were previously predicting a variance, we need the scheduler to ignore it
         scheduler_args = {}
@@ -1304,7 +1305,7 @@ def main(args):
         pipeline = pipeline.to(accelerator.device)
 
         # load attention processors
-        pipeline.load_lora_weights(args.output_dir)
+        # pipeline.load_lora_weights(args.output_dir)
 
         # run inference
         images = []

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -830,7 +830,7 @@ def main(args):
 
     unet.set_attn_processor(unet_lora_attn_procs)
     unet_lora_layers = AttnProcsLayers(unet.attn_processors)
-    initial_state_dict = unet_lora_layers.state_dict()
+    unet_lora_layers.state_dict()
 
     # The text encoder comes from 🤗 transformers, so we cannot directly modify it.
     # So, instead, we monkey-patch the forward calls of its attention-blocks. For this,

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -281,11 +281,11 @@ class UNet2DConditionLoadersMixin:
                     cross_attention_dim = value_dict["to_k_lora.down.weight"].shape[1]
                     attn_processor_class = LoRAAttnProcessor
 
-                # print(f"attn_processor_class: {attn_processor_class}")
+                print(f"attn_processor_class: {attn_processor_class}")
                 attn_processors[key] = attn_processor_class(
                     hidden_size=hidden_size, cross_attention_dim=cross_attention_dim, rank=rank
                 )
-                print(f"{attn_processors[key]} is being loaded with: {value_dict.keys()}")
+                # print(f"{attn_processors[key]} is being loaded with: {value_dict.keys()}")
                 attn_processors[key].load_state_dict(value_dict)
         elif is_custom_diffusion:
             custom_diffusion_grouped_dict = defaultdict(dict)

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -285,7 +285,7 @@ class UNet2DConditionLoadersMixin:
                 attn_processors[key] = attn_processor_class(
                     hidden_size=hidden_size, cross_attention_dim=cross_attention_dim, rank=rank
                 )
-                # print(f"{attn_processors[key]} is being loaded with: {value_dict.keys()}")
+                print(f"{attn_processors[key]} is being loaded with: {value_dict.keys()}")
                 attn_processors[key].load_state_dict(value_dict)
         elif is_custom_diffusion:
             custom_diffusion_grouped_dict = defaultdict(dict)

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -281,6 +281,7 @@ class UNet2DConditionLoadersMixin:
                     cross_attention_dim = value_dict["to_k_lora.down.weight"].shape[1]
                     attn_processor_class = LoRAAttnProcessor
 
+                print(f"attn_processor_class: {attn_processor_class}")
                 attn_processors[key] = attn_processor_class(
                     hidden_size=hidden_size, cross_attention_dim=cross_attention_dim, rank=rank
                 )
@@ -891,6 +892,7 @@ class LoraLoaderMixin:
         # then the `state_dict` keys should have `self.unet_name` and/or `self.text_encoder_name` as
         # their prefixes.
         keys = list(state_dict.keys())
+        print("Inside the lora loader.")
         if all(key.startswith(self.unet_name) or key.startswith(self.text_encoder_name) for key in keys):
             # Load the layers corresponding to UNet.
             unet_keys = [k for k in keys if k.startswith(self.unet_name)]
@@ -899,6 +901,7 @@ class LoraLoaderMixin:
                 k.replace(f"{self.unet_name}.", ""): v for k, v in state_dict.items() if k in unet_keys
             }
             self.unet.load_attn_procs(unet_lora_state_dict)
+            print("UNet lora loaded.")
 
             # Load the layers corresponding to text encoder and make necessary adjustments.
             text_encoder_keys = [k for k in keys if k.startswith(self.text_encoder_name)]

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -281,11 +281,9 @@ class UNet2DConditionLoadersMixin:
                     cross_attention_dim = value_dict["to_k_lora.down.weight"].shape[1]
                     attn_processor_class = LoRAAttnProcessor
 
-                # print(f"attn_processor_class: {attn_processor_class}")
                 attn_processors[key] = attn_processor_class(
                     hidden_size=hidden_size, cross_attention_dim=cross_attention_dim, rank=rank
                 )
-                # print(f"{attn_processors[key]} is being loaded with: {value_dict.keys()}")
                 attn_processors[key].load_state_dict(value_dict)
         elif is_custom_diffusion:
             custom_diffusion_grouped_dict = defaultdict(dict)
@@ -897,7 +895,6 @@ class LoraLoaderMixin:
         # then the `state_dict` keys should have `self.unet_name` and/or `self.text_encoder_name` as
         # their prefixes.
         keys = list(state_dict.keys())
-        # print("Inside the lora loader.")
         if all(key.startswith(self.unet_name) or key.startswith(self.text_encoder_name) for key in keys):
             # Load the layers corresponding to UNet.
             unet_keys = [k for k in keys if k.startswith(self.unet_name)]
@@ -906,7 +903,6 @@ class LoraLoaderMixin:
                 k.replace(f"{self.unet_name}.", ""): v for k, v in state_dict.items() if k in unet_keys
             }
             self.unet.load_attn_procs(unet_lora_state_dict)
-            # print("UNet lora loaded.")
 
             # Load the layers corresponding to text encoder and make necessary adjustments.
             text_encoder_keys = [k for k in keys if k.startswith(self.text_encoder_name)]

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -906,6 +906,7 @@ class LoraLoaderMixin:
 
             # Load the layers corresponding to text encoder and make necessary adjustments.
             text_encoder_keys = [k for k in keys if k.startswith(self.text_encoder_name)]
+            print(text_encoder_keys)
             text_encoder_lora_state_dict = {
                 k.replace(f"{self.text_encoder_name}.", ""): v for k, v in state_dict.items() if k in text_encoder_keys
             }

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -285,6 +285,7 @@ class UNet2DConditionLoadersMixin:
                 attn_processors[key] = attn_processor_class(
                     hidden_size=hidden_size, cross_attention_dim=cross_attention_dim, rank=rank
                 )
+                print(f"{attn_processors[key]} is being loaded with: {value_dict.keys()}")
                 attn_processors[key].load_state_dict(value_dict)
         elif is_custom_diffusion:
             custom_diffusion_grouped_dict = defaultdict(dict)

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -281,7 +281,7 @@ class UNet2DConditionLoadersMixin:
                     cross_attention_dim = value_dict["to_k_lora.down.weight"].shape[1]
                     attn_processor_class = LoRAAttnProcessor
 
-                print(f"attn_processor_class: {attn_processor_class}")
+                # print(f"attn_processor_class: {attn_processor_class}")
                 attn_processors[key] = attn_processor_class(
                     hidden_size=hidden_size, cross_attention_dim=cross_attention_dim, rank=rank
                 )
@@ -893,7 +893,7 @@ class LoraLoaderMixin:
         # then the `state_dict` keys should have `self.unet_name` and/or `self.text_encoder_name` as
         # their prefixes.
         keys = list(state_dict.keys())
-        print("Inside the lora loader.")
+        # print("Inside the lora loader.")
         if all(key.startswith(self.unet_name) or key.startswith(self.text_encoder_name) for key in keys):
             # Load the layers corresponding to UNet.
             unet_keys = [k for k in keys if k.startswith(self.unet_name)]
@@ -902,7 +902,7 @@ class LoraLoaderMixin:
                 k.replace(f"{self.unet_name}.", ""): v for k, v in state_dict.items() if k in unet_keys
             }
             self.unet.load_attn_procs(unet_lora_state_dict)
-            print("UNet lora loaded.")
+            # print("UNet lora loaded.")
 
             # Load the layers corresponding to text encoder and make necessary adjustments.
             text_encoder_keys = [k for k in keys if k.startswith(self.text_encoder_name)]

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -906,11 +906,11 @@ class LoraLoaderMixin:
 
             # Load the layers corresponding to text encoder and make necessary adjustments.
             text_encoder_keys = [k for k in keys if k.startswith(self.text_encoder_name)]
-            logger.info(f"Loading {self.text_encoder_name}.")
             text_encoder_lora_state_dict = {
                 k.replace(f"{self.text_encoder_name}.", ""): v for k, v in state_dict.items() if k in text_encoder_keys
             }
             if len(text_encoder_lora_state_dict) > 0:
+                logger.info(f"Loading {self.text_encoder_name}.")
                 attn_procs_text_encoder = self._load_text_encoder_attn_procs(text_encoder_lora_state_dict)
                 self._modify_text_encoder(attn_procs_text_encoder)
 

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -906,10 +906,10 @@ class LoraLoaderMixin:
 
             # Load the layers corresponding to text encoder and make necessary adjustments.
             text_encoder_keys = [k for k in keys if k.startswith(self.text_encoder_name)]
-            print(text_encoder_keys)
             text_encoder_lora_state_dict = {
                 k.replace(f"{self.text_encoder_name}.", ""): v for k, v in state_dict.items() if k in text_encoder_keys
             }
+            print(f"text_encoder_lora_state_dict: {text_encoder_lora_state_dict.keys()}")
             if len(text_encoder_lora_state_dict) > 0:
                 logger.info(f"Loading {self.text_encoder_name}.")
                 attn_procs_text_encoder = self._load_text_encoder_attn_procs(text_encoder_lora_state_dict)

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -281,11 +281,11 @@ class UNet2DConditionLoadersMixin:
                     cross_attention_dim = value_dict["to_k_lora.down.weight"].shape[1]
                     attn_processor_class = LoRAAttnProcessor
 
-                print(f"attn_processor_class: {attn_processor_class}")
+                # print(f"attn_processor_class: {attn_processor_class}")
                 attn_processors[key] = attn_processor_class(
                     hidden_size=hidden_size, cross_attention_dim=cross_attention_dim, rank=rank
                 )
-                print(f"{attn_processors[key]} is being loaded with: {value_dict.keys()}")
+                # print(f"{attn_processors[key]} is being loaded with: {value_dict.keys()}")
                 attn_processors[key].load_state_dict(value_dict)
         elif is_custom_diffusion:
             custom_diffusion_grouped_dict = defaultdict(dict)

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -271,7 +271,6 @@ class UNet2DConditionLoadersMixin:
                 attn_processor = self
                 for sub_key in key.split("."):
                     attn_processor = getattr(attn_processor, sub_key)
-                    print(f"UNet Load LoRA: {type(attn_processor)}")
 
                 if isinstance(
                     attn_processor, (AttnAddedKVProcessor, SlicedAttnAddedKVProcessor, AttnAddedKVProcessor2_0)
@@ -325,6 +324,10 @@ class UNet2DConditionLoadersMixin:
         attn_processors = {k: v.to(device=self.device, dtype=self.dtype) for k, v in attn_processors.items()}
 
         # set layers
+        print(
+            "All processors are of type: LoRAAttnAddedKVProcessor: ",
+            all(isinstance(attn_processors[k], LoRAAttnAddedKVProcessor) for k in attn_processors),
+        )
         self.set_attn_processor(attn_processors)
 
     def save_attn_procs(

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -271,6 +271,7 @@ class UNet2DConditionLoadersMixin:
                 attn_processor = self
                 for sub_key in key.split("."):
                     attn_processor = getattr(attn_processor, sub_key)
+                    print(f"UNet Load LoRA: {type(attn_processor)}")
 
                 if isinstance(
                     attn_processor, (AttnAddedKVProcessor, SlicedAttnAddedKVProcessor, AttnAddedKVProcessor2_0)

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -290,7 +290,7 @@ class Attention(nn.Module):
             logger.info(f"You are removing possibly trained weights of {self.processor} with {processor}")
             self._modules.pop("processor")
 
-        print(f"Processor type: {type(processor)}")
+        # print(f"Processor type: {type(processor)}")
         self.processor = processor
 
     def forward(self, hidden_states, encoder_hidden_states=None, attention_mask=None, **cross_attention_kwargs):
@@ -759,7 +759,7 @@ class LoRAAttnAddedKVProcessor(nn.Module):
         self.to_out_lora = LoRALinearLayer(hidden_size, hidden_size, rank)
 
     def __call__(self, attn: Attention, hidden_states, encoder_hidden_states=None, attention_mask=None, scale=1.0):
-        print(f"{self.__class__.__name__} have been called.")
+        # print(f"{self.__class__.__name__} have been called.")
         residual = hidden_states
         hidden_states = hidden_states.view(hidden_states.shape[0], hidden_states.shape[1], -1).transpose(1, 2)
         batch_size, sequence_length, _ = hidden_states.shape

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -290,6 +290,7 @@ class Attention(nn.Module):
             logger.info(f"You are removing possibly trained weights of {self.processor} with {processor}")
             self._modules.pop("processor")
 
+        print(f"Processor type: {type(processor)}")
         self.processor = processor
 
     def forward(self, hidden_states, encoder_hidden_states=None, attention_mask=None, **cross_attention_kwargs):
@@ -758,6 +759,7 @@ class LoRAAttnAddedKVProcessor(nn.Module):
         self.to_out_lora = LoRALinearLayer(hidden_size, hidden_size, rank)
 
     def __call__(self, attn: Attention, hidden_states, encoder_hidden_states=None, attention_mask=None, scale=1.0):
+        print(f"{self.__class__.__name__} have been called.")
         residual = hidden_states
         hidden_states = hidden_states.view(hidden_states.shape[0], hidden_states.shape[1], -1).transpose(1, 2)
         batch_size, sequence_length, _ = hidden_states.shape

--- a/src/diffusers/models/unet_2d_condition.py
+++ b/src/diffusers/models/unet_2d_condition.py
@@ -518,9 +518,9 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 f"A dict of processors was passed, but the number of processors {len(processor)} does not match the"
                 f" number of attention layers: {count}. Please make sure to pass {count} processor classes."
             )
-        print("set_attn_processor() is called.")
-        for k in processor:
-            print(f"{k}: {type(processor[k])}")
+        # print("set_attn_processor() is called.")
+        # for k in processor:
+        #     print(f"{k}: {type(processor[k])}")
 
 
         def fn_recursive_attn_processor(name: str, module: torch.nn.Module, processor):

--- a/src/diffusers/models/unet_2d_condition.py
+++ b/src/diffusers/models/unet_2d_condition.py
@@ -522,7 +522,6 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
         # for k in processor:
         #     print(f"{k}: {type(processor[k])}")
 
-
         def fn_recursive_attn_processor(name: str, module: torch.nn.Module, processor):
             if hasattr(module, "set_processor"):
                 if not isinstance(processor, dict):

--- a/src/diffusers/models/unet_2d_condition.py
+++ b/src/diffusers/models/unet_2d_condition.py
@@ -518,6 +518,10 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 f"A dict of processors was passed, but the number of processors {len(processor)} does not match the"
                 f" number of attention layers: {count}. Please make sure to pass {count} processor classes."
             )
+        print("set_attn_processor() is called.")
+        for k in processor:
+            print(f"{k}: {type(processor[k])}")
+
 
         def fn_recursive_attn_processor(name: str, module: torch.nn.Module, processor):
             if hasattr(module, "set_processor"):


### PR DESCRIPTION
Currently, our DreamBooth LoRA training script supports the IF pipeline. 

While nothing seems off on the surface, I think there's something wrong after you try to load the trained LoRA parameters (only for IF) and perform inference with it. 

The inference proceeds without any errors, but it doesn't reflect the subject it was DreamBooth'd on. 

What is more interesting is that when you're running inference in between the training, the results kind of reflect the subject being trained. 

To understand this better, consider the following collage:

<img width="1121" alt="image" src="https://github.com/huggingface/diffusers/assets/22957388/3aaaa613-9d12-47e9-b883-aa7d0d1a514a">

The number of training steps were 100 ([run](https://wandb.ai/sayakpaul/dreambooth-lora/runs/ab9trtsi?workspace=user-sayakpaul)), so gibberish results, but still, it's starting to reflect the dog subject being trained. This becomes more stark when you compare it to the following:

<img width="1529" alt="image" src="https://github.com/huggingface/diffusers/assets/22957388/889233b1-b02f-4842-abd0-5e900f5aa427">

The following results are _after_ you load the LoRA DreamBooth parameters into the pipeline. There is an immediate disparity here. 

So, an immediate place to look at for potential suspects would be the LoRA saving and loading modules:

* This phenomenon doesn't happen when you're performing DreamBooth LoRA with an SD checkpoint (`runwayml/stable-diffusion-v1-5`, for example). 
* I kept strategic debugging messages (which I explain in the comments) to catch potential suspects, but nothing seemed to be off to my eyes. 


## Reproduction

```bash
export MODEL_NAME="DeepFloyd/IF-I-XL-v1.0"
export INSTANCE_DIR="dog"
export OUTPUT_DIR="dreambooth-if-dog"

accelerate launch train_dreambooth_lora.py \
  --report_to wandb \
  --pretrained_model_name_or_path=$MODEL_NAME  \
  --instance_data_dir=$INSTANCE_DIR \
  --output_dir=$OUTPUT_DIR \
  --instance_prompt="a photo of sks dog" \
  --resolution=64 \
  --train_batch_size=4 \
  --gradient_accumulation_steps=1 \
  --learning_rate=5e-6 \
  --mixed_precision="fp16" \
  --scale_lr \
  --max_train_steps=100 \
  --validation_prompt="A photo of sks dog in a bucket" \
  --validation_epochs=10 \
  --checkpointing_steps=50 \
  --pre_compute_text_embeddings \
  --tokenizer_max_length=77 \
  --text_encoder_use_attention_mask \
  --push_to_hub
```

The `dog` dataset can be downloaded like so:

```python
from huggingface_hub import snapshot_download

local_dir = "./dog"
snapshot_download(
    "diffusers/dog-example",
    local_dir=local_dir, repo_type="dataset",
    ignore_patterns=".gitattributes",
)
```

@patrickvonplaten @pcuenca @williamberman do you have any suggestions? Please do consider the PR comments too, to see the debugging I have already done. 