### PR TITLE
[docs] Fix DiffusionPipeline.enable_sequential_cpu_offload docstring

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1224,8 +1224,8 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         Offloads all models to CPU using accelerate, significantly reducing memory usage. When called, all
         `torch.nn.Module` components (except those in `_exclude_from_cpu_offload`) have their state dicts saved to CPU
         and then are moved to `torch.device('meta')` and loaded to GPU only when their specific submodule has its
-        `forward` method called. Note that offloading happens on a submodule basis. Memory savings are higher than
-        with `enable_model_cpu_offload`, but performance is lower.
+        `forward` method called. Note that offloading happens on a submodule basis. Memory savings are higher than with
+        `enable_model_cpu_offload`, but performance is lower.
         """
         if is_accelerate_available() and is_accelerate_version(">=", "0.14.0"):
             from accelerate import cpu_offload

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1221,11 +1221,11 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
 
     def enable_sequential_cpu_offload(self, gpu_id: int = 0, device: Union[torch.device, str] = "cuda"):
         r"""
-        Offloads all models to CPU using accelerate, significantly reducing memory usage. When called, unet,
-        text_encoder, vae and safety checker have their state dicts saved to CPU and then are moved to a
-        `torch.device('meta') and loaded to GPU only when their specific submodule has its `forward` method called.
-        Note that offloading happens on a submodule basis. Memory savings are higher than with
-        `enable_model_cpu_offload`, but performance is lower.
+        Offloads all models to CPU using accelerate, significantly reducing memory usage. When called, all
+        `torch.nn.Module` components (except those in `_exclude_from_cpu_offload`) have their state dicts saved to CPU
+        and then are moved to `torch.device('meta')` and loaded to GPU only when their specific submodule has its
+        `forward` method called. Note that offloading happens on a submodule basis. Memory savings are higher than
+        with `enable_model_cpu_offload`, but performance is lower.
         """
         if is_accelerate_available() and is_accelerate_version(">=", "0.14.0"):
             from accelerate import cpu_offload


### PR DESCRIPTION
# What does this PR do?

This PR fixes an unmatched backtick in `DiffusionPipeline.enable_sequential_cpu_offload` and makes the description more general.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@patrickvonplaten
@stevhliu
