### PR TITLE
Move slower Stable Diffusion Tests to Nightly

### DIFF
--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_img2img.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_img2img.py
@@ -419,33 +419,6 @@ class StableDiffusionImg2ImgPipelineSlowTests(unittest.TestCase):
         for module in pipe.text_encoder, pipe.unet, pipe.vae:
             assert module.device == torch.device("cpu")
 
-    def test_img2img_2nd_order(self):
-        sd_pipe = StableDiffusionImg2ImgPipeline.from_pretrained("runwayml/stable-diffusion-v1-5")
-        sd_pipe.scheduler = HeunDiscreteScheduler.from_config(sd_pipe.scheduler.config)
-        sd_pipe.to(torch_device)
-        sd_pipe.set_progress_bar_config(disable=None)
-
-        inputs = self.get_inputs(torch_device)
-        inputs["num_inference_steps"] = 10
-        inputs["strength"] = 0.75
-        image = sd_pipe(**inputs).images[0]
-
-        expected_image = load_numpy(
-            "https://huggingface.co/datasets/hf-internal-testing/diffusers-images/resolve/main/img2img/img2img_heun.npy"
-        )
-        max_diff = np.abs(expected_image - image).max()
-        assert max_diff < 5e-2
-
-        inputs = self.get_inputs(torch_device)
-        inputs["num_inference_steps"] = 11
-        inputs["strength"] = 0.75
-        image_other = sd_pipe(**inputs).images[0]
-
-        mean_diff = np.abs(image - image_other).mean()
-
-        # images should be very similar
-        assert mean_diff < 5e-2
-
     def test_stable_diffusion_img2img_pipeline_multiple_of_8(self):
         init_image = load_image(
             "https://huggingface.co/datasets/hf-internal-testing/diffusers-images/resolve/main"
@@ -596,3 +569,30 @@ class StableDiffusionImg2ImgPipelineNightlyTests(unittest.TestCase):
         )
         max_diff = np.abs(expected_image - image).max()
         assert max_diff < 1e-3
+
+    def test_img2img_2nd_order(self):
+        sd_pipe = StableDiffusionImg2ImgPipeline.from_pretrained("runwayml/stable-diffusion-v1-5")
+        sd_pipe.scheduler = HeunDiscreteScheduler.from_config(sd_pipe.scheduler.config)
+        sd_pipe.to(torch_device)
+        sd_pipe.set_progress_bar_config(disable=None)
+
+        inputs = self.get_inputs(torch_device)
+        inputs["num_inference_steps"] = 10
+        inputs["strength"] = 0.75
+        image = sd_pipe(**inputs).images[0]
+
+        expected_image = load_numpy(
+            "https://huggingface.co/datasets/hf-internal-testing/diffusers-images/resolve/main/img2img/img2img_heun.npy"
+        )
+        max_diff = np.abs(expected_image - image).max()
+        assert max_diff < 5e-2
+
+        inputs = self.get_inputs(torch_device)
+        inputs["num_inference_steps"] = 11
+        inputs["strength"] = 0.75
+        image_other = sd_pipe(**inputs).images[0]
+
+        mean_diff = np.abs(image - image_other).mean()
+
+        # images should be very similar
+        assert mean_diff < 5e-2

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_k_diffusion.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_k_diffusion.py
@@ -20,16 +20,16 @@ import numpy as np
 import torch
 
 from diffusers import StableDiffusionKDiffusionPipeline
-from diffusers.utils import slow, torch_device
+from diffusers.utils import slow, nightly, torch_device
 from diffusers.utils.testing_utils import enable_full_determinism, require_torch_gpu
 
 
 enable_full_determinism()
 
 
-@slow
+@nightly
 @require_torch_gpu
-class StableDiffusionPipelineIntegrationTests(unittest.TestCase):
+class StableDiffusionKDiffusionPipelineNightlyTests(unittest.TestCase):
     def tearDown(self):
         # clean up the VRAM after each test
         super().tearDown()

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py
@@ -29,7 +29,7 @@ from diffusers import (
     StableDiffusionPanoramaPipeline,
     UNet2DConditionModel,
 )
-from diffusers.utils import slow, torch_device
+from diffusers.utils import slow, torch_device, nightly
 from diffusers.utils.testing_utils import enable_full_determinism, require_torch_gpu, skip_mps
 
 from ..pipeline_params import TEXT_TO_IMAGE_BATCH_PARAMS, TEXT_TO_IMAGE_IMAGE_PARAMS, TEXT_TO_IMAGE_PARAMS
