### PR TITLE
DeepSpeed compatibility + bug fixes

### DIFF
--- a/examples/controlnet/README_sdxl.md
+++ b/examples/controlnet/README_sdxl.md
@@ -61,7 +61,7 @@ wget https://huggingface.co/datasets/huggingface/documentation-images/resolve/ma
 Then run `huggingface-cli login` to log into your Hugging Face account. This is needed to be able to push the trained ControlNet parameters to Hugging Face Hub.
 
 ```bash
-export MODEL_DIR="stabilityai/stable-diffusion-xl-base-1.0"
+export MODEL_DIR="madebyollin/sdxl-vae-fp16-fix"
 export OUTPUT_DIR="path to save model"
 
 accelerate launch train_controlnet_sdxl.py \


### PR DESCRIPTION
# What does this PR do?

Fixes # (issue)

Added compatibility with DeepSpeed which includes adding a dummy learning rate scheduler and optimizer when use_deepspeed argument is set to True (default False).

Issues fixed:
- Validation generated images now can be viewed on WandB (or any other platform). Earlier it used to blacked out. Probably wasn't generating images properly.
- Checkpoint saving now works for multi-GPU training. Earlier it was in a deadlock since accelerator only saved those checkpoints if it was the main process and then invoke accelerator.wait_for_everyone which would put it in an infinite loop.
- Readme for Stable Diffusion XL Control Net mentions the updated, more stable SDXL VAE. The original one absolutely doesn't work.
- Removed XFormers for inference since it's not required.

