### PR TITLE
[Add] cast latent to vae dtype in case of occasionally generating black images

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -752,6 +752,7 @@ class StableDiffusionPipeline(DiffusionPipeline, TextualInversionLoaderMixin, Lo
                         callback(i, t, latents)
 
         if not output_type == "latent":
+            latents = latents.to(self.vae.dtype)
             image = self.vae.decode(latents / self.vae.config.scaling_factor, return_dict=False)[0]
             image, has_nsfw_concept = self.run_safety_checker(image, device, prompt_embeds.dtype)
         else:


### PR DESCRIPTION
Occasionally, the StableDiffusionPipeline results in the generation of solely black images for a certain prompt, random seed, and model combination. This issue appears to stem from a data overflow that occurs during inference under the torch.float16. Some trick to mitigate this problem is to use torch.float32 for inference. Here is a [link](https://huggingface.co/stabilityai/stable-diffusion-2-1/discussions/9) to the discussion. However, I find that a more straightforward solution is to use only the vae in a torch.float32, while the rest of the pipeline can still be in the torch.float16.

For example,

```python
weight_dtype = torch.float16
pipeline = StableDiffusionPipeline(
            vae=vae.to(torch.float32), # only vae in torch.float32
            text_encoder=text_encoder.to(weight_dtype),
            tokenizer=tokenizer,
            unet=unet.to(weight_dtype),
            scheduler=scheduler,
            safety_checker=None,
            feature_extractor=None)
```
Therefore, to align with this trick, it is necessary to convert the latent variable to the VAE data type before forwarding it to vae.decode.

@patrickvonplaten and @sayakpaul

