### PR TITLE
[LoRA] default to None when fc alphas are not available.

### DIFF
--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -1387,8 +1387,8 @@ class LoraLoaderMixin:
 
         if patch_mlp:
             for name, mlp_module in text_encoder_mlp_modules(text_encoder):
-                fc1_alpha = network_alphas.pop(name + ".fc1.lora_linear_layer.down.weight.alpha")
-                fc2_alpha = network_alphas.pop(name + ".fc2.lora_linear_layer.down.weight.alpha")
+                fc1_alpha = network_alphas.pop(name + ".fc1.lora_linear_layer.down.weight.alpha", None)
+                fc2_alpha = network_alphas.pop(name + ".fc2.lora_linear_layer.down.weight.alpha", None)
 
                 mlp_module.fc1 = PatchedLoraProjection(
                     mlp_module.fc1, lora_scale, network_alpha=fc1_alpha, rank=rank, dtype=dtype


### PR DESCRIPTION
Fixes: https://github.com/huggingface/diffusers/issues/4697. 

As discussed via Slack, with this (#4697 just popped up) and #4669 merged, I will reflect on https://github.com/huggingface/diffusers/pull/4669/files#r1300597764 in a new PR. 