### PR TITLE
Make T2I-Adapter downscale padding match the UNet

### DIFF
--- a/src/diffusers/models/adapter.py
+++ b/src/diffusers/models/adapter.py
@@ -20,7 +20,6 @@ import torch.nn as nn
 from ..configuration_utils import ConfigMixin, register_to_config
 from ..utils import logging
 from .modeling_utils import ModelMixin
-from .resnet import Downsample2D
 
 
 logger = logging.get_logger(__name__)

--- a/src/diffusers/models/adapter.py
+++ b/src/diffusers/models/adapter.py
@@ -279,9 +279,8 @@ class T2IAdapter(ModelMixin, ConfigMixin):
 
     @property
     def downscale_factor(self):
-        """The downscale factor applied in the T2I-Adapter's initial pixel
-        unshuffle operation. If an input image's dimensions are not evenly
-        divisible by the downscale_factor then an exception will be raised.
+        """The downscale factor applied in the T2I-Adapter's initial pixel unshuffle operation. If an input image's dimensions are
+        not evenly divisible by the downscale_factor then an exception will be raised.
         """
         return self.adapter.unshuffle.downscale_factor
 

--- a/src/diffusers/models/adapter.py
+++ b/src/diffusers/models/adapter.py
@@ -55,21 +55,23 @@ class MultiAdapter(ModelMixin):
         # be the same for all adapters. Inductively, it also means the
         # downscale_factor and total_downscale_factor must be the same for all
         # adapters.
+        first_adapter_total_downscale_factor = adapters[0].total_downscale_factor
+        first_adapter_downscale_factor = adapters[0].downscale_factor
         for idx in range(1, len(adapters)):
             if (
-                adapters[idx].total_downscale_factor != adapters[0].total_downscale_factor
-                or adapters[idx].downscale_factor != adapters[0].downscale_factor
+                adapters[idx].total_downscale_factor != first_adapter_total_downscale_factor
+                or adapters[idx].downscale_factor != first_adapter_downscale_factor
             ):
                 raise ValueError(
                     f"Expecting all adapters to have the same downscaling behavior, but got:\n"
-                    f"adapters[0].total_downscale_factor={adapters[0].total_downscale_factor}\n"
-                    f"adapters[0].downscale_factor={adapters[0].downscale_factor}\n"
+                    f"adapters[0].total_downscale_factor={first_adapter_total_downscale_factor}\n"
+                    f"adapters[0].downscale_factor={first_adapter_downscale_factor}\n"
                     f"adapter[`{idx}`].total_downscale_factor={adapters[idx].total_downscale_factor}\n"
                     f"adapter[`{idx}`].downscale_factor={adapters[idx].downscale_factor}"
                 )
 
-        self.total_downscale_factor = adapters[0].total_downscale_factor
-        self.downscale_factor = adapters[0].downscale_factor
+        self.total_downscale_factor = first_adapter_total_downscale_factor
+        self.downscale_factor = first_adapter_downscale_factor
 
     def forward(self, xs: torch.Tensor, adapter_weights: Optional[List[float]] = None) -> List[torch.Tensor]:
         r"""

--- a/src/diffusers/models/adapter.py
+++ b/src/diffusers/models/adapter.py
@@ -51,24 +51,26 @@ class MultiAdapter(ModelMixin):
         if len(adapters) == 1:
             raise ValueError("For a single adapter, please use the `T2IAdapter` class instead of `MultiAdapter`")
 
-        # The outputs from each adapter are added together with a weight
-        # This means that the change in dimenstions from downsampling must
-        # be the same for all adapters. Inductively, it also means the total
-        # downscale factor must also be the same for all adapters.
-
-        first_adapter_total_downscale_factor = adapters[0].total_downscale_factor
-
+        # The outputs from each adapter are added together with a weight.
+        # This means that the change in dimensions from downsampling must
+        # be the same for all adapters. Inductively, it also means the
+        # downscale_factor and total_downscale_factor must be the same for all
+        # adapters.
         for idx in range(1, len(adapters)):
-            adapter_idx_total_downscale_factor = adapters[idx].total_downscale_factor
-
-            if adapter_idx_total_downscale_factor != first_adapter_total_downscale_factor:
+            if (
+                adapters[idx].total_downscale_factor != adapters[0].total_downscale_factor
+                or adapters[idx].downscale_factor != adapters[0].downscale_factor
+            ):
                 raise ValueError(
-                    f"Expecting all adapters to have the same total_downscale_factor, "
-                    f"but got adapters[0].total_downscale_factor={first_adapter_total_downscale_factor} and "
-                    f"adapter[`{idx}`]={adapter_idx_total_downscale_factor}"
+                    f"Expecting all adapters to have the same downscaling behavior, but got:\n"
+                    f"adapters[0].total_downscale_factor={adapters[0].total_downscale_factor}\n"
+                    f"adapters[0].downscale_factor={adapters[0].downscale_factor}\n"
+                    f"adapter[`{idx}`].total_downscale_factor={adapters[idx].total_downscale_factor}\n"
+                    f"adapter[`{idx}`].downscale_factor={adapters[idx].downscale_factor}"
                 )
 
         self.total_downscale_factor = adapters[0].total_downscale_factor
