### PR TITLE
fix: incorrect comparison operator

### DIFF
--- a/src/diffusers/utils/constants.py
+++ b/src/diffusers/utils/constants.py
@@ -44,9 +44,9 @@ DEPRECATED_REVISION_ARGS = ["fp16", "non-ema"]
 # For PEFT it is has to be greater than 0.6.0 and for transformers it has to be greater than 4.33.1.
 _required_peft_version = is_peft_available() and version.parse(
     version.parse(importlib.metadata.version("peft")).base_version
-) > version.parse(MIN_PEFT_VERSION)
+) >= version.parse(MIN_PEFT_VERSION)
 _required_transformers_version = is_transformers_available() and version.parse(
     version.parse(importlib.metadata.version("transformers")).base_version
-) > version.parse(MIN_TRANSFORMERS_VERSION)
+) >= version.parse(MIN_TRANSFORMERS_VERSION)
 
 USE_PEFT_BACKEND = _required_peft_version and _required_transformers_version


### PR DESCRIPTION
# What does this PR do?

Use greater than or equal to in version check for PEFT and transformers.

Was unable to load PEFT. I suspected the version check was incorrect because of the naming of the variables `MIN_PEFT_VERSION` and `MIN_TRANSFORMERS_VERSION` and because it worked for me if I changed it.

_There is also no PEFT version v0.5.1 but maybe you allow breaking changes (e.g. v0.6.0) intentionally._

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@patrickvonplaten 