### PR TITLE
[Examples] Improve the model card pushed from the `train_text_to_image.py` script

### DIFF
--- a/examples/text_to_image/README.md
+++ b/examples/text_to_image/README.md
@@ -55,11 +55,11 @@ With `gradient_checkpointing` and `mixed_precision` it should be possible to fin
 <!-- accelerate_snippet_start -->
 ```bash
 export MODEL_NAME="CompVis/stable-diffusion-v1-4"
-export dataset_name="lambdalabs/pokemon-blip-captions"
+export DATASET_NAME="lambdalabs/pokemon-blip-captions"
 
 accelerate launch --mixed_precision="fp16"  train_text_to_image.py \
   --pretrained_model_name_or_path=$MODEL_NAME \
-  --dataset_name=$dataset_name \
+  --dataset_name=$DATASET_NAME \
   --use_ema \
   --resolution=512 --center_crop --random_flip \
   --train_batch_size=1 \
@@ -133,11 +133,11 @@ for running distributed training with `accelerate`. Here is an example command:
 
 ```bash
 export MODEL_NAME="CompVis/stable-diffusion-v1-4"
-export dataset_name="lambdalabs/pokemon-blip-captions"
+export DATASET_NAME="lambdalabs/pokemon-blip-captions"
 
 accelerate launch --mixed_precision="fp16" --multi_gpu  train_text_to_image.py \
   --pretrained_model_name_or_path=$MODEL_NAME \
-  --dataset_name=$dataset_name \
+  --dataset_name=$DATASET_NAME \
   --use_ema \
   --resolution=512 --center_crop --random_flip \
   --train_batch_size=1 \
@@ -274,11 +274,11 @@ pip install -U -r requirements_flax.txt
 
 ```bash
 export MODEL_NAME="duongna/stable-diffusion-v1-4-flax"
-export dataset_name="lambdalabs/pokemon-blip-captions"
+export DATASET_NAME="lambdalabs/pokemon-blip-captions"
 
 python train_text_to_image_flax.py \
   --pretrained_model_name_or_path=$MODEL_NAME \
-  --dataset_name=$dataset_name \
+  --dataset_name=$DATASET_NAME \
   --resolution=512 --center_crop --random_flip \
   --train_batch_size=1 \
   --mixed_precision="fp16" \

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -1062,7 +1062,7 @@ def main():
         pipeline.save_pretrained(args.output_dir)
 
         # Run a final round of inference.
-        images = [None]
+        images = []
         if args.validation_prompts is not None:
             logger.info("Running inference for collecting generated images...")
             pipeline = pipeline.to(accelerator.device)

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -132,15 +132,17 @@ These are the key hyperparameters used during training:
 * Mixed-precision: {args.mixed_precision}
 
 """
+    wandb_info = """
+More information on all the CLI arguments and the environment should be available on the `wandb` run page if you used it via `report_to="wandb"`.
+"""
     if is_wandb_available():
         wandb_run_url = None
         if wandb.run is not None:
             wandb_run_url = wandb.run.url
 
-    wandb_info = f"""
-More information on all the CLI arguments and the environment should be available on the `wandb` run page if you used it via `report_to="wandb"`.
-Check it out here: {wandb_run_url}.
-    """
+    if wandb_run_url is not None:
+        wandb_info += f"Check it out here: {wandb_run_url}."
+
     model_card += wandb_info
 
     with open(os.path.join(repo_folder, "README.md"), "w") as f:

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -1080,7 +1080,7 @@ def main():
             for i in range(len(args.validation_prompts)):
                 with torch.autocast("cuda"):
                     image = pipeline(args.validation_prompts[i], num_inference_steps=20, generator=generator).images[0]
-                    images.append(image)
+                images.append(image)
 
         if args.push_to_hub:
             save_model_card(args, repo_id, images, repo_folder=args.output_dir)

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -115,7 +115,7 @@ from diffusers import DiffusionPipeline
 import torch
 
 pipeline = DiffusionPipeline.from_pretrained("{repo_id}", torch_dtype=torch.float16)
-prompt = f"{args.validation_prompts[0]}"
+prompt = "{args.validation_prompts[0]}"
 image = pipeline(prompt).images[0]
 image.save("my_image.png")
 ```
@@ -130,10 +130,6 @@ Following are the key hyperparameters that were used to run finetuning:
 * Gradient accumulation steps: {args.gradient_accumulation_steps}
 * Image resolution: {args.resolution}
 * Mixed-precision: {args.mixed_precision}
