### PR TITLE
Fix possible re-conversion issues after extracting from safetensors

### DIFF
--- a/scripts/convert_diffusers_to_original_stable_diffusion.py
+++ b/scripts/convert_diffusers_to_original_stable_diffusion.py
@@ -157,6 +157,8 @@ vae_conversion_map_attn = [
     ("k.", "key."),
     ("v.", "value."),
     ("proj_out.", "proj_attn."),
+]
+
 # This is probably not the most ideal solution, but it does work.
 vae_extra_conversion_map = [
     ("to_q", "q"),
@@ -195,6 +197,7 @@ def convert_vae_state_dict(vae_state_dict):
                 keys_to_rename[k] = k.replace(weight_name, real_weight_name)
     for k, v in keys_to_rename.items():
         if k in new_state_dict:
+            print(f"Renaming {k} to {v}")
             new_state_dict[v] = reshape_weight_for_sd(new_state_dict[k])
             del new_state_dict[k]
     return new_state_dict

--- a/scripts/convert_diffusers_to_original_stable_diffusion.py
+++ b/scripts/convert_diffusers_to_original_stable_diffusion.py
@@ -157,6 +157,12 @@ vae_conversion_map_attn = [
     ("k.", "key."),
     ("v.", "value."),
     ("proj_out.", "proj_attn."),
+# This is probably not the most ideal solution, but it does work.
+vae_extra_conversion_map = [
+    ("to_q", "q"),
+    ("to_k", "k"),
+    ("to_v", "v"),
+    ("to_out.0", "proj_out"),
 ]
 
 
@@ -178,11 +184,19 @@ def convert_vae_state_dict(vae_state_dict):
             mapping[k] = v
     new_state_dict = {v: vae_state_dict[k] for k, v in mapping.items()}
     weights_to_convert = ["q", "k", "v", "proj_out"]
+    keys_to_rename = {}
     for k, v in new_state_dict.items():
         for weight_name in weights_to_convert:
             if f"mid.attn_1.{weight_name}.weight" in k:
                 print(f"Reshaping {k} for SD format")
                 new_state_dict[k] = reshape_weight_for_sd(v)
+        for weight_name, real_weight_name in vae_extra_conversion_map:
+            if f"mid.attn_1.{weight_name}.weight" in k or f"mid.attn_1.{weight_name}.bias" in k:
+                keys_to_rename[k] = k.replace(weight_name, real_weight_name)
+    for k, v in keys_to_rename.items():
+        if k in new_state_dict:
+            new_state_dict[v] = reshape_weight_for_sd(new_state_dict[k])
+            del new_state_dict[k]
     return new_state_dict
 
 


### PR DESCRIPTION
Properly rename specific vae keys.

# What does this PR do?

When extracting a sd 1.5 .safetensors using the from_single_file and then save_pretrained methods (as found in the convert_original_stable_diffusion_to_diffusers.py script), a handful of the vae keys are not properly renamed. 

This fixes that issue.

I determined this by first extracting and then re-compiling the v1-5-pruned-emaonly.safetensors file using the stock script, then re-compiling it the same way.

I then did a diff of the keys from the two checkpoints, and noted the differences this change fixes.

After applying this patch, the keys between the two models were almost exactly the same, with the exception of a handful of other keys that don't appear to be related to the actual model weights.

Fixes # (issue)


## Before submitting
- [ x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x ] Did you write any new necessary tests?


## Who can review?

@patrickvonplaten
@sayakpaul

