### PR TITLE
3759 conditioning scale linear scheduling

### DIFF
--- a/src/diffusers/models/controlnet.py
+++ b/src/diffusers/models/controlnet.py
@@ -452,7 +452,7 @@ class ControlNetModel(ModelMixin, ConfigMixin):
         timestep: Union[torch.Tensor, float, int],
         encoder_hidden_states: torch.Tensor,
         controlnet_cond: torch.FloatTensor,
-        conditioning_scale: float = 1.0,
+        conditioning_scale: Union[float, Tuple[float, float]] = 1.0,
         class_labels: Optional[torch.Tensor] = None,
         timestep_cond: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,


### PR DESCRIPTION
From https://github.com/huggingface/diffusers/issues/3759

A draft of the first implementation idea:

A **first implementation** could be: *A tuple[float, float] `(start, end)` as `conditioning_scale` value and (keep the standard float `value` for a fixed `conditioning_scale` value in the same function).*

```python
...

pipe(
    # ...
    conditioning_scale=(0.01, 0.1),
    # ...
)
```