### PR TITLE
Allow setting num_cycles for cosine_with_restarts lr scheduler

### DIFF
--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -286,6 +286,12 @@ def parse_args():
         "--lr_warmup_steps", type=int, default=500, help="Number of steps for the warmup in the lr scheduler."
     )
     parser.add_argument(
+        "--lr_num_cycles",
+        type=int,
+        default=1,
+        help="Number of hard resets of the lr in cosine_with_restarts scheduler.",
+    )
+    parser.add_argument(
         "--dataloader_num_workers",
         type=int,
         default=0,
@@ -739,6 +745,7 @@ def main():
         optimizer=optimizer,
         num_warmup_steps=args.lr_warmup_steps * args.gradient_accumulation_steps,
         num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
+        num_cycles=args.lr_num_cycles * args.gradient_accumulation_steps,
     )
 
     # Prepare everything with our `accelerator`.


### PR DESCRIPTION
Expose `num_cycles` kwarg of `get_schedule()` through `args.lr_num_cycles`. This is similar to the [implementation](https://github.com/huggingface/diffusers/blob/c6ae8837512d0572639b9f57491d4482fdc8948c/examples/controlnet/train_controlnet.py#L360) in current controlnet training script and other training scripts.

Note: different from [the current controlnet training script](https://github.com/huggingface/diffusers/blob/c6ae8837512d0572639b9f57491d4482fdc8948c/examples/controlnet/train_controlnet.py#LL906C18-L906C18), I scale `args.lr_num_cycles` by `gradient_accumulation_steps`, which seems to give the correct behavior.