### PR TITLE
ControNet Inpainting: use masked_image to create initial latents

### DIFF
--- a/src/diffusers/models/controlnet.py
+++ b/src/diffusers/models/controlnet.py
@@ -809,6 +809,7 @@ class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlnetMixin):
         mid_block_res_sample = self.controlnet_mid_block(sample)
 
         # 6. scaling
+        print(f" self.config.global_pool_conditions: {self.config.global_pool_conditions}")
         if guess_mode and not self.config.global_pool_conditions:
             scales = torch.logspace(-1, 0, len(down_block_res_samples) + 1, device=sample.device)  # 0.1 to 1.0
 
@@ -816,6 +817,7 @@ class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlnetMixin):
             down_block_res_samples = [sample * scale for sample, scale in zip(down_block_res_samples, scales)]
             mid_block_res_sample = mid_block_res_sample * scales[-1]  # last one
         else:
+            print(f" conditioning_scale: {conditioning_scale}")
             down_block_res_samples = [sample * conditioning_scale for sample in down_block_res_samples]
             mid_block_res_sample = mid_block_res_sample * conditioning_scale
 

--- a/src/diffusers/models/controlnet.py
+++ b/src/diffusers/models/controlnet.py
@@ -809,7 +809,6 @@ class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlnetMixin):
         mid_block_res_sample = self.controlnet_mid_block(sample)
 
         # 6. scaling
-        print(f" self.config.global_pool_conditions: {self.config.global_pool_conditions}")
         if guess_mode and not self.config.global_pool_conditions:
             scales = torch.logspace(-1, 0, len(down_block_res_samples) + 1, device=sample.device)  # 0.1 to 1.0
 
@@ -817,7 +816,6 @@ class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlnetMixin):
             down_block_res_samples = [sample * scale for sample, scale in zip(down_block_res_samples, scales)]
             mid_block_res_sample = mid_block_res_sample * scales[-1]  # last one
         else:
