### PR TITLE
FIX `force_download` in download utility

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1322,7 +1322,7 @@ class DiffusionPipeline(ConfigMixin):
             snapshot_folder = Path(config_file).parent
             pipeline_is_cached = all((snapshot_folder / f).is_file() for f in expected_files)
 
-            if pipeline_is_cached:
+            if pipeline_is_cached and not force_download:
                 # if the pipeline is cached, we can directly return it
                 # else call snapshot_download
                 return snapshot_folder


### PR DESCRIPTION
In https://github.com/huggingface/diffusers/pull/2515, the implementation to load models has being refactored to make loading faster. However, the `force_download` parameter is not respected anymore. This PR fixes it.

Though `force_download` is a very niche use case, it is still useful when one wants to be sure to restart from scratch, no matter if there cache system got corrupted. It also ease things when debugging (for context: https://github.com/huggingface/huggingface_hub/issues/1549) 