### PR TITLE
[docs] Train Controlnet SDXL - Add example command to train model on 24GB GPU

### DIFF
--- a/examples/controlnet/README_sdxl.md
+++ b/examples/controlnet/README_sdxl.md
@@ -89,24 +89,25 @@ To better track our training experiments, we're using the following flags in the
 
 Our experiments were conducted on a single 40GB A100 GPU.
 
-To train this model in a 24GB memory space we will need to lower the resolution to 512 and raise the gradient_accumulation_steps to 8
-
+To train this model in a 24GB memory space we will need to lower the resolution to 512 and use `gradient_checkpointing`
 ```
-accelerate launch train_controlnet_sdxl.py\
- --pretrained_model_name_or_path=$MODEL_DIR\
- --dataset_name=fusing/fill50k\
- --mixed_precision="fp16"\
- --resolution=512\
- --learning_rate=1e-5\
- --max_train_steps=15000\
- --validation_image "./conditioning_image_1.png" "./conditioning_image_2.png"\
- --validation_prompt "red circle with blue background" "cyan circle with brown floral background"\
- --validation_steps=100\
- --train_batch_size=1\
- --gradient_accumulation_steps=4\
- --report_to="wandb"\
- --seed=1337\
- --push_to_hub
+accelerate launch train_controlnet_sdxl.py \
+ --pretrained_model_name_or_path=$MODEL_DIR \
+ --output_dir=$OUTPUT_DIR \
+ --dataset_name=fusing/fill50k \
+ --mixed_precision="fp16" \
+ --resolution=512 \
+ --learning_rate=1e-5 \
+ --max_train_steps=15000 \
+ --validation_image "./conditioning_image_1.png" "./conditioning_image_2.png" \
+ --validation_prompt "red circle with blue background" "cyan circle with brown floral background" \
+ --validation_steps=100 \
+ --train_batch_size=1 \
+ --gradient_accumulation_steps=1 \
+ --report_to="wandb" \
+ --seed=1337 \
+ --push_to_hub \
+ --gradient_checkpointing
 ```
 
 ### Inference

--- a/examples/controlnet/README_sdxl.md
+++ b/examples/controlnet/README_sdxl.md
@@ -89,6 +89,26 @@ To better track our training experiments, we're using the following flags in the
 
 Our experiments were conducted on a single 40GB A100 GPU.
 
+To train this model in a 24GB memory space we will need to lower the resolution to 512 and raise the gradient_accumulation_steps to 8
+
+```
+accelerate launch train_controlnet_sdxl.py\
+ --pretrained_model_name_or_path=$MODEL_DIR\
+ --dataset_name=fusing/fill50k\
+ --mixed_precision="fp16"\
+ --resolution=512\
+ --learning_rate=1e-5\
+ --max_train_steps=15000\
+ --validation_image "./conditioning_image_1.png" "./conditioning_image_2.png"\
+ --validation_prompt "red circle with blue background" "cyan circle with brown floral background"\
+ --validation_steps=100\
+ --train_batch_size=1\
+ --gradient_accumulation_steps=4\
+ --report_to="wandb"\
+ --seed=1337\
+ --push_to_hub
+```
+
 ### Inference
 
 Once training is done, we can perform inference like so:


### PR DESCRIPTION
# What does this PR do?

Adding an example command to help outline how to train a controlnet on a 24GB GPU if the user does not have access to a 40GB A100

Happy to change verbiage/ close if not valuable but this is what worked for me running on a single 4090 going through this readme

https://wandb.ai/mdcurrent/sd_xl_train_controlnet/runs/tt9m4vhp/overview is the run using this command

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

- Docs: @stevhliu and @yiyixuxu - if this is the wrong team to send it to happy to tag contributors to this file