### PR TITLE
Typo fix in example docstring in audioldm pipeline

### DIFF
--- a/src/diffusers/pipelines/audioldm/pipeline_audioldm.py
+++ b/src/diffusers/pipelines/audioldm/pipeline_audioldm.py
@@ -38,7 +38,7 @@ EXAMPLE_DOC_STRING = """
         >>> pipe = pipe.to("cuda")
 
         >>> prompt = "A hammer hitting a wooden surface"
-        >>> audio = pipe(prompt).audio[0]
+        >>> audio = pipe(prompt).audios[0]
         ```
 """
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes a small typo in the example docstring of the __call__ method of the AudioLDMPipeline class, that made the example give an error.

Specifically:
```
>>> audio = pipe(prompt).audio[0]
```
should be 
```
>>> audio = pipe(prompt).audios[0]
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sanchit-gandhi 
