### PR TITLE
Fix SDXL conversion from original to diffusers

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -1185,6 +1185,7 @@ def download_from_original_stable_diffusion_ckpt(
         StableDiffusionControlNetPipeline,
         StableDiffusionInpaintPipeline,
         StableDiffusionPipeline,
+        StableDiffusionXLPipeline,
         StableDiffusionXLImg2ImgPipeline,
         StableUnCLIPImg2ImgPipeline,
         StableUnCLIPPipeline,
@@ -1542,7 +1543,7 @@ def download_from_original_stable_diffusion_ckpt(
                 checkpoint, config_name, prefix="conditioner.embedders.1.model.", has_projection=True, **config_kwargs
             )
 
-            pipe = pipeline_class(
+            pipe = StableDiffusionXLPipeline(
                 vae=vae,
                 text_encoder=text_encoder,
                 tokenizer=tokenizer,

--- a/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -1185,8 +1185,8 @@ def download_from_original_stable_diffusion_ckpt(
         StableDiffusionControlNetPipeline,
         StableDiffusionInpaintPipeline,
         StableDiffusionPipeline,
-        StableDiffusionXLPipeline,
         StableDiffusionXLImg2ImgPipeline,
+        StableDiffusionXLPipeline,
         StableUnCLIPImg2ImgPipeline,
         StableUnCLIPPipeline,
     )


### PR DESCRIPTION
Hi, long time no see. Great progress here.
I noticed a small bug that prevented the successful conversion of SDXL. 

```
Traceback (most recent call last):
  File "scripts/convert_original_stable_diffusion_to_diffusers.py", line 138, in <module>
    pipe = download_from_original_stable_diffusion_ckpt(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py", line 1545, in download_from_original_stable_diffusion_ckpt
    pipe = pipeline_class(
TypeError: __init__() got an unexpected keyword argument 'text_encoder_2'
```
cc: @patrickvonplaten @sayakpaul 