### PR TITLE
fix a bug in 2nd order schedulers when using in ensemble of experts config

### DIFF
--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
@@ -868,8 +868,14 @@ class StableDiffusionXLControlNetInpaintPipeline(
                 )
             )
 
-            num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
+            num_inference_steps = (timesteps < discrete_timestep_cutoff).sum().item()
             if self.scheduler.order == 2:
+                # if the scheduler is a 2nd order scheduler we ALWAYS have to do +1
+                # because `num_inference_steps` will always be even given that every timestep
+                # (except the highest one) is duplicated. If `num_inference_steps` is even it would
+                # mean that we cut the timesteps in the middle of the denoising step
+                # (between 1st and 2nd devirative) which leads to incorrect results. By adding 1
+                # we ensure that the denoising process always ends after the 2nd derivate step of the scheduler
                 num_inference_steps = num_inference_steps + 1
 
             # because t_n+1 >= t_n, we slice the timesteps starting from the end

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
@@ -871,7 +871,7 @@ class StableDiffusionXLControlNetInpaintPipeline(
             num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
-                
+
             # because t_n+1 >= t_n, we slice the timesteps starting from the end
             timesteps = timesteps[-num_inference_steps:]
             return timesteps, num_inference_steps

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
@@ -868,7 +868,7 @@ class StableDiffusionXLControlNetInpaintPipeline(
                 )
             )
 
-            num_inference_steps = len(list(filter(lambda ts: ts < discrete_timestep_cutoff, timesteps)))
+            num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
             timesteps = timesteps[-num_inference_steps:]

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
@@ -872,7 +872,7 @@ class StableDiffusionXLControlNetInpaintPipeline(
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
                 
-                # because t_n+1 >= t_n, we slice the timesteps starting from the end
+            # because t_n+1 >= t_n, we slice the timesteps starting from the end
             timesteps = timesteps[-num_inference_steps:]
             return timesteps, num_inference_steps
 

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
@@ -867,8 +867,12 @@ class StableDiffusionXLControlNetInpaintPipeline(
                     - (denoising_start * self.scheduler.config.num_train_timesteps)
                 )
             )
-            timesteps = list(filter(lambda ts: ts < discrete_timestep_cutoff, timesteps))
-            return torch.tensor(timesteps), len(timesteps)
+
+            num_inference_steps = len(list(filter(lambda ts: ts < discrete_timestep_cutoff, timesteps)))
+            if self.scheduler.order == 2:
+                num_inference_steps = num_inference_steps + 1
+            timesteps = timesteps[-num_inference_steps:]
+            return timesteps, num_inference_steps
 
         return timesteps, num_inference_steps - t_start
 

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
@@ -871,6 +871,8 @@ class StableDiffusionXLControlNetInpaintPipeline(
             num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
+                
+                # because t_n+1 >= t_n, we slice the timesteps starting from the end
             timesteps = timesteps[-num_inference_steps:]
             return timesteps, num_inference_steps
 

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -515,8 +515,12 @@ class StableDiffusionXLImg2ImgPipeline(
                     - (denoising_start * self.scheduler.config.num_train_timesteps)
                 )
             )
-            timesteps = list(filter(lambda ts: ts < discrete_timestep_cutoff, timesteps))
-            return torch.tensor(timesteps), len(timesteps)
+
+            num_inference_steps = len(list(filter(lambda ts: ts < discrete_timestep_cutoff, timesteps)))
+            if self.scheduler.order == 2:
+                num_inference_steps = num_inference_steps + 1
+            timesteps = timesteps[-num_inference_steps:]
+            return timesteps, num_inference_steps
 
         return timesteps, num_inference_steps - t_start
 

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -516,7 +516,7 @@ class StableDiffusionXLImg2ImgPipeline(
                 )
             )
 
