### PR TITLE
📝 Fix broken link to models documentation

### DIFF
--- a/src/diffusers/models/README.md
+++ b/src/diffusers/models/README.md
@@ -1,3 +1,3 @@
 # Models
 
-For more detail on the models, please refer to the [docs](https://huggingface.co/docs/diffusers/main/en/api/models).
+For more detail on the models, please refer to the [docs](https://huggingface.co/docs/diffusers/api/models/overview).

--- a/src/diffusers/models/README.md
+++ b/src/diffusers/models/README.md
@@ -1,3 +1,3 @@
 # Models
 
-For more detail on the models, please refer to the [docs](https://huggingface.co/docs/diffusers/api/models).
+For more detail on the models, please refer to the [docs](https://huggingface.co/docs/diffusers/main/en/api/models).


### PR DESCRIPTION
@stevenliu and @yiyixu,

Corrected the link to the models documentation in the README. Previously, the link was pointing to an incorrect URL. Now, the link directs users to the correct documentation page for more details on the models.

Thanks! 🙌