### PR TITLE
Avoid computing min() that is expensive when do_normalize is False in the image processor

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -326,7 +326,7 @@ class VaeImageProcessor(ConfigMixin):
 
         # expected range [0,1], normalize to [-1,1]
         do_normalize = self.config.do_normalize
-        if image.min() < 0 and do_normalize:
+        if do_normalize and image.min() < 0:
             warnings.warn(
                 "Passing `image` as torch tensor with value range in [-1,1] is deprecated. The expected value range for image tensor is [0,1] "
                 f"when passing as pytorch tensor or numpy Array. You passed `image` with value range [{image.min()},{image.max()}]",


### PR DESCRIPTION
Avoid extra computing when do_normalize is False

@yiyixuxu maybe you are the one for this one.