### PR TITLE
Add docstrings in forward methods of adapter model

### DIFF
--- a/src/diffusers/models/adapter.py
+++ b/src/diffusers/models/adapter.py
@@ -303,7 +303,7 @@ class FullAdapter(nn.Module):
 
     def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
         r"""
-        This function processes the input tensor `x` through the FullAdapter model and performs operations including 
+        This method processes the input tensor `x` through the FullAdapter model and performs operations including 
         pixel unshuffling, convolution, and a stack of AdapterBlocks. It returns a list of feature tensors, each capturing information at a different stage of processing within 
         the FullAdapter model. The number of feature tensors in the list is determined by the number of downsample blocks
         specified during initialization.
@@ -350,6 +350,11 @@ class FullAdapterXL(nn.Module):
         self.total_downscale_factor = downscale_factor * 2
 
     def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
+        r"""
+        This method takes the tensor x as input and processes it through FullAdapterXL model. FullAdapterXL 
+        extracts extra-large (XL) features from the input image. It consists of multiple blocks, each responsible for 
+        processing and downsampling the input. The feature tensors in the list correspond to the output of each processing block.
+        """
         x = self.unshuffle(x)
         x = self.conv_in(x)
 
@@ -379,6 +384,11 @@ class AdapterBlock(nn.Module):
         )
 
     def forward(self, x):
+        r"""
+        This method takes tensor x as input and performs operations downsampling and convolutional layers if the 
+        self.downsample and self.in_conv properties of AdapterBlock model are specified. Then it applies a series 
+        of residual blocks to the input tensor.
+        """
         if self.downsample is not None:
             x = self.downsample(x)
 

--- a/src/diffusers/models/adapter.py
+++ b/src/diffusers/models/adapter.py
@@ -258,6 +258,12 @@ class T2IAdapter(ModelMixin, ConfigMixin):
             )
 
     def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
+        r"""
+        This function processes the input tensor `x` through the adapter model and returns a list of feature tensors, 
+        each representing information extracted at a different scale from the input.
+        The length of the list is determined by the number of downsample blocks in the Adapter, as specified
+        by the `channels` and `num_res_blocks` parameters during initialization.
+        """
         return self.adapter(x)
 
     @property
@@ -296,6 +302,12 @@ class FullAdapter(nn.Module):
         self.total_downscale_factor = downscale_factor * 2 ** (len(channels) - 1)
 
     def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
+        r"""
+        This function processes the input tensor `x` through the FullAdapter model and performs operations including 
+        pixel unshuffling, convolution, and a stack of AdapterBlocks. It returns a list of feature tensors, each capturing information at a different stage of processing within 
+        the FullAdapter model. The number of feature tensors in the list is determined by the number of downsample blocks
+        specified during initialization.
+        """
         x = self.unshuffle(x)
         x = self.conv_in(x)
 

--- a/src/diffusers/models/adapter.py
+++ b/src/diffusers/models/adapter.py
@@ -304,9 +304,9 @@ class FullAdapter(nn.Module):
     def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
         r"""
         This method processes the input tensor `x` through the FullAdapter model and performs operations including 
-        pixel unshuffling, convolution, and a stack of AdapterBlocks. It returns a list of feature tensors, each capturing information at a different stage of processing within 
-        the FullAdapter model. The number of feature tensors in the list is determined by the number of downsample blocks
-        specified during initialization.
+        pixel unshuffling, convolution, and a stack of AdapterBlocks. It returns a list of feature tensors, each capturing information 
+        at a different stage of processing within the FullAdapter model. The number of feature tensors in the list is determined 
+        by the number of downsample blocks specified during initialization.
         """
         x = self.unshuffle(x)
         x = self.conv_in(x)
@@ -351,9 +351,8 @@ class FullAdapterXL(nn.Module):
 
     def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
         r"""
-        This method takes the tensor x as input and processes it through FullAdapterXL model. FullAdapterXL 
-        extracts extra-large (XL) features from the input image. It consists of multiple blocks, each responsible for 
-        processing and downsampling the input. The feature tensors in the list correspond to the output of each processing block.
+        This method takes the tensor x as input and processes it through FullAdapterXL model. It consists of operations 
+        including unshuffling pixels, applying convolution layer and appending each block into list of feature tensors.
         """
         x = self.unshuffle(x)
         x = self.conv_in(x)
@@ -408,6 +407,10 @@ class AdapterResnetBlock(nn.Module):
         self.block2 = nn.Conv2d(channels, channels, kernel_size=1)
 
     def forward(self, x):
+        r"""
+        This method takes input tensor x and applies a convolutional layer, ReLU activation, 
+        and another convolutional layer on the input tensor. It returns addition with the input tensor.
+        """
         h = x
         h = self.block1(h)
         h = self.act(h)
@@ -447,6 +450,10 @@ class LightAdapter(nn.Module):
         self.total_downscale_factor = downscale_factor * (2 ** len(channels))
 
     def forward(self, x):
+        r"""
+        This method takes the input tensor x and performs downscaling and appends it in list of feature tensors.
+        Each feature tensor corresponds to a different level of processing within the LightAdapter.
+        """
         x = self.unshuffle(x)
 
         features = []
@@ -472,6 +479,10 @@ class LightAdapterBlock(nn.Module):
         self.out_conv = nn.Conv2d(mid_channels, out_channels, kernel_size=1)
 
     def forward(self, x):
+        r"""
+        This method takes tensor x as input and performs downsampling if required. 
+        Then it applies in convolution layer, a sequence of residual blocks, and out convolutional layer.
+        """
         if self.downsample is not None:
             x = self.downsample(x)
 
@@ -490,6 +501,10 @@ class LightAdapterResnetBlock(nn.Module):
         self.block2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
 
     def forward(self, x):
+        r"""
+        This function takes input tensor x and processes it through one convolutional layer, ReLU activation,
+        and another convolutional layer and adds it to input tensor.
+        """
         h = x
         h = self.block1(h)
         h = self.act(h)


### PR DESCRIPTION
# What does this PR do?
Added docstrings to the forward methods of all the classes in adapter models describing the type of parameter, operations performed by the function, and the return value.

Fixes #5231 

## Who can review?
@patrickvonplaten , @stevhliu and @yiyixuxu