+        self.downscale_factor = adapters[0].downscale_factor
 
     def forward(self, xs: torch.Tensor, adapter_weights: Optional[List[float]] = None) -> List[torch.Tensor]:
         r"""
@@ -274,6 +276,14 @@ class T2IAdapter(ModelMixin, ConfigMixin):
     def total_downscale_factor(self):
         return self.adapter.total_downscale_factor
 
+    @property
+    def downscale_factor(self):
+        """The downscale factor applied in the T2I-Adapter's initial pixel
+        unshuffle operation. If an input image's dimensions are not evenly
+        divisible by the downscale_factor then an exception will be raised.
+        """
+        return self.adapter.unshuffle.downscale_factor
+
 
 # full adapter
 
@@ -399,7 +409,7 @@ class AdapterBlock(nn.Module):
 
         self.downsample = None
         if down:
-            self.downsample = Downsample2D(in_channels)
+            self.downsample = nn.AvgPool2d(kernel_size=2, stride=2, ceil_mode=True)
 
         self.in_conv = None
         if in_channels != out_channels:
@@ -526,7 +536,7 @@ class LightAdapterBlock(nn.Module):
 
         self.downsample = None
         if down:
-            self.downsample = Downsample2D(in_channels)
+            self.downsample = nn.AvgPool2d(kernel_size=2, stride=2, ceil_mode=True)
 
         self.in_conv = nn.Conv2d(in_channels, mid_channels, kernel_size=1)
         self.resnets = nn.Sequential(*[LightAdapterResnetBlock(mid_channels) for _ in range(num_res_blocks)])

--- a/src/diffusers/pipelines/t2i_adapter/pipeline_stable_diffusion_adapter.py
+++ b/src/diffusers/pipelines/t2i_adapter/pipeline_stable_diffusion_adapter.py
@@ -568,8 +568,8 @@ class StableDiffusionAdapterPipeline(DiffusionPipeline):
             elif isinstance(image, torch.Tensor):
                 height = image.shape[-2]
 
-            # round down to nearest multiple of `self.adapter.total_downscale_factor`
-            height = (height // self.adapter.total_downscale_factor) * self.adapter.total_downscale_factor
+            # round down to nearest multiple of `self.adapter.downscale_factor`
+            height = (height // self.adapter.downscale_factor) * self.adapter.downscale_factor
 
         if width is None:
             if isinstance(image, PIL.Image.Image):
@@ -577,8 +577,8 @@ class StableDiffusionAdapterPipeline(DiffusionPipeline):
             elif isinstance(image, torch.Tensor):
                 width = image.shape[-1]
 
-            # round down to nearest multiple of `self.adapter.total_downscale_factor`
-            width = (width // self.adapter.total_downscale_factor) * self.adapter.total_downscale_factor
+            # round down to nearest multiple of `self.adapter.downscale_factor`
+            width = (width // self.adapter.downscale_factor) * self.adapter.downscale_factor
 
         return height, width
 

--- a/src/diffusers/pipelines/t2i_adapter/pipeline_stable_diffusion_xl_adapter.py
+++ b/src/diffusers/pipelines/t2i_adapter/pipeline_stable_diffusion_xl_adapter.py
@@ -600,8 +600,8 @@ class StableDiffusionXLAdapterPipeline(
             elif isinstance(image, torch.Tensor):
                 height = image.shape[-2]
 
-            # round down to nearest multiple of `self.adapter.total_downscale_factor`
-            height = (height // self.adapter.total_downscale_factor) * self.adapter.total_downscale_factor
+            # round down to nearest multiple of `self.adapter.downscale_factor`
+            height = (height // self.adapter.downscale_factor) * self.adapter.downscale_factor
 
         if width is None:
             if isinstance(image, PIL.Image.Image):
@@ -609,8 +609,8 @@ class StableDiffusionXLAdapterPipeline(
             elif isinstance(image, torch.Tensor):
                 width = image.shape[-1]
 
-            # round down to nearest multiple of `self.adapter.total_downscale_factor`
-            width = (width // self.adapter.total_downscale_factor) * self.adapter.total_downscale_factor
+            # round down to nearest multiple of `self.adapter.downscale_factor`
+            width = (width // self.adapter.downscale_factor) * self.adapter.downscale_factor
 
         return height, width
 

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_adapter.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_adapter.py
@@ -58,24 +58,23 @@ class AdapterTests:
     def get_dummy_components(self, adapter_type):
         torch.manual_seed(0)
         unet = UNet2DConditionModel(
-            block_out_channels=(32, 32, 32, 64),
+            block_out_channels=(32, 64),
             layers_per_block=2,
             sample_size=32,
             in_channels=4,
             out_channels=4,
-            # Test with all 4 down blocks to ensure that the T2I-Adapter downscaling gets fully exercised in the tests.
-            down_block_types=("CrossAttnDownBlock2D", "CrossAttnDownBlock2D", "CrossAttnDownBlock2D", "DownBlock2D"),
-            up_block_types=("UpBlock2D", "CrossAttnUpBlock2D", "CrossAttnUpBlock2D", "CrossAttnUpBlock2D"),
+            down_block_types=("CrossAttnDownBlock2D", "DownBlock2D"),
+            up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
             cross_attention_dim=32,
         )
         scheduler = PNDMScheduler(skip_prk_steps=True)
         torch.manual_seed(0)
         vae = AutoencoderKL(
-            block_out_channels=[32, 32, 32, 64],
+            block_out_channels=[32, 64],
             in_channels=3,
             out_channels=3,
-            down_block_types=["DownEncoderBlock2D", "DownEncoderBlock2D", "DownEncoderBlock2D", "DownEncoderBlock2D"],
-            up_block_types=["UpDecoderBlock2D", "UpDecoderBlock2D", "UpDecoderBlock2D", "UpDecoderBlock2D"],
+            down_block_types=["DownEncoderBlock2D", "DownEncoderBlock2D"],
+            up_block_types=["UpDecoderBlock2D", "UpDecoderBlock2D"],
             latent_channels=4,
         )
         torch.manual_seed(0)
@@ -98,9 +97,9 @@ class AdapterTests:
         if adapter_type == "full_adapter" or adapter_type == "light_adapter":
             adapter = T2IAdapter(
                 in_channels=3,
-                channels=[32, 32, 32, 64],
+                channels=[32, 64],
                 num_res_blocks=2,
-                downscale_factor=8,
+                downscale_factor=2,
                 adapter_type=adapter_type,
             )
         elif adapter_type == "multi_adapter":
@@ -108,16 +107,16 @@ class AdapterTests:
                 [
                     T2IAdapter(
                         in_channels=3,
-                        channels=[32, 32, 32, 64],
+                        channels=[32, 64],
                         num_res_blocks=2,
-                        downscale_factor=8,
+                        downscale_factor=2,
                         adapter_type="full_adapter",
                     ),
                     T2IAdapter(
                         in_channels=3,
-                        channels=[32, 32, 32, 64],
+                        channels=[32, 64],
                         num_res_blocks=2,
-                        downscale_factor=8,
+                        downscale_factor=2,
                         adapter_type="full_adapter",
                     ),
                 ]
@@ -139,7 +138,7 @@ class AdapterTests:
         }
         return components
 
-    def get_dummy_inputs(self, device, seed=0, height=128, width=128, num_images=1):
+    def get_dummy_inputs(self, device, seed=0, height=64, width=64, num_images=1):
         if num_images == 1:
             image = floats_tensor((1, 3, height, width), rng=random.Random(seed)).to(device)
         else:
@@ -220,10 +219,8 @@ class StableDiffusionFullAdapterPipelineFastTests(AdapterTests, PipelineTesterMi
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
-        assert image.shape == (1, 128, 128, 3)
-        expected_slice = np.array(
-            [0.27978146, 0.36439905, 0.3206715, 0.29253614, 0.36390454, 0.3165658, 0.4384598, 0.43083128, 0.38120443]
-        )
+        assert image.shape == (1, 64, 64, 3)
+        expected_slice = np.array([0.4858, 0.5500, 0.4278, 0.4669, 0.6184, 0.4322, 0.5010, 0.5033, 0.4746])
         assert np.abs(image_slice.flatten() - expected_slice).max() < 5e-3
 
 
@@ -242,10 +239,8 @@ class StableDiffusionLightAdapterPipelineFastTests(AdapterTests, PipelineTesterM
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
-        assert image.shape == (1, 128, 128, 3)
-        expected_slice = np.array(
-            [0.27612323, 0.3632322, 0.31936637, 0.2896598, 0.3640582, 0.31550938, 0.438073, 0.43133593, 0.38108835]
-        )
+        assert image.shape == (1, 64, 64, 3)
+        expected_slice = np.array([0.4965, 0.5548, 0.4330, 0.4771, 0.6226, 0.4382, 0.5037, 0.5071, 0.4782])
         assert np.abs(image_slice.flatten() - expected_slice).max() < 5e-3
 
 
@@ -253,7 +248,7 @@ class StableDiffusionMultiAdapterPipelineFastTests(AdapterTests, PipelineTesterM
     def get_dummy_components(self):
         return super().get_dummy_components("multi_adapter")
 
-    def get_dummy_inputs(self, device, height=128, width=128, seed=0):
+    def get_dummy_inputs(self, device, height=64, width=64, seed=0):
         inputs = super().get_dummy_inputs(device, seed, height=height, width=width, num_images=2)
         inputs["adapter_conditioning_scale"] = [0.5, 0.5]
         return inputs
@@ -269,10 +264,8 @@ class StableDiffusionMultiAdapterPipelineFastTests(AdapterTests, PipelineTesterM
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
-        assert image.shape == (1, 128, 128, 3)
-        expected_slice = np.array(
-            [0.27745497, 0.36333847, 0.32152444, 0.29158655, 0.3639205, 0.31645983, 0.4382596, 0.43064785, 0.3810274]
-        )
+        assert image.shape == (1, 64, 64, 3)
+        expected_slice = np.array([0.4902, 0.5539, 0.4317, 0.4682, 0.6190, 0.4351, 0.5018, 0.5046, 0.4772])
         assert np.abs(image_slice.flatten() - expected_slice).max() < 5e-3
 
     def test_inference_batch_consistent(

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_adapter.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_adapter.py
@@ -18,7 +18,6 @@ import random
 import unittest
 
 import numpy as np
-from parameterized import parameterized
 import torch
 from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
@@ -138,6 +137,93 @@ class AdapterTests:
         }
         return components
 
+    def get_dummy_components_with_full_downscaling(self, adapter_type):
+        """Get dummy components with x8 VAE downscaling and 4 UNet down blocks.
+        These dummy components are intended to fully-exercise the T2I-Adapter
+        downscaling behavior.
+        """
+        torch.manual_seed(0)
+        unet = UNet2DConditionModel(
+            block_out_channels=(32, 32, 32, 64),
+            layers_per_block=2,
+            sample_size=32,
+            in_channels=4,
+            out_channels=4,
+            down_block_types=("CrossAttnDownBlock2D", "CrossAttnDownBlock2D", "CrossAttnDownBlock2D", "DownBlock2D"),
+            up_block_types=("UpBlock2D", "CrossAttnUpBlock2D", "CrossAttnUpBlock2D", "CrossAttnUpBlock2D"),
+            cross_attention_dim=32,
+        )
+        scheduler = PNDMScheduler(skip_prk_steps=True)
+        torch.manual_seed(0)
+        vae = AutoencoderKL(
+            block_out_channels=[32, 32, 32, 64],
+            in_channels=3,
+            out_channels=3,
+            down_block_types=["DownEncoderBlock2D", "DownEncoderBlock2D", "DownEncoderBlock2D", "DownEncoderBlock2D"],
+            up_block_types=["UpDecoderBlock2D", "UpDecoderBlock2D", "UpDecoderBlock2D", "UpDecoderBlock2D"],
+            latent_channels=4,
+        )
+        torch.manual_seed(0)
+        text_encoder_config = CLIPTextConfig(
+            bos_token_id=0,
+            eos_token_id=2,
+            hidden_size=32,
+            intermediate_size=37,
+            layer_norm_eps=1e-05,
+            num_attention_heads=4,
+            num_hidden_layers=5,
+            pad_token_id=1,
+            vocab_size=1000,
+        )
+        text_encoder = CLIPTextModel(text_encoder_config)
+        tokenizer = CLIPTokenizer.from_pretrained("hf-internal-testing/tiny-random-clip")
+
+        torch.manual_seed(0)
+
+        if adapter_type == "full_adapter" or adapter_type == "light_adapter":
+            adapter = T2IAdapter(
+                in_channels=3,
+                channels=[32, 32, 32, 64],
+                num_res_blocks=2,
+                downscale_factor=8,
+                adapter_type=adapter_type,
+            )
+        elif adapter_type == "multi_adapter":
+            adapter = MultiAdapter(
+                [
+                    T2IAdapter(
+                        in_channels=3,
+                        channels=[32, 32, 32, 64],
+                        num_res_blocks=2,
+                        downscale_factor=8,
+                        adapter_type="full_adapter",
+                    ),
+                    T2IAdapter(
+                        in_channels=3,
+                        channels=[32, 32, 32, 64],
+                        num_res_blocks=2,
+                        downscale_factor=8,
+                        adapter_type="full_adapter",
+                    ),
+                ]
+            )
+        else:
+            raise ValueError(
+                f"Unknown adapter type: {adapter_type}, must be one of 'full_adapter', 'light_adapter', or 'multi_adapter''"
+            )
+
+        components = {
+            "adapter": adapter,
+            "unet": unet,
+            "scheduler": scheduler,
+            "vae": vae,
+            "text_encoder": text_encoder,
+            "tokenizer": tokenizer,
+            "safety_checker": None,
+            "feature_extractor": None,
+        }
+        return components
+
     def get_dummy_inputs(self, device, seed=0, height=64, width=64, num_images=1):
         if num_images == 1:
             image = floats_tensor((1, 3, height, width), rng=random.Random(seed)).to(device)
@@ -173,14 +259,13 @@ class AdapterTests:
     def test_inference_batch_single_identical(self):
         self._test_inference_batch_single_identical(expected_max_diff=2e-3)
 
-
     def test_image_dimensions(self):
         """Test that the T2I-Adapter pipeline supports any input dimension that
         is divisible by the adapter's `downscale_factor`. This test was added in
         response to an issue where the T2I Adapter's downscaling padding
         behavior did not match the UNet's behavior.
         """
-        components = self.get_dummy_components()
+        components = self.get_dummy_components_with_full_downscaling()
         sd_pipe = StableDiffusionAdapterPipeline(**components)
         sd_pipe = sd_pipe.to(torch_device)
         sd_pipe.set_progress_bar_config(disable=None)
@@ -208,6 +293,9 @@ class StableDiffusionFullAdapterPipelineFastTests(AdapterTests, PipelineTesterMi
     def get_dummy_components(self):
         return super().get_dummy_components("full_adapter")
 
+    def get_dummy_components_with_full_downscaling(self):
+        return super().get_dummy_components_with_full_downscaling("full_adapter")
+
     def test_stable_diffusion_adapter_default_case(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
         components = self.get_dummy_components()
@@ -228,6 +316,9 @@ class StableDiffusionLightAdapterPipelineFastTests(AdapterTests, PipelineTesterM
     def get_dummy_components(self):
         return super().get_dummy_components("light_adapter")
 
+    def get_dummy_components_with_full_downscaling(self):
+        return super().get_dummy_components_with_full_downscaling("light_adapter")
+
     def test_stable_diffusion_adapter_default_case(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
         components = self.get_dummy_components()
@@ -247,6 +338,9 @@ class StableDiffusionLightAdapterPipelineFastTests(AdapterTests, PipelineTesterM
 class StableDiffusionMultiAdapterPipelineFastTests(AdapterTests, PipelineTesterMixin, unittest.TestCase):
     def get_dummy_components(self):
         return super().get_dummy_components("multi_adapter")
+
+    def get_dummy_components_with_full_downscaling(self):
+        return super().get_dummy_components_with_full_downscaling("multi_adapter")
 
     def get_dummy_inputs(self, device, height=64, width=64, seed=0):
         inputs = super().get_dummy_inputs(device, seed, height=height, width=width, num_images=2)

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_adapter.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_adapter.py
@@ -137,11 +137,13 @@ class AdapterTests:
         }
         return components
 
-    def get_dummy_inputs(self, device, seed=0, num_images=1):
+    def get_dummy_inputs(self, device, seed=0, height=64, width=64, num_images=1):
         if num_images == 1:
-            image = floats_tensor((1, 3, 64, 64), rng=random.Random(seed)).to(device)
+            image = floats_tensor((1, 3, height, width), rng=random.Random(seed)).to(device)
         else:
-            image = [floats_tensor((1, 3, 64, 64), rng=random.Random(seed)).to(device) for _ in range(num_images)]
+            image = [
+                floats_tensor((1, 3, height, width), rng=random.Random(seed)).to(device) for _ in range(num_images)
+            ]
 
         if str(device).startswith("mps"):
             generator = torch.manual_seed(seed)
@@ -215,8 +217,8 @@ class StableDiffusionMultiAdapterPipelineFastTests(AdapterTests, PipelineTesterM
     def get_dummy_components(self):
         return super().get_dummy_components("multi_adapter")
 
-    def get_dummy_inputs(self, device, seed=0):
-        inputs = super().get_dummy_inputs(device, seed, num_images=2)
+    def get_dummy_inputs(self, device, height=64, width=64, seed=0):
+        inputs = super().get_dummy_inputs(device, seed, height=height, width=width, num_images=2)
         inputs["adapter_conditioning_scale"] = [0.5, 0.5]
         return inputs
 

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_adapter.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_adapter.py
@@ -19,6 +19,7 @@ import unittest
 
 import numpy as np
 import torch
+from parameterized import parameterized
 from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
 import diffusers
@@ -259,34 +260,36 @@ class AdapterTests:
     def test_inference_batch_single_identical(self):
         self._test_inference_batch_single_identical(expected_max_diff=2e-3)
 
-    def test_image_dimensions(self):
+    @parameterized.expand(
+        [
+            # (dim=264) The internal feature map will be 33x33 after initial pixel unshuffling (downscaled x8).
+            ((4 * 8 + 1) * 8),
+            # (dim=272) The internal feature map will be 17x17 after the first T2I down block (downscaled x16).
+            ((4 * 4 + 1) * 16),
+            # (dim=288) The internal feature map will be 9x9 after the second T2I down block (downscaled x32).
+            ((4 * 2 + 1) * 32),
+            # (dim=320) The internal feature map will be 5x5 after the third T2I down block (downscaled x64).
+            ((4 * 1 + 1) * 64),
+        ]
+    )
+    def test_multiple_image_dimensions(self, dim):
         """Test that the T2I-Adapter pipeline supports any input dimension that
         is divisible by the adapter's `downscale_factor`. This test was added in
         response to an issue where the T2I Adapter's downscaling padding
         behavior did not match the UNet's behavior.
