### PR TITLE
Trigger CI on ci-* branches

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - ci-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Similar to the config in [transformers](https://github.com/huggingface/transformers/blob/fabe17a726bbf6081cfbcc975d8ac451a81f3e2d/.github/workflows/self-push.yml#L11) and [datasets](https://github.com/huggingface/datasets/blob/d6a61a1af1502677a6f2333896a6ffeede9ca21b/.github/workflows/ci.yml#L10). The goal is to trigger the tests without having to create a dumb PR (like [this one](https://github.com/huggingface/diffusers/pull/3633#issuecomment-1571773934)). Will be helpful for future pre-releases of `huggingface_hub`.