### PR TITLE
Enable ipex optimization on textual-inversion

### DIFF
--- a/examples/textual_inversion/README.md
+++ b/examples/textual_inversion/README.md
@@ -94,6 +94,13 @@ to a number larger than one, *e.g.*:
 --num_vectors 5
 ```
 
+**CPU**: If you run on Intel Gen 4th Xeon (and later), use ipex and bf16 will get a significant acceleration.
+You need to add `--mixed_precision="bf16"` and `--use_ipex` in the command and install the following package:
+```
+pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2 --index-url https://download.pytorch.org/whl/cpu
+pip install intel-extension-for-pytorch==2.0.0
+```
+
 The saved textual inversion vectors will then be larger in size compared to the default case.
 
 ### Inference

--- a/examples/textual_inversion/README.md
+++ b/examples/textual_inversion/README.md
@@ -97,8 +97,7 @@ to a number larger than one, *e.g.*:
 **CPU**: If you run on Intel Gen 4th Xeon (and later), use ipex and bf16 will get a significant acceleration.
 You need to add `--mixed_precision="bf16"` and `--use_ipex` in the command and install the following package:
 ```
-pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2 --index-url https://download.pytorch.org/whl/cpu
-pip install intel-extension-for-pytorch==2.0.0
+pip install intel-extension-for-pytorch
 ```
 
 The saved textual inversion vectors will then be larger in size compared to the default case.

--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -349,7 +349,7 @@ def parse_args():
         action="store_true",
         help=(
             "Whether or not to use ipex to accelerate the training process,"
-            "requires Intel Gen 3rd Xeon (and later) or Intel XPU (PVC)"
+            "requires Intel Gen 3rd Xeon (and later)"
         ),
     )
     parser.add_argument(

--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -348,8 +348,7 @@ def parse_args():
         "--use_ipex",
         action="store_true",
         help=(
-            "Whether or not to use ipex to accelerate the training process,"
-            "requires Intel Gen 3rd Xeon (and later)"
+            "Whether or not to use ipex to accelerate the training process," "requires Intel Gen 3rd Xeon (and later)"
         ),
     )
     parser.add_argument(
@@ -789,6 +788,7 @@ def main():
 
     if args.use_ipex:
         import intel_extension_for_pytorch as ipex
+
         unet = ipex.optimize(unet, dtype=weight_dtype)
         vae = ipex.optimize(vae, dtype=weight_dtype)
 


### PR DESCRIPTION
This PR enables ipex on Intel Gen Xeon (and later).

It will get around 20% speed-up if we use ipex with bf16, compares only enables bf16.