### PR TITLE
Make custom component <> custom remote file mapping really optional.

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1701,8 +1701,8 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
                 if candidate_file in filenames:
                     custom_components[component] = module_candidate
                 elif module_candidate not in LOADABLE_CLASSES and not hasattr(pipelines, module_candidate):
-                    raise ValueError(
-                        f"{candidate_file} as defined in `model_index.json` does not exist in {pretrained_model_name} and is not a module in 'diffusers/pipelines'."
+                    logger.warn(
+                        f"\n{candidate_file} as defined in `model_index.json` does not exist in {pretrained_model_name} and is not a module in 'diffusers/pipelines'."
                     )
 
             if len(variant_filenames) == 0 and variant is not None:


### PR DESCRIPTION


# What does this PR do?

Fixes https://github.com/huggingface/diffusers/issues/6563.

This PR changes `raise ValueError` into a warning to make custom component to custom file mapping really optional as described in the original comments.

This will allow importing a custom component from local files if it cannot be found from remote code (falling into the third case of [`get_class_obj_and_candidates`](https://github.com/huggingface/diffusers/blob/79df50388df09d9615e3c067695a453bb0a694c0/src/diffusers/pipelines/pipeline_utils.py#L325).



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- Pipelines:  @patrickvonplaten and @sayakpaul
