### PR TITLE
[`core` / `Lora`] Fix lora scale on text encoders

### DIFF
--- a/src/diffusers/models/lora.py
+++ b/src/diffusers/models/lora.py
@@ -28,15 +28,15 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 def adjust_lora_scale_text_encoder(text_encoder, lora_scale: float = 1.0):
     for _, attn_module in text_encoder_attn_modules(text_encoder):
         if isinstance(attn_module.q_proj, PatchedLoraProjection):
-            attn_module.q_proj.lora_scale = lora_scale
-            attn_module.k_proj.lora_scale = lora_scale
-            attn_module.v_proj.lora_scale = lora_scale
-            attn_module.out_proj.lora_scale = lora_scale
+            attn_module.q_proj.lora_scale *= lora_scale
+            attn_module.k_proj.lora_scale *= lora_scale
+            attn_module.v_proj.lora_scale *= lora_scale
+            attn_module.out_proj.lora_scale *= lora_scale
 
     for _, mlp_module in text_encoder_mlp_modules(text_encoder):
         if isinstance(mlp_module.fc1, PatchedLoraProjection):
-            mlp_module.fc1.lora_scale = lora_scale
-            mlp_module.fc2.lora_scale = lora_scale
+            mlp_module.fc1.lora_scale *= lora_scale
+            mlp_module.fc2.lora_scale *= lora_scale
 
 
 class LoRALinearLayer(nn.Module):


### PR DESCRIPTION
# What does this PR do?

Found a potential bug in `adjust_lora_scale_text_encoder`

`xxxPipeline` calls under the hood this method: https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/lora.py#L28-L39 to adjust the lora scale on the text encoder. That method seems to force assign the lora_scale of the LoRA layers to a new one. On the other hand, when calling fuse_lora it seems that we multiply the the lora_scale: https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/lora.py#L130
Maybe the reason this has not been flagged by the CI is that self.lora_layer.network_alpha / self.lora_layer.rank was somehow equal to 1.

cc @patrickvonplaten @sayakpaul 
