### PR TITLE
[Text-to-video] Add `torch.compile()` compatibility

### DIFF
--- a/src/diffusers/models/unet_3d_blocks.py
+++ b/src/diffusers/models/unet_3d_blocks.py
@@ -250,10 +250,11 @@ class UNetMidBlock3DCrossAttn(nn.Module):
                 hidden_states,
                 encoder_hidden_states=encoder_hidden_states,
                 cross_attention_kwargs=cross_attention_kwargs,
-            ).sample
+                return_dict=False,
+            )[0]
             hidden_states = temp_attn(
-                hidden_states, num_frames=num_frames, cross_attention_kwargs=cross_attention_kwargs
-            ).sample
+                hidden_states, num_frames=num_frames, cross_attention_kwargs=cross_attention_kwargs, return_dict=False
+            )[0]
             hidden_states = resnet(hidden_states, temb)
             hidden_states = temp_conv(hidden_states, num_frames=num_frames)
 
@@ -377,10 +378,11 @@ class CrossAttnDownBlock3D(nn.Module):
                 hidden_states,
                 encoder_hidden_states=encoder_hidden_states,
                 cross_attention_kwargs=cross_attention_kwargs,
-            ).sample
+                return_dict=False,
+            )[0]
             hidden_states = temp_attn(
-                hidden_states, num_frames=num_frames, cross_attention_kwargs=cross_attention_kwargs
-            ).sample
+                hidden_states, num_frames=num_frames, cross_attention_kwargs=cross_attention_kwargs, return_dict=False
+            )[0]
 
             output_states += (hidden_states,)
 

--- a/src/diffusers/models/unet_3d_blocks.py
+++ b/src/diffusers/models/unet_3d_blocks.py
@@ -592,7 +592,7 @@ class CrossAttnUpBlock3D(nn.Module):
                 hidden_states,
                 encoder_hidden_states=encoder_hidden_states,
                 cross_attention_kwargs=cross_attention_kwargs,
-                return_dict=False
+                return_dict=False,
             )[0]
             hidden_states = temp_attn(
                 hidden_states, num_frames=num_frames, cross_attention_kwargs=cross_attention_kwargs, return_dict=False

--- a/src/diffusers/models/unet_3d_blocks.py
+++ b/src/diffusers/models/unet_3d_blocks.py
@@ -592,10 +592,11 @@ class CrossAttnUpBlock3D(nn.Module):
                 hidden_states,
                 encoder_hidden_states=encoder_hidden_states,
                 cross_attention_kwargs=cross_attention_kwargs,
-            ).sample
+                return_dict=False
+            )[0]
             hidden_states = temp_attn(
-                hidden_states, num_frames=num_frames, cross_attention_kwargs=cross_attention_kwargs
-            ).sample
+                hidden_states, num_frames=num_frames, cross_attention_kwargs=cross_attention_kwargs, return_dict=False
+            )[0]
 
         if self.upsamplers is not None:
             for upsampler in self.upsamplers:

--- a/src/diffusers/models/unet_3d_condition.py
+++ b/src/diffusers/models/unet_3d_condition.py
@@ -526,8 +526,11 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
         sample = self.conv_in(sample)
 
         sample = self.transformer_in(
-            sample, num_frames=num_frames, cross_attention_kwargs=cross_attention_kwargs
-        ).sample
+            sample,
+            num_frames=num_frames,
+            cross_attention_kwargs=cross_attention_kwargs,
+            return_dict=False,
+        )[0]
 
         # 3. down
         down_block_res_samples = (sample,)

--- a/src/diffusers/pipelines/text_to_video_synthesis/pipeline_text_to_video_synth.py
+++ b/src/diffusers/pipelines/text_to_video_synthesis/pipeline_text_to_video_synth.py
@@ -648,7 +648,8 @@ class TextToVideoSDPipeline(DiffusionPipeline, TextualInversionLoaderMixin, Lora
                     t,
                     encoder_hidden_states=prompt_embeds,
                     cross_attention_kwargs=cross_attention_kwargs,
-                ).sample
+                    return_dict=False
+                )[0]
 
                 # perform guidance
                 if do_classifier_free_guidance:

--- a/src/diffusers/pipelines/text_to_video_synthesis/pipeline_text_to_video_synth.py
+++ b/src/diffusers/pipelines/text_to_video_synthesis/pipeline_text_to_video_synth.py
@@ -648,7 +648,7 @@ class TextToVideoSDPipeline(DiffusionPipeline, TextualInversionLoaderMixin, Lora
                     t,
                     encoder_hidden_states=prompt_embeds,
                     cross_attention_kwargs=cross_attention_kwargs,
-                    return_dict=False
+                    return_dict=False,
                 )[0]
 
                 # perform guidance

--- a/src/diffusers/pipelines/text_to_video_synthesis/pipeline_text_to_video_synth_img2img.py
+++ b/src/diffusers/pipelines/text_to_video_synthesis/pipeline_text_to_video_synth_img2img.py
@@ -723,7 +723,8 @@ class VideoToVideoSDPipeline(DiffusionPipeline, TextualInversionLoaderMixin, Lor
                     t,
                     encoder_hidden_states=prompt_embeds,
                     cross_attention_kwargs=cross_attention_kwargs,
-                ).sample
+                    return_dict=False,
+                )[0]
 
                 # perform guidance
                 if do_classifier_free_guidance:


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/diffusers/issues/3915

## Description

`torch.compile()` for the `repeat_interleave()` function was added in a nightly build. See: https://github.com/pytorch/pytorch/issues/99929.

So, once I upgraded to Torch 2.1 nightly, the issue went away. However, there were other issues which are fixed in this PR. The PR takes inspiration from https://github.com/huggingface/diffusers/pull/3313/. 

Even though we're able to successfully compile the model, it takes a hefty amount of time after `torch.compile()` is called on the UNet:

```python
import torch
from diffusers import DiffusionPipeline
from diffusers.utils import export_to_video
from PIL import Image


pipe = DiffusionPipeline.from_pretrained("cerspense/zeroscope_v2_576w", torch_dtype=torch.float16)
pipe.to("cuda")
pipe.enable_vae_slicing()

pipe.unet = torch.compile(pipe.unet, mode="reduce-overhead", fullgraph=True)

prompt = "Darth Vader is surfing on waves"
video_frames = pipe(prompt, num_inference_steps=40, height=320, width=576, num_frames=36).frames
video_path = export_to_video(video_frames, output_video_path="video_576_darth_vader_36.mp4")
```

The first call `pipe` is really time-consuming which is understandable because that is when the compiled UNet model is also used for the first time. But even in the subsequent calls, the timing doesn't seem to improve much. In my experiments, I actually found the runtime to be performing much better without `torch.compile()`. 

Let me know if anything is unclear. 

I leaving the outputs of the progress bars:

**_With_ `torch.compile()`**

<img width="992" alt="image" src="https://github.com/huggingface/diffusers/assets/22957388/6e346889-b069-4e2c-bb7d-ae9aca76da1b">

**_Without_ `torch.compile()`**

<img width="918" alt="image" src="https://github.com/huggingface/diffusers/assets/22957388/4a312ebe-4ef2-4218-b980-7f92283538f7">

My explorations can be found in [this Colab Notebook](https://colab.research.google.com/gist/sayakpaul/58ad90370372ac37adf031e841f041c2/scratchpad.ipynb). 