### PR TITLE
Fix docs typo in PipelineForImageToImage name

### DIFF
--- a/docs/source/en/api/pipelines/auto_pipeline.md
+++ b/docs/source/en/api/pipelines/auto_pipeline.md
@@ -21,7 +21,7 @@ For example, to perform Image-to-Image with the SD1.5 checkpoint, you can do
 ```python
 from diffusers import PipelineForImageToImage
 
-pipe_i2i = PipelineForImageoImage.from_pretrained("runwayml/stable-diffusion-v1-5")
+pipe_i2i = PipelineForImageToImage.from_pretrained("runwayml/stable-diffusion-v1-5")
 ```
 
 It will also help you switch between tasks seamlessly using the same checkpoint without reallocating additional memory. For example, to re-use the Image-to-Image pipeline we just created for inpainting, you can do 


### PR DESCRIPTION
Fix docs typo in PipelineForImageToImage name
This PR fix #4792
Fixes # (issue)
https://github.com/huggingface/diffusers/issues/4792
![image](https://github.com/huggingface/diffusers/assets/54706854/2a6500b9-b699-42c8-9c52-3526b291ef86)

I only change
```python
pipe_i2i = PipelineForImageoImage.from_pretrained("runwayml/stable-diffusion-v1-5")
```
to
```python
pipe_i2i = PipelineForImageToImage.from_pretrained("runwayml/stable-diffusion-v1-5")
```

- [√] This PR fixes a typo or improves the docs

@stevhliu and @yiyixuxu 