-            num_inference_steps = len(list(filter(lambda ts: ts < discrete_timestep_cutoff, timesteps)))
+            num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
             timesteps = timesteps[-num_inference_steps:]

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -519,7 +519,7 @@ class StableDiffusionXLImg2ImgPipeline(
             num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
-                
+
             # because t_n+1 >= t_n, we slice the timesteps starting from the end
             timesteps = timesteps[-num_inference_steps:]
             return timesteps, num_inference_steps

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -519,6 +519,8 @@ class StableDiffusionXLImg2ImgPipeline(
             num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
+                
+                # because t_n+1 >= t_n, we slice the timesteps starting from the end
             timesteps = timesteps[-num_inference_steps:]
             return timesteps, num_inference_steps
 

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -516,8 +516,14 @@ class StableDiffusionXLImg2ImgPipeline(
                 )
             )
 
-            num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
+            num_inference_steps = (timesteps < discrete_timestep_cutoff).sum().item()
             if self.scheduler.order == 2:
+                # if the scheduler is a 2nd order scheduler we ALWAYS have to do +1
+                # because `num_inference_steps` will always be even given that every timestep
+                # (except the highest one) is duplicated. If `num_inference_steps` is even it would
+                # mean that we cut the timesteps in the middle of the denoising step
+                # (between 1st and 2nd devirative) which leads to incorrect results. By adding 1
+                # we ensure that the denoising process always ends after the 2nd derivate step of the scheduler
                 num_inference_steps = num_inference_steps + 1
 
             # because t_n+1 >= t_n, we slice the timesteps starting from the end

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -520,7 +520,7 @@ class StableDiffusionXLImg2ImgPipeline(
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
                 
-                # because t_n+1 >= t_n, we slice the timesteps starting from the end
+            # because t_n+1 >= t_n, we slice the timesteps starting from the end
             timesteps = timesteps[-num_inference_steps:]
             return timesteps, num_inference_steps
 

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -803,7 +803,7 @@ class StableDiffusionXLInpaintPipeline(
             num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
-                
+
             # because t_n+1 >= t_n, we slice the timesteps starting from the end
             timesteps = timesteps[-num_inference_steps:]
             return timesteps, num_inference_steps

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -800,8 +800,14 @@ class StableDiffusionXLInpaintPipeline(
                 )
             )
 
-            num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
+            num_inference_steps = (timesteps < discrete_timestep_cutoff).sum().item()
             if self.scheduler.order == 2:
+                # if the scheduler is a 2nd order scheduler we ALWAYS have to do +1
+                # because `num_inference_steps` will always be even given that every timestep
+                # (except the highest one) is duplicated. If `num_inference_steps` is even it would
+                # mean that we cut the timesteps in the middle of the denoising step
+                # (between 1st and 2nd devirative) which leads to incorrect results. By adding 1
+                # we ensure that the denoising process always ends after the 2nd derivate step of the scheduler
                 num_inference_steps = num_inference_steps + 1
 
             # because t_n+1 >= t_n, we slice the timesteps starting from the end

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -804,7 +804,7 @@ class StableDiffusionXLInpaintPipeline(
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
                 
-                # because t_n+1 >= t_n, we slice the timesteps starting from the end
+            # because t_n+1 >= t_n, we slice the timesteps starting from the end
             timesteps = timesteps[-num_inference_steps:]
             return timesteps, num_inference_steps
 

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -803,6 +803,8 @@ class StableDiffusionXLInpaintPipeline(
             num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
+                
+                # because t_n+1 >= t_n, we slice the timesteps starting from the end
             timesteps = timesteps[-num_inference_steps:]
             return timesteps, num_inference_steps
 

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -800,7 +800,7 @@ class StableDiffusionXLInpaintPipeline(
                 )
             )
 
-            num_inference_steps = len(list(filter(lambda ts: ts < discrete_timestep_cutoff, timesteps)))
+            num_inference_steps = (timesteps < discrete_timestep_cutoff).sum()
             if self.scheduler.order == 2:
                 num_inference_steps = num_inference_steps + 1
             timesteps = timesteps[-num_inference_steps:]

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -799,8 +799,12 @@ class StableDiffusionXLInpaintPipeline(
                     - (denoising_start * self.scheduler.config.num_train_timesteps)
                 )
             )
-            timesteps = list(filter(lambda ts: ts < discrete_timestep_cutoff, timesteps))
-            return torch.tensor(timesteps), len(timesteps)
+
+            num_inference_steps = len(list(filter(lambda ts: ts < discrete_timestep_cutoff, timesteps)))
+            if self.scheduler.order == 2:
+                num_inference_steps = num_inference_steps + 1
+            timesteps = timesteps[-num_inference_steps:]
+            return timesteps, num_inference_steps
 
         return timesteps, num_inference_steps - t_start
 

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -324,8 +324,13 @@ class StableDiffusionXLPipelineFastTests(PipelineLatentTesterMixin, PipelineTest
             pipe_1.scheduler.set_timesteps(num_steps)
             expected_steps = pipe_1.scheduler.timesteps.tolist()
 
-            expected_steps_1 = list(filter(lambda ts: ts >= split, expected_tss))
-            expected_steps_2 = list(filter(lambda ts: ts < split, expected_tss))
+            if pipe_1.scheduler.order == 2:
+                expected_steps_1 = list(filter(lambda ts: ts >= split, expected_tss))
+                expected_steps_2 = expected_steps_1[-1:] + list(filter(lambda ts: ts < split, expected_tss))
+                expected_steps = expected_steps_1 + expected_steps_2
+            else:
+                expected_steps_1 = list(filter(lambda ts: ts >= split, expected_tss))
+                expected_steps_2 = list(filter(lambda ts: ts < split, expected_tss))
 
             # now we monkey patch step `done_steps`
             # list into the step function for testing
@@ -607,13 +612,18 @@ class StableDiffusionXLPipelineFastTests(PipelineLatentTesterMixin, PipelineTest
 
             split_1_ts = num_train_timesteps - int(round(num_train_timesteps * split_1))
             split_2_ts = num_train_timesteps - int(round(num_train_timesteps * split_2))
-            expected_steps_1 = expected_steps[:split_1_ts]
-            expected_steps_2 = expected_steps[split_1_ts:split_2_ts]
-            expected_steps_3 = expected_steps[split_2_ts:]
 
-            expected_steps_1 = list(filter(lambda ts: ts >= split_1_ts, expected_steps))
-            expected_steps_2 = list(filter(lambda ts: ts >= split_2_ts and ts < split_1_ts, expected_steps))
-            expected_steps_3 = list(filter(lambda ts: ts < split_2_ts, expected_steps))
+            if pipe_1.scheduler.order == 2:
+                expected_steps_1 = list(filter(lambda ts: ts >= split_1_ts, expected_steps))
+                expected_steps_2 = expected_steps_1[-1:] + list(
+                    filter(lambda ts: ts >= split_2_ts and ts < split_1_ts, expected_steps)
+                )
+                expected_steps_3 = expected_steps_2[-1:] + list(filter(lambda ts: ts < split_2_ts, expected_steps))
+                expected_steps = expected_steps_1 + expected_steps_2 + expected_steps_3
+            else:
+                expected_steps_1 = list(filter(lambda ts: ts >= split_1_ts, expected_steps))
+                expected_steps_2 = list(filter(lambda ts: ts >= split_2_ts and ts < split_1_ts, expected_steps))
+                expected_steps_3 = list(filter(lambda ts: ts < split_2_ts, expected_steps))
 
             # now we monkey patch step `done_steps`
             # list into the step function for testing

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
@@ -438,7 +438,6 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
                     EulerDiscreteScheduler,
                     DPMSolverMultistepScheduler,
                     UniPCMultistepScheduler,
-                    HeunDiscreteScheduler,
                 ]:
                     assert_run_mixture(steps, split_1, split_2, scheduler_cls)
 

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
@@ -318,11 +318,14 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
             expected_steps = pipe_1.scheduler.timesteps.tolist()
 
             split_ts = num_train_timesteps - int(round(num_train_timesteps * split))
-            expected_steps_1 = expected_steps[:split_ts]
-            expected_steps_2 = expected_steps[split_ts:]
 
-            expected_steps_1 = list(filter(lambda ts: ts >= split_ts, expected_steps))
-            expected_steps_2 = list(filter(lambda ts: ts < split_ts, expected_steps))
+            if pipe_1.scheduler.order == 2:
+                expected_steps_1 = list(filter(lambda ts: ts >= split_ts, expected_steps))
+                expected_steps_2 = expected_steps_1[-1:] + list(filter(lambda ts: ts < split_ts, expected_steps))
+                expected_steps = expected_steps_1 + expected_steps_2
+            else:
+                expected_steps_1 = list(filter(lambda ts: ts >= split_ts, expected_steps))
+                expected_steps_2 = list(filter(lambda ts: ts < split_ts, expected_steps))
 
             # now we monkey patch step `done_steps`
             # list into the step function for testing
@@ -389,13 +392,18 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
 
             split_1_ts = num_train_timesteps - int(round(num_train_timesteps * split_1))
             split_2_ts = num_train_timesteps - int(round(num_train_timesteps * split_2))
-            expected_steps_1 = expected_steps[:split_1_ts]
-            expected_steps_2 = expected_steps[split_1_ts:split_2_ts]
-            expected_steps_3 = expected_steps[split_2_ts:]
 
-            expected_steps_1 = list(filter(lambda ts: ts >= split_1_ts, expected_steps))
-            expected_steps_2 = list(filter(lambda ts: ts >= split_2_ts and ts < split_1_ts, expected_steps))
-            expected_steps_3 = list(filter(lambda ts: ts < split_2_ts, expected_steps))
+            if pipe_1.scheduler.order == 2:
+                expected_steps_1 = list(filter(lambda ts: ts >= split_1_ts, expected_steps))
+                expected_steps_2 = expected_steps_1[-1:] + list(
+                    filter(lambda ts: ts >= split_2_ts and ts < split_1_ts, expected_steps)
+                )
+                expected_steps_3 = expected_steps_2[-1:] + list(filter(lambda ts: ts < split_2_ts, expected_steps))
+                expected_steps = expected_steps_1 + expected_steps_2 + expected_steps_3
+            else:
+                expected_steps_1 = list(filter(lambda ts: ts >= split_1_ts, expected_steps))
+                expected_steps_2 = list(filter(lambda ts: ts >= split_2_ts and ts < split_1_ts, expected_steps))
+                expected_steps_3 = list(filter(lambda ts: ts < split_2_ts, expected_steps))
 
             # now we monkey patch step `done_steps`
             # list into the step function for testing
@@ -438,6 +446,7 @@ class StableDiffusionXLInpaintPipelineFastTests(PipelineLatentTesterMixin, Pipel
                     EulerDiscreteScheduler,
                     DPMSolverMultistepScheduler,
                     UniPCMultistepScheduler,
+                    HeunDiscreteScheduler,
                 ]:
                     assert_run_mixture(steps, split_1, split_2, scheduler_cls)
 


### PR DESCRIPTION
This PR fix the bug reported in https://github.com/huggingface/diffusers/issues/5447 and allow users to 2nd order schedulers for ensemble of experts approach

I'm using an toy example to quickly illustrate the error we are having
* e.g. we have 4 inference steps: `3, 2, 1, 0`
* in `set_timesteps`, we repeat the index for 2nd order update (steps in `[]` are 2nd order update) : `3, [2], 2, [1], 1, [0], 0`
* now we split these timesteps between base and refiner, if the cutoff point is `1`, we will have
   * base: `3, [2], 2`
   * refiner `[1], 1, [0], 0`
 
-> You can see that the timesteps for refiner is wrong now, should be `2, [1], 1, [0], 0`

this script now works
```python
import torch
from diffusers import StableDiffusionXLPipeline, StableDiffusionXLImg2ImgPipeline
from diffusers import HeunDiscreteScheduler

sdxl_model = StableDiffusionXLPipeline.from_pretrained(
    'stabilityai/stable-diffusion-xl-base-1.0',
    torch_dtype=torch.float16,
    use_safetensors=True,
    variant="fp16",
)
sdxl_model.enable_model_cpu_offload()

refiner_model = StableDiffusionXLImg2ImgPipeline.from_pretrained(
    'stabilityai/stable-diffusion-xl-refiner-1.0',
    text_encoder_2=sdxl_model.text_encoder_2,
    vae = sdxl_model.vae,
    torch_dtype=torch.float16,
    use_safetensors=True,
    variant="fp16",
)
refiner_model.enable_model_cpu_offload()

sdxl_model.scheduler = HeunDiscreteScheduler.from_config(sdxl_model.scheduler.config, use_karras_sigmas=True)
refiner_model.scheduler = HeunDiscreteScheduler.from_config(refiner_model.scheduler.config, use_karras_sigmas=True)

generator = torch.Generator(device='cuda').manual_seed(12345)

hnf = 0.5
params = {
    'prompt': ['evening sunset scenery blue sky nature, glass bottle with a galaxy in it'],
    'negative_prompt': ['text, watermark'],
    "num_inference_steps": 50,
    "height": 1024,
    "width": 1024,
    "guidance_scale": 7,
}

sdxl_res = sdxl_model(**params, denoising_end=hnf, generator=generator, output_type='latent')
sdxl_latents = sdxl_res.images

refiner_res = refiner_model(
    output_type="pil",
    image=sdxl_latents,
    prompt=params['prompt'],
    num_inference_steps=params['num_inference_steps'],
    negative_prompt=params['negative_prompt'],
    generator=generator,
    denoising_start=hnf,
)
refiner_imgs = refiner_res.images

refiner_imgs[0].save("out.png")
```

 
![yiyi_test_4_out](https://github.com/huggingface/diffusers/assets/12631849/c6a1b213-1dce-46f0-a3ff-a36b8850f8ed)
