### PR TITLE
[wip] mps: fix torch.where in svd codepath

### DIFF
--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -1334,7 +1334,7 @@ class AlphaBlender(nn.Module):
 
             alpha = torch.where(
                 image_only_indicator.bool(),
-                torch.ones(1, 1, device=image_only_indicator.device),
+                torch.ones(1, 1, device=image_only_indicator.device, dtype=self.mix_factor.dtype),
                 torch.sigmoid(self.mix_factor)[..., None],
             )
 


### PR DESCRIPTION
Conv3D support has just been added to `mps`, but the code path finds this `torch.where` that, in `mps`, requires the data tensors to have the same type. This PR fixes it, but video generation still doesn't work (I'm getting black frames).

Opening this branch so others in the community can test.

Edit: running the pipeline in `float32` works. I used a size of (768, 512) and memory consumption was ~50 GB.
