### PR TITLE
 [Core] enable lora for sdxl adapters too and add slow tests.

### DIFF
--- a/src/diffusers/pipelines/t2i_adapter/pipeline_stable_diffusion_xl_adapter.py
+++ b/src/diffusers/pipelines/t2i_adapter/pipeline_stable_diffusion_xl_adapter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import inspect
+import os
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -1067,3 +1068,77 @@ class StableDiffusionXLAdapterPipeline(
             return (image,)
 
         return StableDiffusionXLPipelineOutput(images=image)
+
+
+    # Overrride to properly handle the loading and unloading of the additional text encoder.
+    # Copied from diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl.StableDiffusionXLPipeline.load_lora_weights
+    def load_lora_weights(self, pretrained_model_name_or_path_or_dict: Union[str, Dict[str, torch.Tensor]], **kwargs):
+        # We could have accessed the unet config from `lora_state_dict()` too. We pass
+        # it here explicitly to be able to tell that it's coming from an SDXL
+        # pipeline.
+        state_dict, network_alphas = self.lora_state_dict(
+            pretrained_model_name_or_path_or_dict,
+            unet_config=self.unet.config,
+            **kwargs,
+        )
+        self.load_lora_into_unet(state_dict, network_alphas=network_alphas, unet=self.unet)
+
+        text_encoder_state_dict = {k: v for k, v in state_dict.items() if "text_encoder." in k}
+        if len(text_encoder_state_dict) > 0:
+            self.load_lora_into_text_encoder(
+                text_encoder_state_dict,
+                network_alphas=network_alphas,
+                text_encoder=self.text_encoder,
+                prefix="text_encoder",
+                lora_scale=self.lora_scale,
+            )
+
+        text_encoder_2_state_dict = {k: v for k, v in state_dict.items() if "text_encoder_2." in k}
+        if len(text_encoder_2_state_dict) > 0:
+            self.load_lora_into_text_encoder(
+                text_encoder_2_state_dict,
+                network_alphas=network_alphas,
+                text_encoder=self.text_encoder_2,
+                prefix="text_encoder_2",
+                lora_scale=self.lora_scale,
+            )
+
+    @classmethod
+    # Copied from diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl.StableDiffusionXLPipeline.save_lora_weights
+    def save_lora_weights(
+        self,
+        save_directory: Union[str, os.PathLike],
+        unet_lora_layers: Dict[str, Union[torch.nn.Module, torch.Tensor]] = None,
+        text_encoder_lora_layers: Dict[str, Union[torch.nn.Module, torch.Tensor]] = None,
+        text_encoder_2_lora_layers: Dict[str, Union[torch.nn.Module, torch.Tensor]] = None,
+        is_main_process: bool = True,
+        weight_name: str = None,
+        save_function: Callable = None,
+        safe_serialization: bool = True,
+    ):
+        state_dict = {}
+
+        def pack_weights(layers, prefix):
+            layers_weights = layers.state_dict() if isinstance(layers, torch.nn.Module) else layers
+            layers_state_dict = {f"{prefix}.{module_name}": param for module_name, param in layers_weights.items()}
+            return layers_state_dict
+
+        state_dict.update(pack_weights(unet_lora_layers, "unet"))
+
+        if text_encoder_lora_layers and text_encoder_2_lora_layers:
+            state_dict.update(pack_weights(text_encoder_lora_layers, "text_encoder"))
+            state_dict.update(pack_weights(text_encoder_2_lora_layers, "text_encoder_2"))
+
+        self.write_lora_layers(
+            state_dict=state_dict,
+            save_directory=save_directory,
+            is_main_process=is_main_process,
+            weight_name=weight_name,
+            save_function=save_function,
+            safe_serialization=safe_serialization,
+        )
+
+    # Copied from diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl.StableDiffusionXLPipeline._remove_text_encoder_monkey_patch
+    def _remove_text_encoder_monkey_patch(self):
+        self._remove_text_encoder_monkey_patch_classmethod(self.text_encoder)
+        self._remove_text_encoder_monkey_patch_classmethod(self.text_encoder_2)

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
@@ -596,7 +596,7 @@ class AdapterSDXLPipelineSlowTests(unittest.TestCase):
         assert images[0].shape == (768, 512, 3)
 
         original_image = images[0, -3:, -3:, -1].flatten()
-        expected_image = np.array([0.5226907,  0.5272584,  0.52255356, 0.50762856, 0.50497484, 0.50656825, 0.5065469,  0.51809096, 0.48973307])
+        assert numpy_cosine_similarity_distance(original_image, expected_image) < 1e-4
         assert np.allclose(original_image, expected_image, atol=1e-04)
 
 

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
@@ -35,8 +35,9 @@ from diffusers import (
 )
 from diffusers.utils import logging
 from diffusers.utils.testing_utils import enable_full_determinism, floats_tensor, torch_device
-from diffusers.utils import load_image, randn_tensor, torch_device
-from diffusers.utils.testing_utils import enable_full_determinism, require_torch_gpu, slow
+from diffusers.utils import load_image
+from diffusers.utils.torch_utils import randn_tensor
+from diffusers.utils.testing_utils import enable_full_determinism, require_torch_gpu, slow, torch_device
 from ..pipeline_params import TEXT_GUIDED_IMAGE_VARIATION_BATCH_PARAMS, TEXT_GUIDED_IMAGE_VARIATION_PARAMS
 from ..test_pipelines_common import (
     PipelineTesterMixin,

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
@@ -623,5 +623,5 @@ class AdapterSDXLPipelineSlowTests(unittest.TestCase):
 
         original_image = images[0, -3:, -3:, -1].flatten()
         expected_image = np.array([0.50346327, 0.50708383, 0.50719553, 0.5135172,  0.5155377,  0.5066059, 0.49680984, 0.5005894,  0.48509413])
-        assert np.allclose(original_image, expected_image, atol=1e-04)
+        assert numpy_cosine_similarity_distance(original_image, expected_image) < 1e-4
 


### PR DESCRIPTION
Fixes https://github.com/huggingface/diffusers/issues/5516 
Additionally, adds SLOW tests for SDXL T2i adapters.


Hello, 
as requested here is a PR to fix the #5516, WIth it's corresponding tests.

I have a few questions : 
- The test seem to fail when this is removed from the pipeline initialization : `torch_dtype=torch.float16`,  But your PR that inspired mine didn't have it(https://github.com/huggingface/diffusers/pull/4666/files).
  This is the error that I get with it : 
`  RuntimeError: Input type (float) and bias type (c10::Half) should be the same`
- I get this warning when I add `.to("CPU")` to the pipeline and the adapter : 
`Pipelines loaded with 'torch_dtype=torch.float16' cannot run with 'cpu' device. It is not recommended to move them to 'cpu' as running them will fail. Please make sure to use an accelerator to run the pipeline in inference, due to the lack of support for'float16' operations on this device in PyTorch. Please, remove the 'torch_dtype=torch.float16' argument, or use another device for inference.`
- Last, In the tests, we load this image : https://huggingface.co/datasets/hf-internal-testing/diffusers-images/resolve/main/t2i_adapter/toy_canny.png, but if we are testing for canny of functions that process images with canny, shouldn't we input a real image and expect this as an output ? Because otherwise we are applying a canny to an already canny image.

I hope this helps. 

@sayakpaul 


