### PR TITLE
Add ddpm kandinsky

### DIFF
--- a/docs/source/en/api/pipelines/kandinsky.mdx
+++ b/docs/source/en/api/pipelines/kandinsky.mdx
@@ -55,6 +55,20 @@ t2i_pipe = DiffusionPipeline.from_pretrained("kandinsky-community/kandinsky-2-1"
 t2i_pipe.to("cuda")
 ```
 
+<Tip warning={true}>
+
+By default, the text-to-image pipeline use [`DDIMScheduler`], you can change the scheduler to [`DDPMScheduler`]
+
+```py
+scheduler = DDPMScheduler.from_pretrained("kandinsky-community/kandinsky-2-1", subfolder="ddpm_scheduler")
+t2i_pipe = DiffusionPipeline.from_pretrained(
+    "kandinsky-community/kandinsky-2-1", scheduler=scheduler, torch_dtype=torch.float16
+)
+t2i_pipe.to("cuda")
+```
+
+</Tip>
+
 Now we pass the prompt through the prior to generate image embeddings. The prior
 returns both the image embeddings corresponding to the prompt and negative/unconditional image 
 embeddings corresponding to an empty string.

--- a/src/diffusers/pipelines/kandinsky/pipeline_kandinsky.py
+++ b/src/diffusers/pipelines/kandinsky/pipeline_kandinsky.py
@@ -14,7 +14,6 @@
 
 from typing import List, Optional, Union
 
-import numpy as np
 import torch
 from transformers import (
     XLMRobertaTokenizer,
@@ -391,7 +390,7 @@ class KandinskyPipeline(DiffusionPipeline):
         image_embeds = torch.cat([negative_image_embeds, image_embeds], dim=0).to(
             dtype=prompt_embeds.dtype, device=device
         )
-        
+
         self.scheduler.set_timesteps(num_inference_steps, device=device)
         timesteps_tensor = self.scheduler.timesteps
 

--- a/src/diffusers/pipelines/kandinsky/pipeline_kandinsky.py
+++ b/src/diffusers/pipelines/kandinsky/pipeline_kandinsky.py
@@ -14,8 +14,8 @@
 
 from typing import List, Optional, Union
 
-import torch
 import numpy as np
+import torch
 from transformers import (
     XLMRobertaTokenizer,
 )
@@ -23,7 +23,7 @@ from transformers import (
 from ...models import UNet2DConditionModel, VQModel
 from ...pipelines import DiffusionPipeline
 from ...pipelines.pipeline_utils import ImagePipelineOutput
-from ...schedulers import DDIMScheduler
+from ...schedulers import DDIMScheduler, DDPMScheduler
 from ...utils import (
     is_accelerate_available,
     is_accelerate_version,
@@ -89,7 +89,7 @@ class KandinskyPipeline(DiffusionPipeline):
             Frozen text-encoder.
         tokenizer ([`XLMRobertaTokenizer`]):
             Tokenizer of class
-        scheduler ([`DDIMScheduler`]):
+        scheduler (Union[`DDIMScheduler`,`DDPMScheduler`]):
             A scheduler to be used in combination with `unet` to generate image latents.
         unet ([`UNet2DConditionModel`]):
             Conditional U-Net architecture to denoise the image embedding.
@@ -102,7 +102,7 @@ class KandinskyPipeline(DiffusionPipeline):
         text_encoder: MultilingualCLIP,
         tokenizer: XLMRobertaTokenizer,
         unet: UNet2DConditionModel,
-        scheduler: DDIMScheduler,
+        scheduler: Union[DDIMScheduler, DDPMScheduler],
         movq: VQModel,
     ):
         super().__init__()
@@ -408,9 +408,9 @@ class KandinskyPipeline(DiffusionPipeline):
         image_embeds = torch.cat([negative_image_embeds, image_embeds], dim=0).to(
             dtype=prompt_embeds.dtype, device=device
         )
-        if hasattr(self.scheduler,"custom_timesteps"):
+        if hasattr(self.scheduler, "custom_timesteps"):
             # if use ddpm scheduler, create timesteps with unclp timestep method and pass a custom timesteps
-            timesteps = self.set_timesteps(num_inference_steps, device=device) 
+            timesteps = self.set_timesteps(num_inference_steps, device=device)
             self.scheduler.set_timesteps(timesteps=timesteps, device=device)
         else:
             self.scheduler.set_timesteps(num_inference_steps, device=device)

--- a/src/diffusers/pipelines/kandinsky/pipeline_kandinsky.py
+++ b/src/diffusers/pipelines/kandinsky/pipeline_kandinsky.py
@@ -15,6 +15,7 @@
 from typing import List, Optional, Union
 
 import torch
+import numpy as np
 from transformers import (
     XLMRobertaTokenizer,
 )
@@ -278,6 +279,23 @@ class KandinskyPipeline(DiffusionPipeline):
         # We'll offload the last model manually.
         self.final_offload_hook = hook
 
+    def set_timesteps(self, num_inference_steps: int, device: Union[str, torch.device] = None):
+        """
+        Sets the discrete timesteps used for the diffusion chain. Supporting function to be run before inference.
+
+        Note that this scheduler uses a slightly different step ratio than the other diffusers schedulers. The
+        different step ratio is to mimic the original karlo implementation and does not affect the quality or accuracy
+        of the results.
+
+        Args:
+            num_inference_steps (`int`):
+                the number of diffusion steps used when generating samples with a pre-trained model.
+        """
+        self.num_inference_steps = num_inference_steps
+        step_ratio = (self.scheduler.config.num_train_timesteps - 1) / (num_inference_steps - 1)
+        timesteps = (np.arange(0, num_inference_steps) * step_ratio).round()[::-1].copy().astype(np.int64)
+        return timesteps
+
     @property
     # Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.StableDiffusionPipeline._execution_device
     def _execution_device(self):
@@ -390,8 +408,13 @@ class KandinskyPipeline(DiffusionPipeline):
         image_embeds = torch.cat([negative_image_embeds, image_embeds], dim=0).to(
             dtype=prompt_embeds.dtype, device=device
         )
+        if hasattr(self.scheduler,"custom_timesteps"):
+            # if use ddpm scheduler, create timesteps with unclp timestep method and pass a custom timesteps
+            timesteps = self.set_timesteps(num_inference_steps, device=device) 
+            self.scheduler.set_timesteps(timesteps=timesteps, device=device)
+        else:
+            self.scheduler.set_timesteps(num_inference_steps, device=device)
 
-        self.scheduler.set_timesteps(num_inference_steps, device=device)
         timesteps_tensor = self.scheduler.timesteps
 
         num_channels_latents = self.unet.config.in_channels
@@ -439,9 +462,6 @@ class KandinskyPipeline(DiffusionPipeline):
                 noise_pred,
                 t,
                 latents,
-                # YiYi notes: only reason this pipeline can't work with unclip scheduler is that can't pass down this argument
-                #             need to use DDPM scheduler instead
-                # prev_timestep=prev_timestep,
                 generator=generator,
             ).prev_sample
         # post-processing

--- a/src/diffusers/schedulers/scheduling_ddpm.py
+++ b/src/diffusers/schedulers/scheduling_ddpm.py
@@ -133,7 +133,7 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
         thresholding: bool = False,
         dynamic_thresholding_ratio: float = 0.995,
         clip_sample_range: float = 1.0,
-        sample_max_value: Optional[float] = 1.0,
+        sample_max_value: float = 1.0,
     ):
         if trained_betas is not None:
             self.betas = torch.tensor(trained_betas, dtype=torch.float32)
@@ -367,14 +367,9 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
             )
 
         # 3. Clip or threshold "predicted x_0"
-        if self.config.sample_max_value is None and self.config.clip_sample:
-            pred_original_sample = torch.clamp(
-                pred_original_sample, -self.config.clip_sample_range, self.config.clip_sample_range
-            )
-
         if self.config.thresholding:
             pred_original_sample = self._threshold_sample(pred_original_sample)
-        elif self.config.sample_max_value is not None and self.config.clip_sample:
+        elif self.config.clip_sample:
             pred_original_sample = pred_original_sample.clamp(
                 -self.config.clip_sample_range, self.config.clip_sample_range
             )


### PR DESCRIPTION
This PR will refactor Kandinsky pipelines to work with both ddpm and ddim scheduler 

@sayakpaul @patrickvonplaten 
currently the scheduler config in Kandinsky repo is for ddim, is there anyway we can also save ddpm scheduler config some where? instead having to manually create the ddpm config when user wants swap it the scheduler? 

```python
from diffusers import KandinskyPipeline, KandinskyPriorPipeline, DDPMScheduler

import torch
import numpy as np

device = "cuda"

# # inputs
prompt= "red cat, 4k photo"

# # create prior 
pipe_prior = KandinskyPriorPipeline.from_pretrained("kandinsky-community/kandinsky-2-1-prior")
pipe_prior.to("cuda")

# use prior to generate image_emb based on our prompt
generator = torch.Generator(device=device).manual_seed(0)
out = pipe_prior(prompt, num_inference_steps=5, generator=generator, )
image_emb = out.image_embeds
zero_image_emb = out.negative_image_embeds


# create diffuser pipeline
model_dtype = torch.float16
pipe = KandinskyPipeline.from_pretrained("kandinsky-community/kandinsky-2-1", torch_dtype =model_dtype )
pipe.to(device)

ddpm_scheduler = DDPMScheduler(
  clip_sample= True,
  clip_sample_range=2.0,
  sample_max_value=None,
  num_train_timesteps= 1000,
  prediction_type= "epsilon",
  variance_type= "learned_range",
  thresholding= True,
  beta_schedule= "linear",
  beta_start= 0.00085,
  beta_end=0.012
)
pipe.scheduler = ddpm_scheduler

generator = torch.Generator(device="cuda").manual_seed(0)
out = pipe(
    prompt,
    image_embeds=image_emb,
    negative_image_embeds =zero_image_emb,
    height=768,
    width=768,
    num_inference_steps=100,
    generator=generator )

image = out.images[0]
```
![yiyi_test_pipe_ddpm3_out](https://github.com/huggingface/diffusers/assets/12631849/24ead08f-d0a2-4866-ad9e-23742b86e938)
