### PR TITLE
Add from_pt flag to enable model from PT

### DIFF
--- a/examples/text_to_image/train_text_to_image_flax.py
+++ b/examples/text_to_image/train_text_to_image_flax.py
@@ -212,7 +212,7 @@ def parse_args():
         "--from_pt",
         action="store_true",
         default=False,
-        help="The flag to indicate if convert models from PyTorch.",
+        help="Flag to indicate whether to convert models from PyTorch.",
     )
 
     args = parser.parse_args()
@@ -380,17 +380,31 @@ def main():
 
     # Load models and create wrapper for stable diffusion
     tokenizer = CLIPTokenizer.from_pretrained(
-        args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="tokenizer"
+        args.pretrained_model_name_or_path,
+        from_pt=args.from_pt,
+        revision=args.revision,
+        subfolder="tokenizer",
     )
     text_encoder = FlaxCLIPTextModel.from_pretrained(
-        args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="text_encoder",
-        dtype=weight_dtype
+        args.pretrained_model_name_or_path,
+        from_pt=args.from_pt,
+        revision=args.revision,
+        subfolder="text_encoder",
+        dtype=weight_dtype,
     )
     vae, vae_params = FlaxAutoencoderKL.from_pretrained(
-        args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="vae", dtype=weight_dtype
+        args.pretrained_model_name_or_path,
+        from_pt=args.from_pt,
+        revision=args.revision,
+        subfolder="vae",
+        dtype=weight_dtype,
     )
     unet, unet_params = FlaxUNet2DConditionModel.from_pretrained(
-        args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="unet", dtype=weight_dtype
+        args.pretrained_model_name_or_path,
+        from_pt=args.from_pt,
+        revision=args.revision,
+        subfolder="unet",
+        dtype=weight_dtype,
     )
 
     # Optimization

--- a/examples/text_to_image/train_text_to_image_flax.py
+++ b/examples/text_to_image/train_text_to_image_flax.py
@@ -208,6 +208,12 @@ def parse_args():
         ),
     )
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
+    parser.add_argument(
+        "--from_pt",
+        action="store_true",
+        default=False,
+        help="The flag to indicate if convert models from PyTorch.",
+    )
 
     args = parser.parse_args()
     env_local_rank = int(os.environ.get("LOCAL_RANK", -1))
@@ -374,16 +380,16 @@ def main():
 
     # Load models and create wrapper for stable diffusion
     tokenizer = CLIPTokenizer.from_pretrained(
-        args.pretrained_model_name_or_path, revision=args.revision, subfolder="tokenizer"
+        args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="tokenizer"
     )
     text_encoder = FlaxCLIPTextModel.from_pretrained(
-        args.pretrained_model_name_or_path, revision=args.revision, subfolder="text_encoder", dtype=weight_dtype
+        args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="text_encoder", dtype=weight_dtype
     )
     vae, vae_params = FlaxAutoencoderKL.from_pretrained(
-        args.pretrained_model_name_or_path, revision=args.revision, subfolder="vae", dtype=weight_dtype
+        args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="vae", dtype=weight_dtype
     )
     unet, unet_params = FlaxUNet2DConditionModel.from_pretrained(
-        args.pretrained_model_name_or_path, revision=args.revision, subfolder="unet", dtype=weight_dtype
+        args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="unet", dtype=weight_dtype
     )
 
     # Optimization