+
+        Note that we have selected `dim` values to produce odd resolutions at
+        each downscaling level.
         """
         components = self.get_dummy_components_with_full_downscaling()
         sd_pipe = StableDiffusionAdapterPipeline(**components)
         sd_pipe = sd_pipe.to(torch_device)
         sd_pipe.set_progress_bar_config(disable=None)
 
-        # Populate a list of test_dims to test odd dimensions at every T2I down
-        # block.
-        test_dims = []
-        base_dim = 4
-        factor = components["adapter"].downscale_factor
-        total_downscale_factor = components["adapter"].total_downscale_factor
-        while factor <= total_downscale_factor:
-            # Add a test dimension such that the internal T2I feature map will
-            # have an odd shape after downscaling by `factor`.
-            test_dims.append((base_dim * total_downscale_factor // factor + 1) * factor)
-            factor *= 2
+        inputs = self.get_dummy_inputs(torch_device, height=dim, width=dim)
+        image = sd_pipe(**inputs).images
 
-        for dim in test_dims:
-            inputs = self.get_dummy_inputs(torch_device, height=dim, width=dim)
-            image = sd_pipe(**inputs).images
-
-            assert image.shape == (1, dim, dim, 3)
+        assert image.shape == (1, dim, dim, 3)
 
 
 class StableDiffusionFullAdapterPipelineFastTests(AdapterTests, PipelineTesterMixin, unittest.TestCase):

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
@@ -292,34 +292,32 @@ class StableDiffusionXLAdapterPipelineFastTests(PipelineTesterMixin, unittest.Te
         )
         assert np.abs(image_slice.flatten() - expected_slice).max() < 5e-3
 
-    def test_image_dimensions(self):
+    @parameterized.expand(
+        [
+            # (dim=144) The internal feature map will be 9x9 after initial pixel unshuffling (downscaled x16).
+            ((4 * 2 + 1) * 16),
+            # (dim=160) The internal feature map will be 5x5 after the first T2I down block (downscaled x32).
+            ((4 * 1 + 1) * 32),
+        ]
+    )
+    def test_multiple_image_dimensions(self, dim):
         """Test that the T2I-Adapter pipeline supports any input dimension that
         is divisible by the adapter's `downscale_factor`. This test was added in
         response to an issue where the T2I Adapter's downscaling padding
         behavior did not match the UNet's behavior.
