### PR TITLE
[docs] Quicktour fixes

### DIFF
--- a/docs/source/en/quicktour.md
+++ b/docs/source/en/quicktour.md
@@ -130,7 +130,7 @@ You can also use the pipeline locally. The only difference is you need to downlo
 Then load the saved weights into the pipeline:
 
 ```python
->>> pipeline = DiffusionPipeline.from_pretrained("./stable-diffusion-v1-5", use_safetensors=True)
+>>> pipeline = DiffusionPipeline.from_pretrained("./stable-diffusion-v1-5", local_files_only=True, use_safetensors=True)
 ```
 
 Now you can run the pipeline as you would in the section above.

--- a/docs/source/en/quicktour.md
+++ b/docs/source/en/quicktour.md
@@ -130,7 +130,7 @@ You can also use the pipeline locally. The only difference is you need to downlo
 Then load the saved weights into the pipeline:
 
 ```python
->>> pipeline = DiffusionPipeline.from_pretrained("./stable-diffusion-v1-5", local_files_only=True, use_safetensors=True)
+>>> pipeline = DiffusionPipeline.from_pretrained("./stable-diffusion-v1-5", use_safetensors=True)
 ```
 
 Now you can run the pipeline as you would in the section above.

--- a/src/diffusers/pipelines/pipeline_flax_utils.py
+++ b/src/diffusers/pipelines/pipeline_flax_utils.py
@@ -280,9 +280,7 @@ class FlaxDiffusionPipeline(ConfigMixin, PushToHubMixin):
         <Tip>
 
         To use private or [gated models](https://huggingface.co/docs/hub/models-gated#gated-models), log-in with
-        `huggingface-cli login`. You can also activate the special
-        [“offline-mode”](https://huggingface.co/diffusers/installation.html#offline-mode) to use this method in a
-        firewalled environment.
+        `huggingface-cli login`.
 
         </Tip>
 


### PR DESCRIPTION
Addresses questions raised in this Slack [thread](https://huggingface.slack.com/archives/C03UQJENJTV/p1695735577276939) from @osanseviero 

> Should we showcase a lighter repo that does not contain so many different weights? Maybe ddpm?

Do you mean showcasing a repo that'll be faster to download or are you worried about the complexity of so many different weights in Stable Diffusion v1.5?

In the case of the latter, I think it may be ok to keep the current repo for continuity with the section above it and because it is the most popular model users that are probably interested in trying. I don't think they'll care too much about all the different weights in the repo since all they have to know right now is just how they can load the model using `from_pretrained`.