### PR TITLE
[bug fix] fixes #6444 - checkpointing save issue in advanced dreambooth lora sdxl script 

### DIFF
--- a/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
+++ b/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
@@ -1337,6 +1337,10 @@ def main(args):
                 text_encoder_lora_layers=text_encoder_one_lora_layers_to_save,
                 text_encoder_2_lora_layers=text_encoder_two_lora_layers_to_save,
             )
+            if args.train_text_encoder_ti:
+                embedding_handler.save_embeddings(
+                    f"{output_dir}/{output_dir}_emb.safetensors",
+                )
 
     def load_model_hook(models, input_dir):
         unet_ = None

--- a/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
+++ b/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
@@ -1339,7 +1339,7 @@ def main(args):
             )
         if args.train_text_encoder_ti:
             embedding_handler.save_embeddings(
-                f"{output_dir}/{output_dir}_emb.safetensors",
+                f"{output_dir}/{args.output_dir}_emb.safetensors",
             )
 
     def load_model_hook(models, input_dir):

--- a/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
+++ b/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
@@ -1338,9 +1338,7 @@ def main(args):
                 text_encoder_2_lora_layers=text_encoder_two_lora_layers_to_save,
             )
         if args.train_text_encoder_ti:
-            embedding_handler.save_embeddings(
-                f"{output_dir}/{args.output_dir}_emb.safetensors",
-            )
+            embedding_handler.save_embeddings(f"{output_dir}/{args.output_dir}_emb.safetensors")
 
     def load_model_hook(models, input_dir):
         unet_ = None

--- a/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
+++ b/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
@@ -1316,9 +1316,10 @@ def main(args):
                 if isinstance(model, type(accelerator.unwrap_model(unet))):
                     unet_lora_layers_to_save = convert_state_dict_to_diffusers(get_peft_model_state_dict(model))
                 elif isinstance(model, type(accelerator.unwrap_model(text_encoder_one))):
-                    text_encoder_one_lora_layers_to_save = convert_state_dict_to_diffusers(
-                        get_peft_model_state_dict(model)
-                    )
+                    if args.train_text_encoder:
+                        text_encoder_one_lora_layers_to_save = convert_state_dict_to_diffusers(
+                            get_peft_model_state_dict(model)
+                        )
                 elif isinstance(model, type(accelerator.unwrap_model(text_encoder_two))):
                     text_encoder_two_lora_layers_to_save = convert_state_dict_to_diffusers(
                         get_peft_model_state_dict(model)

--- a/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
+++ b/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
@@ -1337,10 +1337,10 @@ def main(args):
                 text_encoder_lora_layers=text_encoder_one_lora_layers_to_save,
                 text_encoder_2_lora_layers=text_encoder_two_lora_layers_to_save,
             )
-            if args.train_text_encoder_ti:
-                embedding_handler.save_embeddings(
-                    f"{output_dir}/{output_dir}_emb.safetensors",
-                )
+        if args.train_text_encoder_ti:
+            embedding_handler.save_embeddings(
+                f"{output_dir}/{output_dir}_emb.safetensors",
+            )
 
     def load_model_hook(models, input_dir):
         unet_ = None

--- a/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
+++ b/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
@@ -1321,9 +1321,10 @@ def main(args):
                             get_peft_model_state_dict(model)
                         )
                 elif isinstance(model, type(accelerator.unwrap_model(text_encoder_two))):
-                    text_encoder_two_lora_layers_to_save = convert_state_dict_to_diffusers(
-                        get_peft_model_state_dict(model)
-                    )
+                    if args.train_text_encoder:
+                        text_encoder_two_lora_layers_to_save = convert_state_dict_to_diffusers(
+                            get_peft_model_state_dict(model)
+                        )
                 else:
                     raise ValueError(f"unexpected save model: {model.__class__}")
 


### PR DESCRIPTION
Fixes the bug described in [#6444](https://github.com/huggingface/diffusers/issues/6444) that occurs when both
(`--checkpointing_steps < --max_train_steps`) and `--train_text_encoder_ti` is enabled. 

When enabling pivotal tuning, since we optimize the embeddings but we don't modify the text encoder weights, we shouldn't be saving text encoder lora layers in each checkpoint (which is what cause the error). This PR modifies `save_model_hook` such that they're saved only when full text encoder fine tuning is performed