### PR TITLE
fix a bug in `from_pretrained` when load optional components

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1013,7 +1013,11 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         init_dict, unused_kwargs, _ = pipeline_class.extract_init_dict(config_dict, **kwargs)
 
         # define init kwargs
-        init_kwargs = {k: init_dict.pop(k) for k in optional_kwargs if k in init_dict and not k in pipeline_class._optional_components}
+        init_kwargs = {
+            k: init_dict.pop(k)
+            for k in optional_kwargs
+            if k in init_dict and k not in pipeline_class._optional_components
+        }
         init_kwargs = {**init_kwargs, **passed_pipe_kwargs}
 
         # remove `null` components

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1012,7 +1012,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
 
         init_dict, unused_kwargs, _ = pipeline_class.extract_init_dict(config_dict, **kwargs)
 
-        # define init kwargs
+        # define init kwargs and make sure that optional component modules are filtered out
         init_kwargs = {
             k: init_dict.pop(k)
             for k in optional_kwargs

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1013,7 +1013,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         init_dict, unused_kwargs, _ = pipeline_class.extract_init_dict(config_dict, **kwargs)
 
         # define init kwargs
-        init_kwargs = {k: init_dict.pop(k) for k in optional_kwargs if k in init_dict}
+        init_kwargs = {k: init_dict.pop(k) for k in optional_kwargs if k in init_dict and not k in pipeline_class._optional_components}
         init_kwargs = {**init_kwargs, **passed_pipe_kwargs}
 
         # remove `null` components

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -691,7 +691,6 @@ class StableDiffusionXLPipelineFastTests(PipelineLatentTesterMixin, PipelineTest
         # ensure the results are not equal
         assert np.abs(image_slice_1.flatten() - image_slice_3.flatten()).max() > 1e-4
 
-    @require_torch_gpu
     def test_stable_diffusion_xl_save_from_pretrained(self):
         pipes = []
         components = self.get_dummy_components()

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import copy
+import tempfile
 import unittest
 
 import numpy as np
@@ -689,3 +690,26 @@ class StableDiffusionXLPipelineFastTests(PipelineLatentTesterMixin, PipelineTest
 
         # ensure the results are not equal
         assert np.abs(image_slice_1.flatten() - image_slice_3.flatten()).max() > 1e-4
+
+    @require_torch_gpu
+    def test_stable_diffusion_xl_save_from_pretrained(self):
+        pipes = []
+        components = self.get_dummy_components()
+        sd_pipe = StableDiffusionXLPipeline(**components).to(torch_device)
+        pipes.append(sd_pipe)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            sd_pipe.save_pretrained(tmpdirname)
+            sd_pipe = StableDiffusionXLPipeline.from_pretrained(tmpdirname).to(torch_device)
+        pipes.append(sd_pipe)
+
+        image_slices = []
+        for pipe in pipes:
+            pipe.unet.set_default_attn_processor()
+
+            inputs = self.get_dummy_inputs(torch_device)
+            image = pipe(**inputs).images
+
+            image_slices.append(image[0, -3:, -3:, -1].flatten())
+
+        assert np.abs(image_slices[0] - image_slices[1]).max() < 1e-3


### PR DESCRIPTION
Below script currently fails but will be fixed with this PR (see more details about the error here  https://github.com/huggingface/diffusers/issues/4686
) 
```python
import torch
from diffusers import StableDiffusionUpscalePipeline

model_id = "stabilityai/stable-diffusion-x4-upscaler"
cache_path = "/home/yiyi_huggingface_co/cache"

pipe = StableDiffusionUpscalePipeline.from_pretrained(
    model_id,
    variant="fp16",
    torch_dtype=torch.float16
)
pipe.save_pretrained(cache_path)

pipe = StableDiffusionUpscalePipeline.from_pretrained(
    pretrained_model_name_or_path=cache_path,
    variant="fp16",
    torch_dtype=torch.float16
)
```

currently, when we call `from_pretrained()`,  optional components are treated same as optional kwargs - they are passed to the `init()` directly, but they should be handled as modules 

https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/pipeline_utils.py#L1016
