### PR TITLE
auto type conversion

### DIFF
--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -558,7 +558,7 @@ class StableDiffusionControlNetPipeline(
             control_guidance_start = [control_guidance_start]
             
         if isinstance(control_guidance_end, float):
-            control_guidance_end = [control_guidance_start]
+            control_guidance_end = [control_guidance_end]
             
         if len(control_guidance_start) != len(control_guidance_end):
             raise ValueError(

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -554,6 +554,12 @@ class StableDiffusionControlNetPipeline(
         else:
             assert False
 
+        if isinstance(control_guidance_start, float):
+            control_guidance_start = [control_guidance_start]
+            
+        if isinstance(control_guidance_end, float):
+            control_guidance_end = [control_guidance_start]
+            
         if len(control_guidance_start) != len(control_guidance_end):
             raise ValueError(
                 f"`control_guidance_start` has {len(control_guidance_start)} elements, but `control_guidance_end` has {len(control_guidance_end)} elements. Make sure to provide the same number of elements to each list."

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -554,7 +554,7 @@ class StableDiffusionControlNetPipeline(
         else:
             assert False
 
-        if isinstance(control_guidance_start, float):
+        if not isinstance(control_guidance_start, (tuple, list)):
             control_guidance_start = [control_guidance_start]
             
         if isinstance(control_guidance_end, float):

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -557,7 +557,7 @@ class StableDiffusionControlNetPipeline(
         if not isinstance(control_guidance_start, (tuple, list)):
             control_guidance_start = [control_guidance_start]
             
-        if isinstance(control_guidance_end, float):
+        if not isinstance(control_guidance_end, (tuple, list)):
             control_guidance_end = [control_guidance_end]
             
         if len(control_guidance_start) != len(control_guidance_end):


### PR DESCRIPTION
Default value of `control_guidance_start` and `control_guidance_end` in `StableDiffusionControlNetPipeline.check_inputs` function causes `TypeError: object of type 'float' has no len()`

Proposed fix: 
Convert `control_guidance_start` and `control_guidance_end` to type list if float

# What does this PR do?

Fixes #4269

@holwech 
