### PR TITLE
Add the SDE variant of DPM-Solver and DPM-Solver++ to DPM Single Step

### DIFF
--- a/tests/schedulers/test_scheduler_dpm_single.py
+++ b/tests/schedulers/test_scheduler_dpm_single.py
@@ -175,16 +175,20 @@ class DPMSolverSinglestepSchedulerTest(SchedulerCommonTest):
             self.check_over_configs(prediction_type=prediction_type)
 
     def test_solver_order_and_type(self):
-        for algorithm_type in ["dpmsolver", "dpmsolver++"]:
+        for algorithm_type in ["dpmsolver", "dpmsolver++", "sde-dpmsolver", "sde-dpmsolver++"]:
             for solver_type in ["midpoint", "heun"]:
                 for order in [1, 2, 3]:
                     for prediction_type in ["epsilon", "sample"]:
-                        self.check_over_configs(
-                            solver_order=order,
-                            solver_type=solver_type,
-                            prediction_type=prediction_type,
-                            algorithm_type=algorithm_type,
-                        )
+                        if algorithm_type in ["sde-dpmsolver", "sde-dpmsolver++"]:
+                            if order == 3:
+                                continue
+                        else:
+                            self.check_over_configs(
+                                solver_order=order,
+                                solver_type=solver_type,
+                                prediction_type=prediction_type,
+                                algorithm_type=algorithm_type,
+                            )
                         sample = self.full_loop(
                             solver_order=order,
                             solver_type=solver_type,


### PR DESCRIPTION
Following up on our conversation at https://github.com/huggingface/diffusers/issues/4167#issuecomment-1648464442

Uses the same approach as https://github.com/huggingface/diffusers/pull/3344/files

**Note:** This PR is not ready to merge yet, since it's not clear whether to use `sigma_s0` or `sigma_s1` in the second-order update. **There is a discrepancy between the implementations of single-step and multi-step for second-order.**

The current Single Step implementation uses `sigma_s1` for the second-order update: https://github.com/huggingface/diffusers/blob/45f6d52b109604d6754ffefa9e289acd1df92994/src/diffusers/schedulers/scheduling_dpmsolver_singlestep.py#L503

While the reference PR for Multi Step uses `sigma_s0` for the second-order update: https://github.com/huggingface/diffusers/pull/3344/files#diff-517cce3913a4b16e1d17a0b945a920e400aa5553471df6cd85f71fc8f079b4b4R478

@patrickvonplaten I don't know which is the correct one. Is it a bug in multi-step, or single-step, or should I use `sigma_s1` for single-step?

The test doesn't pass right now due to this error, I intentionally left the code in this state.

Thanks!