### PR TITLE
set the model to train state before accelerator prepare

### DIFF
--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -752,6 +752,7 @@ def main():
         num_cycles=args.lr_num_cycles,
     )
 
+    text_encoder.train()
     # Prepare everything with our `accelerator`.
     text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
         text_encoder, optimizer, train_dataloader, lr_scheduler


### PR DESCRIPTION

Fixes # (issue)

if use cpu ipex. error like
Traceback (most recent call last):
  File "/home/ywan171/diffusers/examples/textual_inversion/textual_inversion.py", line 989, in <modu
    main()
  File "/home/ywan171/diffusers/examples/textual_inversion/textual_inversion.py", line 756, in main
    text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
  File "/home/ywan171/miniconda3/envs/diffuser/lib/python3.9/site-packages/accelerate/accelerator.py
    args = self._prepare_ipex(*args)
  File "/home/ywan171/miniconda3/envs/diffuser/lib/python3.9/site-packages/accelerate/accelerator.py
    model, optimizer = ipex.optimize(model, optimizer=optimizer, dtype=dtype, inplace=True, level="O
  File "/home/ywan171/miniconda3/envs/diffuser/lib/python3.9/site-packages/intel_extension_for_pytor
    assert optimizer is None, "The optimizer should not be given for inference mode"
AssertionError: The optimizer should not be given for inference mode
My guessed rank = 2
Traceback (most recent call last):
  File "/home/ywan171/diffusers/examples/textual_inversion/textual_inversion.py", line 989, in <modu
    main()
  File "/home/ywan171/diffusers/examples/textual_inversion/textual_inversion.py", line 756, in main
    text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
  File "/home/ywan171/miniconda3/envs/diffuser/lib/python3.9/site-packages/accelerate/accelerator.py
    args = self._prepare_ipex(*args)
  File "/home/ywan171/miniconda3/envs/diffuser/lib/python3.9/site-packages/accelerate/accelerator.py
    model, optimizer = ipex.optimize(model, optimizer=optimizer, dtype=dtype, inplace=True, level="O
  File "/home/ywan171/miniconda3/envs/diffuser/lib/python3.9/site-packages/intel_extension_for_pytor
    assert optimizer is None, "The optimizer should not be given for inference mode"
AssertionError: The optimizer should not be given for inference mode
My guessed rank = 3
Traceback (most recent call last):
  File "/home/ywan171/diffusers/examples/textual_inversion/textual_inversion.py", line 989, in <modu
    main()
  File "/home/ywan171/diffusers/examples/textual_inversion/textual_inversion.py", line 756, in main
    text_encoder, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
  File "/home/ywan171/miniconda3/envs/diffuser/lib/python3.9/site-packages/accelerate/accelerator.py
    args = self._prepare_ipex(*args)
  File "/home/ywan171/miniconda3/envs/diffuser/lib/python3.9/site-packages/accelerate/accelerator.py
    model, optimizer = ipex.optimize(model, optimizer=optimizer, dtype=dtype, inplace=True, level="O
  File "/home/ywan171/miniconda3/envs/diffuser/lib/python3.9/site-packages/intel_extension_for_pytor
    assert optimizer is None, "The optimizer should not be given for inference mode"
AssertionError: The optimizer should not be given for inference mode
My guessed rank = 1



## Who can review?

- Training examples: @sayakpaul and @patrickvonplaten
