### PR TITLE
[LoRA] add an error message when dealing with _best_guess_weight_name ofline

### DIFF
--- a/src/diffusers/loaders/lora.py
+++ b/src/diffusers/loaders/lora.py
@@ -311,7 +311,7 @@ class LoraLoaderMixin:
             targeted_files = [
                 f for f in os.listdir(pretrained_model_name_or_path_or_dict) if f.endswith(file_extension)
             ]
-        elif not local_files_only:
+        else:
             files_in_repo = model_info(pretrained_model_name_or_path_or_dict).siblings
             targeted_files = [f.rfilename for f in files_in_repo if f.rfilename.endswith(file_extension)]
         if len(targeted_files) == 0:


### PR DESCRIPTION
# What does this PR do?

Potentially fixes: https://github.com/huggingface/diffusers/issues/6089. https://github.com/huggingface/diffusers/issues/6110 is related too. I decided to throw an error rather than trying to engineer a solution. I think that's best here because `_best_guess_weight_name()` solves a particular use case and I don't think we should overengineer it. 