### PR TITLE
[docs] Fix title

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -19,6 +19,7 @@
     title: Train a diffusion model
   - local: tutorials/using_peft_for_inference
     title: Inference with PEFT
+  title: Tutorials
 - sections:
   - sections:
     - local: using-diffusers/loading_overview


### PR DESCRIPTION
Adds back the missing Tutorial section title