### PR TITLE
Fixed HFlip probability in train_diffusion_dpo_sdxl.py

### DIFF
--- a/examples/research_projects/diffusion_dpo/train_diffusion_dpo_sdxl.py
+++ b/examples/research_projects/diffusion_dpo/train_diffusion_dpo_sdxl.py
@@ -702,7 +702,7 @@ def main(args):
     # Preprocessing the datasets.
     train_resize = transforms.Resize(args.resolution, interpolation=transforms.InterpolationMode.BILINEAR)
     train_crop = transforms.RandomCrop(args.resolution) if args.random_crop else transforms.CenterCrop(args.resolution)
-    train_flip = transforms.RandomHorizontalFlip(p=1.0)
+    train_flip = transforms.RandomHorizontalFlip(p=0.5)
     to_tensor = transforms.ToTensor()
     normalize = transforms.Normalize([0.5], [0.5])
 


### PR DESCRIPTION
# What does this PR do?

State before: The Diffusion-DPO script initialized the HorizontalFlip transform with p=1.0. This means every image would be horizontal flipped deterministically.

State now: Switched to p=0.5.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
Follow-up micro-fix to https://github.com/huggingface/diffusers/pull/6422


## Who can review?

@sayakpaul 