### PR TITLE
[`PEFT` / `LoRA` ] Kohya checkpoints support

### DIFF
--- a/src/diffusers/utils/state_dict_utils.py
+++ b/src/diffusers/utils/state_dict_utils.py
@@ -37,6 +37,8 @@ DIFFUSERS_TO_PEFT = {
     ".v_proj.lora_linear_layer.down": ".v_proj.lora_A",
     ".out_proj.lora_linear_layer.up": ".out_proj.lora_B",
     ".out_proj.lora_linear_layer.down": ".out_proj.lora_A",
+    ".lora_linear_layer.up": ".lora_B",
+    ".lora_linear_layer.down": ".lora_A",
 }
 
 DIFFUSERS_OLD_TO_PEFT = {


### PR DESCRIPTION
# What does this PR do?

Currently if a user uses peft main + transformers main + diffusers main, generating images with kohya checkpoints does not work.

The script below:

```python
import torch
from diffusers import StableDiffusionPipeline, DPMSolverMultistepScheduler

pipeline = StableDiffusionPipeline.from_pretrained(
    "gsdf/Counterfeit-V2.5", torch_dtype=torch.float16, safety_checker=None
).to("cuda")
pipeline.scheduler = DPMSolverMultistepScheduler.from_config(
    pipeline.scheduler.config, use_karras_sigmas=True
)

pipeline.load_lora_weights(
    "sayakpaul/civitai-light-shadow-lora", weight_name="light_and_shadow.safetensors"
)
prompt = "masterpiece, best quality, 1girl, at dusk"
negative_prompt = ("(low quality, worst quality:1.4), (bad anatomy), (inaccurate limb:1.2), "
                   "bad composition, inaccurate eyes, extra digit, fewer digits, (extra arms:1.2), large breasts")

image = pipeline(prompt=prompt, 
    negative_prompt=negative_prompt, 
    width=512, 
    height=768, 
    num_inference_steps=15, 
    generator=torch.manual_seed(156),
    cross_attention_kwargs={"scale": 0.5}
).images[0]
image.save("image-kohya-original-te-peft.png")
```

Crashes because of MLP keys not being properly converted for text encoders
With this PR the generated image is identical to the one generated on main branch without PEFT:

![Screenshot 2023-09-27 at 17 32 34](https://github.com/huggingface/diffusers/assets/49240599/c2362de0-1952-472b-a44c-742392a161ff)

cc @patrickvonplaten @sayakpaul @pacman100 

