### PR TITLE
fix a bug in inpaint pipeline when use regular text2image unet 

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -999,8 +999,11 @@ class StableDiffusionInpaintPipeline(
                 latents = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs, return_dict=False)[0]
 
                 if num_channels_unet == 4:
-                    init_latents_proper = image_latents[:1]
-                    init_mask = mask[:1]
+                    init_latents_proper = image_latents
+                    if do_classifier_free_guidance:
+                        init_mask, _ = mask.chunk(2)
+                    else:
+                        init_mask = mask
 
                     if i < len(timesteps) - 1:
                         noise_timestep = timesteps[i + 1]


### PR DESCRIPTION
This PR fixes the bug reported here https://github.com/huggingface/diffusers/issues/4854

The issue comes from this line of code here - when we use inpainting pipeline with a regular text-to-image unet with 4 channels, it will only use the first image when given more than one image inputs. 

https://github.com/huggingface/diffusers/blob/19edca82f1ff194c07317369a92b470dbae97f34/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py#L1002

I'm not sure if there is a reason it was currently done this way though. 


This code currently fails but will be fixed in this PR 
```python
import PIL
import requests
import torch
from io import BytesIO

from diffusers import StableDiffusionInpaintPipeline


def download_image(url):
    response = requests.get(url)
    return PIL.Image.open(BytesIO(response.content)).convert("RGB")


imgs = []
masks = []

for img_url, mask_url in [
    ("https://i.ibb.co/DM9qbW8/x0.png","https://i.ibb.co/4TTHp6w/xxx.png"),
    ("https://i.ibb.co/J7DXFmB/x1.png","https://i.ibb.co/2gkxyWB/x1.png"),
    ("https://i.ibb.co/8gRgDYG/x3.png","https://i.ibb.co/WvZ7Q5h/x2.png"),
    ("https://i.ibb.co/KXVWT5D/x4.png","https://i.ibb.co/P5rTZFQ/x3.png")]:

    imgs.append(download_image(img_url))
    masks.append(download_image(mask_url))

pipe = StableDiffusionInpaintPipeline.from_pretrained(
    "runwayml/stable-diffusion-v1-5",
    #"rv51_inpaint",
    revision="fp16",
    torch_dtype=torch.float16,
)
pipe = pipe.to("cuda")

prompt = "Face of a yellow cat, high resolution, sitting on a park bench"

images = pipe(
    prompt=[prompt]*4, 
    image=imgs, 
    mask_image=masks,
    width=512,
    height=512
).images

for i, image in enumerate(images):
    image.save(f"yiyi_test_1_out_{i}.png")
```