### PR TITLE
Iterate over unique tokens to avoid duplicate replacements for multivector embeddings

### DIFF
--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -456,7 +456,8 @@ class TextualInversionLoaderMixin:
             `str`: The converted prompt
         """
         tokens = tokenizer.tokenize(prompt)
-        for token in tokens:
+        unique_tokens = set(tokens)
+        for token in unique_tokens:
             if token in tokenizer.added_tokens_encoder:
                 replacement = token
                 i = 1

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -663,22 +663,6 @@ class DownloadTests(unittest.TestCase):
                 out = pipe(prompt, num_inference_steps=1, output_type="numpy").images
                 assert out.shape == (1, 128, 128, 3)
 
-        # multiple references to multi embedding
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            ten = {"<cat>": torch.cat([3 * torch.ones((1, 32)), 4 * torch.ones((1, 32)), 5 * torch.ones((1, 32))])}
-            torch.save(ten, os.path.join(tmpdirname, "learned_embeds.bin"))
-
-            pipe.load_textual_inversion(tmpdirname)
-
-            assert (
-                pipe._maybe_convert_prompt("<cat> <cat>", pipe.tokenizer)
-                == "<cat> <cat>_1 <cat>_2 <cat> <cat>_1 <cat>_2"
-            )
-
-            prompt = "hey <cat> <cat>"
-            out = pipe(prompt, num_inference_steps=1, output_type="numpy").images
-            assert out.shape == (1, 128, 128, 3)
-
         # single token state dict load
         ten = {"<x>": torch.ones((32,))}
         pipe.load_textual_inversion(ten)
@@ -735,6 +719,18 @@ class DownloadTests(unittest.TestCase):
         assert pipe._maybe_convert_prompt("<xxxx>", pipe.tokenizer) == "<xxxx> <xxxx>_1 <xxxx>_2"
 
         prompt = "hey <xxxx>"
+        out = pipe(prompt, num_inference_steps=1, output_type="numpy").images
+        assert out.shape == (1, 128, 128, 3)
+
+        # multiple references to multi embedding
+        ten = {"<cat>": torch.ones(3, 32)}
+        pipe.load_textual_inversion(ten)
+
+        assert (
+            pipe._maybe_convert_prompt("<cat> <cat>", pipe.tokenizer) == "<cat> <cat>_1 <cat>_2 <cat> <cat>_1 <cat>_2"
+        )
+
+        prompt = "hey <cat> <cat>"
         out = pipe(prompt, num_inference_steps=1, output_type="numpy").images
         assert out.shape == (1, 128, 128, 3)
 

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -670,7 +670,10 @@ class DownloadTests(unittest.TestCase):
 
             pipe.load_textual_inversion(tmpdirname)
 
-            assert pipe._maybe_convert_prompt("<cat> <cat>", pipe.tokenizer) == "<cat> <cat>_1 <cat>_2 <cat> <cat>_1 <cat>_2"
+            assert (
+                pipe._maybe_convert_prompt("<cat> <cat>", pipe.tokenizer)
+                == "<cat> <cat>_1 <cat>_2 <cat> <cat>_1 <cat>_2"
+            )
 
             prompt = "hey <cat> <cat>"
             out = pipe(prompt, num_inference_steps=1, output_type="numpy").images

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -663,6 +663,19 @@ class DownloadTests(unittest.TestCase):
                 out = pipe(prompt, num_inference_steps=1, output_type="numpy").images
                 assert out.shape == (1, 128, 128, 3)
 
+        # multiple references to multi embedding
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            ten = {"<cat>": torch.cat([3 * torch.ones((1, 32)), 4 * torch.ones((1, 32)), 5 * torch.ones((1, 32))])}
+            torch.save(ten, os.path.join(tmpdirname, "learned_embeds.bin"))
+
+            pipe.load_textual_inversion(tmpdirname)
+
+            assert pipe._maybe_convert_prompt("<cat> <cat>", pipe.tokenizer) == "<cat> <cat>_1 <cat>_2 <cat> <cat>_1 <cat>_2"
+
+            prompt = "hey <cat> <cat>"
+            out = pipe(prompt, num_inference_steps=1, output_type="numpy").images
+            assert out.shape == (1, 128, 128, 3)
+
         # single token state dict load
         ten = {"<x>": torch.ones((32,))}
         pipe.load_textual_inversion(ten)


### PR DESCRIPTION
Unfortunately I could not find and issues referencing this behavior, but this PR fixes an issue where repeating a token corresponding to a multi-vector embedding is not handled properly. 
As an example, if we have a 4-vector embedding stored as `bad_quality.pt`
```python
pipe.load_textual_inversion('bad_quality.pt', token='bad_quality')
pipe.tokenizer.added_tokens_encoder 
# {'bad_quality': 49408, 'bad_quality_1': 49409, 'bad_quality_2': 49410, 'bad_quality_3': 49411}

pipe.maybe_convert_prompt('saturated, bad_quality, blurry, soft')
# saturated, bad_quality bad_quality_1 bad_quality_2 bad_quality_3, blurry, soft

pipe.maybe_convert_prompt('saturated, bad_quality, blurry, bad_quality, soft')
# 'saturated, bad_quality bad_quality_1 bad_quality_2 bad_quality_3 bad_quality bad_quality_1 bad_quality_2 bad_quality_3_1 bad_quality bad_quality_1 bad_quality_2 bad_quality_3_2 bad_quality bad_quality_1 bad_quality_2 bad_quality_3_3, blurry, bad_quality bad_quality_1 bad_quality_2 bad_quality_3 bad_quality bad_quality_1 bad_quality_2 bad_quality_3_1 bad_quality bad_quality_1 bad_quality_2 bad_quality_3_2 bad_quality bad_quality_1 bad_quality_2 bad_quality_3_3, soft'

# expected output:
# saturated, bad_quality bad_quality_1 bad_quality_2 bad_quality_3, blurry, bad_quality bad_quality_1 bad_quality_2 bad_quality_3, soft
```

The reason this occurs is because `TextualInversionLoaderMixin._maybe_convert_prompt` attempts to find and expand tokens that represent multi-vector embeddings with a token per vector. In the example above, this equates to:
```python
prompt.replace('bad_quality', 'bad_quality bad_quality_1 bad_quality_2 bad_quality_3')
```
Yet this is repeated unnecessarily when the identifier for the multi-vector embedding appears more than once in the prompt. 

I expect there will be many changes in this area in future to improve how multi-vector embeddings are handled, but for now, simply iterating through the set of unique tokens will fix the issue. 
