### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/source/en/api/pipelines/auto_pipeline.md
+++ b/docs/source/en/api/pipelines/auto_pipeline.md
@@ -42,7 +42,7 @@ Check out the [AutoPipeline](/tutorials/autopipeline) tutorial to learn how to u
 `AutoPipeline` supports text-to-image, image-to-image, and inpainting for the following diffusion models:
 
 - [Stable Diffusion](./stable_diffusion)
-- [ControlNet](./api/pipelines/controlnet)
+- [ControlNet](./controlnet)
 - [Stable Diffusion XL (SDXL)](./stable_diffusion/stable_diffusion_xl)
 - [DeepFloyd IF](./if) 
 - [Kandinsky](./kandinsky)


### PR DESCRIPTION
The link for `ControlNet` is broken on [this page](https://huggingface.co/docs/diffusers/api/pipelines/auto_pipeline). This PR fixes it.

**Current url:** https://huggingface.co/docs/diffusers/api/pipelines/api/pipelines/controlnet
**New url:** https://huggingface.co/docs/diffusers/api/pipelines/controlnet