### PR TITLE
[`PEFT`] Fix peft ci

### DIFF
--- a/src/diffusers/models/lora.py
+++ b/src/diffusers/models/lora.py
@@ -31,7 +31,12 @@ def adjust_lora_scale_text_encoder(text_encoder, lora_scale: float = 1.0, use_pe
 
         for module in text_encoder.modules():
             if isinstance(module, LoraLayer):
-                module.scaling[module.active_adapter] = lora_scale
+                active_adapter = module.active_adapter
+                if isinstance(active_adapter, list):
+                    for adapter in active_adapter:
+                        module.scaling[adapter] = lora_scale
+                else:
+                    module.scaling[module.active_adapter] = lora_scale
     else:
         for _, attn_module in text_encoder_attn_modules(text_encoder):
             if isinstance(attn_module.q_proj, PatchedLoraProjection):


### PR DESCRIPTION
# What does this PR do?

Fixes the current PEFT LoRA CI - we also need: https://github.com/huggingface/transformers/pull/26407 to be merged 

With https://github.com/huggingface/peft/pull/905 being merged, the logic for manipulating the active adapter(s) has changed a bit. Now, `active_adapter` is a property method and returns a list, in order to deal with multiple adapter inference. 

This PR adjusts the current PEFT integration by properly dealing with the case `module.active_adapter` returns a list, therefore fixing the multiple adapter case

cc @BenjaminBossan @pacman100 @patrickvonplaten @sayakpaul 
