### PR TITLE
[SVD] support generators that are created on GPU

### DIFF
--- a/src/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
+++ b/src/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
@@ -431,6 +431,7 @@ class StableVideoDiffusionPipeline(DiffusionPipeline):
         # 4. Encode input image using VAE
         image = self.image_processor.preprocess(image, height=height, width=width)
         noise = randn_tensor(image.shape, generator=generator, device=self.vae.device, dtype=image.dtype)
+        print(noise.device, image.device)
         image = image + noise_aug_strength * noise
 
         needs_upcasting = self.vae.dtype == torch.float16 and self.vae.config.force_upcast

--- a/src/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
+++ b/src/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
@@ -161,7 +161,8 @@ class StableVideoDiffusionPipeline(DiffusionPipeline):
         num_videos_per_prompt,
         do_classifier_free_guidance,
     ):
-        image = image.to(device=device)
+        if device is not None:
+            image = image.to(device=device)
         image_latents = self.vae.encode(image).latent_dist.mode()
 
         if do_classifier_free_guidance:
@@ -429,16 +430,20 @@ class StableVideoDiffusionPipeline(DiffusionPipeline):
         fps = fps - 1
 
         # 4. Encode input image using VAE
-        image = self.image_processor.preprocess(image, height=height, width=width)
-        noise = randn_tensor(image.shape, generator=generator, device=self.vae.device, dtype=image.dtype)
-        print(noise.device, image.device)
+        image = self.image_processor.preprocess(image, height=height, width=width).to(device)
+        noise = randn_tensor(image.shape, generator=generator, device=device, dtype=image.dtype)
         image = image + noise_aug_strength * noise
 
         needs_upcasting = self.vae.dtype == torch.float16 and self.vae.config.force_upcast
         if needs_upcasting:
             self.vae.to(dtype=torch.float32)
 
-        image_latents = self._encode_vae_image(image, device, num_videos_per_prompt, self.do_classifier_free_guidance)
+        image_latents = self._encode_vae_image(
+            image,
+            device=None,
+            num_videos_per_prompt=num_videos_per_prompt,
+            do_classifier_free_guidance=self.do_classifier_free_guidance,
+        )
         image_latents = image_latents.to(image_embeddings.dtype)
 
         # cast back to fp16 if needed

--- a/src/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
+++ b/src/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
@@ -430,7 +430,7 @@ class StableVideoDiffusionPipeline(DiffusionPipeline):
 
         # 4. Encode input image using VAE
         image = self.image_processor.preprocess(image, height=height, width=width)
-        noise = randn_tensor(image.shape, generator=generator, device=image.device, dtype=image.dtype)
+        noise = randn_tensor(image.shape, generator=generator, device=self.vae.device, dtype=image.dtype)
         image = image + noise_aug_strength * noise
 
         needs_upcasting = self.vae.dtype == torch.float16 and self.vae.config.force_upcast

--- a/src/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
+++ b/src/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py
@@ -161,8 +161,7 @@ class StableVideoDiffusionPipeline(DiffusionPipeline):
         num_videos_per_prompt,
         do_classifier_free_guidance,
     ):
-        if device is not None:
-            image = image.to(device=device)
+        image = image.to(device=device)
         image_latents = self.vae.encode(image).latent_dist.mode()
 
         if do_classifier_free_guidance:
@@ -440,7 +439,7 @@ class StableVideoDiffusionPipeline(DiffusionPipeline):
 
         image_latents = self._encode_vae_image(
             image,
-            device=None,
+            device=device,
             num_videos_per_prompt=num_videos_per_prompt,
             do_classifier_free_guidance=self.do_classifier_free_guidance,
         )

--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -63,6 +63,7 @@ def randn_tensor(
                     f" slighly speed up this function by passing a generator that was created on the {device} device."
                 )
         elif gen_device_type != device.type and gen_device_type == "cuda":
+            print(f"gen_device_type: {gen_device_type} device.type: {device.type}")
             raise ValueError(f"Cannot generate a {device} tensor from a generator of type {gen_device_type}.")
 
     # make sure generator list of length 1 is treated like a non-list

--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -63,7 +63,6 @@ def randn_tensor(
                     f" slighly speed up this function by passing a generator that was created on the {device} device."
                 )
         elif gen_device_type != device.type and gen_device_type == "cuda":
-            print(f"gen_device_type: {gen_device_type} device.type: {device.type}")
             raise ValueError(f"Cannot generate a {device} tensor from a generator of type {gen_device_type}.")
 
     # make sure generator list of length 1 is treated like a non-list


### PR DESCRIPTION
# What does this PR do?

With the current version of SVD, one cannot do:

```python
import torch

from diffusers import StableVideoDiffusionPipeline
from diffusers.utils import load_image, export_to_video

pipe = StableVideoDiffusionPipeline.from_pretrained(
    "stabilityai/stable-video-diffusion-img2vid-xt", torch_dtype=torch.float16, variant="fp16"
)
pipe.enable_model_cpu_offload()

# Load the conditioning image
image = load_image("https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/svd/rocket.png")
image = image.resize((1024, 576))

generator = torch.Generator(device="cuda").manual_seed(42)
frames = pipe(image, decode_chunk_size=8, generator=generator).frames[0]

export_to_video(frames, "generated.mp4", fps=7)
```

It leads to:

```bash
Traceback (most recent call last):
  File "/home/sayak/svd.py", line 16, in <module>
    frames = pipe(image, generator=generator).frames[0]
  File "/home/sayak/.pyenv/versions/diffusers/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/sayak/diffusers/src/diffusers/pipelines/stable_video_diffusion/pipeline_stable_video_diffusion.py", line 433, in __call__
    noise = randn_tensor(image.shape, generator=generator, device=image.device, dtype=image.dtype)
  File "/home/sayak/diffusers/src/diffusers/utils/torch_utils.py", line 66, in randn_tensor
    raise ValueError(f"Cannot generate a {device} tensor from a generator of type {gen_device_type}.")
ValueError: Cannot generate a cpu tensor from a generator of type cuda.
```

This PR fixes that. 