### PR TITLE
[FIX BUG] add config_files parser #5114

### DIFF
--- a/scripts/convert_original_stable_diffusion_to_diffusers.py
+++ b/scripts/convert_original_stable_diffusion_to_diffusers.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         "--config_files",
         default=None,
         type=str,
-        help="The YAML config file corresponding to the original architecture.",
+        help="The YAML config file corresponding to the architecture.",
     )
     parser.add_argument(
         "--num_in_channels",

--- a/scripts/convert_original_stable_diffusion_to_diffusers.py
+++ b/scripts/convert_original_stable_diffusion_to_diffusers.py
@@ -36,6 +36,12 @@ if __name__ == "__main__":
         help="The YAML config file corresponding to the original architecture.",
     )
     parser.add_argument(
+        "--config_files",
+        default=None,
+        type=str,
+        help="The YAML config file corresponding to the original architecture.",
+    )
+    parser.add_argument(
         "--num_in_channels",
         default=None,
         type=int,


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/diffusers/blob/8263cf00f832399bca215e29fa7572e0b0bde4da/scripts/convert_original_stable_diffusion_to_diffusers.py#L157C9-L157C40

I added it because there was no config_files parser.

```python
parser.add_argument(
        "--config_files",
        default=None,
        type=str,
        help="The YAML config file corresponding to the architecture.",
    )
```
Fixes #5114 
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
## Who can review?
 Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.