### PR TITLE
Fix bug in ControlNetPipelines with MultiControlNetModel of length 1

### DIFF
--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -952,7 +952,7 @@ class StableDiffusionControlNetPipeline(DiffusionPipeline, TextualInversionLoade
                 1.0 - float(i / len(timesteps) < s or (i + 1) / len(timesteps) > e)
                 for s, e in zip(control_guidance_start, control_guidance_end)
             ]
-            controlnet_keep.append(keeps[0] if len(keeps) == 1 else keeps)
+            controlnet_keep.append(keeps[0] if isinstance(controlnet, ControlNetModel) else keeps)
 
         # 8. Denoising loop
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_img2img.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_img2img.py
@@ -1045,7 +1045,7 @@ class StableDiffusionControlNetImg2ImgPipeline(DiffusionPipeline, TextualInversi
                 1.0 - float(i / len(timesteps) < s or (i + 1) / len(timesteps) > e)
                 for s, e in zip(control_guidance_start, control_guidance_end)
             ]
-            controlnet_keep.append(keeps[0] if len(keeps) == 1 else keeps)
+            controlnet_keep.append(keeps[0] if isinstance(controlnet, ControlNetModel) else keeps)
 
         # 8. Denoising loop
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
@@ -1280,7 +1280,7 @@ class StableDiffusionControlNetInpaintPipeline(DiffusionPipeline, TextualInversi
                 1.0 - float(i / len(timesteps) < s or (i + 1) / len(timesteps) > e)
                 for s, e in zip(control_guidance_start, control_guidance_end)
             ]
-            controlnet_keep.append(keeps[0] if len(keeps) == 1 else keeps)
+            controlnet_keep.append(keeps[0] if isinstance(controlnet, ControlNetModel) else keeps)
 
         # 8. Denoising loop
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order

--- a/tests/pipelines/controlnet/test_controlnet.py
+++ b/tests/pipelines/controlnet/test_controlnet.py
@@ -360,11 +360,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         inputs = self.get_dummy_inputs(torch_device)
         inputs["num_inference_steps"] = steps
         inputs["controlnet_conditioning_scale"] = scale
-        output_3 = pipe(
-            **inputs,
-            control_guidance_start=[0.1, 0.3],
-            control_guidance_end=[0.2, 0.7],
-        )[0]
+        output_3 = pipe(**inputs, control_guidance_start=[0.1, 0.3], control_guidance_end=[0.2, 0.7])[0]
 
         inputs = self.get_dummy_inputs(torch_device)
         inputs["num_inference_steps"] = steps

--- a/tests/pipelines/controlnet/test_controlnet.py
+++ b/tests/pipelines/controlnet/test_controlnet.py
@@ -295,7 +295,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         text_encoder = CLIPTextModel(text_encoder_config)
         tokenizer = CLIPTokenizer.from_pretrained("hf-internal-testing/tiny-random-clip")
 
-        controlnet = MultiControlNetModel([controlnet1, controlnet2][:self.num_controlnet_models])
+        controlnet = MultiControlNetModel([controlnet1, controlnet2][: self.num_controlnet_models])
 
         components = {
             "unet": unet,
@@ -328,7 +328,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
                 generator=generator,
                 device=torch.device(device),
             ),
