### PR TITLE
UnCLIP Image Interpolation -> Keep same initial noise across interpolation steps

### DIFF
--- a/examples/community/unclip_image_interpolation.py
+++ b/examples/community/unclip_image_interpolation.py
@@ -385,7 +385,7 @@ class UnCLIPImageInterpolationPipeline(DiffusionPipeline):
             decoder_latents,
             self.decoder_scheduler,
         )
-        decoder_latents = decoder_latents.repeat((steps, 1, 1, 1))
+        decoder_latents = decoder_latents.repeat((batch_size, 1, 1, 1))
 
         for i, t in enumerate(self.progress_bar(decoder_timesteps_tensor)):
             # expand the latents if we are doing classifier free guidance

--- a/examples/community/unclip_image_interpolation.py
+++ b/examples/community/unclip_image_interpolation.py
@@ -376,7 +376,7 @@ class UnCLIPImageInterpolationPipeline(DiffusionPipeline):
         height = self.decoder.config.sample_size
         width = self.decoder.config.sample_size
 
-        # Get the decoder latents for 1 step and then repeat the same tensor for the entire batch to keep same noise across all batches
+        # Get the decoder latents for 1 step and then repeat the same tensor for the entire batch to keep same noise across all interpolation steps.
         decoder_latents = self.prepare_latents(
             (1, num_channels_latents, height, width),
             text_encoder_hidden_states.dtype,

--- a/examples/community/unclip_image_interpolation.py
+++ b/examples/community/unclip_image_interpolation.py
@@ -376,14 +376,16 @@ class UnCLIPImageInterpolationPipeline(DiffusionPipeline):
         height = self.decoder.config.sample_size
         width = self.decoder.config.sample_size
 
+        # Get the decoder latents for 1 step and then repeat the same tensor for the entire batch to keep same noise across all batches
         decoder_latents = self.prepare_latents(
-            (batch_size, num_channels_latents, height, width),
+            (1, num_channels_latents, height, width),
             text_encoder_hidden_states.dtype,
             device,
             generator,
             decoder_latents,
             self.decoder_scheduler,
         )
+        decoder_latents = decoder_latents.repeat((steps, 1, 1, 1))
 
         for i, t in enumerate(self.progress_bar(decoder_timesteps_tensor)):
             # expand the latents if we are doing classifier free guidance


### PR DESCRIPTION
This change is more in line with the DallE-2 paper which describes: 

> The second option (for image interpolation) involves fixing the DDIM latent to a randomly-sampled value for all interpolates in the trajectory. This results in an infinite number of trajectories between x1 and x2, though the endpoints of these trajectories will generally no longer coincide with the original images.