### PR TITLE
[Safetensors] make safetensors a required dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ _deps = [
     "pytest-timeout",
     "pytest-xdist",
     "ruff>=0.0.241",
-    "safetensors",
+    "safetensors>=0.3.1",
     "sentencepiece>=0.1.91,!=0.1.92",
     "scipy",
     "onnx",
@@ -227,6 +227,7 @@ install_requires = [
     deps["numpy"],
     deps["regex"],
     deps["requests"],
+    deps["safetensors"],
     deps["Pillow"],
 ]
 

--- a/src/diffusers/dependency_versions_table.py
+++ b/src/diffusers/dependency_versions_table.py
@@ -30,7 +30,7 @@ deps = {
     "pytest-timeout": "pytest-timeout",
     "pytest-xdist": "pytest-xdist",
     "ruff": "ruff>=0.0.241",
-    "safetensors": "safetensors",
+    "safetensors": "safetensors>=0.3.1",
     "sentencepiece": "sentencepiece>=0.1.91,!=0.1.92",
     "scipy": "scipy",
     "onnx": "onnx",


### PR DESCRIPTION
# What does this PR do?

Following `transformers`, let's make `safetensors` a required dependency: https://github.com/huggingface/transformers/pull/23254/files

