### PR TITLE
download_from_original_stable_diffusion_ckpt initializes correct default pipeline for SDXL

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -1231,13 +1231,11 @@ def download_from_original_stable_diffusion_ckpt(
         StableDiffusionInpaintPipeline,
         StableDiffusionPipeline,
         StableDiffusionUpscalePipeline,
+        StableDiffusionXLPipeline,
         StableDiffusionXLImg2ImgPipeline,
         StableUnCLIPImg2ImgPipeline,
         StableUnCLIPPipeline,
     )
-
-    if pipeline_class is None:
-        pipeline_class = StableDiffusionPipeline if not controlnet else StableDiffusionControlNetPipeline
 
     if prediction_type == "v-prediction":
         prediction_type = "v_prediction"
@@ -1333,6 +1331,13 @@ def download_from_original_stable_diffusion_ckpt(
         if image_size is None:
             image_size = 1024
 
+    if pipeline_class is None:
+        # Check if we have a SDXL or SD model and initialize default pipeline
+        if model_type not in ["SDXL", "SDXL-Refiner"]:
+            pipeline_class = StableDiffusionPipeline if not controlnet else StableDiffusionControlNetPipeline
+        else:
+            pipeline_class = StableDiffusionXLPipeline if model_type == "SDXL" else StableDiffusionXLImg2ImgPipeline
+
     if num_in_channels is None and pipeline_class == StableDiffusionInpaintPipeline:
         num_in_channels = 9
     if num_in_channels is None and pipeline_class == StableDiffusionUpscalePipeline:
@@ -1400,6 +1405,7 @@ def download_from_original_stable_diffusion_ckpt(
         )
     # make sure scheduler works correctly with DDIM
     scheduler.register_to_config(clip_sample=False)
+
 
     if scheduler_type == "pndm":
         config = dict(scheduler.config)

--- a/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -1334,9 +1334,17 @@ def download_from_original_stable_diffusion_ckpt(
     if pipeline_class is None:
         # Check if we have a SDXL or SD model and initialize default pipeline
         if model_type not in ["SDXL", "SDXL-Refiner"]:
-            pipeline_class = StableDiffusionPipeline if not controlnet else StableDiffusionControlNetPipeline
+            pipeline_class = (
+                StableDiffusionPipeline
+                if not controlnet
+                else StableDiffusionControlNetPipeline
+            )
         else:
-            pipeline_class = StableDiffusionXLPipeline if model_type == "SDXL" else StableDiffusionXLImg2ImgPipeline
+            pipeline_class = (
+                StableDiffusionXLPipeline
+                if model_type == "SDXL"
+                else StableDiffusionXLImg2ImgPipeline
+            )
 
     if num_in_channels is None and pipeline_class == StableDiffusionInpaintPipeline:
         num_in_channels = 9

--- a/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -1334,17 +1334,9 @@ def download_from_original_stable_diffusion_ckpt(
     if pipeline_class is None:
         # Check if we have a SDXL or SD model and initialize default pipeline
         if model_type not in ["SDXL", "SDXL-Refiner"]:
-            pipeline_class = (
-                StableDiffusionPipeline
-                if not controlnet
-                else StableDiffusionControlNetPipeline
-            )
+            pipeline_class = StableDiffusionPipeline if not controlnet else StableDiffusionControlNetPipeline
         else:
-            pipeline_class = (
-                StableDiffusionXLPipeline
-                if model_type == "SDXL"
-                else StableDiffusionXLImg2ImgPipeline
-            )
+            pipeline_class = StableDiffusionXLPipeline if model_type == "SDXL" else StableDiffusionXLImg2ImgPipeline
 
     if num_in_channels is None and pipeline_class == StableDiffusionInpaintPipeline:
         num_in_channels = 9
@@ -1413,7 +1405,6 @@ def download_from_original_stable_diffusion_ckpt(
         )
     # make sure scheduler works correctly with DDIM
     scheduler.register_to_config(clip_sample=False)
-
 
     if scheduler_type == "pndm":
         config = dict(scheduler.config)

--- a/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -1231,8 +1231,8 @@ def download_from_original_stable_diffusion_ckpt(
         StableDiffusionInpaintPipeline,
         StableDiffusionPipeline,
         StableDiffusionUpscalePipeline,
-        StableDiffusionXLPipeline,
         StableDiffusionXLImg2ImgPipeline,
+        StableDiffusionXLPipeline,
         StableUnCLIPImg2ImgPipeline,
         StableUnCLIPPipeline,
     )


### PR DESCRIPTION
# What does this PR do?

Previously the `download_from_original_stable_diffusion_ckpt` function, when run with a SDXL model, would default to a `StableDiffusionPipeline` pipeline class. This would lead to downstream errors because the SDXL model has a `text_encoder_2` which is not recognized in the `StableDiffusionPipeline`.

A few lines below, the function checks if the model is a SDXL or SDXL-Refiner and sets the `model_type` variable accordingly.  

I moved the initialization of the default pipeline (when None is set specifically) below this detection if the model is SDXL or SDXL-Refiner and initialize the correct default pipeline. This makes it easier for users who for example run the `convert_original_stable_diffusion_to_diffusers.py` script.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
 **_This issue came to my attention only a few hours ago and I immediately fixed it but it was part of a discussion at [Issue#4488](https://github.com/huggingface/diffusers/issues/4488). It basically adds a better default to [MR#4461](https://github.com/huggingface/diffusers/pull/4461)_**
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation). _**No changes needed**_
- [ ] Did you write any new necessary tests? **_Not necessary imo_**


## Who can review?
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@patrickvonplaten @yiyixuxu 

