### PR TITLE
Model path for sdxl wrong in dreambooth README

### DIFF
--- a/examples/dreambooth/README_sdxl.md
+++ b/examples/dreambooth/README_sdxl.md
@@ -76,7 +76,7 @@ This will also allow us to push the trained LoRA parameters to the Hugging Face 
 Now, we can launch training using:
 
 ```bash
-export MODEL_NAME="diffusers/stable-diffusion-xl-base-0.9"
+export MODEL_NAME="stabilityai/stable-diffusion-xl-base-0.9"
 export INSTANCE_DIR="dog"
 export OUTPUT_DIR="lora-trained-xl"
 


### PR DESCRIPTION
# What does this PR do?

Model path for sdxl was wrong in the dreambooth README



## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
## Who can review?

@sayakpaul