### PR TITLE
make enable_sequential_cpu_offload more generic for third-party devices

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1129,7 +1129,7 @@ class DiffusionPipeline(ConfigMixin):
             self.to("cpu", silence_dtype_warnings=True)
             device_mod = getattr(torch, self.device.type, None)
             if hasattr(device_mod, "empty_cache") and device_mod.is_available():
-                device_mod.empty_cache() # otherwise we don't see the memory savings (but they probably exist)
+                device_mod.empty_cache()  # otherwise we don't see the memory savings (but they probably exist)
 
         for name, model in self.components.items():
             if not isinstance(model, torch.nn.Module):

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1127,7 +1127,9 @@ class DiffusionPipeline(ConfigMixin):
 
         if self.device.type != "cpu":
             self.to("cpu", silence_dtype_warnings=True)
-            torch.cuda.empty_cache()  # otherwise we don't see the memory savings (but they probably exist)
+            device_mod = getattr(torch, self.device.type, None)
+            if hasattr(device_mod, "empty_cache") and device_mod.is_available():
+                device_mod.empty_cache() # otherwise we don't see the memory savings (but they probably exist)
 
         for name, model in self.components.items():
             if not isinstance(model, torch.nn.Module):


### PR DESCRIPTION
# What does this PR do?
This PR make `enable_sequential_cpu_offload` more generic for third-party devices.

---

I noticed that in https://github.com/huggingface/diffusers/pull/4114,   `enable_sequential_cpu_offload` has been refactored to be more generic for other devices.
But inside the function `enable_sequential_cpu_offload`, we use `torch.cuda.empty_cache` to release all unoccupied cache memory, which has no effect for other devices (such as `xpu`)
https://github.com/huggingface/diffusers/blob/7a47df22a5db7366f83a943ea5f56f509a9a0330/src/diffusers/pipelines/pipeline_utils.py#L1128-L1130
We could change `torch.cuda.empty_cache()` with another from outside, like
```diff
+ torch.cuda.empty_cache = torch.xpu.empty_cache
device = torch.device("xpu")
pipeline.enable_sequential_cpu_offload(device=device)
```
but it looks a little weird. 



I think a better way is 
- get the device module according to the device type first
- and then call the corresponding `empty_cache` method. 

Now, we can use `enable_sequential_cpu_offload` more conveniently with `xpu`, like 
```
device = torch.device("xpu")
pipeline.enable_sequential_cpu_offload(device=device)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
 @patrickvonplaten and @sayakpaul

