### PR TITLE
fix a bug on `torch_dtype` argument in `from_single_file` of ControlNetModel

### DIFF
--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -3171,7 +3171,7 @@ class FromOriginalControlnetMixin:
         )
 
         if torch_dtype is not None:
-            controlnet.to(torch_dtype=torch_dtype)
+            controlnet.to(dtype=torch_dtype)
 
         return controlnet
 


### PR DESCRIPTION
The following code snippet will throw `TypeError` for now:

```python
import torch
from diffusers import ControlNetModel
controlnet = ControlNetModel.from_single_file(
    "./control_sd15_canny.pth", torch_dtype=torch.float16, local_files_only=True
)
```

which gives us:
```bash
Traceback (most recent call last):
  File "D:\AI\diffusers_test.py", line 5, in <module>
    controlnet = ControlNetModel.from_single_file(
  File "D:\Programming\miniconda3\lib\site-packages\diffusers\loaders.py", line 2665, in from_single_file
    controlnet.to(torch_dtype=torch_dtype)
  File "D:\Programming\miniconda3\lib\site-packages\torch\nn\modules\module.py", line 1141, in to
    device, dtype, non_blocking, convert_to_format = torch._C._nn._parse_to(*args, **kwargs)
TypeError: to() received an invalid combination of arguments - got (torch_dtype=torch.dtype, ), but expected one of:
 * (torch.device device, torch.dtype dtype, bool non_blocking, bool copy, *, torch.memory_format memory_format)
 * (torch.dtype dtype, bool non_blocking, bool copy, *, torch.memory_format memory_format)
 * (Tensor tensor, bool non_blocking, bool copy, *, torch.memory_format memory_format)
```


The reason is that the parameter name `torch_dtype` [here](https://github.com/huggingface/diffusers/blob/main/src/diffusers/loaders.py#L3174) is wrong, it should be `dtype` instead of `torch_dtype`, according to the function signature of the inherited `to` method from Pytorch [module.py](https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/module.py#L1043).