### PR TITLE
Allow controlnets to be loaded (from ckpt) in a parallel thread with a SD model (ckpt), and speed it up slightly

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -1070,7 +1070,9 @@ def convert_controlnet_checkpoint(
     if cross_attention_dim is not None:
         ctrlnet_config["cross_attention_dim"] = cross_attention_dim
 
-    controlnet = ControlNetModel(**ctrlnet_config)
+    ctx = init_empty_weights if is_accelerate_available() else nullcontext
+    with ctx():
+        controlnet = ControlNetModel(**ctrlnet_config)
 
     # Some controlnet ckpt files are distributed independently from the rest of the
     # model components i.e. https://huggingface.co/thibaud/controlnet-sd21/
@@ -1088,7 +1090,11 @@ def convert_controlnet_checkpoint(
         skip_extract_state_dict=skip_extract_state_dict,
     )
 
-    controlnet.load_state_dict(converted_ctrl_checkpoint)
+    if is_accelerate_available():
+        for param_name, param in converted_ctrl_checkpoint.items():
+            set_module_tensor_to_device(controlnet, param_name, "cpu", value=param)
+    else:
+        controlnet.load_state_dict(converted_ctrl_checkpoint)
 
     return controlnet
 


### PR DESCRIPTION
Avoids `meta` tensor errors (due to a race condition described in https://github.com/huggingface/diffusers/issues/4296).

This allows a controlnet model to be loaded in parallel with an SD model (in two separate threads). As a side-effect, it speeds up the controlnet model instantiation, by following the pattern used for unet and other sub-modules.

While this isn't a broader fix for the race-condition mentioned in #4296, it fixes the problem for Controlnet.

If there's a different way to address this issue, I'd be happy to alter the PR! :)

Thanks!

@patrickvonplaten @sayakpaul 