### PR TITLE
save a lot of GPU memory for final inference

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_sdxl.py
+++ b/examples/dreambooth/train_dreambooth_lora_sdxl.py
@@ -1677,6 +1677,16 @@ def main(args):
             text_encoder_2_lora_layers=text_encoder_2_lora_layers,
         )
 
+        # remove unuse a lot of GPU memory for Final inference 
+        unet = unet.cpu()
+        text_encoder_one = text_encoder_one.cpu()
+        text_encoder_two = text_encoder_two.cpu()
+        del unet,text_encoder_one,text_encoder_two
+        del optimizer
+        torch.cuda.empty_cache()
+        if args.train_text_encoder:
+            del text_encoder_lora_layers, text_encoder_2_lora_layers
+            
         # Final inference
         # Load previous pipeline
         vae = AutoencoderKL.from_pretrained(


### PR DESCRIPTION
remove unuse parameters and models

Fixes # (issue):
     if not remove unet and text_encoder_one, and text_encoder_two. it will cost 2 times GPU memory for inference. So When train lora is finished. I delete parameters and model that was used in training .



