### PR TITLE
add fix to be able use StableDiffusionXLAdapterPipeline.from_single_file

### DIFF
--- a/src/diffusers/loaders.py
+++ b/src/diffusers/loaders.py
@@ -2727,6 +2727,7 @@ class FromSingleFileMixin:
         text_encoder = kwargs.pop("text_encoder", None)
         vae = kwargs.pop("vae", None)
         controlnet = kwargs.pop("controlnet", None)
+        adapter = kwargs.pop("adapter", None)
         tokenizer = kwargs.pop("tokenizer", None)
 
         torch_dtype = kwargs.pop("torch_dtype", None)
@@ -2819,6 +2820,7 @@ class FromSingleFileMixin:
             model_type=model_type,
             stable_unclip=stable_unclip,
             controlnet=controlnet,
+            adapter=adapter,
             from_safetensors=from_safetensors,
             extract_ema=extract_ema,
             image_size=image_size,

--- a/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -1145,6 +1145,7 @@ def download_from_original_stable_diffusion_ckpt(
     stable_unclip_prior: Optional[str] = None,
     clip_stats_path: Optional[str] = None,
     controlnet: Optional[bool] = None,
+    adapter: Optional[bool] = None,
     load_safety_checker: bool = True,
     pipeline_class: DiffusionPipeline = None,
     local_files_only=False,
@@ -1720,6 +1721,18 @@ def download_from_original_stable_diffusion_ckpt(
                     tokenizer_2=tokenizer_2,
                     unet=unet,
                     controlnet=controlnet,
+                    scheduler=scheduler,
+                    force_zeros_for_empty_prompt=True,
+                )
+            elif adapter:
+                pipe = pipeline_class(
+                    vae=vae,
+                    text_encoder=text_encoder,
+                    tokenizer=tokenizer,
+                    text_encoder_2=text_encoder_2,
+                    tokenizer_2=tokenizer_2,
+                    unet=unet,
+                    adapter=adapter,
                     scheduler=scheduler,
                     force_zeros_for_empty_prompt=True,
                 )


### PR DESCRIPTION
# What does this PR do?

It wasn't possible to use from_single_file in the STableDiffusionXLAdapterPipeline since the adapter was not to send through the loaders it was checked only for controlnet pipeline so I added the adapter parameter and handle it internally.

Fixes # (issue)
 
## Before submitting
* [ ]  This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
* [x]  Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
* [x]  Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
* [ ]  Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
* [ ]  Did you make sure to update the documentation with your changes? Here are the
  [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
  [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
* [ ]  Did you write any new necessary tests?
