### PR TITLE
[Core] adds `display_total_parameters()` to let the users get a breakdown of the number of parameters easily.

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1839,10 +1839,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         """
 
         def format_dict(dict):
-            return (
-                "\n".join([f"- {prop}: {val} ({val.num_parameters() / 1e6} Million)" for prop, val in dict.items()])
-                + "\n"
-            )
+            return "\n".join([f"- {prop}: {val} ({val / 1e6} Million)" for prop, val in dict.items()]) + "\n"
 
         num_params_breakup = {
             name: component.num_parameters()

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1842,12 +1842,12 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             return "\n".join([f"- {prop}: {val}" for prop, val in dict.items()]) + "\n"
 
         num_params_breakup = {
-            name: component.num_parameters()
-            for name, component in self.components().items()
+            name: f"{component.num_parameters()}" + f" ({component.num_parameters() / 1e6} Million)"
+            for name, component in self.components.items()
             if isinstance(component, torch.nn.Module)
         }
         total_params = sum(params for _, params in num_params_breakup.items())
 
         print("\nBreakdown of the number of the parameters for the `torch.nn.Module` components of the pipeline:\n")
         print(format_dict(num_params_breakup))
-        print(f"Total number of parameters the pipeline has: {total_params}.\n")
+        print(f"Total number of parameters the pipeline has: {total_params} ({total_params / 1e6} Million).\n")

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1857,6 +1857,6 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         }
         total_params = sum(params for _, params in num_params_breakup.items())
 
-        print("\nBreakdown of the number of the parameters for the `torch.nn.Module` components of the pipeline:\n")
+        print("\nBreakdown of the number of the parameters for each `torch.nn.Module` component of the pipeline:\n")
         print(format_dict(num_params_breakup))
         print(f"Total number of parameters the pipeline has: {total_params} ({total_params / 1e6} Million).\n")

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1831,3 +1831,23 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
 
         for module in modules:
             module.set_attention_slice(slice_size)
+
+    def display_total_parameters(self):
+        r"""
+        Gives a breakdown of the number of parameters each `torch.nn.Module` component has. Also shows the sum of the
+        parameters each module-level component has.
+        """
+
+        def format_dict(dict):
+            return "\n".join([f"- {prop}: {val}" for prop, val in dict.items()]) + "\n"
+
+        num_params_breakup = {
+            name: component.num_parameters()
+            for name, component in self.components().items()
+            if isinstance(component, torch.nn.Module)
+        }
+        total_params = sum(params for _, params in num_params_breakup.items())
+
+        print("\nBreakdown of the number of the parameters for the `torch.nn.Module` components of the pipeline:\n")
+        print(format_dict(num_params_breakup))
+        print(f"Total number of parameters the pipeline has: {total_params}.\n")

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1836,6 +1836,15 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         r"""
         Gives a breakdown of the number of parameters each `torch.nn.Module` component has. Also shows the sum of the
         parameters each module-level component has.
+
+        Examples:
+
+        ```py
+        >>> from diffusers import DiffusionPipeline
+
+        >>> pipe = DiffusionPipeline.from_pretrained("stabilityai/stable-diffusion-2-1")
+        >>> pipe.display_total_parameters()
+        ```
         """
 
         def format_dict(dict):

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1839,10 +1839,13 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         """
 
         def format_dict(dict):
-            return "\n".join([f"- {prop}: {val}" for prop, val in dict.items()]) + "\n"
+            return (
+                "\n".join([f"- {prop}: {val} ({val.num_parameters() / 1e6} Million)" for prop, val in dict.items()])
+                + "\n"
+            )
 
         num_params_breakup = {
-            name: f"{component.num_parameters()}" + f" ({component.num_parameters() / 1e6} Million)"
+            name: component.num_parameters()
             for name, component in self.components.items()
             if isinstance(component, torch.nn.Module)
         }


### PR DESCRIPTION
## Usage

```python
from diffusers import DiffusionPipeline
pipe = DiffusionPipeline.from_pretrained("stabilityai/stable-diffusion-2-1")

pipe.display_total_parameters()
```

Outputs:

```bash
Breakdown of the number of the parameters for each `torch.nn.Module` component of the pipeline:

- vae: 83653863 (83.653863 Million)
- text_encoder: 340387840 (340.38784 Million)
- unet: 865910724 (865.910724 Million)

Total number of parameters the pipeline has: 1289952427 (1289.952427 Million).
```