### PR TITLE
Fix push_to_hub in train_text_to_image_lora_sdxl.py example

### DIFF
--- a/examples/text_to_image/train_text_to_image_lora_sdxl.py
+++ b/examples/text_to_image/train_text_to_image_lora_sdxl.py
@@ -1262,8 +1262,8 @@ def main(args):
                 repo_id,
                 images=images,
                 base_model=args.pretrained_model_name_or_path,
+                dataset_name=args.dataset_name,
                 train_text_encoder=args.train_text_encoder,
-                prompt=args.instance_prompt,
                 repo_folder=args.output_dir,
                 vae_path=args.pretrained_vae_model_name_or_path,
             )


### PR DESCRIPTION
# What does this PR do?

Fixes push to hub action in `train_text_to_image_lora_sdxl.py` example

- in the last step it failed on missing `instance_prompt`, it seem the function call didn't match parameters
- 
```python
def save_model_card(
    repo_id: str,
    images=None,
    base_model=str,
    dataset_name=str,
    train_text_encoder=False,
    repo_folder=None,
    vae_path=None,
)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- Training examples: @sayakpaul and @patrickvonplaten