### PR TITLE
Fixes eval generator init in `train_text_to_image_lora.py`

### DIFF
--- a/examples/text_to_image/train_text_to_image_lora.py
+++ b/examples/text_to_image/train_text_to_image_lora.py
@@ -825,7 +825,9 @@ def main():
                 pipeline.set_progress_bar_config(disable=True)
 
                 # run inference
-                generator = torch.Generator(device=accelerator.device).manual_seed(args.seed)
+                generator = torch.Generator(device=accelerator.device)
+                if args.seed is not None:
+                    generator = generator.manual_seed(args.seed)
                 images = []
                 for _ in range(args.num_validation_images):
                     images.append(
@@ -881,7 +883,9 @@ def main():
     pipeline.unet.load_attn_procs(args.output_dir)
 
     # run inference
-    generator = torch.Generator(device=accelerator.device).manual_seed(args.seed)
+    generator = torch.Generator(device=accelerator.device)
+    if args.seed is not None:
+        generator = generator.manual_seed(args.seed)
     images = []
     for _ in range(args.num_validation_images):
         images.append(pipeline(args.validation_prompt, num_inference_steps=30, generator=generator).images[0])


### PR DESCRIPTION
If you run the LoRA training script without specifying a seed, the run will crash during the validation stage when it creates a PRNG generator. This is just because `generator.manual_seed(...)` can't take `None` as input, so this PR just checks whether it is not `None`.

Error you get without this fix:
```
Steps:  22%|████████▌                             | 4500/20000 [2:12:18<7:35:53,  1.76s/it, lr=1e-5, step_loss=0.0717]06/05/2023 20:33:40 - INFO - accelerate.accelerator - Saving current state to sd-snoopy-model/checkpoint-4500
06/05/2023 20:33:40 - INFO - accelerate.checkpointing - Model weights saved in sd-snoopy-model/checkpoint-4500/pytorch_model.bin
06/05/2023 20:33:40 - INFO - accelerate.checkpointing - Optimizer state saved in sd-snoopy-model/checkpoint-4500/optimizer.bin
06/05/2023 20:33:40 - INFO - accelerate.checkpointing - Scheduler state saved in sd-snoopy-model/checkpoint-4500/scheduler.bin
06/05/2023 20:33:40 - INFO - accelerate.checkpointing - Random states saved in sd-snoopy-model/checkpoint-4500/random_states_0.pkl
06/05/2023 20:33:40 - INFO - __main__ - Saved state to sd-snoopy-model/checkpoint-4500
Steps:  24%|█████████▍                             | 4841/20000 [2:22:20<7:32:40,  1.79s/it, lr=1e-5, step_loss=0.106]06/05/2023 20:43:42 - INFO - __main__ - Running validation...
 Generating 4 images with prompt: Snoopy at the beach. grayscale. 2000. Snoopy..
Downloading (…)ain/model_index.json: 100%|████████████████████████████████████████████| 541/541 [00:00<00:00, 301kB/s]
Downloading (…)_checker/config.json: 100%|████████████████████████████████████████| 4.56k/4.56k [00:00<00:00, 577kB/s]
Downloading (…)rocessor_config.json: 100%|████████████████████████████████████████████| 342/342 [00:00<00:00, 136kB/s]
Downloading (…)nfig-checkpoint.json: 100%|████████████████████████████████████████████| 209/209 [00:00<00:00, 104kB/s]
Downloading pytorch_model.bin: 100%|██████████████████████████████████████████████| 1.22G/1.22G [00:10<00:00, 114MB/s]
Fetching 14 files: 100%|██████████████████████████████████████████████████████████████| 14/14 [00:11<00:00,  1.27it/s]
{'requires_safety_checker'} was not found in config. Values will be initialized to default values.11<00:29,  2.95s/it]
{'norm_num_groups'} was not found in config. Values will be initialized to default values..22G [00:10<00:00, 93.2MB/s]
{'prediction_type'} was not found in config. Values will be initialized to default values.
`text_config_dict` is provided which will be used to initialize `CLIPTextConfig`. The value `text_config["id2label"]` will be overriden.
Traceback (most recent call last):
  File "/home/alex/work/diffusers/examples/text_to_image/train_text_to_image_lora.py", line 924, in <module>
    main()
  File "/home/alex/work/diffusers/examples/text_to_image/train_text_to_image_lora.py", line 844, in main
    generator = torch.Generator(device=accelerator.device).manual_seed(args.seed)
RuntimeError: manual_seed expected a long, but got NoneType
```
Thanks 🤗 