### PR TITLE
Assert unet frozen in LoRA

### DIFF
--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1185,6 +1185,7 @@ class LoraLoaderMixin:
         # If the serialization format is new (introduced in https://github.com/huggingface/diffusers/pull/2918),
         # then the `state_dict` keys should have `self.unet_name` and/or `self.text_encoder_name` as
         # their prefixes.
+        assert not unet.requires_grad_, "U-Net's attention should be frozen before LoRA"
         keys = list(state_dict.keys())
 
         if all(key.startswith(cls.unet_name) or key.startswith(cls.text_encoder_name) for key in keys):
@@ -1207,6 +1208,7 @@ class LoraLoaderMixin:
             warnings.warn(warn_message)
 
         # load loras into unet
+        assert not unet.requires_grad_
         unet.load_attn_procs(state_dict, network_alphas=network_alphas)
 
     @classmethod

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -551,6 +551,7 @@ class LoRAAttnProcessor(nn.Module):
     def __call__(
         self, attn: Attention, hidden_states, encoder_hidden_states=None, attention_mask=None, scale=1.0, temb=None
     ):
+        assert not attn.requires_grad_, "U-Net's attention should be frozen before LoRA"
         residual = hidden_states
 
         if attn.spatial_norm is not None:
@@ -849,6 +850,7 @@ class LoRAAttnAddedKVProcessor(nn.Module):
         self.to_out_lora = LoRALinearLayer(hidden_size, hidden_size, rank, network_alpha)
 
     def __call__(self, attn: Attention, hidden_states, encoder_hidden_states=None, attention_mask=None, scale=1.0):
+        assert not attn.requires_grad_, "U-Net's attention should be frozen before LoRA"
         residual = hidden_states
         hidden_states = hidden_states.view(hidden_states.shape[0], hidden_states.shape[1], -1).transpose(1, 2)
         batch_size, sequence_length, _ = hidden_states.shape
@@ -1197,6 +1199,7 @@ class LoRAXFormersAttnProcessor(nn.Module):
     def __call__(
         self, attn: Attention, hidden_states, encoder_hidden_states=None, attention_mask=None, scale=1.0, temb=None
     ):
+        assert not attn.requires_grad_, "U-Net's attention should be frozen before LoRA"
         residual = hidden_states
 
         if attn.spatial_norm is not None:
@@ -1297,6 +1300,7 @@ class LoRAAttnProcessor2_0(nn.Module):
         self.to_out_lora = LoRALinearLayer(out_hidden_size, out_hidden_size, out_rank, network_alpha)
 
     def __call__(self, attn: Attention, hidden_states, encoder_hidden_states=None, attention_mask=None, scale=1.0):
+        assert not attn.requires_grad_, "U-Net's attention should be frozen before LoRA"
         residual = hidden_states
 
         input_ndim = hidden_states.ndim

--- a/tests/models/test_lora_layers.py
+++ b/tests/models/test_lora_layers.py
@@ -113,6 +113,7 @@ class LoraLoaderMixinTests(unittest.TestCase):
             up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
             cross_attention_dim=32,
         )
+        unet.requires_grad_ = False
         scheduler = DDIMScheduler(
             beta_start=0.00085,
             beta_end=0.012,
@@ -243,6 +244,7 @@ class LoraLoaderMixinTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             unet = sd_pipe.unet
+            unet.requires_grad_ = False
             unet.set_attn_processor(unet_lora_attn_procs)
             unet.save_attn_procs(tmpdirname, safe_serialization=False)
             self.assertTrue(os.path.isfile(os.path.join(tmpdirname, "pytorch_lora_weights.bin")))
@@ -504,6 +506,7 @@ class SDXLLoraLoaderMixinTests(unittest.TestCase):
             projection_class_embeddings_input_dim=80,  # 6 * 8 + 32
             cross_attention_dim=64,
         )
+        unet.requires_grad_ = False
         scheduler = EulerDiscreteScheduler(
             beta_start=0.00085,
             beta_end=0.012,


### PR DESCRIPTION
# What does this PR do?
Unet's should be frozen for LoRA. Previous examples count on [the user freezing the weights](https://github.com/huggingface/diffusers/blob/74d902eb59f873b6156621220937f8e2521dfdc0/examples/text_to_image/train_text_to_image_lora.py#L429C1-L429C1), but this isn't enforced.

I haven't been able to figure out why exactly the failing tests fail-- afaict, the [unet](https://github.com/huggingface/diffusers/blob/74d902eb59f873b6156621220937f8e2521dfdc0/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L677) here _should_ be `requires_grad_` false (confirmed by printing state), but it still raises the assertion I added here. Any ideas?


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul
