### PR TITLE
Fix convert_original_stable_diffusion_to_diffusers script

### DIFF
--- a/scripts/convert_original_stable_diffusion_to_diffusers.py
+++ b/scripts/convert_original_stable_diffusion_to_diffusers.py
@@ -152,7 +152,7 @@ if __name__ == "__main__":
         pipeline_class = None
 
     pipe = download_from_original_stable_diffusion_ckpt(
-        checkpoint_path=args.checkpoint_path,
+        checkpoint_path_or_dict=args.checkpoint_path,
         original_config_file=args.original_config_file,
         image_size=args.image_size,
         prediction_type=args.prediction_type,


### PR DESCRIPTION
Fix method call signature

```
(ds2) alex@big ~/d/d/scripts (main) [1]> python convert_original_stable_diffusion_to_diffusers.py --from_safetensors --checkpoint_path /home/alex/devel/civtai-checkpoints/ --dump_path /home/alex/devel/civtai-checkpoints
WARNING[XFORMERS]: xFormers can't load C++/CUDA extensions. xFormers was built for:
    PyTorch 1.13.1+cu117 with CUDA 1107 (you have 2.1.0.dev20230318+cu118)
    Python  3.10.9 (you have 3.10.10)
  Please reinstall xformers (see https://github.com/facebookresearch/xformers#installing-xformers)
  Memory-efficient attention, SwiGLU, sparse and more won't be available.
  Set XFORMERS_MORE_DETAILS=1 for more details
Traceback (most recent call last):
  File "/home/alex/devel/diffusers/scripts/convert_original_stable_diffusion_to_diffusers.py", line 154, in <module>
    pipe = download_from_original_stable_diffusion_ckpt(
TypeError: download_from_original_stable_diffusion_ckpt() got an unexpected keyword argument 'checkpoint_path'

```

seems after refactoring method expect 'checkpoint_path_or_dict'