-
-## Environment
-
-{os.system("diffusers-cli env")}
 
 """
     if is_wandb_available():

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -139,8 +139,8 @@ These are the key hyperparameters used during training:
             wandb_run_url = wandb.run.url
 
     if wandb_run_url is not None:
-        wandb_info = """
- More information on all the CLI arguments and the environment are available on your [`wandb` run page]({wandb_run_url}).
+        wandb_info = f"""
+More information on all the CLI arguments and the environment are available on your [`wandb` run page]({wandb_run_url}).
 """
 
     model_card += wandb_info

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -103,7 +103,7 @@ inference: true
     model_card = f"""
 # Text-to-image finetuning - {repo_id}
 
-This pipeline was finetuned from {args.pretrained_model_name_or_path} on the {args.dataset_name} dataset. Below are some examples images that were generated with the finetuned pipeline (with the following prompts: {args.validation_prompts}): \n
+This pipeline was finetuned from **{args.pretrained_model_name_or_path}** on the **{args.dataset_name}** dataset. Below are some examples images that were generated with the finetuned pipeline (with the following prompts: {args.validation_prompts}): \n
 {img_str}
 
 ## Pipeline usage
@@ -114,8 +114,8 @@ You can use the pipeline like so:
 from diffusers import DiffusionPipeline
 import torch
 
-pipeline = DiffusionPipeline.from_pretrained({repo_id}, torch_dtype=torch.float16)
-prompt = "..."
+pipeline = DiffusionPipeline.from_pretrained("{repo_id}", torch_dtype=torch.float16)
+prompt = f"{args.validation_prompts[0]}"
 image = pipeline(prompt).images[0]
 image.save("my_image.png")
 ```
@@ -130,6 +130,10 @@ Following are the key hyperparameters that were used to run finetuning:
 * Gradient accumulation steps: {args.gradient_accumulation_steps}
 * Image resolution: {args.resolution}
 * Mixed-precision: {args.mixed_precision}
+
+## Environment
+
+{os.system("diffusers-cli env")}
 
 """
     if is_wandb_available():

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -836,8 +836,10 @@ def main():
     weight_dtype = torch.float32
     if accelerator.mixed_precision == "fp16":
         weight_dtype = torch.float16
+        args.mixed_precision = accelerator.mixed_precision
     elif accelerator.mixed_precision == "bf16":
         weight_dtype = torch.bfloat16
+        args.mixed_precision = accelerator.mixed_precision
 
     # Move text_encode and vae to gpu and cast to weight_dtype
     text_encoder.to(accelerator.device, dtype=weight_dtype)

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -81,7 +81,7 @@ def save_model_card(
     repo_folder=None,
 ):
     img_str = ""
-    if images is not None:
+    if len(images) > 0:
         image_grid = make_image_grid(images, 1, len(args.validation_prompts))
         image_grid.save(os.path.join(repo_folder, "val_imgs_grid.png"))
         img_str += "![val_imgs_grid](./val_imgs_grid.png)\n"
@@ -1062,7 +1062,7 @@ def main():
         pipeline.save_pretrained(args.output_dir)
 
         # Run a final round of inference.
-        images = None
+        images = [None]
         if args.validation_prompts is not None:
             logger.info("Running inference for collecting generated images...")
             pipeline = pipeline.to(accelerator.device)

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -132,16 +132,16 @@ These are the key hyperparameters used during training:
 * Mixed-precision: {args.mixed_precision}
 
 """
-    wandb_info = """
-More information on all the CLI arguments and the environment should be available on the `wandb` run page if you used it via `report_to="wandb"`.
-"""
+    wandb_info = ""
     if is_wandb_available():
         wandb_run_url = None
         if wandb.run is not None:
             wandb_run_url = wandb.run.url
 
     if wandb_run_url is not None:
-        wandb_info += f"Check it out here: {wandb_run_url}."
+        wandb_info = """
+ More information on all the CLI arguments and the environment are available on your [`wandb` run page]({wandb_run_url}).
+"""
 
     model_card += wandb_info
 
@@ -1026,13 +1026,12 @@ def main():
                 break
 
         if accelerator.is_main_process:
-            images = None
             if args.validation_prompts is not None and epoch % args.validation_epochs == 0:
                 if args.use_ema:
                     # Store the UNet parameters temporarily and load the EMA parameters to perform inference.
                     ema_unet.store(unet.parameters())
                     ema_unet.copy_to(unet.parameters())
-                images = log_validation(
+                log_validation(
                     vae,
                     text_encoder,
                     tokenizer,

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -138,7 +138,7 @@ Following are the key hyperparameters that were used to run finetuning:
             wandb_run_url = wandb.run.url
 
     wandb_info = f"""
