### PR TITLE
Flax: Ignore PyTorch, ONNX files when they coexist with Flax weights

### DIFF
--- a/src/diffusers/pipelines/pipeline_flax_utils.py
+++ b/src/diffusers/pipelines/pipeline_flax_utils.py
@@ -341,8 +341,8 @@ class FlaxDiffusionPipeline(ConfigMixin, PushToHubMixin):
             allow_patterns = [os.path.join(k, "*") for k in folder_names]
             allow_patterns += [FLAX_WEIGHTS_NAME, SCHEDULER_CONFIG_NAME, CONFIG_NAME, cls.config_name]
 
-            # make sure we don't download PyTorch weights, unless when using from_pt
-            ignore_patterns = "*.bin" if not from_pt else []
+            ignore_patterns = ["*.bin", "*.safetensors"] if not from_pt else []
+            ignore_patterns += ["*.onnx", "*.onnx_data", "*.xml", "*.pb"]
 
             if cls != FlaxDiffusionPipeline:
                 requested_pipeline_class = cls.__name__


### PR DESCRIPTION
The following will download safetensors and onnx files:

```Python
from diffusers.pipelines import FlaxStableDiffusionXLPipeline
_ = FlaxStableDiffusionXLPipeline.from_pretrained(
    "stabilityai/stable-diffusion-xl-base-1.0",
    revision="refs/pr/95",
)
```

Ideally we should bring over some of the logic we've been adding to `pipeline_utils.py`, but this PR does the trick for now.
