### PR TITLE
[docs] Fix syntax for compel

### DIFF
--- a/docs/source/en/using-diffusers/weighted_prompts.md
+++ b/docs/source/en/using-diffusers/weighted_prompts.md
@@ -144,7 +144,7 @@ A conjunction diffuses each prompt independently and concatenates their results 
   
 ```py
 prompt_embeds = compel_proc('["a red cat", "playing with a", "ball"].and()')
-generator = torch.Generator(device="cuda").manual_seed(33)
+generator = torch.Generator(device="cuda").manual_seed(55)
 
 image = pipe(prompt_embeds=prompt_embeds, generator=generator, num_inference_steps=20).images[0]
 image

--- a/docs/source/en/using-diffusers/weighted_prompts.md
+++ b/docs/source/en/using-diffusers/weighted_prompts.md
@@ -143,7 +143,7 @@ image
 A conjunction diffuses each prompt independently and concatenates their results by their weighted sum. Add `.and()` to the end of a list of prompts to create a conjunction:
   
 ```py
-prompt_embeds = compel_proc('("a red cat, playing with a, ball").and()')
+prompt_embeds = compel_proc('["a red cat", "playing with a", "ball"].and()')
 generator = torch.Generator(device="cuda").manual_seed(33)
 
 image = pipe(prompt_embeds=prompt_embeds, generator=generator, num_inference_steps=20).images[0]


### PR DESCRIPTION
Corrects usage for the `.and()` operator.