-More information on all the CLI arguments should be available on the `wandb` run page if you used it via `report_to="wandb"`.
+More information on all the CLI arguments and the environment should be available on the `wandb` run page if you used it via `report_to="wandb"`.
 Check it out here: {wandb_run_url}.
     """
     model_card += wandb_info

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -103,7 +103,7 @@ inference: true
     model_card = f"""
 # Text-to-image finetuning - {repo_id}
 
-This pipeline was finetuned from **{args.pretrained_model_name_or_path}** on the **{args.dataset_name}** dataset. Below are some examples images that were generated with the finetuned pipeline (with the following prompts: {args.validation_prompts}): \n
+This pipeline was finetuned from **{args.pretrained_model_name_or_path}** on the **{args.dataset_name}** dataset. Below are some example images generated with the finetuned pipeline using the following prompts: {args.validation_prompts}: \n
 {img_str}
 
 ## Pipeline usage
@@ -122,7 +122,7 @@ image.save("my_image.png")
 
 ## Training info
 
-Following are the key hyperparameters that were used to run finetuning:
+These are the key hyperparameters used during training:
 
 * Epochs: {args.num_train_epochs}
 * Learning rate: {args.learning_rate}

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -126,7 +126,7 @@ Following are the key hyperparameters that were used to run finetuning:
 
 * Epochs: {args.num_train_epochs}
 * Learning rate: {args.learning_rate}
-* Batch size: {args.sample_batch_size}
+* Batch size: {args.train_batch_size}
 * Gradient accumulation steps: {args.gradient_accumulation_steps}
 * Image resolution: {args.resolution}
 * Mixed-precision: {args.mixed_precision}

--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -1078,8 +1078,9 @@ def main():
                 generator = torch.Generator(device=accelerator.device).manual_seed(args.seed)
 
             for i in range(len(args.validation_prompts)):
-                image = pipeline(args.validation_prompts[i], num_inference_steps=20, generator=generator).images[0]
-                images.append(image)
+                with torch.autocast("cuda"):
+                    image = pipeline(args.validation_prompts[i], num_inference_steps=20, generator=generator).images[0]
+                    images.append(image)
 
         if args.push_to_hub:
             save_model_card(args, repo_id, images, repo_folder=args.output_dir)


### PR DESCRIPTION
Currently, our training examples include limited information in the model cards. For example, one doesn't know how the code should be run with the model artifact(s) from the training examples just by taking a look at the corresponding model repository (such as [this one](https://huggingface.co/sayakpaul/lora-trained)).

We can improve this.  

So, to that end, this PR modifies the `train_text_to_image.py` to include a code snippet in the model card that we create from the example itself. Additionally, it includes the following things in the model card for a better developer experience which can be enabled directly from the Hub:

* Info on key training hyperparameters
* Dataset (and properly links that to the model card metadata)
* Weights and Biases run page when available (which discloses all the CLI args passed to the training script and details on the env such as accelerator type, etc.)

Here's how a pipeline repo looks like with the changes introduced in this PR: https://huggingface.co/sayakpaul/new_sd_pokemon.

The training was conducted with the following command:

```bash
export MODEL_NAME="CompVis/stable-diffusion-v1-4"
export DATASET_NAME="lambdalabs/pokemon-blip-captions"

accelerate launch train_text_to_image.py   \
  --pretrained_model_name_or_path=$MODEL_NAME   \
  --dataset_name=$DATASET_NAME   \
  --mixed_precision="fp16"   \
  --resolution=512 --center_crop --random_flip   \
  --train_batch_size=1   \
  --gradient_accumulation_steps=4   \
  --gradient_checkpointing   \
  --max_train_steps=100   \
  --learning_rate=1e-05   \
  --max_grad_norm=1   --lr_scheduler="constant" --lr_warmup_steps=0   \
  --output_dir="sd-pokemon-model"   \
  --report_to="wandb"   \
  --validation_epochs=1 \
  --validation_prompts "cute dragon creature" "cute pokemon creature" "blue pokemon"   \
  --checkpointing_steps=50   \
  --output_dir="new_sd_pokemon"   \
  --push_to_hub
```

If there's a consensus, I can adapt these changes and include them in the rest of the scripts. Thanks to @osanseviero for the hint. 