### PR TITLE
[AudioLDM Docs] Fix docs for output

### DIFF
--- a/docs/source/en/api/pipelines/audioldm.md
+++ b/docs/source/en/api/pipelines/audioldm.md
@@ -46,6 +46,5 @@ Make sure to check out the Schedulers [guide](/using-diffusers/schedulers) to le
 	- all
 	- __call__
 
-## StableDiffusionPipelineOutput
-
-[[autodoc]] pipelines.stable_diffusion.StableDiffusionPipelineOutput
+## AudioPipelineOutput
+[[autodoc]] pipelines.AudioPipelineOutput


### PR DESCRIPTION
# What does this PR do?

The PR #3905 updated the pipeline docs for AudioLDM, including adding a section on the output type. This PR corrects the output type from a `StableDiffusionPipelineOutput`, to an `AudioPipelineOutput`.