### PR TITLE
[Docs] Fix a code example in the ControlNet Inpainting documentation

### DIFF
--- a/docs/source/en/using-diffusers/controlnet.md
+++ b/docs/source/en/using-diffusers/controlnet.md
@@ -203,7 +203,7 @@ def make_inpaint_condition(image, image_mask):
     image_mask = np.array(image_mask.convert("L")).astype(np.float32) / 255.0
 
     assert image.shape[0:1] == image_mask.shape[0:1]
-    image[image_mask > 0.5] = 1.0  # set as masked pixel
+    image[image_mask > 0.5] = -1.0  # set as masked pixel
     image = np.expand_dims(image, 0).transpose(0, 3, 1, 2)
     image = torch.from_numpy(image)
     return image


### PR DESCRIPTION
# Fix a code example in the ControlNet Inpainting documentation

In the old code example, the masked region of images is filled with 1.0.
However, doc string and implementation require filling in with -1.0.
https://github.com/huggingface/diffusers/blob/aedd78767c99f7bc26a532622d4006280cc6c00d/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py#L75
https://github.com/huggingface/diffusers/blob/aedd78767c99f7bc26a532622d4006280cc6c00d/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py#L221


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?


## Who can review?

Core library:
- Docs: @stevhliu and @yiyixuxu



