### PR TITLE
fix une2td ignoring class_labels

### DIFF
--- a/src/diffusers/models/unet_2d.py
+++ b/src/diffusers/models/unet_2d.py
@@ -293,7 +293,7 @@ class UNet2DModel(ModelMixin, ConfigMixin):
             emb = emb + class_emb
         elif self.class_embedding is None and class_labels is not None:
             raise ValueError("class_embedding needs to be initialized in order to use class conditioning")
-          
+
         # 2. pre-process
         skip_sample = sample
         sample = self.conv_in(sample)

--- a/src/diffusers/models/unet_2d.py
+++ b/src/diffusers/models/unet_2d.py
@@ -292,7 +292,7 @@ class UNet2DModel(ModelMixin, ConfigMixin):
             class_emb = self.class_embedding(class_labels).to(dtype=self.dtype)
             emb = emb + class_emb
         elif self.class_embedding is None and class_labels is not None:
-            raise ValueError("class_embedding needs to be initialized to use class conditioning")
+            raise ValueError("class_embedding needs to be initialized in order to use class conditioning")
           
         # 2. pre-process
         skip_sample = sample

--- a/src/diffusers/models/unet_2d.py
+++ b/src/diffusers/models/unet_2d.py
@@ -291,7 +291,9 @@ class UNet2DModel(ModelMixin, ConfigMixin):
 
             class_emb = self.class_embedding(class_labels).to(dtype=self.dtype)
             emb = emb + class_emb
-
+        elif self.class_embedding is None and class_labels is not None:
+            raise ValueError("class_embedding needs to be initialized to use class conditioning")
+          
         # 2. pre-process
         skip_sample = sample
         sample = self.conv_in(sample)


### PR DESCRIPTION
# What does this PR do?

UNet2DModel ignores class_labels parameter when class_embedding is not initialized and does not give any error. This causes users to give pass a parameter that does not change anything. I changed the code so that it gives error and user becomes aware that they have to initialize class_embeddings. I opened an issue about this before: https://github.com/huggingface/diffusers/issues/5330

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case : https://github.com/huggingface/diffusers/issues/5330
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.