### PR TITLE
Fix `UnboundLocalError` during LoRA loading

### DIFF
--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1054,6 +1054,7 @@ class LoraLoaderMixin:
                     if not allow_pickle:
                         raise e
                     # try loading non-safetensors weights
+                    model_file = None
                     pass
             if model_file is None:
                 model_file = _get_model_file(


### PR DESCRIPTION
# What does this PR do?

Bug: when calling `pipe.load_lora_weights(lora_model_path)` with `lora_model_path` of something like `pytorch_lora_weights.bin` and safetensors is installed, there is a codepath that produces an `UnboundLocalError`:

```
Traceback (most recent call last):
  File "/home/diffusers/run_cross_model_evals.py", line 79, in <module>
    run_evaluations()
  File "/home/diffusers/run_cross_model_evals.py", line 63, in run_evaluations
    images_by_model[model_name] = take_samples(lora_file)
  File "/home/diffusers/run_cross_model_evals.py", line 42, in take_samples
    pipe.load_lora_weights(lora_model_path)                                                                                                                   
  File "/home/diffusers/src/diffusers/loaders.py", line 937, in load_lora_weights                                  
    state_dict, network_alphas = self.lora_state_dict(pretrained_model_name_or_path_or_dict, **kwargs)
  File "/home/diffusers/src/diffusers/loaders.py", line 1084, in lora_state_dict                                     
    for k in state_dict.keys()
UnboundLocalError: local variable 'state_dict' referenced before assignment 
```

Explanation: The code attempts to load with safetensors first and then fallback on `torch.load`. However when `safetensors.torch.load_file` produces an exception `model_file` is still set, causing the fallback load to never occur.


Looks like @patrickvonplaten @sayakpaul may be the relevant reviewers.
