### PR TITLE
[Docs] Clarify that these are two separate examples

### DIFF
--- a/docs/source/en/training/lora.md
+++ b/docs/source/en/training/lora.md
@@ -113,12 +113,14 @@ Load the LoRA weights from your finetuned model *on top of the base model weight
 ```py
 >>> pipe.unet.load_attn_procs(lora_model_path)
 >>> pipe.to("cuda")
-# use half the weights from the LoRA finetuned model and half the weights from the base model
 
+# use half the weights from the LoRA finetuned model and half the weights from the base model
 >>> image = pipe(
 ...     "A pokemon with blue eyes.", num_inference_steps=25, guidance_scale=7.5, cross_attention_kwargs={"scale": 0.5}
 ... ).images[0]
-# use the weights from the fully finetuned LoRA model
+
+# OR, use the weights from the fully finetuned LoRA model
+# >>> image = pipe("A pokemon with blue eyes.", num_inference_steps=25, guidance_scale=7.5).images[0]
 
 >>> image.save("blue_pokemon.png")
 ```
@@ -224,15 +226,17 @@ Load the LoRA weights from your finetuned DreamBooth model *on top of the base m
 ```py
 >>> pipe.unet.load_attn_procs(lora_model_path)
 >>> pipe.to("cuda")
-# use half the weights from the LoRA finetuned model and half the weights from the base model
 
+# use half the weights from the LoRA finetuned model and half the weights from the base model
 >>> image = pipe(
 ...     "A picture of a sks dog in a bucket.",
 ...     num_inference_steps=25,
 ...     guidance_scale=7.5,
 ...     cross_attention_kwargs={"scale": 0.5},
 ... ).images[0]
-# use the weights from the fully finetuned LoRA model
+
+# OR, use the weights from the fully finetuned LoRA model
+# >>> image = pipe("A picture of a sks dog in a bucket.", num_inference_steps=25, guidance_scale=7.5).images[0]
 
 >>> image.save("bucket-dog.png")
 ```

--- a/docs/source/en/training/lora.md
+++ b/docs/source/en/training/lora.md
@@ -120,7 +120,6 @@ Load the LoRA weights from your finetuned model *on top of the base model weight
 ... ).images[0]
 # use the weights from the fully finetuned LoRA model
 
->>> image = pipe("A pokemon with blue eyes.", num_inference_steps=25, guidance_scale=7.5).images[0]
 >>> image.save("blue_pokemon.png")
 ```
 
@@ -235,7 +234,6 @@ Load the LoRA weights from your finetuned DreamBooth model *on top of the base m
 ... ).images[0]
 # use the weights from the fully finetuned LoRA model
 
->>> image = pipe("A picture of a sks dog in a bucket.", num_inference_steps=25, guidance_scale=7.5).images[0]
 >>> image.save("bucket-dog.png")
 ```
 


### PR DESCRIPTION
`pipe()` is run twice.  One is with `cross_attention_kwargs` and the other (next line) removes it.  This appears to be a typo.

- Docs: @stevhliu and @yiyixuxu