### PR TITLE
Update default t2i_adapter command to use vae fix

### DIFF
--- a/examples/controlnet/README_sdxl.md
+++ b/examples/controlnet/README_sdxl.md
@@ -66,6 +66,7 @@ export OUTPUT_DIR="path to save model"
 
 accelerate launch train_controlnet_sdxl.py \
  --pretrained_model_name_or_path=$MODEL_DIR \
+ --pretrained_vae_model_name_or_path "madebyollin/sdxl-vae-fp16-fix" \ # Vae fix is required to converge with dataset "fusing/fill50k"
  --output_dir=$OUTPUT_DIR \
  --dataset_name=fusing/fill50k \
  --mixed_precision="fp16" \

--- a/examples/t2i_adapter/README_sdxl.md
+++ b/examples/t2i_adapter/README_sdxl.md
@@ -66,6 +66,7 @@ export OUTPUT_DIR="path to save model"
 
 accelerate launch train_t2i_adapter_sdxl.py \
  --pretrained_model_name_or_path=$MODEL_DIR \
+ --pretrained_vae_model_name_or_path "madebyollin/sdxl-vae-fp16-fix" \ # Vae fix is required to converge with dataset "fusing/fill50k"
  --output_dir=$OUTPUT_DIR \
  --dataset_name=fusing/fill50k \
  --mixed_precision="fp16" \


### PR DESCRIPTION
# What does this PR do?

The default SDXL vae goes completely dark by step 100. 

Seems like the solid fill task of "fusing/fill50k" is going to be particularly adversarial and find a local minima of pure black.