### PR TITLE
[docs] Internal classes API

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -166,8 +166,6 @@
   - sections:
     - local: api/configuration
       title: Configuration
-    - local: api/diffusion_pipeline
-      title: Diffusion Pipeline
     - local: api/loaders
       title: Loaders
     - local: api/logging

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -382,6 +382,8 @@
       title: VQDiffusionScheduler
     title: Schedulers
   - sections:
+    - local: api/internal_classes_overview
+      title: Overview
     - local: api/attnprocessor
       title: Attention Processor
     - local: api/activations

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -164,24 +164,16 @@
   title: Conceptual Guides
 - sections:
   - sections:
-    - local: api/activations
-      title: Custom activation functions
-    - local: api/normalization
-      title: Custom normalization layers
-    - local: api/attnprocessor
-      title: Attention Processor
-    - local: api/logging
-      title: Logging
     - local: api/configuration
       title: Configuration
-    - local: api/outputs
-      title: Outputs
+    - local: api/diffusion_pipeline
+      title: Diffusion Pipeline
     - local: api/loaders
       title: Loaders
-    - local: api/utilities
-      title: Utilities
-    - local: api/image_processor
-      title: VAE Image Processor
+    - local: api/logging
+      title: Logging
+    - local: api/outputs
+      title: Outputs
     title: Main Classes
   - sections:
     - local: api/models/overview
@@ -389,4 +381,16 @@
     - local: api/schedulers/vq_diffusion
       title: VQDiffusionScheduler
     title: Schedulers
+  - sections:
+    - local: api/attnprocessor
+      title: Attention Processor
+    - local: api/activations
+      title: Custom activation functions
+    - local: api/normalization
+      title: Custom normalization layers
+    - local: api/utilities
+      title: Utilities
+    - local: api/image_processor
+      title: VAE Image Processor
+    title: Internal classes   
   title: API

--- a/docs/source/en/api/internal_classes_overview.md
+++ b/docs/source/en/api/internal_classes_overview.md
@@ -1,0 +1,3 @@
+# Overview
+
+The APIs in this section are more experimental and prone to breaking changes. Most of them are used internally for development, but they may also be useful to you if you're interested in building a diffusion model with some custom parts or if you're interested in some of our helper utilities for working with 🤗 Diffusers.


### PR DESCRIPTION
From this [comment](https://github.com/huggingface/diffusers/pull/5493#discussion_r1368983480), this PR reorders some of the more experimental APIs into an internal helper section. I left some of the more important classes like `Configuration` and `Outputs` in the main classes for higher visibility, but let me know if you want to move those as well.