### PR TITLE
Update StableDiffusionPipeline to accept ORTModule

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -24,6 +24,7 @@ from ...configuration_utils import FrozenDict
 from ...image_processor import VaeImageProcessor
 from ...loaders import FromCkptMixin, LoraLoaderMixin, TextualInversionLoaderMixin
 from ...models import AutoencoderKL, UNet2DConditionModel
+from onnxruntime.training.ortmodule import ORTModule
 from ...schedulers import KarrasDiffusionSchedulers
 from ...utils import (
     deprecate,
@@ -111,7 +112,7 @@ class StableDiffusionPipeline(DiffusionPipeline, TextualInversionLoaderMixin, Lo
         vae: AutoencoderKL,
         text_encoder: CLIPTextModel,
         tokenizer: CLIPTokenizer,
-        unet: UNet2DConditionModel,
+        unet: Union[UNet2DConditionModel, ORTModule],
         scheduler: KarrasDiffusionSchedulers,
         safety_checker: StableDiffusionSafetyChecker,
         feature_extractor: CLIPImageProcessor,

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -109,8 +109,8 @@ class StableDiffusionPipeline(DiffusionPipeline, TextualInversionLoaderMixin, Lo
 
     def __init__(
         self,
-        vae: AutoencoderKL,
-        text_encoder: CLIPTextModel,
+        vae: Union[AutoencoderKL, ORTModule],
+        text_encoder: Union[CLIPTextModel, ORTModule],
         tokenizer: CLIPTokenizer,
         unet: Union[UNet2DConditionModel, ORTModule],
         scheduler: KarrasDiffusionSchedulers,


### PR DESCRIPTION
**This PR allows an `ORTModule` object to be passed into `StableDiffusionPipeline` to perform inference.**

Context: During fine-tuning of text-to-image task, a `StableDiffusionPipeline` object is used to perform a visual inspection of the model's abilities. This pipeline fails when passed an `ORTModule` object with the following error. See below for reproduction instructions.

#### Error:
```
Traceback (most recent call last):
  File "train_text_to_image_ort.py", line 977, in <module>
    main()
  File "train_text_to_image_ort.py", line 955, in main
    pipeline = StableDiffusionPipeline.from_pretrained(
  File "/opt/conda/envs/ptca/lib/python3.8/site-packages/diffusers/pipelines/pipeline_utils.py", line 1056, in from_pretrained
    maybe_raise_or_warn(
  File "/opt/conda/envs/ptca/lib/python3.8/site-packages/diffusers/pipelines/pipeline_utils.py", line 299, in maybe_raise_or_warn
    raise ValueError(
ValueError: ORTModule(
  (module): UNet2DConditionModel(
    (conv_in): Conv2d(4, 320, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
    ...
    (conv_out): Conv2d(320, 4, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))
  )
) is of type: <class 'onnxruntime.training.ortmodule.ortmodule.ORTModule'>, but should be <class 'diffusers.models.modeling_utils.ModelMixin'>
```

#### Reproduction Instructions:

```Dockerfile
FROM ptebic.azurecr.io/internal/azureml/aifx/nightly-ubuntu2004-cu117-py38-torch210dev:latest

RUN pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu118
RUN pip install accelerate datasets transformers
RUN pip install git+https://github.com/huggingface/diffusers

WORKDIR workspace
RUN git clone https://github.com/huggingface/diffusers.git
RUN cd diffusers/examples/research_projects/onnxruntime/text_to_image && \
pip install -r requirements.txt && \
accelerate launch --config_file=accelerate_config.yaml --mixed_precision=fp16 train_text_to_image.py --pretrained_model_name_or_path=CompVis/stable-diffusion-v1-4 --dataset_name=lambdalabs/pokemon-blip-captions --use_ema --resolution=512 --center_crop --random_flip --train_batch_size=1 --gradient_accumulation_steps=4 --gradient_checkpointing --max_train_steps=5 --learning_rate=1e-05 --max_grad_norm=1 --lr_scheduler=constant --lr_warmup_steps=0 --output_dir=sd-pokemon-model
```

#### accelerate_config.yaml
```yaml
compute_environment: LOCAL_MACHINE
deepspeed_config:
  gradient_accumulation_steps: 4
  offload_optimizer_device: none
  offload_param_device: none
  zero3_init_flag: false
  zero_stage: 2
distributed_type: DEEPSPEED
downcast_bf16: 'no'
machine_rank: 0
main_training_function: main
mixed_precision: fp16
num_machines: 1
num_processes: 8
rdzv_backend: static
same_network: true
tpu_env: []
tpu_use_cluster: false
tpu_use_sudo: false
use_cpu: false
```
