### PR TITLE
add pipeline_class_name argument to Stable Diffusion conversion script

### DIFF
--- a/src/diffusers/pipelines/kandinsky/pipeline_kandinsky_combined.py
+++ b/src/diffusers/pipelines/kandinsky/pipeline_kandinsky_combined.py
@@ -203,10 +203,10 @@ class KandinskyCombinedPipeline(DiffusionPipeline):
 
     def enable_sequential_cpu_offload(self, gpu_id=0):
         r"""
-        Offloads all models (`unet`, `text_encoder`, `vae`, and `safety checker` state dicts) to CPU using 🤗 Accelerate, significantly reducing memory usage. Models are moved to a
-        `torch.device('meta')` and loaded on a GPU only when their specific submodule's `forward` method is called.
-        Offloading happens on a submodule basis. Memory savings are higher than using
-        `enable_model_cpu_offload`, but performance is lower.
+        Offloads all models (`unet`, `text_encoder`, `vae`, and `safety checker` state dicts) to CPU using 🤗
+        Accelerate, significantly reducing memory usage. Models are moved to a `torch.device('meta')` and loaded on a
+        GPU only when their specific submodule's `forward` method is called. Offloading happens on a submodule basis.
+        Memory savings are higher than using `enable_model_cpu_offload`, but performance is lower.
         """
         self.prior_pipe.enable_sequential_cpu_offload(gpu_id=gpu_id)
         self.decoder_pipe.enable_sequential_cpu_offload(gpu_id=gpu_id)


### PR DESCRIPTION
this PR add the `pipeline_class` argument to the convert_original_stable_diffusion_to_diffusers.py

fix:
https://github.com/huggingface/diffusers/pull/4280