### PR TITLE
Add Option for Pyramid Noise to SDXL train script

### DIFF
--- a/examples/text_to_image/train_text_to_image_sdxl.py
+++ b/examples/text_to_image/train_text_to_image_sdxl.py
@@ -506,7 +506,7 @@ def get_noise_like(x, args):
         noise = pyramid_noise_like(x, discount=discount, random_multiplier=True)
 
         return noise
-    elif noise_type = "offset":
+    elif noise_type == "offset":
         noise = torch.randn_like(model_input)
         if args.noise_offset:
             # https://www.crosslabs.org//blog/diffusion-with-offset-noise

--- a/examples/text_to_image/train_text_to_image_sdxl.py
+++ b/examples/text_to_image/train_text_to_image_sdxl.py
@@ -494,6 +494,7 @@ def parse_args(input_args=None):
 # Function for generating training noise, defaults to:
 # * "white" = high freq white noise(very stable, does not capture low freq well)
 # * "pyramid" = stable at the right values, covers a range of frequencies
+# * "offset" = adds low frequency noise to the base noise
 #
 # Sample noise that we'll add to the latents
 def get_noise_like(x, args):

--- a/examples/text_to_image/train_text_to_image_sdxl.py
+++ b/examples/text_to_image/train_text_to_image_sdxl.py
@@ -519,12 +519,8 @@ def get_noise_like(x, args):
 # From J. Whitaker Multi Resolution Noise
 #
 # https://wandb.ai/johnowhitaker/multires_noise/reports/Multi-Resolution-Noise-for-Diffusion-Model-Training--VmlldzozNjYyOTU2
-#
-# With a slight modification for defaulting to deterministic freq scaling ratios(r)
-# this better suites the use case where we want to generate these later at
-# inference time.
 def pyramid_noise_like(x, discount=0.9, random_multiplier=True):
-  b, c, w, h = x.shape # EDIT: w and h get over-written, rename for a different variant!
+  b, c, w, h = x.shape
   u = nn.Upsample(size=(w, h), mode='bilinear')
   noise = torch.randn_like(x)
   for i in range(16):


### PR DESCRIPTION
This changes the offset_nose arg to be a noise_type arg.

Currently allows 3 options between:
* Standard white noise
* Pyramid Noise
* Offset Noise

@sayakpaul
@patrickvonplaten

