### PR TITLE
[LoRA] Fix SDXL text encoder LoRAs

### DIFF
--- a/docs/source/en/training/lora.md
+++ b/docs/source/en/training/lora.md
@@ -401,5 +401,4 @@ Thanks to [@isidentical](https://github.com/isidentical) for helping us on integ
 
 ### Known limitations specific to the Kohya-styled LoRAs
 
-* SDXL LoRAs that have both the text encoders are currently leading to weird results. We're actively investigating the issue. 
 * When images don't looks similar to other UIs such ComfyUI, it can be beacause of multiple reasons as explained [here](https://github.com/huggingface/diffusers/pull/4287/#issuecomment-1655110736). 

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1214,6 +1214,7 @@ class LoraLoaderMixin:
                 network_alphas = {
                     k.replace(f"{cls.unet_name}.", ""): v for k, v in network_alphas.items() if k in alpha_keys
                 }
+                print(f"From UNet: {alpha_keys}")
 
         else:
             # Otherwise, we're dealing with the old format. This means the `state_dict` should only
@@ -1373,7 +1374,6 @@ class LoraLoaderMixin:
 
         lora_parameters = []
         network_alphas = {} if network_alphas is None else network_alphas
-        print(f"From text encoder: {network_alphas}")
         for name, attn_module in text_encoder_attn_modules(text_encoder):
             query_alpha = network_alphas.get(name + ".k.proj.alpha")
             key_alpha = network_alphas.get(name + ".q.proj.alpha")

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1358,14 +1358,15 @@ class LoraLoaderMixin:
 
         lora_parameters = []
         network_alphas = {} if network_alphas is None else network_alphas
-        text_encoder_net_alphas = list(filter(lambda x: "text" in x, network_alphas))
-        print(f"Text encoder network alphas: {list(filter(lambda x: x.startswith('text_encoder'), text_encoder_net_alphas))[:10]}")
-        print(f"Text encoder 2 network alphas: {list(filter(lambda x: x.startswith('text_encoder_2'), text_encoder_net_alphas))[:10]}")
+        # text_encoder_net_alphas = list(filter(lambda x: "text" in x, network_alphas))
+        # print(f"Text encoder network alphas: {list(filter(lambda x: x.startswith('text_encoder'), text_encoder_net_alphas))[:10]}")
+        # print(f"Text encoder 2 network alphas: {list(filter(lambda x: x.startswith('text_encoder_2'), text_encoder_net_alphas))[:10]}")
         for name, attn_module in text_encoder_attn_modules(text_encoder):
-            query_alpha = network_alphas.get(name + ".k.proj.alpha", None)
-            key_alpha = network_alphas.get(name + ".q.proj.alpha", None)
-            value_alpha = network_alphas.get(name + ".v.proj.alpha", None)
-            proj_alpha = network_alphas.get(name + ".out.proj.alpha", None)
+            print(f"From modification: {name}")
+            query_alpha = network_alphas.get(name + ".k.proj.alpha")
+            key_alpha = network_alphas.get(name + ".q.proj.alpha")
+            value_alpha = network_alphas.get(name + ".v.proj.alpha")
+            proj_alpha = network_alphas.get(name + ".out.proj.alpha")
 
             attn_module.q_proj = PatchedLoraProjection(
                 attn_module.q_proj, lora_scale, network_alpha=query_alpha, rank=rank, dtype=dtype

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1303,6 +1303,7 @@ class LoraLoaderMixin:
                     network_alphas = {
                         k.replace(f"{prefix}.", ""): v for k, v in network_alphas.items() if k in alpha_keys
                     }
+                    print(list(network_alphas.keys())[:10])
                     print(f"{prefix} alphas: {alpha_keys[:10]}")
 
                 cls._modify_text_encoder(

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1310,7 +1310,9 @@ class LoraLoaderMixin:
                     network_alphas = {
                         k.replace(f"{prefix}.", ""): v for k, v in network_alphas.items() if k in alpha_keys
                     }
-
+                if "2" not in prefix:
+                    any_te2 = any("text_encoder_2" in k for k in network_alphas)
+                    print(f"{prefix}: {any_te2}")
                 cls._modify_text_encoder(
                     text_encoder,
                     lora_scale,
@@ -1378,6 +1380,7 @@ class LoraLoaderMixin:
             key_alpha = network_alphas.get(name + ".q.proj.alpha")
             value_alpha = network_alphas.get(name + ".v.proj.alpha")
             proj_alpha = network_alphas.get(name + ".out.proj.alpha")
+            print(name + ".k.proj.alpha", name + ".q.proj.alpha", name + ".v.proj.alpha", ame + ".out.proj.alpha")
             print(query_alpha, key_alpha, value_alpha, proj_alpha)
 
             attn_module.q_proj = PatchedLoraProjection(
@@ -1401,6 +1404,7 @@ class LoraLoaderMixin:
             lora_parameters.extend(attn_module.out_proj.lora_linear_layer.parameters())
 
         if patch_mlp:
+            # Handle this too (sayakpaul).
             for name, mlp_module in text_encoder_mlp_modules(text_encoder):
                 fc1_alpha = network_alphas.get(name + ".fc1.alpha")
                 fc2_alpha = network_alphas.get(name + ".fc2.alpha")

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1207,7 +1207,7 @@ class LoraLoaderMixin:
                 network_alphas = {
                     k.replace(f"{cls.unet_name}.", ""): v for k, v in network_alphas.items() if k in alpha_keys
                 }
-                print(f"UNet network alphas: {network_alphas}")
+                print(f"UNet network alphas: {alpha_keys[:10]}")
 
         else:
             # Otherwise, we're dealing with the old format. This means the `state_dict` should only
@@ -1241,7 +1241,7 @@ class LoraLoaderMixin:
         # If the serialization format is new (introduced in https://github.com/huggingface/diffusers/pull/2918),
         # then the `state_dict` keys should have `self.unet_name` and/or `self.text_encoder_name` as
         # their prefixes.
-        print("Text encoder called.")
+        print(f"{prefix} called.")
         keys = list(state_dict.keys())
         prefix = cls.text_encoder_name if prefix is None else prefix
 
@@ -1359,7 +1359,7 @@ class LoraLoaderMixin:
         lora_parameters = []
         network_alphas = {} if network_alphas is None else network_alphas
         text_encoder_net_alphas = list(filter(lambda x: "text" in x, network_alphas))
-        print(f"Text encoder network alphas: {text_encoder_net_alphas}")
+        print(f"Text encoder network alphas: {text_encoder_net_alphas[:10]}")
         for name, attn_module in text_encoder_attn_modules(text_encoder):
             query_alpha = network_alphas.get(name + ".k.proj.alpha", None)
             key_alpha = network_alphas.get(name + ".q.proj.alpha", None)
@@ -1657,8 +1657,7 @@ class LoraLoaderMixin:
 
         te_alphas = list(filter(lambda x: "unet" in x, network_alphas))
         unet_alphas = list(filter(lambda x: "text_encoder" in x, network_alphas))
-        print(len(te_alphas), len(unet_alphas))
-        print(te_alphas, unet_alphas)
+        print(f"From load_lora_weights: {len(te_alphas)}, {len(unet_alphas)}")
 
         new_state_dict = {**unet_state_dict, **te_state_dict}
         return new_state_dict, network_alphas

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1359,7 +1359,8 @@ class LoraLoaderMixin:
         lora_parameters = []
         network_alphas = {} if network_alphas is None else network_alphas
         text_encoder_net_alphas = list(filter(lambda x: "text" in x, network_alphas))
-        print(f"Text encoder network alphas: {text_encoder_net_alphas[:10]}")
+        print(f"Text encoder network alphas: {list(filter(lambda x: x.startswith('text_encoder'), text_encoder_net_alphas))[:10]}")
+        print(f"Text encoder 2 network alphas: {list(filter(lambda x: x.startswith('text_encoder_2'), text_encoder_net_alphas))[:10]}")
         for name, attn_module in text_encoder_attn_modules(text_encoder):
             query_alpha = network_alphas.get(name + ".k.proj.alpha", None)
             key_alpha = network_alphas.get(name + ".q.proj.alpha", None)

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -352,7 +352,7 @@ class UNet2DConditionLoadersMixin:
                 if network_alphas is not None:
                     for k in network_alphas:
                         if k.replace(".alpha", "") in key:
-                            mapped_network_alphas.update({attn_processor_key: network_alphas[k]})
+                            mapped_network_alphas.update({attn_processor_key: network_alphas.pop(k)})
             
             if not is_network_alphas_none:
                 if len(network_alphas) > 0:

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1248,6 +1248,7 @@ class LoraLoaderMixin:
         # If the serialization format is new (introduced in https://github.com/huggingface/diffusers/pull/2918),
         # then the `state_dict` keys should have `self.unet_name` and/or `self.text_encoder_name` as
         # their prefixes.
+        print("Text encoder called.")
         keys = list(state_dict.keys())
         prefix = cls.text_encoder_name if prefix is None else prefix
 

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1362,11 +1362,12 @@ class LoraLoaderMixin:
         # print(f"Text encoder network alphas: {list(filter(lambda x: x.startswith('text_encoder'), text_encoder_net_alphas))[:10]}")
         # print(f"Text encoder 2 network alphas: {list(filter(lambda x: x.startswith('text_encoder_2'), text_encoder_net_alphas))[:10]}")
         for name, attn_module in text_encoder_attn_modules(text_encoder):
-            print(f"From modification: {name}")
+            # print(f"From modification: {name}")
             query_alpha = network_alphas.get(name + ".k.proj.alpha")
             key_alpha = network_alphas.get(name + ".q.proj.alpha")
             value_alpha = network_alphas.get(name + ".v.proj.alpha")
             proj_alpha = network_alphas.get(name + ".out.proj.alpha")
+            print(query_alpha, key_alpha, value_alpha, proj_alpha)
 
             attn_module.q_proj = PatchedLoraProjection(
                 attn_module.q_proj, lora_scale, network_alpha=query_alpha, rank=rank, dtype=dtype

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1201,6 +1201,7 @@ class LoraLoaderMixin:
         # If the serialization format is new (introduced in https://github.com/huggingface/diffusers/pull/2918),
         # then the `state_dict` keys should have `self.unet_name` and/or `self.text_encoder_name` as
         # their prefixes.
+        print("UNet called.")
         keys = list(state_dict.keys())
 
         if all(key.startswith(cls.unet_name) or key.startswith(cls.text_encoder_name) for key in keys):

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1521,10 +1521,6 @@ class LoraLoaderMixin:
             lora_name_up = lora_name + ".lora_up.weight"
             lora_name_alpha = lora_name + ".alpha"
 
-            # if lora_name_alpha in state_dict:
-            #     alpha = state_dict.pop(lora_name_alpha).item()
-            #     network_alphas.update({lora_name_alpha: alpha})
-
             if lora_name.startswith("lora_unet_"):
                 diffusers_name = key.replace("lora_unet_", "").replace("_", ".")
 
@@ -1665,6 +1661,10 @@ class LoraLoaderMixin:
         )
         if te2_state_dict is not None:
             te_state_dict.update(te2_state_dict)
+
+        te_alphas = list(filter(lambda x: "unet" in x, network_alphas))
+        unet_alphas = list(filter(lambda x: "text_encoder" in x, network_alphas))
+        print(len(te_alphas), len(unet_alphas))
 
         new_state_dict = {**unet_state_dict, **te_state_dict}
         return new_state_dict, network_alphas

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import re
+import copy
 import warnings
 from collections import defaultdict
 from contextlib import nullcontext
@@ -350,7 +351,8 @@ class UNet2DConditionLoadersMixin:
 
                 # Create another `mapped_network_alphas` dictionary so that we can properly map them.
                 if network_alphas is not None:
-                    for k in network_alphas:
+                    network_alphas_ = copy.deepcopy(network_alphas)
+                    for k in network_alphas_:
                         if k.replace(".alpha", "") in key:
                             mapped_network_alphas.update({attn_processor_key: network_alphas.pop(k)})
             

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1310,6 +1310,7 @@ class LoraLoaderMixin:
                         k.replace(f"{prefix}.", ""): v for k, v in network_alphas.items() if k in alpha_keys
                     }
                     print(f"{prefix}: {alpha_keys[:20]}")
+                    print(f"{prefix}: {any('text_encoder_2' in k for k in alpha_keys)}")
                 
                 cls._modify_text_encoder(
                     text_encoder,
@@ -1373,6 +1374,7 @@ class LoraLoaderMixin:
         lora_parameters = []
         network_alphas = {} if network_alphas is None else network_alphas
         is_network_alphas_populated = len(network_alphas) > 0
+        print(f"is_network_alphas_populated: {is_network_alphas_populated}")
         for name, attn_module in text_encoder_attn_modules(text_encoder):
             query_alpha = network_alphas.pop(name + ".to_q_lora.down.weight.alpha", None)
             key_alpha = network_alphas.pop(name + ".to_k_lora.down.weight.alpha", None)
@@ -1405,6 +1407,7 @@ class LoraLoaderMixin:
             for name, mlp_module in text_encoder_mlp_modules(text_encoder):
                 fc1_alpha = network_alphas.pop(name + ".fc1.lora_linear_layer.down.weight.alpha")
                 fc2_alpha = network_alphas.pop(name + ".fc2.lora_linear_layer.down.weight.alpha")
+                print(fc1_alpha, fc2_alpha)
 
                 mlp_module.fc1 = PatchedLoraProjection(
                     mlp_module.fc1, lora_scale, network_alpha=fc1_alpha, rank=rank, dtype=dtype

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1655,8 +1655,10 @@ class LoraLoaderMixin:
         if te2_state_dict is not None:
             te_state_dict.update(te2_state_dict)
 
-        te_alphas = list(filter(lambda x: "unet" in x, network_alphas))
-        unet_alphas = list(filter(lambda x: "text_encoder" in x, network_alphas))
+        unet_alphas = list(filter(lambda x: "unet" in x, network_alphas))
+        te_alphas = list(filter(lambda x: "text_encoder" in x, network_alphas))
+        any_te2 = any("text_encoder_2" in k for k in te_alphas)
+        print(f"Any text encoder 2 alpha present: {any_te2}")
         print(f"From load_lora_weights: {len(te_alphas)}, {len(unet_alphas)}")
 
         new_state_dict = {**unet_state_dict, **te_state_dict}

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1214,7 +1214,6 @@ class LoraLoaderMixin:
                 network_alphas = {
                     k.replace(f"{cls.unet_name}.", ""): v for k, v in network_alphas.items() if k in alpha_keys
                 }
-                print(f"UNet network alphas: {alpha_keys[:10]}")
 
         else:
             # Otherwise, we're dealing with the old format. This means the `state_dict` should only
@@ -1380,7 +1379,7 @@ class LoraLoaderMixin:
             key_alpha = network_alphas.get(name + ".q.proj.alpha")
             value_alpha = network_alphas.get(name + ".v.proj.alpha")
             proj_alpha = network_alphas.get(name + ".out.proj.alpha")
-            print(name + ".k.proj.alpha", name + ".q.proj.alpha", name + ".v.proj.alpha", ame + ".out.proj.alpha")
+            print(name + ".k.proj.alpha", name + ".q.proj.alpha", name + ".v.proj.alpha", name + ".out.proj.alpha")
             print(query_alpha, key_alpha, value_alpha, proj_alpha)
 
             attn_module.q_proj = PatchedLoraProjection(

--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1303,8 +1303,8 @@ class LoraLoaderMixin:
                     network_alphas = {
                         k.replace(f"{prefix}.", ""): v for k, v in network_alphas.items() if k in alpha_keys
                     }
-                    print(list(network_alphas.keys())[:10])
-                    print(f"{prefix} alphas: {alpha_keys[:10]}")
+                    # print(list(network_alphas.keys())[:10])
+                    # print(f"{prefix} alphas: {alpha_keys[:10]}")
 
                 cls._modify_text_encoder(
                     text_encoder,

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -876,25 +876,25 @@ class StableDiffusionXLPipeline(DiffusionPipeline, FromSingleFileMixin, LoraLoad
         )
         self.load_lora_into_unet(state_dict, network_alphas=network_alphas, unet=self.unet)
 
-        text_encoder_state_dict = {k: v for k, v in state_dict.items() if "text_encoder." in k}
-        if len(text_encoder_state_dict) > 0:
-            self.load_lora_into_text_encoder(
-                text_encoder_state_dict,
-                network_alphas=network_alphas,
-                text_encoder=self.text_encoder,
-                prefix="text_encoder",
-                lora_scale=self.lora_scale,
-            )
+        # text_encoder_state_dict = {k: v for k, v in state_dict.items() if "text_encoder." in k}
+        # if len(text_encoder_state_dict) > 0:
+        #     self.load_lora_into_text_encoder(
+        #         text_encoder_state_dict,
+        #         network_alphas=network_alphas,
+        #         text_encoder=self.text_encoder,
+        #         prefix="text_encoder",
+        #         lora_scale=self.lora_scale,
+        #     )
 
-        text_encoder_2_state_dict = {k: v for k, v in state_dict.items() if "text_encoder_2." in k}
-        if len(text_encoder_2_state_dict) > 0:
-            self.load_lora_into_text_encoder(
-                text_encoder_2_state_dict,
-                network_alphas=network_alphas,
-                text_encoder=self.text_encoder_2,
-                prefix="text_encoder_2",
-                lora_scale=self.lora_scale,
-            )
+        # text_encoder_2_state_dict = {k: v for k, v in state_dict.items() if "text_encoder_2." in k}
+        # if len(text_encoder_2_state_dict) > 0:
+        #     self.load_lora_into_text_encoder(
+        #         text_encoder_2_state_dict,
+        #         network_alphas=network_alphas,
+        #         text_encoder=self.text_encoder_2,
+        #         prefix="text_encoder_2",
+        #         lora_scale=self.lora_scale,
+        #     )
 
     @classmethod
     def save_lora_weights(

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -876,25 +876,25 @@ class StableDiffusionXLPipeline(DiffusionPipeline, FromSingleFileMixin, LoraLoad
         )
         self.load_lora_into_unet(state_dict, network_alphas=network_alphas, unet=self.unet)
 
-        # text_encoder_state_dict = {k: v for k, v in state_dict.items() if "text_encoder." in k}
-        # if len(text_encoder_state_dict) > 0:
-        #     self.load_lora_into_text_encoder(
-        #         text_encoder_state_dict,
-        #         network_alphas=network_alphas,
-        #         text_encoder=self.text_encoder,
-        #         prefix="text_encoder",
-        #         lora_scale=self.lora_scale,
-        #     )
+        text_encoder_state_dict = {k: v for k, v in state_dict.items() if "text_encoder." in k}
+        if len(text_encoder_state_dict) > 0:
+            self.load_lora_into_text_encoder(
+                text_encoder_state_dict,
+                network_alphas=network_alphas,
+                text_encoder=self.text_encoder,
+                prefix="text_encoder",
+                lora_scale=self.lora_scale,
+            )
 
-        # text_encoder_2_state_dict = {k: v for k, v in state_dict.items() if "text_encoder_2." in k}
-        # if len(text_encoder_2_state_dict) > 0:
-        #     self.load_lora_into_text_encoder(
-        #         text_encoder_2_state_dict,
-        #         network_alphas=network_alphas,
-        #         text_encoder=self.text_encoder_2,
-        #         prefix="text_encoder_2",
-        #         lora_scale=self.lora_scale,
-        #     )
+        text_encoder_2_state_dict = {k: v for k, v in state_dict.items() if "text_encoder_2." in k}
+        if len(text_encoder_2_state_dict) > 0:
+            self.load_lora_into_text_encoder(
+                text_encoder_2_state_dict,
+                network_alphas=network_alphas,
+                text_encoder=self.text_encoder_2,
+                prefix="text_encoder_2",
+                lora_scale=self.lora_scale,
+            )
 
     @classmethod
     def save_lora_weights(

--- a/tests/models/test_lora_layers.py
+++ b/tests/models/test_lora_layers.py
@@ -737,6 +737,7 @@ class LoraIntegrationTests(unittest.TestCase):
         ).images
 
         images = images[0, -3:, -3:, -1].flatten()
+        print(", ".join([str(round(x, 4)) for x in images.tolist()]))
         expected = np.array([0.3725, 0.3767, 0.3761, 0.3796, 0.3827, 0.3763, 0.3831, 0.3809, 0.3392])
 
         self.assertTrue(np.allclose(images, expected, atol=1e-4))

--- a/tests/models/test_lora_layers.py
+++ b/tests/models/test_lora_layers.py
@@ -760,7 +760,7 @@ class LoraIntegrationTests(unittest.TestCase):
 
         self.assertTrue(np.allclose(images, expected, atol=1e-4))
 
-    def test_unload_lora(self):
+    def test_unload_kohya_lora(self):
         generator = torch.manual_seed(0)
         prompt = "masterpiece, best quality, mountain"
         num_inference_steps = 2

--- a/tests/models/test_lora_layers.py
+++ b/tests/models/test_lora_layers.py
@@ -737,8 +737,7 @@ class LoraIntegrationTests(unittest.TestCase):
         ).images
 
         images = images[0, -3:, -3:, -1].flatten()
-        print(", ".join([str(round(x, 4)) for x in images.tolist()]))
-        expected = np.array([0.3725, 0.3767, 0.3761, 0.3796, 0.3827, 0.3763, 0.3831, 0.3809, 0.3392])
+        expected = np.array([0.3636, 0.3708, 0.3694, 0.3679, 0.3829, 0.3677, 0.3692, 0.3688, 0.3292])
 
         self.assertTrue(np.allclose(images, expected, atol=1e-4))
 


### PR DESCRIPTION
This PR fixes the LoRA loading part for the text encoders, especially the ones we see for SDXL 0.9. 

Additionally, it also refactors some of the loading logic to help make the `state_dict` parsing easier. 

I tested with the following:

```python
from diffusers import DiffusionPipeline, DPMSolverMultistepScheduler
import safetensors
import torch 

base_model_id = "stabilityai/stable-diffusion-xl-base-0.9"
pipeline = DiffusionPipeline.from_pretrained(base_model_id, torch_dtype=torch.float16).to("cuda:0")
pipeline.scheduler = DPMSolverMultistepScheduler.from_config(
    pipeline.scheduler.config, algorithm_type="sde-dpmsolver++"
)
pipeline.load_lora_weights(".", weight_name="daiton.safetensors")

prompt = "alien, monster, daiton, high resolution, 4k, photorealistic, in a spaceship, gloomy"
generator = torch.manual_seed(22)
num_inference_steps = 50
guidance_scale = 5

image = pipeline(
    prompt=prompt, num_inference_steps=num_inference_steps,
    generator=generator, guidance_scale=guidance_scale
).images[0]
image.save("image.png")
```

And got: 

![image](https://github.com/huggingface/diffusers/assets/22957388/2ac9f119-e4c6-47ff-a855-ab22821599f5)

LoRA is from here: https://civitai.com/models/108448/daiton-sdxl-test

@patrickvonplaten I see we don't do SLOW tests for SDXL, probably because we run the SLOW tests on a V100, which might fall short for running SDXL. I am bringing it up because I wanted to add a couple of slow tests to `test_lora_layers.py` to test the SDXL LoRAs from CivitAI. 