-            print(f" conditioning_scale: {conditioning_scale}")
             down_block_res_samples = [sample * conditioning_scale for sample in down_block_res_samples]
             mid_block_res_sample = mid_block_res_sample * conditioning_scale
 

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
@@ -1241,6 +1241,7 @@ class StableDiffusionControlNetInpaintPipeline(
         num_channels_latents = self.vae.config.latent_channels
         num_channels_unet = self.unet.config.in_channels
         return_image_latents = num_channels_unet == 4
+        
         if num_channels_unet == 4 and masked_content == "blank":
             init_image = masked_image_latents.chunk(2)[0]
 

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
@@ -982,7 +982,7 @@ class StableDiffusionControlNetInpaintPipeline(
         control_guidance_start: Union[float, List[float]] = 0.0,
         control_guidance_end: Union[float, List[float]] = 1.0,
         clip_skip: Optional[int] = None,
-        masked_content="original",  # original, blank
+        masked_content="original",  # original, blank, fill
     ):
         r"""
         The call function to the pipeline for generation.
@@ -1204,6 +1204,8 @@ class StableDiffusionControlNetInpaintPipeline(
             assert False
 
         # 4. Preprocess mask and image - resizes image and mask w.r.t height and width
+        if masked_content == "fill":
+            image = self.image_processor.fill_mask(image, mask_image)
         init_image = self.image_processor.preprocess(image, height=height, width=width)
         init_image = init_image.to(dtype=torch.float32)
 

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
@@ -982,7 +982,7 @@ class StableDiffusionControlNetInpaintPipeline(
         control_guidance_start: Union[float, List[float]] = 0.0,
         control_guidance_end: Union[float, List[float]] = 1.0,
         clip_skip: Optional[int] = None,
-        use_masked_image_as_init=True,
+        masked_content="original",  # original, blank
     ):
         r"""
         The call function to the pipeline for generation.
@@ -1078,6 +1078,13 @@ class StableDiffusionControlNetInpaintPipeline(
             clip_skip (`int`, *optional*):
                 Number of layers to be skipped from CLIP while computing the prompt embeddings. A value of 1 means that
                 the output of the pre-final layer will be used for computing the prompt embeddings.
+            masked_content(`str`, *optional*, defaults to `"original"`):
+                This option determines how the masked content on the original image would affect the generation
+                process. Choose from `"original"` or `"blank"`. If `"original"`, the entire image will be used to
+                create the initial latent, therefore the maksed content in will influence the result. If `"blank"`, the
+                masked image will be used to create initial latent, therefore the masked content will not have any
+                influence on the results. This option is only applicable when you use inpainting pipeline with
+                text-to-image Unet Model.
 
         Examples:
 
@@ -1232,7 +1239,7 @@ class StableDiffusionControlNetInpaintPipeline(
         num_channels_latents = self.vae.config.latent_channels
         num_channels_unet = self.unet.config.in_channels
         return_image_latents = num_channels_unet == 4
-        if num_channels_unet == 4 and not use_masked_image_as_init:
+        if num_channels_unet == 4 and masked_content == "blank":
             init_image = masked_image_latents.chunk(2)[0]
 
         latents_outputs = self.prepare_latents(

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
@@ -982,7 +982,7 @@ class StableDiffusionControlNetInpaintPipeline(
         control_guidance_start: Union[float, List[float]] = 0.0,
         control_guidance_end: Union[float, List[float]] = 1.0,
         clip_skip: Optional[int] = None,
-        masked_content="original",  # original, blank, fill
+        masked_content: str = "original",  # original, blank, fill
     ):
         r"""
         The call function to the pipeline for generation.
@@ -1241,7 +1241,7 @@ class StableDiffusionControlNetInpaintPipeline(
         num_channels_latents = self.vae.config.latent_channels
         num_channels_unet = self.unet.config.in_channels
         return_image_latents = num_channels_unet == 4
-        
+
         if num_channels_unet == 4 and masked_content == "blank":
             init_image = masked_image_latents.chunk(2)[0]
 

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
@@ -1232,11 +1232,8 @@ class StableDiffusionControlNetInpaintPipeline(
         num_channels_latents = self.vae.config.latent_channels
         num_channels_unet = self.unet.config.in_channels
         return_image_latents = num_channels_unet == 4
-        init_image = (
-            masked_image_latents.chunk(2)[0]
-            if num_channels_unet == 4 and not use_masked_image_as_init
-            else init_image,
-        )
+        if num_channels_unet == 4 and not use_masked_image_as_init:
+            init_image = masked_image_latents.chunk(2)[0]
 
         latents_outputs = self.prepare_latents(
             batch_size * num_images_per_prompt,

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
@@ -1138,6 +1138,7 @@ class StableDiffusionControlNetInpaintPipeline(
             else controlnet.nets[0].config.global_pool_conditions
         )
         guess_mode = guess_mode or global_pool_conditions
+        print(f" guess_mode: {guess_mode}")
 
         # 3. Encode input prompt
         text_encoder_lora_scale = (
@@ -1343,6 +1344,7 @@ class StableDiffusionControlNetInpaintPipeline(
                         )
 
                     latents = (1 - init_mask) * init_latents_proper + init_mask * latents
+                    print(f" init_mask: {init_mask.shape}, {init_mask.abs().sum()}")
 
                 # call the callback, if provided
                 if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
@@ -976,6 +976,7 @@ class StableDiffusionXLControlNetInpaintPipeline(
         aesthetic_score: float = 6.0,
         negative_aesthetic_score: float = 2.5,
         clip_skip: Optional[int] = None,
+        masked_content="original",  # original, blank
     ):
         r"""
         Function invoked when calling the pipeline for generation.
@@ -1105,6 +1106,13 @@ class StableDiffusionXLControlNetInpaintPipeline(
             clip_skip (`int`, *optional*):
                 Number of layers to be skipped from CLIP while computing the prompt embeddings. A value of 1 means that
                 the output of the pre-final layer will be used for computing the prompt embeddings.
+            masked_content(`str`, *optional*, defaults to `"original"`):
+                This option determines how the masked content on the original image would affect the generation
+                process. Choose from `"original"` or `"blank"`. If `"original"`, the entire image will be used to
+                create the initial latent, therefore the maksed content in will influence the result. If `"blank"`, the
+                masked image will be used to create initial latent, therefore the masked content will not have any
+                influence on the results. This option is only applicable when you use inpainting pipeline with
+                text-to-image Unet Model.
 
         Examples:
 
@@ -1268,10 +1276,25 @@ class StableDiffusionXLControlNetInpaintPipeline(
         masked_image = init_image * (mask < 0.5)
         _, _, height, width = init_image.shape
 
+        # 7. Prepare mask latent variables
+        mask, masked_image_latents = self.prepare_mask_latents(
+            mask,
+            masked_image,
+            batch_size * num_images_per_prompt,
+            height,
+            width,
+            prompt_embeds.dtype,
+            device,
+            generator,
+            do_classifier_free_guidance,
+        )
+
         # 6. Prepare latent variables
         num_channels_latents = self.vae.config.latent_channels
         num_channels_unet = self.unet.config.in_channels
         return_image_latents = num_channels_unet == 4
+        if num_channels_unet == 4 and masked_content == "blank":
+            init_image = masked_image_latents.chunk(2)[0]
 
         add_noise = True if denoising_start is None else False
         latents_outputs = self.prepare_latents(
@@ -1295,19 +1318,6 @@ class StableDiffusionXLControlNetInpaintPipeline(
             latents, noise, image_latents = latents_outputs
         else:
             latents, noise = latents_outputs
-
-        # 7. Prepare mask latent variables
-        mask, masked_image_latents = self.prepare_mask_latents(
-            mask,
-            masked_image,
-            batch_size * num_images_per_prompt,
-            height,
-            width,
-            prompt_embeds.dtype,
-            device,
-            generator,
-            do_classifier_free_guidance,
-        )
 
         # 8. Check that sizes of mask, masked image and latents match
         if num_channels_unet == 9:

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -738,6 +738,7 @@ class StableDiffusionInpaintPipeline(
         callback_steps: int = 1,
         cross_attention_kwargs: Optional[Dict[str, Any]] = None,
         clip_skip: int = None,
+        masked_content="original",  # original, blank
     ):
         r"""
         The call function to the pipeline for generation.
@@ -813,6 +814,14 @@ class StableDiffusionInpaintPipeline(
             clip_skip (`int`, *optional*):
                 Number of layers to be skipped from CLIP while computing the prompt embeddings. A value of 1 means that
                 the output of the pre-final layer will be used for computing the prompt embeddings.
+            masked_content(`str`, *optional*, defaults to `"original"`):
+                This option determines how the masked content on the original image would affect the generation
+                process. Choose from `"original"` or `"blank"`. If `"original"`, the entire image will be used to
+                create the initial latent, therefore the maksed content in will influence the result. If `"blank"`, the
+                masked image will be used to create initial latent, therefore the masked content will not have any
+                influence on the results. This option is only applicable when you use inpainting pipeline with
+                text-to-image Unet Model.
+
         Examples:
 
         ```py
@@ -923,10 +932,33 @@ class StableDiffusionInpaintPipeline(
         init_image = self.image_processor.preprocess(image, height=height, width=width)
         init_image = init_image.to(dtype=torch.float32)
 
+        # 7. Prepare mask latent variables
+        mask_condition = self.mask_processor.preprocess(mask_image, height=height, width=width)
+
+        if masked_image_latents is None:
+            masked_image = init_image * (mask_condition < 0.5)
+        else:
+            masked_image = masked_image_latents
+
+        mask, masked_image_latents = self.prepare_mask_latents(
+            mask_condition,
+            masked_image,
+            batch_size * num_images_per_prompt,
+            height,
+            width,
+            prompt_embeds.dtype,
+            device,
+            generator,
+            do_classifier_free_guidance,
+        )
+
         # 6. Prepare latent variables
         num_channels_latents = self.vae.config.latent_channels
         num_channels_unet = self.unet.config.in_channels
         return_image_latents = num_channels_unet == 4
+
+        if num_channels_unet == 4 and masked_content == "blank":
+            init_image = masked_image_latents.chunk(2)[0]
 
         latents_outputs = self.prepare_latents(
             batch_size * num_images_per_prompt,
@@ -948,26 +980,6 @@ class StableDiffusionInpaintPipeline(
             latents, noise, image_latents = latents_outputs
         else:
             latents, noise = latents_outputs
-
-        # 7. Prepare mask latent variables
-        mask_condition = self.mask_processor.preprocess(mask_image, height=height, width=width)
-
-        if masked_image_latents is None:
-            masked_image = init_image * (mask_condition < 0.5)
-        else:
-            masked_image = masked_image_latents
-
-        mask, masked_image_latents = self.prepare_mask_latents(
-            mask_condition,
-            masked_image,
-            batch_size * num_images_per_prompt,
-            height,
-            width,
-            prompt_embeds.dtype,
-            device,
-            generator,
-            do_classifier_free_guidance,
-        )
 
         # 8. Check that sizes of mask, masked image and latents match
         if num_channels_unet == 9:

--- a/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
@@ -290,7 +290,7 @@ class ControlNetPipelineSDXLFastTests(
         output = sd_pipe(**inputs)
         image_slice = output.images[0, -3:, -3:, -1]
         expected_slice = np.array(
-            [0.5381963, 0.4836803, 0.45821992, 0.5577731, 0.51210403, 0.4794795, 0.59282357, 0.5647199, 0.43100584]
+            [0.5381064, 0.39685374, 0.4803775, 0.6868999, 0.5960682, 0.58983135, 0.59488124, 0.5560177, 0.5095338]
         )
 
         # make sure that it's equal

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_inpaint.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_inpaint.py
@@ -257,10 +257,12 @@ class StableDiffusionInpaintPipelineFastTests(
         masked_image = image * (mask < 0.5)
 
         generator = torch.Generator(device=device).manual_seed(0)
+        torch.randn((1, 4, 32, 32), generator=generator)
         image_latents = (
             sd_pipe.vae.encode(image).latent_dist.sample(generator=generator) * sd_pipe.vae.config.scaling_factor
         )
-        torch.randn((1, 4, 32, 32), generator=generator)
+
+        generator = torch.Generator(device=device).manual_seed(0)
         mask_latents = (
             sd_pipe.vae.encode(masked_image).latent_dist.sample(generator=generator)
             * sd_pipe.vae.config.scaling_factor
@@ -270,6 +272,7 @@ class StableDiffusionInpaintPipelineFastTests(
         inputs["mask_image"] = mask
         inputs["strength"] = 0.9
         generator = torch.Generator(device=device).manual_seed(0)
+        torch.randn((1, 4, 32, 32), generator=generator)
         torch.randn((1, 4, 32, 32), generator=generator)
         inputs["generator"] = generator
         out_1 = sd_pipe(**inputs).images
@@ -372,7 +375,9 @@ class StableDiffusionSimpleInpaintPipelineFastTests(StableDiffusionInpaintPipeli
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 64, 64, 3)
-        expected_slice = np.array([0.6584, 0.5424, 0.5649, 0.5449, 0.5897, 0.6111, 0.5404, 0.5463, 0.5214])
+        expected_slice = np.array(
+            [0.41372567, 0.41823727, 0.40892008, 0.5120787, 0.456928, 0.514932, 0.4214989, 0.45367384, 0.48013452]
+        )
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_inpaint.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_inpaint.py
@@ -197,7 +197,9 @@ class StableDiffusionInpaintPipelineFastTests(
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 64, 64, 3)
-        expected_slice = np.array([0.4703, 0.5697, 0.3879, 0.5470, 0.6042, 0.4413, 0.5078, 0.4728, 0.4469])
+        expected_slice = np.array(
+            [0.7116542, 0.5356421, 0.5738175, 0.5997549, 0.6192689, 0.6549013, 0.60130644, 0.57260084, 0.5453409]
+        )
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_inpaint.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_inpaint.py
@@ -139,8 +139,9 @@ class StableDiffusion2InpaintPipelineFastTests(
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 64, 64, 3)
-        expected_slice = np.array([0.4727, 0.5735, 0.3941, 0.5446, 0.5926, 0.4394, 0.5062, 0.4654, 0.4476])
-
+        expected_slice = np.array(
+            [0.71828955, 0.5354332, 0.58167696, 0.5995904, 0.6197585, 0.6600398, 0.6049546, 0.5725968, 0.54803497]
+        )
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
     def test_inference_batch_single_identical(self):

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
@@ -193,7 +193,9 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
 
         assert image.shape == (1, 64, 64, 3)
 
-        expected_slice = np.array([0.8029, 0.5523, 0.5825, 0.6003, 0.6702, 0.7018, 0.6369, 0.5955, 0.5123])
+        expected_slice = np.array(
+            [0.47297692, 0.43896025, 0.40697068, 0.45582378, 0.4125126, 0.5327985, 0.38261384, 0.47744697, 0.47403562]
+        )
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
@@ -290,7 +292,9 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
 
         assert image.shape == (1, 64, 64, 3)
 
-        expected_slice = np.array([0.7045, 0.4838, 0.5454, 0.6270, 0.6168, 0.6717, 0.6484, 0.5681, 0.4922])
+        expected_slice = np.array(
+            [0.51198494, 0.49192587, 0.414692, 0.4513318, 0.44658783, 0.5387383, 0.39105427, 0.49726686, 0.46108854]
+        )
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
@@ -547,14 +551,17 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
         masked_image = image * (mask < 0.5)
 
         generator = torch.Generator(device=device).manual_seed(0)
-        image_latents = sd_pipe._encode_vae_image(image, generator=generator)
         torch.randn((1, 4, 32, 32), generator=generator)
+        image_latents = sd_pipe._encode_vae_image(image, generator=generator)
+
+        generator = torch.Generator(device=device).manual_seed(0)
         mask_latents = sd_pipe._encode_vae_image(masked_image, generator=generator)
         inputs["image"] = image_latents
         inputs["masked_image_latents"] = mask_latents
         inputs["mask_image"] = mask
         inputs["strength"] = 0.9
         generator = torch.Generator(device=device).manual_seed(0)
+        torch.randn((1, 4, 32, 32), generator=generator)
         torch.randn((1, 4, 32, 32), generator=generator)
         inputs["generator"] = generator
         out_1 = sd_pipe(**inputs).images


### PR DESCRIPTION
In `StableDiffusionControlNetInpaintPipeline` we use entire image (including the mask area) to create the initial `latents` - This will cause the pixels in masked area to influence our generation results, and is particularly a problem when we use a `strength` value that's not `1.0`. some of the issues reported in https://github.com/huggingface/diffusers/issues/3959#issuecomment-1718362350 maybe related to this too

## testing results
I've attached the script I use for testing in this PR. In this particular example, we removed the masked area from the image and paste it over with black background. so in the input image, mask area = black

image and mask inputs for the pipeline
image           |  mask
:-------------------------:|:-------------------------:
![g_rgb](https://github.com/huggingface/diffusers/assets/12631849/d70e06bc-3267-40d5-a145-611c173dcd09) | ![g_mask](https://github.com/huggingface/diffusers/assets/12631849/c2cac05e-abe0-4dc8-b9a8-e91934319b00)

###  `strength=0.99`
 our pipeline was not able to generate new background according to the text prompt for `strength = 0.99`. See outputs below, both outputs are generated with `seed = 0` using the testing script I provided

main          | this PR
:-------------------------:|:-------------------------:
![yiyi_test_1_out_0_strength_0 99_main](https://github.com/huggingface/diffusers/assets/12631849/34a8d6db-64b6-4df1-878c-6346d2f8b158) | ![yiyi_test_1_out_0_strength_0 99_testing](https://github.com/huggingface/diffusers/assets/12631849/0be27651-f852-4bfb-9c36-4454fc345ba7) 

### `strength = 1.0`
with `strength=1.0`, the initial latent we use is pure noise. so our pipeline was able to generate new backgroun. However, because this line here https://github.com/huggingface/diffusers/blob/bc7a4d4917456afd70913be85bd25c556c25862c/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py#L1383 you can still see a lot of the black background from the input image got sneaked in the generated image and make the mask border super obvious.  In this example we used a mask that's super closely aligned to the object, I think this issue would be more obvious if the mask is less carefully draw 

main          | this PR
:-------------------------:|:-------------------------:
![yiyi_test_1_out_0_main](https://github.com/huggingface/diffusers/assets/12631849/672e9248-c1c4-46e2-af89-6b9d16abd052) | ![yiyi_test_1_out_0_testing](https://github.com/huggingface/diffusers/assets/12631849/c6fe04dc-7e0c-452d-bd14-635a26e393c1)

### fix unmasked area

in auto1111, it actually always paste the unmasked area over the generated output as final step. https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/5ef669de080814067961f28357256e8fe27544f4/modules/processing.py#L929C32-L929C32

We have a section in our doc about how to preserve the unmaksed area. But maybe we should add to the code since I found the results are significant better

https://github.com/huggingface/diffusers/blob/bc7a4d4917456afd70913be85bd25c556c25862c/docs/source/en/using-diffusers/inpaint.md?plain=1#L295 

### improved outputs with this PR
I think the outputs are consistently pretty ok ((I think these generations are of same quality as auto1111 with similar settings) when we also:
1. set `strength=0.99` 
2. fix unmasked area 

image generated using the testing script, for seed `0 ~ 9`
![yiyi_test_1_out_0_strength_0 99_fix_unmask_testing](https://github.com/huggingface/diffusers/assets/12631849/57933123-e9d5-48e3-a9a4-568bf3081462)
![yiyi_test_1_out_1_strength_0 99_fix_unmask_testing](https://github.com/huggingface/diffusers/assets/12631849/70a94dd6-4afa-413e-b0d2-10b2a07463e7)
![yiyi_test_1_out_2_strength_0 99_fix_unmask_testing](https://github.com/huggingface/diffusers/assets/12631849/dd1c2884-cc59-4916-a13d-80d66b73a297)
![yiyi_test_1_out_3_strength_0 99_fix_unmask_testing](https://github.com/huggingface/diffusers/assets/12631849/c35eefe2-da32-4304-8ec0-44b69773622f)
![yiyi_test_1_out_4_strength_0 99_fix_unmask_testing](https://github.com/huggingface/diffusers/assets/12631849/37496b58-c7c3-4402-884e-0e77e0c623ca)
![yiyi_test_1_out_5_strength_0 99_fix_unmask_testing](https://github.com/huggingface/diffusers/assets/12631849/91eb54df-03dc-405a-b239-06656e59c89f)
![yiyi_test_1_out_6_strength_0 99_fix_unmask_testing](https://github.com/huggingface/diffusers/assets/12631849/e5cc1765-775b-48ec-b0b1-7c534049a1b9)
![yiyi_test_1_out_7_strength_0 99_fix_unmask_testing](https://github.com/huggingface/diffusers/assets/12631849/13b19620-6f20-4f98-9836-2a033f32e063)
![yiyi_test_1_out_8_strength_0 99_fix_unmask_testing](https://github.com/huggingface/diffusers/assets/12631849/93ce4382-45c8-4d16-9371-c0fd53218407)
![yiyi_test_1_out_9_strength_0 99_fix_unmask_testing](https://github.com/huggingface/diffusers/assets/12631849/4d7a3bcd-2901-4886-a093-fd287e8dac56)

## testing script
```python
from diffusers import StableDiffusionControlNetInpaintPipeline, EulerAncestralDiscreteScheduler, ControlNetModel
from diffusers.utils import load_image
import torch
import PIL
from PIL import Image
import numpy as np

branch_name = "testing" # "main"/"testing"
strength = 0.95

rgba_init_image = load_image("https://huggingface.co/datasets/YiYiXu/testing-images/resolve/main/g.png")
image_mask = load_image("https://huggingface.co/datasets/YiYiXu/testing-images/resolve/main/g_mask.png")
control_image = load_image("https://huggingface.co/datasets/YiYiXu/testing-images/resolve/main/g_canny.png")

def flatten(img, bgcolor="#ffffff"):
    if img.mode == "RGBA":
        background = Image.new('RGBA', img.size, bgcolor)
        background.paste(img, mask=img)
        img = background
    return img.convert('RGB')

# create an init_image with white background
init_image = flatten(rgba_init_image)

dtype = torch.float16
controlnet_canny_model_id = "lllyasviel/sd-controlnet-canny"

controlnet = ControlNetModel.from_pretrained(
            controlnet_canny_model_id, torch_dtype=dtype).to("cuda")

controlnet_inpaint_pipe = StableDiffusionControlNetInpaintPipeline.from_pretrained(
            "runwayml/stable-diffusion-v1-5",
            controlnet=controlnet,
            torch_dtype=dtype,
            safety_checker=None,
        )
controlnet_inpaint_pipe.to("cuda")

controlnet_inpaint_pipe.scheduler = EulerAncestralDiscreteScheduler.from_config(
            controlnet_inpaint_pipe.scheduler.config)


# Convert mask to grayscale NumPy array
mask_image_arr = np.array(image_mask.convert("L"))
# Add a channel dimension to the end of the grayscale mask
mask_image_arr = mask_image_arr[:, :, None]
# Binarize the mask: 1s correspond to the pixels which are repainted
mask_image_arr = mask_image_arr.astype(np.float32) / 255.0
mask_image_arr[mask_image_arr < 0.5] = 0
mask_image_arr[mask_image_arr >= 0.5] = 1


for seed in range(10):
    generator = torch.Generator(device="cuda").manual_seed(seed)
    output = controlnet_inpaint_pipe(
        image=init_image,
        mask_image=image_mask,
        strength=strength,
        prompt="a bottle emerging from ripples in a lake surrounded by plants and flowers",
        negative_prompt="blurry, bad quality, painting, cgi, malformation",
        guidance_scale=7.,
        num_inference_steps=40,
        control_image=control_image,
        controlnet_conditioning_scale=1.0,
        control_guidance_start=0.0,
        control_guidance_end=1.0,
        masked_content="blank",
        )
    repainted_image = output.images[0]
   
    output.images[0].save(f"out_{seed}_strength_{strength}_{branch_name}.png")

    # Take the masked pixels from the repainted image and the unmasked pixels from the initial image
    unmasked_unchanged_image_arr = (1 - mask_image_arr) * init_image + mask_image_arr * repainted_image
    unmasked_unchanged_image = PIL.Image.fromarray(unmasked_unchanged_image_arr.round().astype("uint8"))
    unmasked_unchanged_image.save(f"out_{seed}_strength_{strength}_fix_unmask_{branch_name}.png")
```