### PR TITLE
Fix embeddings for classic models

### DIFF
--- a/src/diffusers/models/unet_2d_condition.py
+++ b/src/diffusers/models/unet_2d_condition.py
@@ -773,6 +773,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
         t_emb = t_emb.to(dtype=sample.dtype)
 
         emb = self.time_embedding(t_emb, timestep_cond)
+        aug_emb = None
 
         if self.class_embedding is not None:
             if class_labels is None:
@@ -823,7 +824,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
             add_embeds = add_embeds.to(emb.dtype)
             aug_emb = self.add_embedding(add_embeds)
 
-        emb = emb + aug_emb
+        emb = emb + aug_emb if aug_emb is not None else emb
 
         if self.time_embed_act is not None:
             emb = self.time_embed_act(emb)


### PR DESCRIPTION
Fix problem introduced here (`aug_emb` may be undefined): https://github.com/huggingface/diffusers/commit/50df26c1411c7f5c3c7973815b367ea5f31071a7#diff-82dc116be034805ec08e24069d853854b00fe559f5178b87269653fa43d1e7c8R825

The alternative is to go back to running `emb = emb + aug_emb` inside all the `if` branches. Which one do you like better @patrickvonplaten?