### PR TITLE
[WIP ] Proposal to address precision issues in CI

### DIFF
--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 import numpy as np
+from numpy.linalg import norm
 import PIL.Image
 import PIL.ImageOps
 import requests
@@ -70,6 +71,13 @@ def torch_all_close(a, b, *args, **kwargs):
     if not torch.allclose(a, b, *args, **kwargs):
         assert False, f"Max diff is absolute {(a - b).abs().max()}. Diff tensor is {(a - b).abs()}."
     return True
+
+
+def numpy_cosine_similarity_distance(a, b):
+    similarity = np.dot(a, b) / (norm(a) * norm(b))
+    distance = 1.0 - similarity.mean()
+
+    return distance
 
 
 def print_tensor_test(tensor, filename="test_corrections.txt", expected_tensor_name="expected_slice"):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -22,7 +22,12 @@ from diffusers.image_processor import VaeImageProcessor
 from diffusers.schedulers import KarrasDiffusionSchedulers
 from diffusers.utils import logging
 from diffusers.utils.import_utils import is_accelerate_available, is_accelerate_version, is_xformers_available
-from diffusers.utils.testing_utils import CaptureLogger, require_torch, torch_device
+from diffusers.utils.testing_utils import (
+    CaptureLogger,
+    require_torch,
+    torch_device,
+    numpy_cosine_similarity_distance,
+)
 
 from ..others.test_utils import TOKEN, USER, is_staging_test
 
@@ -543,7 +548,7 @@ class PipelineTesterMixin:
         output = pipe(**self.get_dummy_inputs(torch_device))[0]
         output_fp16 = pipe_fp16(**self.get_dummy_inputs(torch_device))[0]
 
-        max_diff = np.abs(to_np(output) - to_np(output_fp16)).max()
+        max_diff = numpy_cosine_similarity_distance(to_np(output).flatten(), to_np(output_fp16).flatten())
         self.assertLess(max_diff, expected_max_diff, "The outputs of the fp16 and fp32 pipelines are too different.")
 
     @unittest.skipIf(torch_device != "cuda", reason="float16 requires CUDA")


### PR DESCRIPTION
# What does this PR do?
Looking through the precision related tests Push failures, I noticed that most of the 85 failures are coming from tests defined in the PipelineMixin class. With 30 failures coming from test_float16_inference The reason for this is that all Pipeline tests inherit from this Mixin class, and run their tests with the default precision tolerance for the test.

Given that most pipelines on Slow Tests are using different checkpoints, they tend to produce very different levels of precision error.
e.g. (notice that Panorama, IF, and Kandinsky have different scales of error)
```
FAILED tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py::StableDiffusionPanoramaPipelineFastTests::test_float16_inference - AssertionError: 0.9291724 not less than 0.01 : The outputs of the fp16 and fp32 pipelines are too different.
FAILED tests/pipelines/deepfloyd_if/test_if_img2img_superresolution.py::IFImg2ImgSuperResolutionPipelineFastTests::test_float16_inference - AssertionError: 0.010922372 not less than 0.01 : The outputs of the fp16 and fp32 pipelines are too different.
FAILED tests/pipelines/kandinsky_v22/test_kandinsky.py::KandinskyV22PipelineFastTests::test_float16_inference - AssertionError: 0.05452037 not less than 0.01 : The outputs of the fp16 and fp32 pipelines are too different.
========================================================================== 30 failed, 63 warnings in 30.36s ==========================================================================
```
Rather than hardcoding these precision values into the individual tests, I am proposing that we use a measurement metric that is slightly more robust to the small numerical fluctuations caused by GPU Non-Determinism. Using cosine similarity distance between the generated outputs of the pipelines and our expected output to assess similarity.

```python
def numpy_cosine_similarity_distance(generated_output, expected_output):
    similarity = np.dot(generated_output, expected_output) / (norm(generated_output) * norm(expected_output))
    distance = 1.0 - similarity.mean()

    return distance    
```
Results from running the same tests with Cosine Similarity Distance and the default precision tolerance 
```
FAILED tests/pipelines/stable_diffusion/test_stable_diffusion_pix2pix_zero.py::StableDiffusionPix2PixZeroPipelineFastTests::test_float16_inference - AssertionError: 0.08929622173309326 not less than 0.01 : The outputs of the fp16 and fp32 pipelines are too different.
FAILED tests/pipelines/stable_diffusion/test_stable_diffusion_model_editing.py::StableDiffusionModelEditingPipelineFastTests::test_float16_inference - AssertionError: 0.08928412199020386 not less than 0.01 : The outputs of the fp16 and fp32 pipelines are too different.
FAILED tests/pipelines/shap_e/test_shap_e_img2img.py::ShapEImg2ImgPipelineFastTests::test_float16_inference - RuntimeError: cumsum_cuda_kernel does not have a deterministic implementation, but you set 'torch.use_deterministic_algorithms(True)'. You can turn off determinism just for this ...
FAILED tests/pipelines/stable_diffusion/test_stable_diffusion_panorama.py::StableDiffusionPanoramaPipelineFastTests::test_float16_inference - AssertionError: 0.09012287855148315 not less than 0.01 : The outputs of the fp16 and fp32 pipelines are too different.
===================================================================== 4 failed, 26 passed, 63 warnings in 29.90s ===================================================================== 
```

To test the sensitivity of Cosine Similarity I ran a quick test, by adding gradually increasing levels of noise to a flattened image numpy array and measured the Max Abs Distance (what we use now) and the Cosine Similarity

Notice that at low noise levels (caused by GPU non-determinism) Cosine Similarity is relatively flat. 

![csd-low-noise](https://github.com/huggingface/diffusers/assets/7529846/9dfa97f3-31b3-447f-bc4b-a8eb4712fd6d)

At higher noise levels Cosine Similarity does start to change more significantly.  

![csd-high-noise](https://github.com/huggingface/diffusers/assets/7529846/8aa5f825-94d5-4fe7-ad51-0ed2544cd76f)
 
Colab Notebook with Full Analysis:
https://colab.research.google.com/gist/DN6/fcbc10649977fbecd604e5feef1f5b05/cosine-similarity-tests.ipynb

Moving other precision related tests to use Cosine Distance will likely lead to a big reduction in flaky test behaviour due to GPU no determinism. Opening this PR for thoughts and discussion. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @williamberman and @patrickvonplaten
- Pipelines:  @patrickvonplaten and @sayakpaul
- Training examples: @sayakpaul and @patrickvonplaten
- Docs: @stevenliu and @yiyixu
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @patrickvonplaten and @sayakpaul

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
