### PR TITLE
[docs] Add note in UniDiffusers Doc about PyTorch 1.X numerical stability issue

### DIFF
--- a/docs/source/en/api/pipelines/unidiffuser.md
+++ b/docs/source/en/api/pipelines/unidiffuser.md
@@ -20,9 +20,11 @@ The abstract from the [paper](https://arxiv.org/abs/2303.06555) is:
 
 You can find the original codebase at [thu-ml/unidiffuser](https://github.com/thu-ml/unidiffuser) and additional checkpoints at [thu-ml](https://huggingface.co/thu-ml).
 
-Tips:
+<Tip warning={true}>
 
-- There is currently an issue on PyTorch 1.X where the output images are all black or the pixel values become `NaNs`. This issue can be mitigated by switching to PyTorch 2.X.
+There is currently an issue on PyTorch 1.X where the output images are all black or the pixel values become `NaNs`. This issue can be mitigated by switching to PyTorch 2.X.
+
+</Tip>
 
 This pipeline was contributed by [dg845](https://github.com/dg845). ❤️
 

--- a/docs/source/en/api/pipelines/unidiffuser.md
+++ b/docs/source/en/api/pipelines/unidiffuser.md
@@ -20,6 +20,10 @@ The abstract from the [paper](https://arxiv.org/abs/2303.06555) is:
 
 You can find the original codebase at [thu-ml/unidiffuser](https://github.com/thu-ml/unidiffuser) and additional checkpoints at [thu-ml](https://huggingface.co/thu-ml).
 
+Tips:
+
+- There is currently an issue on PyTorch 1.X where the output images are all black or the pixel values become `NaNs`. This issue can be mitigated by switching to PyTorch 2.X.
+
 This pipeline was contributed by [dg845](https://github.com/dg845). ❤️
 
 ## Usage Examples


### PR DESCRIPTION
# What does this PR do?

This PR modifies the `UniDiffuserPipeline` docs to add a note regarding the fact that the UniDiffuser pipeline currently has numerical stability issues on PyTorch 1.X, which causes the output images to become all `NaN`s or all black. This issue can be mitigated by switching to PyTorch 2.X.

I will try to open a PR to address this issue in the near future, but in the meantime I think it makes sense to note this in the docs until the issue is fixed.

Addresses #3951.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@patrickvonplaten 
@sayakpaul
