### PR TITLE
 refactor kandinsky img2img for ddpm

### DIFF
--- a/src/diffusers/pipelines/kandinsky/pipeline_kandinsky_img2img.py
+++ b/src/diffusers/pipelines/kandinsky/pipeline_kandinsky_img2img.py
@@ -516,9 +516,17 @@ class KandinskyImg2ImgPipeline(DiffusionPipeline):
             )[0]
 
             if do_classifier_free_guidance:
-                noise_pred, _ = noise_pred.split(latents.shape[1], dim=1)
+                noise_pred, variance_pred = noise_pred.split(latents.shape[1], dim=1)
                 noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                _, variance_pred_text = variance_pred.chunk(2)
                 noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+                noise_pred = torch.cat([noise_pred, variance_pred_text], dim=1)
+
+            if not (
+                hasattr(self.scheduler.config, "variance_type")
+                and self.scheduler.config.variance_type in ["learned", "learned_range"]
+            ):
+                noise_pred, _ = noise_pred.split(latents.shape[1], dim=1)
 
             # compute the previous noisy sample x_t -> x_t-1
             latents = self.scheduler.step(


### PR DESCRIPTION
this PR refactor the img2img so that it's compatible with ddpm scheduler 

```python
from diffusers import KandinskyImg2ImgPipeline, KandinskyPriorPipeline, DDPMScheduler
from PIL import Image

import torch

REPO_PRIOR = "kandinsky-community/kandinsky-2-1-prior"
REPO = "kandinsky-community/kandinsky-2-1"

model_dtype = torch.float16

prompt = "A red cartoon frog, 4k"

# create prior 
pipe_prior = KandinskyPriorPipeline.from_pretrained(REPO_PRIOR, torch_dtype=model_dtype)
pipe_prior.to("cuda")

# create img2img pipeline
scheduler = DDPMScheduler.from_pretrained(REPO, subfolder="ddpm_scheduler")
pipe = KandinskyImg2ImgPipeline.from_pretrained(REPO, scheduler=scheduler, torch_dtype=model_dtype)
pipe.to("cuda")

# use prior to generate image_emb based on our prompt
generator = torch.Generator(device='cuda').manual_seed(0)
image_emb, zero_image_emb = pipe_prior(prompt, num_inference_steps=25, generator=generator,).to_tuple()


init_image = Image.open("frog.png")
generator = torch.Generator(device='cuda').manual_seed(0)

out = pipe(
    prompt=prompt, 
    image=init_image, 
    height=768, 
    width=768, 
    num_inference_steps=100, 
    generator=generator, 
    image_embeds=image_emb, 
    negative_image_embeds=zero_image_emb, 
    strength=0.2,) 

out.images[0].save("frog_out.png")
```
![yiyi_test_img2img_ddpm_out](https://github.com/huggingface/diffusers/assets/12631849/55831bc7-3dce-4886-8c1a-58decbf95705)
