### PR TITLE
[docs] Fix SVD video

### DIFF
--- a/docs/source/en/using-diffusers/svd.md
+++ b/docs/source/en/using-diffusers/svd.md
@@ -53,8 +53,9 @@ frames = pipe(image, decode_chunk_size=8, generator=generator).frames[0]
 export_to_video(frames, "generated.mp4", fps=7)
 ```
 
-<video width="1024" height="576" controls>
-  <source src="https://i.imgur.com/jJzVDKw.mp4" type="video/mp4">
+<video controls width="1024" height="576">
+  <source src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/svd/rocket_generated.webm" type="video/webm" />
+  <source src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/svd/rocket_generated.mp4" type="video/mp4" />
 </video>
 
 <Tip>


### PR DESCRIPTION
Fixes the video link from the Hub to use a more supported format - `webm` - for Chrome, and the `mp4` file is able to play without any issues in Safari :)