-        ][:self.num_controlnet_models]
+        ][: self.num_controlnet_models]
 
         inputs = {
             "prompt": "A painting of a squirrel eating a burger",
@@ -341,7 +341,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
 
         return inputs
 
-    def _test_with_varying_num_models(self, test, num_models = [1, 2]):
+    def _test_with_varying_num_models(self, test, num_models=[1, 2]):
         # Run test for varying number of ControlNet models
         for n in num_models:
             self.num_controlnet_models = n
@@ -368,12 +368,18 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         inputs = self.get_dummy_inputs(torch_device)
         inputs["num_inference_steps"] = steps
         inputs["controlnet_conditioning_scale"] = scale
-        output_3 = pipe(**inputs, control_guidance_start=[0.1, 0.3][:self.num_controlnet_models], control_guidance_end=[0.2, 0.7][:self.num_controlnet_models])[0]
+        output_3 = pipe(
+            **inputs,
+            control_guidance_start=[0.1, 0.3][: self.num_controlnet_models],
+            control_guidance_end=[0.2, 0.7][: self.num_controlnet_models],
+        )[0]
 
         inputs = self.get_dummy_inputs(torch_device)
         inputs["num_inference_steps"] = steps
         inputs["controlnet_conditioning_scale"] = scale
-        output_4 = pipe(**inputs, control_guidance_start=0.4, control_guidance_end=[0.5, 0.8][:self.num_controlnet_models])[0]
+        output_4 = pipe(
+            **inputs, control_guidance_start=0.4, control_guidance_end=[0.5, 0.8][: self.num_controlnet_models]
+        )[0]
 
         # make sure that all outputs are different
         assert np.sum(np.abs(output_1 - output_2)) > 1e-3

--- a/tests/pipelines/controlnet/test_controlnet.py
+++ b/tests/pipelines/controlnet/test_controlnet.py
@@ -368,12 +368,12 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         inputs = self.get_dummy_inputs(torch_device)
         inputs["num_inference_steps"] = steps
         inputs["controlnet_conditioning_scale"] = scale
-        output_3 = pipe(**inputs, control_guidance_start=[0.1, 0.3], control_guidance_end=[0.2, 0.7])[0]
+        output_3 = pipe(**inputs, control_guidance_start=[0.1, 0.3][:self.num_controlnet_models], control_guidance_end=[0.2, 0.7][:self.num_controlnet_models])[0]
 
         inputs = self.get_dummy_inputs(torch_device)
         inputs["num_inference_steps"] = steps
         inputs["controlnet_conditioning_scale"] = scale
-        output_4 = pipe(**inputs, control_guidance_start=0.4, control_guidance_end=[0.5, 0.8])[0]
+        output_4 = pipe(**inputs, control_guidance_start=0.4, control_guidance_end=[0.5, 0.8][:self.num_controlnet_models])[0]
 
         # make sure that all outputs are different
         assert np.sum(np.abs(output_1 - output_2)) > 1e-3

--- a/tests/pipelines/controlnet/test_controlnet.py
+++ b/tests/pipelines/controlnet/test_controlnet.py
@@ -17,7 +17,6 @@ import gc
 import tempfile
 import traceback
 import unittest
-from typing import Literal
 
 import numpy as np
 import torch
@@ -221,7 +220,6 @@ class StableDiffusionMultiControlNetPipelineFastTests(
     params = TEXT_TO_IMAGE_PARAMS
     batch_params = TEXT_TO_IMAGE_BATCH_PARAMS
     image_params = frozenset([])  # TO_DO: add image_params once refactored VaeImageProcessor.preprocess
-    num_controlnet_models: Literal[1, 2] = 2
 
     def get_dummy_components(self):
         torch.manual_seed(0)
@@ -295,7 +293,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         text_encoder = CLIPTextModel(text_encoder_config)
         tokenizer = CLIPTokenizer.from_pretrained("hf-internal-testing/tiny-random-clip")
 
-        controlnet = MultiControlNetModel([controlnet1, controlnet2][: self.num_controlnet_models])
+        controlnet = MultiControlNetModel([controlnet1, controlnet2])
 
         components = {
             "unet": unet,
@@ -328,7 +326,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
                 generator=generator,
                 device=torch.device(device),
             ),
-        ][: self.num_controlnet_models]
+        ]
 
         inputs = {
             "prompt": "A painting of a squirrel eating a burger",
@@ -341,13 +339,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
 
         return inputs
 
-    def _test_with_varying_num_models(self, test, num_models=[1, 2]):
-        # Run test for varying number of ControlNet models
-        for n in num_models:
-            self.num_controlnet_models = n
-            test()
-
-    def _test_control_guidance_switch(self):
+    def test_control_guidance_switch(self):
         components = self.get_dummy_components()
         pipe = self.pipeline_class(**components)
         pipe.to(torch_device)
@@ -370,27 +362,22 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         inputs["controlnet_conditioning_scale"] = scale
         output_3 = pipe(
             **inputs,
-            control_guidance_start=[0.1, 0.3][: self.num_controlnet_models],
-            control_guidance_end=[0.2, 0.7][: self.num_controlnet_models],
+            control_guidance_start=[0.1, 0.3],
+            control_guidance_end=[0.2, 0.7],
         )[0]
 
         inputs = self.get_dummy_inputs(torch_device)
         inputs["num_inference_steps"] = steps
         inputs["controlnet_conditioning_scale"] = scale
-        output_4 = pipe(
-            **inputs, control_guidance_start=0.4, control_guidance_end=[0.5, 0.8][: self.num_controlnet_models]
-        )[0]
+        output_4 = pipe(**inputs, control_guidance_start=0.4, control_guidance_end=[0.5, 0.8])[0]
 
         # make sure that all outputs are different
         assert np.sum(np.abs(output_1 - output_2)) > 1e-3
         assert np.sum(np.abs(output_1 - output_3)) > 1e-3
         assert np.sum(np.abs(output_1 - output_4)) > 1e-3
 
-    def test_control_guidance_switch(self):
-        self._test_with_varying_num_models(self._test_control_guidance_switch)
-
     def test_attention_slicing_forward_pass(self):
-        self._test_with_varying_num_models(lambda: self._test_attention_slicing_forward_pass(expected_max_diff=2e-3))
+        return self._test_attention_slicing_forward_pass(expected_max_diff=2e-3)
 
     @unittest.skipIf(
         torch_device != "cuda" or not is_xformers_available(),
@@ -400,7 +387,180 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         self._test_xformers_attention_forwardGenerator_pass(expected_max_diff=2e-3)
 
     def test_inference_batch_single_identical(self):
-        self._test_with_varying_num_models(lambda: self._test_inference_batch_single_identical(expected_max_diff=2e-3))
+        self._test_inference_batch_single_identical(expected_max_diff=2e-3)
+
+    def test_save_pretrained_raise_not_implemented_exception(self):
+        components = self.get_dummy_components()
+        pipe = self.pipeline_class(**components)
+        pipe.to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                # save_pretrained is not implemented for Multi-ControlNet
+                pipe.save_pretrained(tmpdir)
+            except NotImplementedError:
+                pass
+
+
+class StableDiffusionMultiControlNetOneModelPipelineFastTests(
+    PipelineTesterMixin, PipelineKarrasSchedulerTesterMixin, unittest.TestCase
+):
+    pipeline_class = StableDiffusionControlNetPipeline
+    params = TEXT_TO_IMAGE_PARAMS
+    batch_params = TEXT_TO_IMAGE_BATCH_PARAMS
+    image_params = frozenset([])  # TO_DO: add image_params once refactored VaeImageProcessor.preprocess
+
+    def get_dummy_components(self):
+        torch.manual_seed(0)
+        unet = UNet2DConditionModel(
+            block_out_channels=(32, 64),
+            layers_per_block=2,
+            sample_size=32,
+            in_channels=4,
+            out_channels=4,
+            down_block_types=("DownBlock2D", "CrossAttnDownBlock2D"),
+            up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
+            cross_attention_dim=32,
+        )
+        torch.manual_seed(0)
+
+        def init_weights(m):
+            if isinstance(m, torch.nn.Conv2d):
+                torch.nn.init.normal(m.weight)
+                m.bias.data.fill_(1.0)
+
+        controlnet = ControlNetModel(
+            block_out_channels=(32, 64),
+            layers_per_block=2,
+            in_channels=4,
+            down_block_types=("DownBlock2D", "CrossAttnDownBlock2D"),
+            cross_attention_dim=32,
+            conditioning_embedding_out_channels=(16, 32),
+        )
+        controlnet.controlnet_down_blocks.apply(init_weights)
+
+        torch.manual_seed(0)
+        scheduler = DDIMScheduler(
+            beta_start=0.00085,
+            beta_end=0.012,
+            beta_schedule="scaled_linear",
+            clip_sample=False,
+            set_alpha_to_one=False,
+        )
+        torch.manual_seed(0)
+        vae = AutoencoderKL(
+            block_out_channels=[32, 64],
+            in_channels=3,
+            out_channels=3,
+            down_block_types=["DownEncoderBlock2D", "DownEncoderBlock2D"],
+            up_block_types=["UpDecoderBlock2D", "UpDecoderBlock2D"],
+            latent_channels=4,
+        )
+        torch.manual_seed(0)
+        text_encoder_config = CLIPTextConfig(
+            bos_token_id=0,
+            eos_token_id=2,
+            hidden_size=32,
+            intermediate_size=37,
+            layer_norm_eps=1e-05,
+            num_attention_heads=4,
+            num_hidden_layers=5,
+            pad_token_id=1,
+            vocab_size=1000,
+        )
+        text_encoder = CLIPTextModel(text_encoder_config)
+        tokenizer = CLIPTokenizer.from_pretrained("hf-internal-testing/tiny-random-clip")
+
+        controlnet = MultiControlNetModel([controlnet])
+
+        components = {
+            "unet": unet,
+            "controlnet": controlnet,
+            "scheduler": scheduler,
+            "vae": vae,
+            "text_encoder": text_encoder,
+            "tokenizer": tokenizer,
+            "safety_checker": None,
+            "feature_extractor": None,
+        }
+        return components
+
+    def get_dummy_inputs(self, device, seed=0):
+        if str(device).startswith("mps"):
+            generator = torch.manual_seed(seed)
+        else:
+            generator = torch.Generator(device=device).manual_seed(seed)
+
+        controlnet_embedder_scale_factor = 2
+
+        images = [
+            randn_tensor(
+                (1, 3, 32 * controlnet_embedder_scale_factor, 32 * controlnet_embedder_scale_factor),
+                generator=generator,
+                device=torch.device(device),
+            ),
+        ]
+
+        inputs = {
+            "prompt": "A painting of a squirrel eating a burger",
+            "generator": generator,
+            "num_inference_steps": 2,
+            "guidance_scale": 6.0,
+            "output_type": "numpy",
+            "image": images,
+        }
+
+        return inputs
+
+    def test_control_guidance_switch(self):
+        components = self.get_dummy_components()
+        pipe = self.pipeline_class(**components)
+        pipe.to(torch_device)
+
+        scale = 10.0
+        steps = 4
+
+        inputs = self.get_dummy_inputs(torch_device)
+        inputs["num_inference_steps"] = steps
+        inputs["controlnet_conditioning_scale"] = scale
+        output_1 = pipe(**inputs)[0]
+
+        inputs = self.get_dummy_inputs(torch_device)
+        inputs["num_inference_steps"] = steps
+        inputs["controlnet_conditioning_scale"] = scale
+        output_2 = pipe(**inputs, control_guidance_start=0.1, control_guidance_end=0.2)[0]
+
+        inputs = self.get_dummy_inputs(torch_device)
+        inputs["num_inference_steps"] = steps
+        inputs["controlnet_conditioning_scale"] = scale
+        output_3 = pipe(
+            **inputs,
+            control_guidance_start=[0.1],
+            control_guidance_end=[0.2],
+        )[0]
+
+        inputs = self.get_dummy_inputs(torch_device)
+        inputs["num_inference_steps"] = steps
+        inputs["controlnet_conditioning_scale"] = scale
+        output_4 = pipe(**inputs, control_guidance_start=0.4, control_guidance_end=[0.5])[0]
+
+        # make sure that all outputs are different
+        assert np.sum(np.abs(output_1 - output_2)) > 1e-3
+        assert np.sum(np.abs(output_1 - output_3)) > 1e-3
+        assert np.sum(np.abs(output_1 - output_4)) > 1e-3
+
+    def test_attention_slicing_forward_pass(self):
+        return self._test_attention_slicing_forward_pass(expected_max_diff=2e-3)
+
+    @unittest.skipIf(
+        torch_device != "cuda" or not is_xformers_available(),
+        reason="XFormers attention is only available with CUDA and `xformers` installed",
+    )
+    def test_xformers_attention_forwardGenerator_pass(self):
+        self._test_xformers_attention_forwardGenerator_pass(expected_max_diff=2e-3)
+
+    def test_inference_batch_single_identical(self):
+        self._test_inference_batch_single_identical(expected_max_diff=2e-3)
 
     def test_save_pretrained_raise_not_implemented_exception(self):
         components = self.get_dummy_components()


### PR DESCRIPTION
# What does this PR do?

Hey @patrickvonplaten and @sayakpaul!

In the latest implementation that added `control_guidance_start` and `control_guidance_end`, the code that computes `controlnet_keep` uses `len(keeps) == 1` to decide whether to `controlnet_keep` should be a list of floats or list of lists.

But ControlNetPipelines supplied with a **list of one ControlNetModel** initializes a MultiControlNetModel as well.

This causes a bug when a ControlNetPipeline is supplied with a **list of one ControlNetModel** because that initializes a MultiControlNetModel but `controlnet_keep` is computed as a list of floats.
On runtime an error will be raised when computing `cond_scale` at each timestep - `TypeError: can't multiply sequence by non-int of type 'float'`.

This fix changes the following in the 3 ControlNetPipeline files:

Previous code:
```
controlnet_keep.append(keeps[0] if len(keeps) == 1 else keeps)
```

Fixed code:
```
controlnet_keep.append(keeps[0] if isinstance(controlnet, ControlNetModel) else keeps)
```

The fix accounts for the edge case where MultiControlNetModels have only one controlnet.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
