### PR TITLE
fix RuntimeError: Input type (float) and bias type (c10::Half) should be the same

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -1031,6 +1031,9 @@ class StableDiffusionPipeline(
                         callback(step_idx, t, latents)
 
         if not output_type == "latent":
+            # Ensure latents are always the same type as the VAE
+            latents = latents.to(next(iter(self.vae.post_quant_conv.parameters())).dtype)
+            
             image = self.vae.decode(latents / self.vae.config.scaling_factor, return_dict=False, generator=generator)[
                 0
             ]

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -1033,7 +1033,6 @@ class StableDiffusionPipeline(
         if not output_type == "latent":
             # Ensure latents are always the same type as the VAE
             latents = latents.to(next(iter(self.vae.post_quant_conv.parameters())).dtype)
-            
             image = self.vae.decode(latents / self.vae.config.scaling_factor, return_dict=False, generator=generator)[
                 0
             ]


### PR DESCRIPTION
When run train_text_to_image_lora.py , RuntimeError: Input type (float) and bias type (c10::Half) should be the same
occur 

this is the same issues as [#4796](https://github.com/huggingface/diffusers/pull/4796)

apply the update to pipeline_stable_diffusion.py too

Fixes # (issue)
RuntimeError: Input type (float) and bias type (c10::Half) should be the same
