### PR TITLE
[`LoRA`] Make optional arguments explicit

### DIFF
--- a/src/diffusers/models/transformer_2d.py
+++ b/src/diffusers/models/transformer_2d.py
@@ -284,7 +284,7 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
 
             hidden_states = self.norm(hidden_states)
             if not self.use_linear_projection:
-                hidden_states = self.proj_in(hidden_states, lora_scale)
+                hidden_states = self.proj_in(hidden_states, scale=lora_scale)
                 inner_dim = hidden_states.shape[1]
                 hidden_states = hidden_states.permute(0, 2, 3, 1).reshape(batch, height * width, inner_dim)
             else:


### PR DESCRIPTION
# What does this PR do?

As discussed offline, scale is an optional argument so we should pass it explcitily, this PR makes things compatible with PEFT together with https://github.com/huggingface/peft/pull/933

cc @patrickvonplaten @sayakpaul 

This should at least fix current issues with diffusers + PEFT for inference, for merge_and_unload we can investigate further