### PR TITLE
[Fix bugs] pipeline_controlnet_sd_xl.py

### DIFF
--- a/examples/research_projects/controlnetxs/pipeline_controlnet_xs_sd_xl.py
+++ b/examples/research_projects/controlnetxs/pipeline_controlnet_xs_sd_xl.py
@@ -1041,11 +1041,6 @@ class StableDiffusionXLControlNetXSPipeline(
                         step_idx = i // getattr(self.scheduler, "order", 1)
                         callback(step_idx, t, latents)
 
-        # manually for max memory savings
-        if self.vae.dtype == torch.float16 and self.vae.config.force_upcast:
-            self.upcast_vae()
-            latents = latents.to(next(iter(self.vae.post_quant_conv.parameters())).dtype)
-
         if not output_type == "latent":
             # make sure the VAE is in float32 mode, as it overflows in float16
             needs_upcasting = self.vae.dtype == torch.float16 and self.vae.config.force_upcast

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl.py
@@ -1404,11 +1404,6 @@ class StableDiffusionXLControlNetPipeline(
                         step_idx = i // getattr(self.scheduler, "order", 1)
                         callback(step_idx, t, latents)
 
-        # manually for max memory savings
-        if self.vae.dtype == torch.float16 and self.vae.config.force_upcast:
-            self.upcast_vae()
-            latents = latents.to(next(iter(self.vae.post_quant_conv.parameters())).dtype)
-
         if not output_type == "latent":
             # make sure the VAE is in float32 mode, as it overflows in float16
             needs_upcasting = self.vae.dtype == torch.float16 and self.vae.config.force_upcast


### PR DESCRIPTION
# What does this PR do?

Fixes a upcasting bug. 

Let's have a quick review here.

```
# manually for max memory savings
if self.vae.dtype == torch.float16 and self.vae.config.force_upcast:
    self.upcast_vae()
    latents = latents.to(next(iter(self.vae.post_quant_conv.parameters())).dtype)

if not output_type == "latent":
    # make sure the VAE is in float32 mode, as it overflows in float16
    needs_upcasting = self.vae.dtype == torch.float16 and self.vae.config.force_upcast

    if needs_upcasting:
        self.upcast_vae()
        latents = latents.to(next(iter(self.vae.post_quant_conv.parameters())).dtype)

    image = self.vae.decode(latents / self.vae.config.scaling_factor, return_dict=False)[0]

    # cast back to fp16 if needed
    if needs_upcasting:
        self.vae.to(dtype=torch.float16)
```

Assuming that we set our model to float16. At the first `if`, the vae and latents are upcasted to float32 for avoiding overflow. Then, `needs_upcasting` is False as the vae is in float32 now. The image is decoded in float32. Everything works fine.

But if we conduct the second inference, the vae is still in float32 while the latents is in float16, then we will encounter `RuntimeError: Input type (torch.cuda.HalfTensor) and weight type (torch.cuda.FloatTensor) should be the same`. Removing the first few lines solves the problem.