### PR TITLE
Fixed DiffusionPipeline optional modules usage

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -660,7 +660,7 @@ class DiffusionPipeline(ConfigMixin):
                 f"It seems like you have activated model offloading by calling `enable_model_cpu_offload`, but are now manually moving the pipeline to GPU. It is strongly recommended against doing so as memory gains from offloading are likely to be lost. Offloading automatically takes care of moving the individual components {', '.join(self.components.keys())} to GPU when needed. To make sure offloading works as expected, you should consider moving the pipeline back to CPU: `pipeline.to('cpu')` or removing the move altogether if you use offloading."
             )
 
-        module_names, _ = self._get_signature_keys(self)
+        module_names = set().union(*self._get_signature_keys(self))
         modules = [getattr(self, n, None) for n in module_names]
         modules = [m for m in modules if isinstance(m, torch.nn.Module)]
 
@@ -701,7 +701,7 @@ class DiffusionPipeline(ConfigMixin):
         Returns:
             `torch.device`: The torch device on which the pipeline is located.
         """
-        module_names, _ = self._get_signature_keys(self)
+        module_names = set().union(*self._get_signature_keys(self))
         modules = [getattr(self, n, None) for n in module_names]
         modules = [m for m in modules if isinstance(m, torch.nn.Module)]
 
@@ -1451,7 +1451,7 @@ class DiffusionPipeline(ConfigMixin):
             for child in module.children():
                 fn_recursive_set_mem_eff(child)
 
-        module_names, _ = self._get_signature_keys(self)
+        module_names = set().union(*self._get_signature_keys(self))
         modules = [getattr(self, n, None) for n in module_names]
         modules = [m for m in modules if isinstance(m, torch.nn.Module)]
 
@@ -1483,7 +1483,7 @@ class DiffusionPipeline(ConfigMixin):
         self.enable_attention_slicing(None)
 
     def set_attention_slice(self, slice_size: Optional[int]):
-        module_names, _ = self._get_signature_keys(self)
+        module_names = set().union(*self._get_signature_keys(self))
         modules = [getattr(self, n, None) for n in module_names]
         modules = [m for m in modules if isinstance(m, torch.nn.Module) and hasattr(m, "set_attention_slice")]
 


### PR DESCRIPTION
# What does this PR do?

I've discovered a strange behaviour of DiffusionPipeline, but I am not sure, if it was intended, or not. When somebody writes his custom DiffusionPipeline and calls one of the following methods:

- `.to`
- `.set_use_memory_efficient_attention_xformers`
- `.enable_attention_slicing`

these methods are not propagated to optional modules set in pipeline constructor if they have a default value set (when you want to provide a correct python typing in pipeline constructor).

Here is a small demonstration:
```python 
from typing import Optional

import torch
from diffusers.pipeline_utils import DiffusionPipeline
from transformers import (
    CLIPTextModel,
    CLIPVisionModel,
    CLIPTokenizer,
    CLIPImageProcessor,
)

class CustomDiffusionPipelineWithOptionals(DiffusionPipeline):
    _optional_components = ["vision_encoder", "vision_processor"]

    def __init__(
        self,
        text_encoder: CLIPTextModel,
        tokenizer: CLIPTokenizer,
        vision_encoder: Optional[CLIPVisionModel] = None,
        vision_processor: Optional[CLIPImageProcessor] = None,
    ):
        super().__init__()

        self.register_modules(
            text_encoder=text_encoder,
            tokenizer=tokenizer,
            vision_encoder=vision_encoder,
            vision_processor=vision_processor,
        )

    def __call__(self, text: str):
        ...

device = torch.device('cuda:0')

text_encoder = CLIPTextModel.from_pretrained('openai/clip-vit-large-patch14')
tokenizer = CLIPTokenizer.from_pretrained('openai/clip-vit-large-patch14')
vision_encoder = CLIPVisionModel.from_pretrained('openai/clip-vit-large-patch14')
vision_processor = CLIPImageProcessor.from_pretrained('openai/clip-vit-large-patch14')

pipeline = CustomDiffusionPipelineWithOptionals(
    text_encoder=text_encoder,
    tokenizer=tokenizer,
    vision_encoder=vision_encoder,
    vision_processor=vision_processor
).to(device)

print(f'{pipeline.text_encoder.device = }')
print(f'{pipeline.vision_encoder.device = }')
# pipeline.text_encoder.device = device(type='cuda', index=0)
# pipeline.vision_encoder.device = device(type='cpu') - ???
```

Although, everything works fine in case you do not provide a predefined default value:

```python
from typing import Optional

import torch
from diffusers.pipeline_utils import DiffusionPipeline
from transformers import (
    CLIPTextModel,
    CLIPVisionModel,
    CLIPTokenizer,
    CLIPImageProcessor,
)

class CustomDiffusionPipeline(DiffusionPipeline):
    _optional_components = ["vision_encoder", "vision_processor"]

    def __init__(
        self,
        text_encoder: CLIPTextModel,
        tokenizer: CLIPTokenizer,
        vision_encoder: CLIPVisionModel,
        vision_processor: CLIPImageProcessor,
    ):
        super().__init__()

        self.register_modules(
            text_encoder=text_encoder,
            tokenizer=tokenizer,
            vision_encoder=vision_encoder,
            vision_processor=vision_processor,
        )

    def __call__(self, text: str):
        ...

device = torch.device('cuda:0')

text_encoder = CLIPTextModel.from_pretrained('openai/clip-vit-large-patch14')
tokenizer = CLIPTokenizer.from_pretrained('openai/clip-vit-large-patch14')
vision_encoder = CLIPVisionModel.from_pretrained('openai/clip-vit-large-patch14')
vision_processor = CLIPImageProcessor.from_pretrained('openai/clip-vit-large-patch14')

pipeline = CustomDiffusionPipeline(
    text_encoder=text_encoder,
    tokenizer=tokenizer,
    vision_encoder=vision_encoder,
    vision_processor=vision_processor
).to(device)

print(f'{pipeline.text_encoder.device = }')
print(f'{pipeline.vision_encoder.device = }')
# pipeline.text_encoder.device = device(type='cuda', index=0)
# pipeline.vision_encoder.device = device(type='cuda', index=0)
```  

I am not sure whether the optional logic violates the requirement for pipeline feature-complete user interfaces, but the fix is quite simple and from my perspective doesn't break any logic, so I've made a small modification to fix this issue.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@patrickvonplaten, you review is kindly appreciated.
