### PR TITLE
Revert "introduce minimalistic reimplementation of SDXL on the SDXL doc"

### DIFF
--- a/docs/source/en/api/pipelines/stable_diffusion/stable_diffusion_xl.md
+++ b/docs/source/en/api/pipelines/stable_diffusion/stable_diffusion_xl.md
@@ -425,7 +425,3 @@ prompt = "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"
 prompt_2 = "monet painting"
 image = pipe(prompt=prompt, prompt_2=prompt_2).images[0]
 ```
-
-## Single-file Implementation of SDXL Unet Model
-
-If you are curious about how SDXL Unet is implemented and would like to make quick modifications / experimentations, you can alternatively head to [`minSDXL`](https://github.com/cloneofsimo/minSDXL) that is very `diffusers` friendly. It is a single-file implementation of SDXL Unet model that is written in PyTorch with exact same model naming and structure as in `diffusers`.


### PR DESCRIPTION
Reverts huggingface/diffusers#4532

Any chance we can put this on a non-API doc? We should really try to keep API docs clean for diffusers code only