### PR TITLE
set config from original module but set compiled module on class

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -485,17 +485,19 @@ class DiffusionPipeline(ConfigMixin):
             if module is None:
                 register_dict = {name: (None, None)}
             else:
-                # register the original module, not the dynamo compiled one
+                # register the config from the original module, not the dynamo compiled one
                 if is_compiled_module(module):
-                    module = module._orig_mod
+                    not_compiled_module = module._orig_mod
+                else:
+                    not_compiled_module = module
 
-                library = module.__module__.split(".")[0]
+                library = not_compiled_module.__module__.split(".")[0]
 
                 # check if the module is a pipeline module
-                module_path_items = module.__module__.split(".")
+                module_path_items = not_compiled_module.__module__.split(".")
                 pipeline_dir = module_path_items[-2] if len(module_path_items) > 2 else None
 
-                path = module.__module__.split(".")
+                path = not_compiled_module.__module__.split(".")
                 is_pipeline_module = pipeline_dir in path and hasattr(pipelines, pipeline_dir)
 
                 # if library is not in LOADABLE_CLASSES, then it is a custom module.
@@ -504,10 +506,10 @@ class DiffusionPipeline(ConfigMixin):
                 if is_pipeline_module:
                     library = pipeline_dir
                 elif library not in LOADABLE_CLASSES:
-                    library = module.__module__
+                    library = not_compiled_module.__module__
 
                 # retrieve class_name
-                class_name = module.__class__.__name__
+                class_name = not_compiled_module.__class__.__name__
 
                 register_dict = {name: (library, class_name)}
 

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -61,6 +61,7 @@ from diffusers.utils import (
     CONFIG_NAME,
     WEIGHTS_NAME,
     floats_tensor,
+    is_compiled_module,
     nightly,
     require_torch_2,
     slow,
@@ -99,6 +100,11 @@ def _test_from_save_pretrained_dynamo(in_queue, out_queue, timeout):
         scheduler = DDPMScheduler(num_train_timesteps=10)
 
         ddpm = DDPMPipeline(model, scheduler)
+
+        # previous diffusers versions stripped compilation off
+        # compiled modules
+        assert is_compiled_module(ddpm.unet)
+
         ddpm.to(torch_device)
         ddpm.set_progress_bar_config(disable=None)
 


### PR DESCRIPTION
If you passed a compiled module to the pipeline constructor, this would silently strip the compilation and set the uncompiled module on the pipeline

Before:
```py
from diffusers import UNet2DConditionModel
import torch
from diffusers import DiffusionPipeline

unet = UNet2DConditionModel.from_pretrained("runwayml/stable-diffusion-v1-5", subfolder="unet")

print(unet.__class__)
# diffusers.models.unet_2d_condition.UNet2DConditionModel

unet = torch.compile(unet)

print(unet.__class__)
# torch._dynamo.eval_frame.OptimizedModule

pipe = DiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5", unet=unet)

print(pipe.unet.__class__)
# diffusers.models.unet_2d_condition.UNet2DConditionModel
```

Now:
```py
>>> from diffusers import UNet2DConditionModel
>>> import torch
>>> from diffusers import DiffusionPipeline
>>>
>>> unet = UNet2DConditionModel.from_pretrained("runwayml/stable-diffusion-v1-5", subfolder="unet")
>>>
>>> print(unet.__class__)
<class 'diffusers.models.unet_2d_condition.UNet2DConditionModel'>
>>> # diffusers.models.unet_2d_condition.UNet2DConditionModel
>>>
>>> unet = torch.compile(unet)
>>>
>>> print(unet.__class__)
<class 'torch._dynamo.eval_frame.OptimizedModule'>
>>> # torch._dynamo.eval_frame.OptimizedModule
>>>
>>> pipe = DiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5", unet=unet)
`text_config_dict` is provided which will be used to initialize `CLIPTextConfig`. The value `text_config["id2label"]` will be overriden.
>>>
>>> print(pipe.unet.__class__)
<class 'torch._dynamo.eval_frame.OptimizedModule'>
```