### PR TITLE
Fix Prodigy optimizer in SDXL Dreambooth script

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_sdxl.py
+++ b/examples/dreambooth/train_dreambooth_lora_sdxl.py
@@ -1141,13 +1141,29 @@ def main(args):
             import prodigyopt
         except ImportError:
             raise ImportError("To use Prodigy, please install the prodigyopt library: `pip install prodigyopt`")
-
+        
         optimizer_class = prodigyopt.Prodigy
 
+        if args.learning_rate <= 0.1:
+            logger.warn(
+                "Learning rate is too low. When using prodigy, it's generally better to set learning rate around 1.0"
+            )
+        if args.train_text_encoder and args.text_encoder_lr:
+            logger.warn(
+                f"Learning rates were provided both for the unet and the text encoder- e.g. text_encoder_lr:"
+                f" {args.text_encoder_lr} and learning_rate: {args.learning_rate}. "
+                f"When using prodigy only learning_rate is used as the initial learning rate."
+            )
+            # changes the learning rate of text_encoder_parameters_one and text_encoder_parameters_two to be
+            # --learning_rate
+            params_to_optimize[1]["lr"] = args.learning_rate
+            params_to_optimize[2]["lr"] = args.learning_rate
+        
         optimizer = optimizer_class(
             params_to_optimize,
             lr=args.learning_rate,
             betas=(args.adam_beta1, args.adam_beta2),
+            beta3=args.prodigy_beta3,
             weight_decay=args.adam_weight_decay,
             eps=args.adam_epsilon,
             decouple=args.prodigy_decouple,

--- a/examples/dreambooth/train_dreambooth_lora_sdxl.py
+++ b/examples/dreambooth/train_dreambooth_lora_sdxl.py
@@ -1141,7 +1141,7 @@ def main(args):
             import prodigyopt
         except ImportError:
             raise ImportError("To use Prodigy, please install the prodigyopt library: `pip install prodigyopt`")
-        
+
         optimizer_class = prodigyopt.Prodigy
 
         if args.learning_rate <= 0.1:

--- a/examples/dreambooth/train_dreambooth_lora_sdxl.py
+++ b/examples/dreambooth/train_dreambooth_lora_sdxl.py
@@ -1158,7 +1158,7 @@ def main(args):
             # --learning_rate
             params_to_optimize[1]["lr"] = args.learning_rate
             params_to_optimize[2]["lr"] = args.learning_rate
-        
+
         optimizer = optimizer_class(
             params_to_optimize,
             lr=args.learning_rate,


### PR DESCRIPTION
# What does this PR do?

Re-adds the exact same Prodigy-related parameters to the SDXL Dreambooth training script that were removed in the PEFT integration commit - see here: https://github.com/huggingface/diffusers/commit/c2717317f03b12535cfd02b477ace61189e10e4b#diff-21097f487be9184775f962c08b5cd60b92a31a99da8f3e0d8caf7867f50644d9L1197-L1216

This removal at first glance doesn't seem related to PEFT, and can affect how the prodigyopt works. 

## Who can review?

@sayakpaul , @younesbelkada 
