### PR TITLE
Fix a bug of flip in SDXL training script

### DIFF
--- a/examples/text_to_image/train_text_to_image_lora_sdxl.py
+++ b/examples/text_to_image/train_text_to_image_lora_sdxl.py
@@ -834,6 +834,9 @@ def main(args):
         for image in images:
             original_sizes.append((image.height, image.width))
             image = train_resize(image)
+            if args.random_flip and random.random() < 0.5:
+                # flip
+                image = train_flip(image)
             if args.center_crop:
                 y1 = max(0, int(round((image.height - args.resolution) / 2.0)))
                 x1 = max(0, int(round((image.width - args.resolution) / 2.0)))
@@ -841,10 +844,6 @@ def main(args):
             else:
                 y1, x1, h, w = train_crop.get_params(image, (args.resolution, args.resolution))
                 image = crop(image, y1, x1, h, w)
-            if args.random_flip and random.random() < 0.5:
-                # flip
-                x1 = image.width - x1
-                image = train_flip(image)
             crop_top_left = (y1, x1)
             crop_top_lefts.append(crop_top_left)
             image = train_transforms(image)

--- a/examples/text_to_image/train_text_to_image_sdxl.py
+++ b/examples/text_to_image/train_text_to_image_sdxl.py
@@ -842,6 +842,9 @@ def main(args):
         for image in images:
             original_sizes.append((image.height, image.width))
             image = train_resize(image)
+            if args.random_flip and random.random() < 0.5:
+                # flip
+                image = train_flip(image)
             if args.center_crop:
                 y1 = max(0, int(round((image.height - args.resolution) / 2.0)))
                 x1 = max(0, int(round((image.width - args.resolution) / 2.0)))
@@ -849,10 +852,6 @@ def main(args):
             else:
                 y1, x1, h, w = train_crop.get_params(image, (args.resolution, args.resolution))
                 image = crop(image, y1, x1, h, w)
-            if args.random_flip and random.random() < 0.5:
-                # flip
-                x1 = image.width - x1
-                image = train_flip(image)
             crop_top_left = (y1, x1)
             crop_top_lefts.append(crop_top_left)
             image = train_transforms(image)


### PR DESCRIPTION
# What does this PR do?

Fixes a problem mentioned in https://github.com/huggingface/diffusers/pull/4632#issuecomment-1681650226. For now, the crop condition is problematic because of the flip operation.

First, the following lines should be changed from
```
image = crop(image, y1, x1, h, w)
if args.random_flip and random.random() < 0.5:
    # flip
    x1 = image.width - x1 # here, image.width is not in original state, but in cropped image state
    image = train_flip(image)
```

to

```
orig_width = image.width
image = crop(image, y1, x1, h, w)
if args.random_flip and random.random() < 0.5:
    # flip
    x1 = orig_width - x1 # the width should be in original state
    image = train_flip(image)
```

Then, to avoid confusion about the coordinates order, it is elegant to conduct flip before crop.
```
if args.random_flip and random.random() < 0.5:
    # flip
    image = train_flip(image)
image = train_resize(image)
```