### PR TITLE
Make `UNet2DConditionOutput` pickle-able

### DIFF
--- a/src/diffusers/models/unet_2d_condition.py
+++ b/src/diffusers/models/unet_2d_condition.py
@@ -55,7 +55,7 @@ class UNet2DConditionOutput(BaseOutput):
             Hidden states conditioned on `encoder_hidden_states` input. Output of last layer of model.
     """
 
-    sample: torch.FloatTensor
+    sample: torch.FloatTensor = None
 
 
 class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin):

--- a/tests/models/test_models_unet_2d_condition.py
+++ b/tests/models/test_models_unet_2d_condition.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 import copy
-from dataclasses import dataclass
 import gc
 import os
 import tempfile
 import unittest
+from dataclasses import dataclass
 
 import torch
 from parameterized import parameterized

--- a/tests/models/test_models_unet_2d_condition.py
+++ b/tests/models/test_models_unet_2d_condition.py
@@ -797,7 +797,7 @@ class UNet2DConditionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.Test
 
         sample_copy = copy.copy(sample)
 
-        assert sample == sample_copy
+        assert (sample - sample_copy).abs().max() < 1e-4
 
 
 @slow

--- a/tests/models/test_models_unet_2d_condition.py
+++ b/tests/models/test_models_unet_2d_condition.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+from dataclasses import dataclass
 import gc
 import os
 import tempfile
@@ -25,6 +27,7 @@ from pytest import mark
 from diffusers import UNet2DConditionModel
 from diffusers.models.attention_processor import CustomDiffusionAttnProcessor, LoRAAttnProcessor
 from diffusers.utils import (
+    BaseOutput,
     floats_tensor,
     load_hf_numpy,
     logging,
@@ -1088,3 +1091,13 @@ class UNet2DConditionModelIntegrationTests(unittest.TestCase):
         expected_output_slice = torch.tensor(expected_slice)
 
         assert torch_all_close(output_slice, expected_output_slice, atol=5e-3)
+
+    def test_pickle():
+        @dataclass
+        class NetParams(BaseOutput):
+            sample: torch.FloatTensor
+
+        m = NetParams(sample=torch.randn(1, 10))
+        n = copy.copy(m)
+
+        assert m == n


### PR DESCRIPTION
This PR addresses [previous concerns](https://github.com/huggingface/diffusers/issues/3327) that the output of the UNet's forward pass is not copy-able. The root cause appears to be because [copy fails on collections.OrderedDict dataclass with required args](https://github.com/python/cpython/issues/105736). The solution presented sets a default value for `sample` such that is it no longer a required parameter of the output class while still erroring when missing since the default setting is `None` ([link](https://github.com/huggingface/transformers/pull/8989) to similar solution for different model).

Reproduction Instructions:
```python
from diffusers.utils import BaseOutput
from dataclasses import dataclass
import copy

@dataclass
class NetParams(BaseOutput):
    sample: torch.FloatTensor

m = NetParams(sample=torch.randn(1, 10))
n = copy.copy(m)
```