--- a/examples/text_to_image/train_text_to_image_flax.py
+++ b/examples/text_to_image/train_text_to_image_flax.py
@@ -383,7 +383,8 @@ def main():
         args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="tokenizer"
     )
     text_encoder = FlaxCLIPTextModel.from_pretrained(
-        args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="text_encoder", dtype=weight_dtype
+        args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="text_encoder",
+        dtype=weight_dtype
     )
     vae, vae_params = FlaxAutoencoderKL.from_pretrained(
         args.pretrained_model_name_or_path, from_pt=args.from_pt, revision=args.revision, subfolder="vae", dtype=weight_dtype


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? The issue [link](https://github.com/huggingface/diffusers/issues/5461)
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @williamberman and @patrickvonplaten
- Pipelines:  @patrickvonplaten and @sayakpaul
- Training examples: @sayakpaul and @patrickvonplaten
- Docs: @stevhliu and @yiyixuxu
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @patrickvonplaten and @sayakpaul

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->

@patrickvonplaten @pcuenca

Tested with `--from_pt`, and it worked as expected:

```
ranran@t1v-n-aad126dc-w-0:~/diffusers/examples/text_to_image$ export TPU_PREMAPPED_BUFFER_SIZE=4294967296 && JAX_PLATFORMS=tpu,cpu python3 train_text_to_image_flax.py --pretrained_model_name_or_path=stabilityai/stable-diffusion-2-1 --dataset_name=lambdalabs/pokemon-blip-captions --resolution=256 --center_crop --random_flip --train_batch_size=8 --mixed_precision=bf16 --max_train_steps=3000 --learning_rate=1e-05 --max_grad_norm=1 --output_dir=sd-bf16-model --image_column=image --caption_column=text --from_pt
2023-10-24 01:02:22.680066: E tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc:9342] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
2023-10-24 01:02:22.680112: E tensorflow/compiler/xla/stream_executor/cuda/cuda_fft.cc:609] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
2023-10-24 01:02:22.680146: E tensorflow/compiler/xla/stream_executor/cuda/cuda_blas.cc:1518] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
2023-10-24 01:02:23.420819: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
loading file vocab.json from cache at /home/ranran/.cache/huggingface/hub/models--stabilityai--stable-diffusion-2-1/snapshots/5cae40e6a2745ae2b01ad92ae5043f95f23644d6/tokenizer/vocab.json
loading file merges.txt from cache at /home/ranran/.cache/huggingface/hub/models--stabilityai--stable-diffusion-2-1/snapshots/5cae40e6a2745ae2b01ad92ae5043f95f23644d6/tokenizer/merges.txt
loading file added_tokens.json from cache at None
loading file special_tokens_map.json from cache at /home/ranran/.cache/huggingface/hub/models--stabilityai--stable-diffusion-2-1/snapshots/5cae40e6a2745ae2b01ad92ae5043f95f23644d6/tokenizer/special_tokens_map.json
loading file tokenizer_config.json from cache at /home/ranran/.cache/huggingface/hub/models--stabilityai--stable-diffusion-2-1/snapshots/5cae40e6a2745ae2b01ad92ae5043f95f23644d6/tokenizer/tokenizer_config.json
loading file tokenizer.json from cache at None
loading configuration file config.json from cache at /home/ranran/.cache/huggingface/hub/models--stabilityai--stable-diffusion-2-1/snapshots/5cae40e6a2745ae2b01ad92ae5043f95f23644d6/text_encoder/config.json
Model config CLIPTextConfig {
  "_name_or_path": "hf-models/stable-diffusion-v2-768x768/text_encoder",
  "architectures": [
    "CLIPTextModel"
  ],
  "attention_dropout": 0.0,
  "bos_token_id": 0,
  "dropout": 0.0,
  "eos_token_id": 2,
  "hidden_act": "gelu",
  "hidden_size": 1024,
  "initializer_factor": 1.0,
  "initializer_range": 0.02,
  "intermediate_size": 4096,
  "layer_norm_eps": 1e-05,
  "max_position_embeddings": 77,
  "model_type": "clip_text_model",
  "num_attention_heads": 16,
  "num_hidden_layers": 23,
  "pad_token_id": 1,
  "projection_dim": 512,
  "torch_dtype": "float32",
  "transformers_version": "4.34.1",
  "vocab_size": 49408
}

loading weights file pytorch_model.bin from cache at /home/ranran/.cache/huggingface/hub/models--stabilityai--stable-diffusion-2-1/snapshots/5cae40e6a2745ae2b01ad92ae5043f95f23644d6/text_encoder/pytorch_model.bin
Loading PyTorch weights from /home/ranran/.cache/huggingface/hub/models--stabilityai--stable-diffusion-2-1/snapshots/5cae40e6a2745ae2b01ad92ae5043f95f23644d6/text_encoder/pytorch_model.bin
PyTorch checkpoint contains 340,387,917 parameters.
Some weights of the model checkpoint at stabilityai/stable-diffusion-2-1 were not used when initializing FlaxCLIPTextModel: {('text_model', 'embeddings', 'position_ids')}
- This IS expected if you are initializing FlaxCLIPTextModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
- This IS NOT expected if you are initializing FlaxCLIPTextModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
All the weights of FlaxCLIPTextModel were initialized from the model checkpoint at stabilityai/stable-diffusion-2-1.
If your task is similar to the task the model of the checkpoint was trained on, you can already use FlaxCLIPTextModel for predictions without further training.
10/24/2023 01:08:35 - INFO - __main__ - ***** Running training *****
10/24/2023 01:08:35 - INFO - __main__ -   Num examples = 833
10/24/2023 01:08:35 - INFO - __main__ -   Num Epochs = 116
10/24/2023 01:08:35 - INFO - __main__ -   Instantaneous batch size per device = 8
10/24/2023 01:08:35 - INFO - __main__ -   Total train batch size (w. parallel & distributed) = 32
10/24/2023 01:08:35 - INFO - __main__ -   Total optimization steps = 3000
Epoch... (1/116 | Loss: 0.7180335521697998)                                                                                        
Epoch... (2/116 | Loss: 0.43771886825561523)                                                                                       
Epoch... (3/116 | Loss: 0.26194703578948975)                                                                                       
Epoch... (4/116 | Loss: 0.13119475543498993)                                                                                       
Epoch... (5/116 | Loss: 0.1085905134677887)                                                                                        
Epoch... (6/116 | Loss: 0.09535876661539078)                                                                                       
Epoch... (7/116 | Loss: 0.1026906818151474)                                                                                        
Epoch... (8/116 | Loss: 0.12104104459285736)                                                                                       
Epoch... (9/116 | Loss: 0.10453010350465775)                                                                                       
Epoch... (10/116 | Loss: 0.17062756419181824)                                                                                      
Epoch... (11/116 | Loss: 0.14385651051998138)                                                                                      
Epoch... (12/116 | Loss: 0.2031339406967163)                                                                                       
Epoch... (13/116 | Loss: 0.16443254053592682)                                                                                      
Epoch... (14/116 | Loss: 0.20865577459335327)                                                                                      
Epoch... (15/116 | Loss: 0.18580672144889832)                                                                                      
Epoch... (16/116 | Loss: 0.15176695585250854)                                                                                      
Epoch... (17/116 | Loss: 0.19028088450431824)                                                                                      
Epoch... (18/116 | Loss: 0.19435754418373108)                                                                                      
Epoch... (19/116 | Loss: 0.18245089054107666)                                                                                      
Epoch... (20/116 | Loss: 0.19878770411014557)                                                                                      
Epoch... (21/116 | Loss: 0.1917506754398346)                                                                                       
Epoch... (22/116 | Loss: 0.17860080301761627)                                                                                      
Epoch... (23/116 | Loss: 0.22167636454105377)                                                                                      
Epoch... (24/116 | Loss: 0.15921765565872192)                                                                                      
Epoch... (25/116 | Loss: 0.15307846665382385)                                                                                      
Epoch... (26/116 | Loss: 0.1590590476989746)                                                                                       
```