### PR TITLE
fix typo to ensure `make test-examples`  work correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test:
 # Run tests for examples
 
 test-examples:
-	python -m pytest -n auto --dist=loadfile -s -v ./examples/pytorch/
+	python -m pytest -n auto --dist=loadfile -s -v ./examples/
 
 
 # Release stuff


### PR DESCRIPTION
# What does this PR do?
Currently, when you type `make test-examples`, the associated test cases cannot be run.
This PR fixes this issue.

@patrickvonplaten 