### PR TITLE
Fixed `get_word_inds` mistake/typo in P2P community pipeline (breaking code examples)

### DIFF
--- a/examples/community/pipeline_prompt2prompt.py
+++ b/examples/community/pipeline_prompt2prompt.py
@@ -681,7 +681,7 @@ def get_word_inds(text: str, word_place: int, tokenizer):
     split_text = text.split(" ")
     if isinstance(word_place, str):
         word_place = [i for i, word in enumerate(split_text) if word_place == word]
-    elif isinstance(word_place, str):
+    elif isinstance(word_place, int):
         word_place = [word_place]
     out = []
     if len(word_place) > 0:


### PR DESCRIPTION
# What does this PR do?

The function `get_word_inds` in `pipeline_prompt2prompt` is taking a string of text and either a word (str) or a word index (int) and returned the indices of token(s) the word would be encoded to.

However, there was a typo, in which in the second `if` branch the word was checked to be a `str` **again**, not `int`, which resulted in an [example code from the docs](https://github.com/huggingface/diffusers/tree/main/examples/community#prompt2prompt-pipeline) to result in an error
