### PR TITLE
Fix loading if unexpected keys are present

### DIFF
--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -639,7 +639,9 @@ class ModelMixin(torch.nn.Module):
                             unexpected_keys = [k for k in unexpected_keys if re.search(pat, k) is None]
 
                     if len(unexpected_keys) > 0:
-                        logger.warn(f"Some weights of the model checkpoint were not used when initializing {cls.__name__}: \n {[', '.join(unexpected_keys)]}")
+                        logger.warn(
+                            f"Some weights of the model checkpoint were not used when initializing {cls.__name__}: \n {[', '.join(unexpected_keys)]}"
+                        )
 
                 else:  # else let accelerate handle loading and dispatching.
                     # Load weights and dispatch according to the device_map

--- a/src/diffusers/pipelines/unidiffuser/modeling_text_decoder.py
+++ b/src/diffusers/pipelines/unidiffuser/modeling_text_decoder.py
@@ -60,6 +60,7 @@ class UniDiffuserTextDecoder(ModelMixin, ConfigMixin, ModuleUtilsMixin):
             Whether to scale keys (K) prior to computing attention (dot-product) and upcast attention
             dot-product/softmax to float() when training with mixed precision.
     """
+
     _keys_to_ignore_on_load_unexpected = [r"h\.\d+\.attn\.bias", r"h\.\d+\.attn\.masked_bias"]
 
     @register_to_config


### PR DESCRIPTION
In `transformers >= 4.30`, the GPT2 model removes the persistency flag for weights which means that when someone does:

```py
from transformers import GPT2Model

# download gpt2_checkpoint and load as state dict
state_dict = # load gpt2 checkpoint

model = GPT2Model(config)

model.load_state_dict(state_dict) # <- this might now fail
```

We fix this in `diffusers` by using the same: `_keys_to_ignore_on_load_unexpected` logic that is used in `transformers`: 
https://github.com/huggingface/transformers/pull/23256

Need to do a release before end of day so sadly no time.