### PR TITLE
Lora fix

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_sdxl.py
+++ b/examples/dreambooth/train_dreambooth_lora_sdxl.py
@@ -652,7 +652,7 @@ def main(args):
             logger.info(f"Number of class images to sample: {num_new_images}.")
 
             sample_dataset = PromptDataset(args.class_prompt, num_new_images)
-            sample_dataloader = torch.utils.data.DataLoader(sample_dataset, batch_size=args.sample_batch_size)
+            sample_dataloader = torch.utils.data.DataLoader(sample_dataset, batch_size=args.sample_batch_size, shuffle=True, drop_last=True)
 
             sample_dataloader = accelerator.prepare(sample_dataloader)
             pipeline.to(accelerator.device)
@@ -974,6 +974,7 @@ def main(args):
         shuffle=True,
         collate_fn=lambda examples: collate_fn(examples, args.with_prior_preservation),
         num_workers=args.dataloader_num_workers,
+        drop_last=True,
     )
 
     # Scheduler and math around the number of training steps.

--- a/examples/dreambooth/train_dreambooth_lora_sdxl.py
+++ b/examples/dreambooth/train_dreambooth_lora_sdxl.py
@@ -1104,7 +1104,9 @@ def main(args):
                         "time_ids": add_time_ids.repeat(elems_to_repeat, 1),
                         "text_embeds": unet_add_text_embeds.repeat(elems_to_repeat, 1),
                     }
-                    prompt_embeds = prompt_embeds.repeat(elems_to_repeat, 1, 1)
+                    if prompt_embeds.shape[0] < elems_to_repeat:
+                        prompt_embeds = prompt_embeds.repeat(elems_to_repeat, 1, 1)
+                        
                     model_pred = unet(
                         noisy_model_input,
                         timesteps,


### PR DESCRIPTION
# What does this PR do?

Make the LORA sdxl trainer work with arbitrary batch sizes
(currently it will fail on eg 3 imgs with bs=2 since the last batch will have only 1 sample).
To fix this:
- drop the last batch
- shuffle in between epochs to make sure all imgs are used
- make sure prompt_embeds is only repeated if needed