+
+        Note that we have selected `dim` values to produce odd resolutions at
+        each downscaling level.
         """
         components = self.get_dummy_components_with_full_downscaling()
         sd_pipe = StableDiffusionXLAdapterPipeline(**components)
         sd_pipe = sd_pipe.to(torch_device)
         sd_pipe.set_progress_bar_config(disable=None)
 
-        # Populate a list of test_dims to test odd dimensions at every T2I down
-        # block.
-        test_dims = []
-        base_dim = 4
-        factor = components["adapter"].downscale_factor
-        total_downscale_factor = components["adapter"].total_downscale_factor
-        while factor <= total_downscale_factor:
-            # Add a test dimension such that the internal T2I feature map will
-            # have an odd shape after downscaling by `factor`.
-            test_dims.append((base_dim * total_downscale_factor // factor + 1) * factor)
-            factor *= 2
+        inputs = self.get_dummy_inputs(torch_device, height=dim, width=dim)
+        image = sd_pipe(**inputs).images
 
-        for dim in test_dims:
-            inputs = self.get_dummy_inputs(torch_device, height=dim, width=dim)
-            image = sd_pipe(**inputs).images
-
-            assert image.shape == (1, dim, dim, 3)
+        assert image.shape == (1, dim, dim, 3)
 
     @parameterized.expand(["full_adapter", "full_adapter_xl", "light_adapter"])
     def test_total_downscale_factor(self, adapter_type):

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
@@ -187,6 +187,35 @@ class StableDiffusionXLAdapterPipelineFastTests(PipelineTesterMixin, unittest.Te
         )
         assert np.abs(image_slice.flatten() - expected_slice).max() < 5e-3
 
+    def test_image_dimensions(self):
+        """Test that the T2I-Adapter pipeline supports any input dimension that
+        is divisible by the adapter's `downscale_factor`. This test was added in
+        response to an issue where the T2I Adapter's downscaling padding
+        behavior did not match the UNet's behavior.
+        """
+        components = self.get_dummy_components()
+        sd_pipe = StableDiffusionXLAdapterPipeline(**components)
+        sd_pipe = sd_pipe.to(torch_device)
+        sd_pipe.set_progress_bar_config(disable=None)
+
+        # Populate a list of test_dims to test odd dimensions at every T2I down
+        # block.
+        test_dims = []
+        base_dim = 4
+        factor = components["adapter"].downscale_factor
+        total_downscale_factor = components["adapter"].total_downscale_factor
+        while factor <= total_downscale_factor:
+            # Add a test dimension such that the internal T2I feature map will
+            # have an odd shape after downscaling by `factor`.
+            test_dims.append((base_dim * total_downscale_factor // factor + 1) * factor)
+            factor *= 2
+
+        for dim in test_dims:
+            inputs = self.get_dummy_inputs(torch_device, height=dim, width=dim)
+            image = sd_pipe(**inputs).images
+
+            assert image.shape == (1, dim, dim, 3)
+
     @parameterized.expand(["full_adapter", "full_adapter_xl", "light_adapter"])
     def test_total_downscale_factor(self, adapter_type):
         """Test that the T2IAdapter correctly reports its total_downscale_factor."""

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
@@ -147,11 +147,13 @@ class StableDiffusionXLAdapterPipelineFastTests(PipelineTesterMixin, unittest.Te
         }
         return components
 
-    def get_dummy_inputs(self, device, seed=0, num_images=1):
+    def get_dummy_inputs(self, device, seed=0, height=64, width=64, num_images=1):
         if num_images == 1:
-            image = floats_tensor((1, 3, 64, 64), rng=random.Random(seed)).to(device)
+            image = floats_tensor((1, 3, height, width), rng=random.Random(seed)).to(device)
         else:
-            image = [floats_tensor((1, 3, 64, 64), rng=random.Random(seed)).to(device) for _ in range(num_images)]
+            image = [
+                floats_tensor((1, 3, height, width), rng=random.Random(seed)).to(device) for _ in range(num_images)
+            ]
 
         if str(device).startswith("mps"):
             generator = torch.manual_seed(seed)
@@ -222,8 +224,8 @@ class StableDiffusionXLMultiAdapterPipelineFastTests(
     def get_dummy_components(self):
         return super().get_dummy_components("multi_adapter")
 
-    def get_dummy_inputs(self, device, seed=0):
-        inputs = super().get_dummy_inputs(device, seed, num_images=2)
+    def get_dummy_inputs(self, device, seed=0, height=64, width=64):
+        inputs = super().get_dummy_inputs(device, seed, height, width, num_images=2)
         inputs["adapter_conditioning_scale"] = [0.5, 0.5]
         return inputs
 

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
@@ -48,20 +48,19 @@ class StableDiffusionXLAdapterPipelineFastTests(PipelineTesterMixin, unittest.Te
     def get_dummy_components(self, adapter_type="full_adapter_xl"):
         torch.manual_seed(0)
         unet = UNet2DConditionModel(
-            block_out_channels=(32, 32, 64),
+            block_out_channels=(32, 64),
             layers_per_block=2,
             sample_size=32,
             in_channels=4,
             out_channels=4,
-            # Test with all 3 down blocks to ensure that the T2I-Adapter downscaling gets fully exercised in the tests.
-            down_block_types=("DownBlock2D", "CrossAttnDownBlock2D", "CrossAttnDownBlock2D"),
-            up_block_types=("CrossAttnUpBlock2D", "CrossAttnUpBlock2D", "UpBlock2D"),
+            down_block_types=("DownBlock2D", "CrossAttnDownBlock2D"),
+            up_block_types=("CrossAttnUpBlock2D", "UpBlock2D"),
             # SD2-specific config below
-            attention_head_dim=2,
+            attention_head_dim=(2, 4),
             use_linear_projection=True,
             addition_embed_type="text_time",
             addition_time_embed_dim=8,
-            transformer_layers_per_block=1,
+            transformer_layers_per_block=(1, 2),
             projection_class_embeddings_input_dim=80,  # 6 * 8 + 32
             cross_attention_dim=64,
         )
@@ -74,11 +73,11 @@ class StableDiffusionXLAdapterPipelineFastTests(PipelineTesterMixin, unittest.Te
         )
         torch.manual_seed(0)
         vae = AutoencoderKL(
-            block_out_channels=[32, 32, 32, 64],
+            block_out_channels=[32, 64],
             in_channels=3,
             out_channels=3,
-            down_block_types=["DownEncoderBlock2D", "DownEncoderBlock2D", "DownEncoderBlock2D", "DownEncoderBlock2D"],
-            up_block_types=["UpDecoderBlock2D", "UpDecoderBlock2D", "UpDecoderBlock2D", "UpDecoderBlock2D"],
+            down_block_types=["DownEncoderBlock2D", "DownEncoderBlock2D"],
+            up_block_types=["UpDecoderBlock2D", "UpDecoderBlock2D"],
             latent_channels=4,
             sample_size=128,
         )
@@ -105,9 +104,9 @@ class StableDiffusionXLAdapterPipelineFastTests(PipelineTesterMixin, unittest.Te
         if adapter_type == "full_adapter_xl":
             adapter = T2IAdapter(
                 in_channels=3,
-                channels=[32, 32, 64],
+                channels=[32, 64],
                 num_res_blocks=2,
-                downscale_factor=16,
+                downscale_factor=4,
                 adapter_type=adapter_type,
             )
         elif adapter_type == "multi_adapter":
@@ -115,16 +114,16 @@ class StableDiffusionXLAdapterPipelineFastTests(PipelineTesterMixin, unittest.Te
                 [
                     T2IAdapter(
                         in_channels=3,
-                        channels=[32, 32, 64],
+                        channels=[32, 64],
                         num_res_blocks=2,
-                        downscale_factor=16,
+                        downscale_factor=4,
                         adapter_type="full_adapter_xl",
                     ),
                     T2IAdapter(
                         in_channels=3,
-                        channels=[32, 32, 64],
+                        channels=[32, 64],
                         num_res_blocks=2,
-                        downscale_factor=16,
+                        downscale_factor=4,
                         adapter_type="full_adapter_xl",
                     ),
                 ]
@@ -183,7 +182,7 @@ class StableDiffusionXLAdapterPipelineFastTests(PipelineTesterMixin, unittest.Te
 
         assert image.shape == (1, 64, 64, 3)
         expected_slice = np.array(
-            [0.54066867, 0.5574119, 0.47273698, 0.62617165, 0.576637, 0.50059223, 0.5860178, 0.5637511, 0.5143911]
+            [0.5752919, 0.6022097, 0.4728038, 0.49861962, 0.57084894, 0.4644975, 0.5193715, 0.5133664, 0.4729858]
         )
         assert np.abs(image_slice.flatten() - expected_slice).max() < 5e-3
 
@@ -272,7 +271,7 @@ class StableDiffusionXLMultiAdapterPipelineFastTests(
 
         assert image.shape == (1, 64, 64, 3)
         expected_slice = np.array(
-            [0.54532427, 0.5617021, 0.46638602, 0.6338569, 0.5826053, 0.5019801, 0.59624064, 0.5663944, 0.5151665]
+            [0.5813032, 0.60995954, 0.47563356, 0.5056669, 0.57199144, 0.4631841, 0.5176794, 0.51252556, 0.47183886]
         )
         assert np.abs(image_slice.flatten() - expected_slice).max() < 5e-3
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #5377 

This PR updates the padding behavior of the T2I-Adapter down blocks to more closely mirror the padding behavior of the UNet model.

Prior to this change, the T2I-Adapter pipelines only worked with input/output image dimensions that were multiples of the T2I-Adapter's total downscale factor (64 for SD1 and 32 for SDXL). After this change, the same pipelines can be run with input/output dimensions that are multiples of the T2I-Adapter's initial pixel unshuffling downscale factor (8 for SD1 and 16 for SDXL).

# Manual Testing

The change is covered by unit tests, but the following script can be used as a visual regression test for this feature. This script is adapted from [this comment on the original issue](https://github.com/huggingface/diffusers/issues/5377#issuecomment-1764510314).

```python
import torch
from PIL import Image
from controlnet_aux import PidiNetDetector
import numpy as np
from diffusers import T2IAdapter, StableDiffusionAdapterPipeline

in_dims = (680, 384)
#in_dims = (640, 384)

image = Image.open("dog.png")
processor = PidiNetDetector.from_pretrained("lllyasviel/Annotators")
sketch_image = processor(image).resize(in_dims).convert("L")
tensor_img = (torch.from_numpy(np.array(sketch_image).astype(np.float32) / 255.0) > 0.5).float()
sketch_image = tensor_img.numpy()
sketch_image = (sketch_image * 255).astype(np.uint8)
sketch_image = Image.fromarray(sketch_image)
sketch_image.save("sketch.png")
adapter = T2IAdapter.from_pretrained("TencentARC/t2iadapter_sketch_sd15v2", torch_dtype=torch.float16)
pipe = StableDiffusionAdapterPipeline.from_pretrained(
    "runwayml/stable-diffusion-v1-5", adapter=adapter, safety_checker=None, torch_dtype=torch.float16, variant="fp16"
)
pipe.to("cuda")
generator = torch.Generator().manual_seed(0)
sketch_image_out = pipe(prompt="a dog", image=sketch_image, generator=generator).images[0]
sketch_image_out.save("sketch_image_out.png")

print(f"In dims: {in_dims}, Out dims: {(sketch_image_out.width, sketch_image_out.height)}")
```

Input `dog.png`:
![image](https://github.com/huggingface/diffusers/assets/14897797/9701ed4e-c312-4589-ab3d-d9516cd50d5f)

## Before this change, `in_dims=(680, 384)`

Note that output dimensions do not match input dimensions.
`In dims: (680, 384), Out dims: (640, 384)`
![image](https://github.com/huggingface/diffusers/assets/14897797/1f5c2b04-8261-4060-a053-32ead9872375)

## Before this change, `in_dims=(640, 384)`
`In dims: (640, 384), Out dims: (640, 384)`
![image](https://github.com/huggingface/diffusers/assets/14897797/898037b1-2f6d-440b-9d86-f8ad53dab762)

## After this change, `in_dims=(680, 384)`

The output dimensions match the input dimensions, as expected. The change in the output's appearance is expected, because the latent dimension has changed, so the same random seed no longer produces the same noise.
`In dims: (680, 384), Out dims: (680, 384)`

![image](https://github.com/huggingface/diffusers/assets/14897797/b6cc7538-bced-4e47-a70f-36567595b1f7)

## After this change, `in_dims=(640, 384)`

The output image for dimensions that already 'worked' is identical to before the change.
`In dims: (640, 384), Out dims: (640, 384)`

![image](https://github.com/huggingface/diffusers/assets/14897797/2259ffc1-bea2-4c0a-a190-bdd09887c7d1)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @williamberman and @patrickvonplaten
- Pipelines:  @patrickvonplaten and @sayakpaul
- Training examples: @sayakpaul and @patrickvonplaten
- Docs: @stevhliu and @yiyixuxu
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @patrickvonplaten and @sayakpaul

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
