### PR TITLE
[DiffusionPipeline] Deprecate not throwing error when loading non-existant variant

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1213,6 +1213,15 @@ class DiffusionPipeline(ConfigMixin):
             filenames = {sibling.rfilename for sibling in info.siblings}
             model_filenames, variant_filenames = variant_compatible_siblings(filenames, variant=variant)
 
+            if len(variant_filenames) == 0 and variant is not None:
+                deprecation_message = (
+                    f"You are trying to load the model files of the `variant={variant}`, but no such modeling files are available."
+                    f"The default model files: {model_filenames} will be loaded instead. Make sure to not load from `variant={variant}`"
+                    "if such variant modeling files are not available. Doing so will lead to an error in v0.22.0 as defaulting to non-variant"
+                    "modeling files will is deprecated."
+                )
+                deprecate("no variant default", "0.22.0", deprecation_message, standard_warn=False)
+
             # remove ignored filenames
             model_filenames = set(model_filenames) - set(ignore_filenames)
             variant_filenames = set(variant_filenames) - set(ignore_filenames)

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1218,7 +1218,7 @@ class DiffusionPipeline(ConfigMixin):
                     f"You are trying to load the model files of the `variant={variant}`, but no such modeling files are available."
                     f"The default model files: {model_filenames} will be loaded instead. Make sure to not load from `variant={variant}`"
                     "if such variant modeling files are not available. Doing so will lead to an error in v0.22.0 as defaulting to non-variant"
-                    "modeling files will is deprecated."
+                    "modeling files is deprecated."
                 )
                 deprecate("no variant default", "0.22.0", deprecation_message, standard_warn=False)
 

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -1382,7 +1382,7 @@ class PipelineFastTests(unittest.TestCase):
 
         all_model_files, variant_model_files = variant_compatible_siblings(filenames, variant=variant)
 
-        # make sure that none of the model names are variable model names
+        # make sure that none of the model names are variant model names
         assert len(variant_model_files) == 0
         assert len(all_model_files) > 0
 

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -17,6 +17,7 @@ import gc
 import json
 import os
 import random
+import glob
 import shutil
 import sys
 import tempfile
@@ -33,6 +34,7 @@ from parameterized import parameterized
 from PIL import Image
 from requests.exceptions import HTTPError
 from transformers import CLIPImageProcessor, CLIPModel, CLIPTextConfig, CLIPTextModel, CLIPTokenizer
+from transformers.utils import cached_file
 
 from diffusers import (
     AutoencoderKL,
@@ -56,6 +58,7 @@ from diffusers import (
     UniPCMultistepScheduler,
     logging,
 )
+from diffusers.pipelines.pipeline_utils import variant_compatible_siblings
 from diffusers.schedulers.scheduling_utils import SCHEDULER_CONFIG_NAME
 from diffusers.utils import (
     CONFIG_NAME,
@@ -1360,6 +1363,27 @@ class PipelineFastTests(unittest.TestCase):
             assert sd.config.requires_safety_checker == [True, True]
             assert sd.config.safety_checker != (None, None)
             assert sd.config.feature_extractor != (None, None)
+
+    def test_warning_no_variant_available(self):
+        variant = "fp16"
+        with self.assertWarns(FutureWarning) as warning_context:
+            cached_folder = StableDiffusionPipeline.download("hf-internal-testing/diffusers-stable-diffusion-tiny-all", variant=variant)
+
+        assert "but no such modeling files are available" in str(warning_context.warning)
+        assert variant in str(warning_context.warning)
+
+        def get_all_filenames(directory):
+            filenames = glob.glob(directory + '/**', recursive=True)
+            filenames = [f for f in filenames if os.path.isfile(f)]
+            return filenames
+
+        filenames = get_all_filenames(str(cached_folder))
+
+        all_model_files, variant_model_files = variant_compatible_siblings(filenames, variant=variant)
+
+        # make sure that none of the model names are variable model names
+        assert len(variant_model_files) == 0
+        assert len(all_model_files) > 0
 
 
 @slow

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 import gc
+import glob
 import json
 import os
 import random
-import glob
 import shutil
 import sys
 import tempfile
@@ -34,7 +34,6 @@ from parameterized import parameterized
 from PIL import Image
 from requests.exceptions import HTTPError
 from transformers import CLIPImageProcessor, CLIPModel, CLIPTextConfig, CLIPTextModel, CLIPTokenizer
-from transformers.utils import cached_file
 
 from diffusers import (
     AutoencoderKL,
@@ -1367,13 +1366,15 @@ class PipelineFastTests(unittest.TestCase):
     def test_warning_no_variant_available(self):
         variant = "fp16"
         with self.assertWarns(FutureWarning) as warning_context:
-            cached_folder = StableDiffusionPipeline.download("hf-internal-testing/diffusers-stable-diffusion-tiny-all", variant=variant)
+            cached_folder = StableDiffusionPipeline.download(
+                "hf-internal-testing/diffusers-stable-diffusion-tiny-all", variant=variant
+            )
 
         assert "but no such modeling files are available" in str(warning_context.warning)
         assert variant in str(warning_context.warning)
 
         def get_all_filenames(directory):
-            filenames = glob.glob(directory + '/**', recursive=True)
+            filenames = glob.glob(directory + "/**", recursive=True)
             filenames = [f for f in filenames if os.path.isfile(f)]
             return filenames
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Thanks for pointing out this problem @vladmandic . Upon thinking about it, I don't think we should even allow default to fp32 when trying to load "fp16" variants. Added a deprecation warning now.

Note that one can very easily test with this function if the variant is present: https://github.com/huggingface/diffusers/pull/4011/files#r1257526906

So ideally this should be done before downloading - e.g. via:

```py
from huggingface_hub import model_info

info = model_info("<your/repo/id>")
filenames = {sibling.rfilename for sibling in info.siblings}
```

We can however also very easily check post-download what variants have been downloaded as shown here: https://github.com/huggingface/diffusers/pull/4011#discussion_r1257526906