### PR TITLE
Fix offline mode import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ _deps = [
     "filelock",
     "flax>=0.4.1",
     "hf-doc-builder>=0.3.0",
-    "huggingface-hub>=0.19.4",
+    "huggingface-hub>=0.20.2",
     "requests-mock==1.10.0",
     "importlib_metadata",
     "invisible-watermark>=0.2.0",

--- a/src/diffusers/dependency_versions_table.py
+++ b/src/diffusers/dependency_versions_table.py
@@ -9,7 +9,7 @@ deps = {
     "filelock": "filelock",
     "flax": "flax>=0.4.1",
     "hf-doc-builder": "hf-doc-builder>=0.3.0",
-    "huggingface-hub": "huggingface-hub>=0.19.4",
+    "huggingface-hub": "huggingface-hub>=0.20.2",
     "requests-mock": "requests-mock==1.10.0",
     "importlib_metadata": "importlib_metadata",
     "invisible-watermark": "invisible-watermark>=0.2.0",


### PR DESCRIPTION
Follow-up PR after https://github.com/huggingface/diffusers/pull/6456 (cc @sayakpaul).

In https://github.com/huggingface/diffusers/pull/6456, I added support for offline mode. However I forgot to update `huggingface_hub` version in the dependencies as highlighted by @voytez in https://github.com/huggingface/diffusers/pull/6456#issuecomment-1877767481.

This PR fixes this by making `huggingface_hub>=0.20.2` the minimal version. This shouldn't cause any problem as diffusers is already compatible with `0.20.2` and I'm not aware of any library pinning `huggingface_hub<0.20`.

(for the record, setting `HF_HUB_OFFLINE=1` doesn't raise an error when calling `model_info(...)` on versions <0.20.x)