### PR TITLE
Fix the Kandinsky pipeline example

### DIFF
--- a/src/diffusers/pipelines/kandinsky/pipeline_kandinsky.py
+++ b/src/diffusers/pipelines/kandinsky/pipeline_kandinsky.py
@@ -41,13 +41,13 @@ EXAMPLE_DOC_STRING = """
         >>> from diffusers import KandinskyPipeline, KandinskyPriorPipeline
         >>> import torch
 
-        >>> pipe_prior = KandinskyPriorPipeline.from_pretrained("kandinsky-community/Kandinsky-prior")
+        >>> pipe_prior = KandinskyPriorPipeline.from_pretrained("kandinsky-community/Kandinsky-2-1-prior")
         >>> pipe_prior.to("cuda")
 
         >>> prompt = "red cat, 4k photo"
         >>> out = pipe_prior(prompt)
-        >>> image_emb = out.images
-        >>> zero_image_emb = out.zero_embeds
+        >>> image_emb = out.image_embeds
+        >>> negative_image_embeds = out.negative_image_embeds
 
         >>> pipe = KandinskyPipeline.from_pretrained("kandinsky-community/kandinsky-2-1")
         >>> pipe.to("cuda")
@@ -55,7 +55,7 @@ EXAMPLE_DOC_STRING = """
         >>> image = pipe(
         ...     prompt,
         ...     image_embeds=image_emb,
-        ...     negative_image_embeds=zero_image_emb,
+        ...     negative_image_embeds=negative_image_embeds,
         ...     height=768,
         ...     width=768,
         ...     num_inference_steps=100,


### PR DESCRIPTION
- correct model id
- use the new KandinskyPriorPipelineOutput member names