### PR TITLE
EulerDiscreteScheduler add `rescale_betas_zero_snr`

### DIFF
--- a/src/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_discrete.py
@@ -213,7 +213,7 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         if rescale_betas_zero_snr:
             # Close to 0 without being 0 so first sigma is not inf
             # FP16 smallest positive subnormal works well here
-            self.alphas_cumprod[-1] = 2 ** -24
+            self.alphas_cumprod[-1] = 2**-24
 
         sigmas = np.array(((1 - self.alphas_cumprod) / self.alphas_cumprod) ** 0.5)
         timesteps = np.linspace(0, num_train_timesteps - 1, num_train_timesteps, dtype=float)[::-1].copy()

--- a/src/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_discrete.py
@@ -92,6 +92,7 @@ def betas_for_alpha_bar(
     return torch.tensor(betas, dtype=torch.float32)
 
 
+# Copied from diffusers.schedulers.scheduling_ddim.rescale_zero_terminal_snr
 def rescale_zero_terminal_snr(betas):
     """
     Rescales betas to have zero terminal SNR Based on https://arxiv.org/pdf/2305.08891.pdf (Algorithm 1)

--- a/tests/schedulers/test_scheduler_euler.py
+++ b/tests/schedulers/test_scheduler_euler.py
@@ -45,6 +45,10 @@ class EulerDiscreteSchedulerTest(SchedulerCommonTest):
     def test_karras_sigmas(self):
         self.check_over_configs(use_karras_sigmas=True, sigma_min=0.02, sigma_max=700.0)
 
+    def test_rescale_betas_zero_snr(self):
+        for rescale_betas_zero_snr in [True, False]:
+            self.check_over_configs(rescale_betas_zero_snr=rescale_betas_zero_snr)
+
     def test_full_loop_no_noise(self):
         scheduler_class = self.scheduler_classes[0]
         scheduler_config = self.get_scheduler_config()


### PR DESCRIPTION
### Overview
Adds support for the `rescale_betas_zero_snr` config option to EulerDiscreteScheduler. Currently it works equivelently to DDIM with the concession that the final alpha_cumprod is patched to 2 ** -24 to resolve the `inf` issue, similar to what ComfyUI does.

~~This does not follow the 'curve' so to speak, and a value closer to 0 would be more appropriate, however lower values such as 2 ** -24 run into precision issues on fp16/bf16 inference. A more proper fix would be finding exactly where the precision issues lie in the pipeline code and resolving them (upcast?).  don't think I am math enough for this; 2 ** -16 is satisfactory from my benchmark images on the model "ptx0/terminus-xl-gamma-training".~~

I have fixed the precision issues by upcasting the sample for the duration of the step() function, then re-casting back to the model's dtype before return. There appears to be no performance loss.

### Examples
Unpatched EulerDiscrete
![unpatched](https://github.com/huggingface/diffusers/assets/39478211/816bc7ee-114e-4088-a7c5-71f2cef96293)

DDIM as reference
![ddim](https://github.com/huggingface/diffusers/assets/39478211/661bbb1f-4667-4fc2-9721-3e6755895da4)

Patched EulerDiscrete
![00012](https://github.com/huggingface/diffusers/assets/39478211/30b560d1-82dd-4f3c-9c47-7e626188ab4a)

### Uncertainties
 - The function `rescale_zero_terminal_snr` could reasonably be moved to `scheduling_utils.py` and shared between EulerDiscrete and DDIM, however with convention shown via `betas_for_alpha_bar` I've opted to duplicate it. If I or someone eventually adds ZSNR support to other samplers, this may be desirable.