### PR TITLE
fix: redefinition

### DIFF
--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -752,8 +752,8 @@ class ResnetBlock2D(nn.Module):
             hidden_states = self.norm2(hidden_states)
 
         if temb is not None and self.time_embedding_norm == "scale_shift":
-            scale, shift = torch.chunk(temb, 2, dim=1)
-            hidden_states = hidden_states * (1 + scale) + shift
+            _scale, _shift = torch.chunk(temb, 2, dim=1)
+            hidden_states = hidden_states * (1 + _scale) + _shift
 
         hidden_states = self.nonlinearity(hidden_states)
 


### PR DESCRIPTION
Actually, you are overwriting an existing variable `scale` (float) with `sliced tensor` and nothing good is happening next.

I suggest this this naming