### PR TITLE
[Torch compile] Fix torch compile for controlnet

### DIFF
--- a/src/diffusers/models/controlnet.py
+++ b/src/diffusers/models/controlnet.py
@@ -723,7 +723,7 @@ class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlnetMixin):
             class_emb = self.class_embedding(class_labels).to(dtype=self.dtype)
             emb = emb + class_emb
 
-        if "addition_embed_type" in self.config:
+        if self.config.addition_embed_type is not None:
             if self.config.addition_embed_type == "text":
                 aug_emb = self.add_embedding(encoder_hidden_states)
 


### PR DESCRIPTION
# What does this PR do?

The previous release accidentally broke `torch.compile` for ControlNet for SD 1.5 as discovered in https://github.com/huggingface/diffusers/issues/4731

This PR fixes it. We should probably do a patch release here since the last PR broke functionality that was previously possible. 

cc @sayakpaul 