### PR TITLE
update mapping

### DIFF
--- a/docs/source/en/api/schedulers/overview.md
+++ b/docs/source/en/api/schedulers/overview.md
@@ -29,8 +29,8 @@ Many schedulers are implemented from the [k-diffusion](https://github.com/crowso
 | DPM++ 2M SDE Karras | [`DPMSolverMultistepScheduler`]     | init with `use_karras_sigmas=True` and `algorithm_type="sde-dpmsolver++"`                                     |
 | DPM++ 2S a          | N/A                                 | very similar to  `DPMSolverSinglestepScheduler`                         |
 | DPM++ 2S a Karras   | N/A                                 | very similar to  `DPMSolverSinglestepScheduler(use_karras_sigmas=True, ...)` |
-| DPM++ SDE           | [`DPMSolverSinglestepScheduler`]    |                                                                                                               |
-| DPM++ SDE Karras    | [`DPMSolverSinglestepScheduler`]    | init with `use_karras_sigmas=True`                                                                            |
+| DPM++ SDE           | [`DPMSolverSDEScheduler`]    |                                                                                                               |
+| DPM++ SDE Karras    | [`DPMSolverSDEScheduler`]    | init with `use_karras_sigmas=True`                                                                            |
 | DPM2                | [`KDPM2DiscreteScheduler`]          |                                                                                                               |
 | DPM2 Karras         | [`KDPM2DiscreteScheduler`]          | init with `use_karras_sigmas=True`                                                                            |
 | DPM2 a              | [`KDPM2AncestralDiscreteScheduler`] |                                                                                                               |


### PR DESCRIPTION
@damian0815 pointed it out in https://github.com/huggingface/diffusers/issues/4875 that `DPMSolverSinglestepScheduler` does not support its SDE variant yet. So I'm updating the mapping table accordingly for DPM++ SDE

also happy to open an PR to add SDE too 


