### PR TITLE
[From single file] remove depr warning

### DIFF
--- a/src/diffusers/loaders/single_file.py
+++ b/src/diffusers/loaders/single_file.py
@@ -282,7 +282,7 @@ class FromSingleFileMixin:
         )
 
         if torch_dtype is not None:
-            pipe.to(torch_dtype=torch_dtype)
+            pipe.to(dtype=torch_dtype)
 
         return pipe
 


### PR DESCRIPTION
# What does this PR do?

```py
.to(torch_dtype=...)
```

is deprecated in favor of:

```py
.to(dtype=...)
```