### PR TITLE
🛠️ Fix widget format for advanced training

### DIFF
--- a/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
+++ b/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
@@ -161,8 +161,6 @@ tags:
 base_model: {base_model}
 instance_prompt: {instance_prompt}
 license: openrail++
-widget:
-    - text: '{validation_prompt if validation_prompt else instance_prompt}'
 ---
 """
 


### PR DESCRIPTION
I think in a bit of an unrelated matter, #5778 added two lines to the `train_dreambooth_lora_sdxl_advanced.py` which breaks the `*.yaml` format for that script, as there's already a string that handles that here: https://github.com/huggingface/diffusers/blob/main/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py#L115

This PR reverts that.