### PR TITLE
Remove unused parameters and fixed `FutureWarning`

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddim_inverse.py
+++ b/src/diffusers/schedulers/scheduling_ddim_inverse.py
@@ -293,9 +293,6 @@ class DDIMInverseScheduler(SchedulerMixin, ConfigMixin):
         model_output: torch.FloatTensor,
         timestep: int,
         sample: torch.FloatTensor,
-        eta: float = 0.0,
-        use_clipped_model_output: bool = False,
-        variance_noise: Optional[torch.FloatTensor] = None,
         return_dict: bool = True,
     ) -> Union[DDIMSchedulerOutput, Tuple]:
         """
@@ -332,7 +329,7 @@ class DDIMInverseScheduler(SchedulerMixin, ConfigMixin):
         # 1. get previous step value (=t+1)
         prev_timestep = timestep
         timestep = min(
-            timestep - self.config.num_train_timesteps // self.num_inference_steps, self.num_train_timesteps - 1
+            timestep - self.config.num_train_timesteps // self.config.num_inference_steps, self.num_train_timesteps - 1
         )
 
         # 2. compute alphas, betas

--- a/src/diffusers/schedulers/scheduling_ddim_inverse.py
+++ b/src/diffusers/schedulers/scheduling_ddim_inverse.py
@@ -329,7 +329,7 @@ class DDIMInverseScheduler(SchedulerMixin, ConfigMixin):
         # 1. get previous step value (=t+1)
         prev_timestep = timestep
         timestep = min(
-            timestep - self.config.num_train_timesteps // self.config.num_inference_steps, self.num_train_timesteps - 1
+            timestep - self.config.num_train_timesteps // self.num_inference_steps, self.config.num_train_timesteps - 1
         )
 
         # 2. compute alphas, betas

--- a/tests/schedulers/test_scheduler_ddim_inverse.py
+++ b/tests/schedulers/test_scheduler_ddim_inverse.py
@@ -7,7 +7,7 @@ from .test_schedulers import SchedulerCommonTest
 
 class DDIMInverseSchedulerTest(SchedulerCommonTest):
     scheduler_classes = (DDIMInverseScheduler,)
-    forward_default_kwargs = (("eta", 0.0), ("num_inference_steps", 50))
+    forward_default_kwargs = (("num_inference_steps", 50),)
 
     def get_scheduler_config(self, **kwargs):
         config = {
@@ -26,7 +26,7 @@ class DDIMInverseSchedulerTest(SchedulerCommonTest):
         scheduler_config = self.get_scheduler_config(**config)
         scheduler = scheduler_class(**scheduler_config)
 
-        num_inference_steps, eta = 10, 0.0
+        num_inference_steps = 10
 
         model = self.dummy_model()
         sample = self.dummy_sample_deter
@@ -35,7 +35,7 @@ class DDIMInverseSchedulerTest(SchedulerCommonTest):
 
         for t in scheduler.timesteps:
             residual = model(sample, t)
-            sample = scheduler.step(residual, t, sample, eta).prev_sample
+            sample = scheduler.step(residual, t, sample).prev_sample
 
         return sample
 


### PR DESCRIPTION
# What does this PR do?

Remove unused parameters for `DDIMInverseScheduler` and fix the `FutureWarning` about accessing the instance directly with `self`.

```
FutureWarning: Accessing config attribute `num_train_timesteps` directly via 'DDIMInverseScheduler' object attribute is deprecated. Please access 'num_train_timesteps' over 'DDIMInverseScheduler's config object instead, e.g. 'scheduler.config.num_train_timesteps'.
  deprecate("direct config name access", "1.0.0", deprecation_message, standard_warn=False)
```
