### PR TITLE
[Flax SDXL] fix zero out sdxl

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_flax_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_flax_stable_diffusion_xl.py
@@ -188,9 +188,10 @@ class FlaxStableDiffusionXLPipeline(FlaxDiffusionPipeline):
         # Get unconditional embeddings
         batch_size = prompt_embeds.shape[0]
         if neg_prompt_ids is None:
-            neg_prompt_ids = self.prepare_inputs([""] * batch_size)
-
-        neg_prompt_embeds, negative_pooled_embeds = self.get_embeddings(neg_prompt_ids, params)
+            neg_prompt_embeds = jnp.zeros_like(prompt_embeds)
+            negative_pooled_embeds = jnp.zeros_like(pooled_embeds)
+        else:
+            neg_prompt_embeds, negative_pooled_embeds = self.get_embeddings(neg_prompt_ids, params)
 
         add_time_ids = self._get_add_time_ids(
             (height, width), (0, 0), (height, width), prompt_embeds.shape[0], dtype=prompt_embeds.dtype


### PR DESCRIPTION
# What does this PR do?

Make sure SDXL zeros out prompt_embeds and pool_embeds correctly in Flax. The following now gives identical results:

**Flax**:
```py
from diffusers import FlaxStableDiffusionXLPipeline
import numpy as np
import jax.numpy as jnp
import jax

path = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"

pipe, params = FlaxStableDiffusionXLPipeline.from_pretrained(path)

prompt = "An astronaut riding a green horse on Mars"
steps = 3

batch_size, height, width, ch = 1, 32, 32, 4
num_elems = batch_size * height * width * ch
rng = jax.random.PRNGKey(0)
latents = (jnp.arange(num_elems) / num_elems)[:, None, None, None].reshape(batch_size, ch, width, height)

print("latents", np.abs(np.asarray(latents)).sum())

prompt_embeds = pipe.prepare_inputs(prompt)

image = pipe(prompt_embeds, params, rng, latents=latents, num_inference_steps=3, output_type="np").images[0]

print(np.abs(np.asarray(image)).sum())
```

**PyTorch**:
```py
import torch
import numpy as np
from diffusers import StableDiffusionXLPipeline

path = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"

pipe = StableDiffusionXLPipeline.from_pretrained(path)
pipe.unet.set_default_attn_processor()

prompt = "An astronaut riding a green horse on Mars"
steps = 3

batch_size, height, width, ch = 1, 32, 32, 4
num_elems = batch_size * height * width * ch
latents = (torch.arange(num_elems) / num_elems)[:, None, None, None].reshape(batch_size, ch, width, height)
print("latents", latents.abs().sum())

image = pipe(prompt, latents=latents, num_inference_steps=3, output_type="np", guidance_scale=7.5).images[0]

print(np.abs(image).sum())
```