### PR TITLE
[Custom Pipelines] Make sure that community pipelines can use repo revision

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -353,13 +353,18 @@ def _get_pipeline_class(
         else:
             file_name = CUSTOM_PIPELINE_FILE_NAME
 
+        if repo_id is not None and hub_revision is not None:
+            # if we load the pipeline code from the Hub
+            # make sure to overwrite the `revison`
+            revision = hub_revision
+
         return get_class_from_dynamic_module(
             custom_pipeline,
             module_file=file_name,
             class_name=class_name,
             repo_id=repo_id,
             cache_dir=cache_dir,
-            revision=revision if hub_revision is None else hub_revision,
+            revision=revision,
         )
 
     if class_obj != DiffusionPipeline:


### PR DESCRIPTION
# What does this PR do?

This PR makes sure that community pipelines can correctly load revision-specific code from checkpoints. It fixes the following edge case: https://huggingface.co/SimianLuo/LCM_Dreamshaper_v7#usage-deprecated