### PR TITLE
fix sdxl-inpaint fast test

### DIFF
--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
@@ -139,6 +139,7 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
             "generator": generator,
             "num_inference_steps": 2,
             "guidance_scale": 6.0,
+            "strength": 1.0,
             "output_type": "np",
         }
         return inputs


### PR DESCRIPTION
Changing the default strength value for sdxl-inpainting broke the tests (https://github.com/huggingface/diffusers/pull/4858); fixing it here!