### PR TITLE
Make sure Flax pipelines can be loaded into PyTorch

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1443,7 +1443,9 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             ]
 
             # retrieve passed components that should not be downloaded
-            import ipdb; ipdb.set_trace()
+            import ipdb
+
+            ipdb.set_trace()
             pipeline_class = _get_pipeline_class(
                 cls,
                 config_dict,

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1443,9 +1443,6 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             ]
 
             # retrieve passed components that should not be downloaded
-            import ipdb
-
-            ipdb.set_trace()
             pipeline_class = _get_pipeline_class(
                 cls,
                 config_dict,

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -342,7 +342,12 @@ def _get_pipeline_class(
         return class_obj
 
     diffusers_module = importlib.import_module(class_obj.__module__.split(".")[0])
-    pipeline_cls = getattr(diffusers_module, config["_class_name"])
+    class_name = config["_class_name"]
+
+    if class_name.startswith("Flax"):
+        class_name = class_name[4:]
+
+    pipeline_cls = getattr(diffusers_module, class_name)
 
     if load_connected_pipeline:
         from .auto_pipeline import _get_connected_pipeline
@@ -1438,6 +1443,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             ]
 
             # retrieve passed components that should not be downloaded
+            import ipdb; ipdb.set_trace()
             pipeline_class = _get_pipeline_class(
                 cls,
                 config_dict,

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -57,7 +57,7 @@ from diffusers import (
     UniPCMultistepScheduler,
     logging,
 )
-from diffusers.pipelines.pipeline_utils import variant_compatible_siblings
+from diffusers.pipelines.pipeline_utils import _get_pipeline_class, variant_compatible_siblings
 from diffusers.schedulers.scheduling_utils import SCHEDULER_CONFIG_NAME
 from diffusers.utils import (
     CONFIG_NAME,
@@ -804,6 +804,14 @@ class DownloadTests(unittest.TestCase):
             # https://huggingface.co/hf-internal-testing/tiny-stable-diffusion-pipe/blob/main/unet/diffusion_flax_model.msgpack
             assert not any(f in ["vae/diffusion_pytorch_model.bin", "text_encoder/config.json"] for f in files)
             assert len(files) == 14
+
+    def test_get_pipeline_class_from_flax(self):
+        flax_config = {"_class_name": "FlaxStableDiffusionPipeline"}
+        config = {"_class_name": "StableDiffusionPipeline"}
+
+        # when loading a PyTorch Pipeline from a FlaxPipeline `model_index.json`, e.g.: https://huggingface.co/hf-internal-testing/tiny-stable-diffusion-lms-pipe/blob/7a9063578b325779f0f1967874a6771caa973cad/model_index.json#L2
+        # we need to make sure that we don't load the Flax Pipeline class, but instead the PyTorch pipeline class
+        assert _get_pipeline_class(DiffusionPipeline, flax_config) == _get_pipeline_class(DiffusionPipeline, config)
 
 
 class CustomPipelineTests(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

The test failure is due to an edge case of this repo: https://huggingface.co/hf-internal-testing/tiny-stable-diffusion-lms-pipe/blob/7a9063578b325779f0f1967874a6771caa973cad/model_index.json#L2

As you can see the repo contains both Flax and PyTorch weights, but Flax weights are exceptionally the principal weights here. Therefore the `model_index.json` has `FlaxStableDiffusionPipeline` as the main class. 

To allow loading such a pipeline in PyTorch we need to make sure that we never try to import a Flax pipeline class.