@@ -245,9 +245,9 @@ class StableDiffusionPanoramaPipelineFastTests(PipelineLatentTesterMixin, Pipeli
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
 
-@slow
+@nightly
 @require_torch_gpu
-class StableDiffusionPanoramaSlowTests(unittest.TestCase):
+class StableDiffusionPanoramaNightlyTests(unittest.TestCase):
     def tearDown(self):
         super().tearDown()
         gc.collect()
@@ -268,6 +268,7 @@ class StableDiffusionPanoramaSlowTests(unittest.TestCase):
         model_ckpt = "stabilityai/stable-diffusion-2-base"
         scheduler = DDIMScheduler.from_pretrained(model_ckpt, subfolder="scheduler")
         pipe = StableDiffusionPanoramaPipeline.from_pretrained(model_ckpt, scheduler=scheduler, safety_checker=None)
+        pipe.unet.set_default_attn_processor()
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
         pipe.enable_attention_slicing()
@@ -298,6 +299,7 @@ class StableDiffusionPanoramaSlowTests(unittest.TestCase):
         pipe = StableDiffusionPanoramaPipeline.from_pretrained(
             "stabilityai/stable-diffusion-2-base", safety_checker=None
         )
+        pipe.unet.set_default_attn_processor()
         pipe.scheduler = LMSDiscreteScheduler.from_config(pipe.scheduler.config)
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
@@ -379,6 +381,7 @@ class StableDiffusionPanoramaSlowTests(unittest.TestCase):
         model_ckpt = "stabilityai/stable-diffusion-2-base"
         scheduler = DDIMScheduler.from_pretrained(model_ckpt, subfolder="scheduler")
         pipe = StableDiffusionPanoramaPipeline.from_pretrained(model_ckpt, scheduler=scheduler, safety_checker=None)
+        pipe.unet.set_default_attn_processor()
         pipe = pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
         pipe.enable_attention_slicing()
@@ -396,6 +399,7 @@ class StableDiffusionPanoramaSlowTests(unittest.TestCase):
         model_ckpt = "stabilityai/stable-diffusion-2-base"
         scheduler = DDIMScheduler.from_pretrained(model_ckpt, subfolder="scheduler")
         pipe = StableDiffusionPanoramaPipeline.from_pretrained(model_ckpt, scheduler=scheduler, safety_checker=None)
+        pipe.unet.set_default_attn_processor()
         pipe = pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
         pipe.enable_attention_slicing(1)

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_sag.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_sag.py
@@ -26,7 +26,7 @@ from diffusers import (
     StableDiffusionSAGPipeline,
     UNet2DConditionModel,
 )
-from diffusers.utils import slow, torch_device
+from diffusers.utils import slow, nightly, torch_device
 from diffusers.utils.testing_utils import enable_full_determinism, require_torch_gpu
 
 from ..pipeline_params import TEXT_TO_IMAGE_BATCH_PARAMS, TEXT_TO_IMAGE_IMAGE_PARAMS, TEXT_TO_IMAGE_PARAMS
@@ -116,9 +116,9 @@ class StableDiffusionSAGPipelineFastTests(PipelineLatentTesterMixin, PipelineTes
         super().test_inference_batch_single_identical(expected_max_diff=3e-3)
 
 
-@slow
+@nightly
 @require_torch_gpu
-class StableDiffusionPipelineIntegrationTests(unittest.TestCase):
+class StableDiffusionSAGPipelineNightlyTests(unittest.TestCase):
     def tearDown(self):
         # clean up the VRAM after each test
         super().tearDown()


### PR DESCRIPTION
# What does this PR do?
Moves certain slow tests from running on every push to running nightly. 

Durations for these tests are listed below (based on latest CI/CD run) 

```
168.26s call     tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py::InversionPipelineSlowTests::test_stable_diffusion_2_pix2pix_full
147.82s call     tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py::StableDiffusionPanoramaSlowTests::test_stable_diffusion_panorama_pipeline_with_sequential_cpu_offloading
78.59s call     tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py::InversionPipelineSlowTests::test_stable_diffusion_pix2pix_full
61.46s call     tests/pipelines/stable_diffusion/test_cycle_diffusion.py::CycleDiffusionPipelineIntegrationTests::test_cycle_diffusion_pipeline
53.52s call     tests/pipelines/stable_diffusion_2/test_stable_diffusion_v_pred.py::StableDiffusion2VPredictionPipelineIntegrationTests::test_stable_diffusion_text2img_pipeline_unflawed
47.28s call     tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py::StableDiffusionPanoramaSlowTests::test_stable_diffusion_panorama_default
37.77s call     tests/pipelines/stable_diffusion/test_cycle_diffusion.py::CycleDiffusionPipelineIntegrationTests::test_cycle_diffusion_pipeline_fp16
29.97s call     tests/pipelines/stable_diffusion/test_stable_diffusion_k_diffusion.py::StableDiffusionPipelineIntegrationTests::test_stable_diffusion_2
28.28s call     tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py::StableDiffusionPanoramaSlowTests::test_stable_diffusion_panorama_k_lms
28.24s call     tests/pipelines/stable_diffusion/test_stable_diffusion_k_diffusion.py::StableDiffusionPipelineIntegrationTests::test_stable_diffusion_noise_sampler_seed
27.93s call     tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py::StableDiffusionPanoramaSlowTests::test_stable_diffusion_panorama_intermediate_state
26.89s call     tests/pipelines/stable_diffusion/test_stable_diffusion_k_diffusion.py::StableDiffusionPipelineIntegrationTests::test_stable_diffusion_karras_sigmas
```

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @williamberman and @patrickvonplaten
- Pipelines:  @patrickvonplaten and @sayakpaul
- Training examples: @sayakpaul and @patrickvonplaten
- Docs: @stevenliu and @yiyixu
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @patrickvonplaten and @sayakpaul

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
