### PR TITLE
Fix from_ckpt for Stable Diffusion 2.x

### DIFF
--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1418,23 +1418,25 @@ class FromCkptMixin:
 
         # TODO: For now we only support stable diffusion
         stable_unclip = None
+        model_type = None
         controlnet = False
 
         if pipeline_name == "StableDiffusionControlNetPipeline":
-            model_type = "FrozenCLIPEmbedder"
+            # Model type will be inferred from the checkpoint.
             controlnet = True
         elif "StableDiffusion" in pipeline_name:
-            model_type = "FrozenCLIPEmbedder"
+            # Model type will be inferred from the checkpoint.
+            pass
         elif pipeline_name == "StableUnCLIPPipeline":
-            model_type == "FrozenOpenCLIPEmbedder"
+            model_type = "FrozenOpenCLIPEmbedder"
             stable_unclip = "txt2img"
         elif pipeline_name == "StableUnCLIPImg2ImgPipeline":
-            model_type == "FrozenOpenCLIPEmbedder"
+            model_type = "FrozenOpenCLIPEmbedder"
             stable_unclip = "img2img"
         elif pipeline_name == "PaintByExamplePipeline":
-            model_type == "PaintByExample"
+            model_type = "PaintByExample"
         elif pipeline_name == "LDMTextToImagePipeline":
-            model_type == "LDMTextToImage"
+            model_type = "LDMTextToImage"
         else:
             raise ValueError(f"Unhandled pipeline class: {pipeline_name}")
 


### PR DESCRIPTION
Fix #3661 

This is because `from_ckpt` uses `FrozenCLIPEmbedder` for `StableDiffusionPipeline` but it should be `FrozenOpenCLIPEmbedder`  in Stable Diffusion 2.x.

The original `download_from_original_stable_diffusion_ckpt` uses a layer that only presents in Stable Diffusion 2.x checkpoint to infer the `model_type`, which is not work with `from_ckpt` because it overrides the param. I think we can just leave the `model_type` empty for Stable Diffusion pipelines and then it will be inferred correctly.

By the way, this PR also fixes some invalid assignments for `model_type`.