### PR TITLE
correct unload_ip_adapter: only unload `feature_extractor` if it's by default None

### DIFF
--- a/src/diffusers/loaders/ip_adapter.py
+++ b/src/diffusers/loaders/ip_adapter.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from pathlib import Path
 from typing import Dict, List, Union
 
@@ -205,8 +206,15 @@ class IPAdapterMixin:
             self.image_encoder = None
             self.register_to_config(image_encoder=[None, None])
 
-        # remove feature extractor
-        if hasattr(self, "feature_extractor") and getattr(self, "feature_extractor", None) is not None:
+        # remove feature extractor if it is not required by the pipeline
+        required_parameters = set(
+            {k for k, v in inspect.signature(self.__init__).parameters.items() if v.default == inspect._empty}
+        )
+        if (
+            hasattr(self, "feature_extractor")
+            and getattr(self, "feature_extractor", None) is not None
+            and "feature_extractor" not in required_parameters
+        ):
             self.feature_extractor = None
             self.register_to_config(feature_extractor=[None, None])
 


### PR DESCRIPTION
fix https://github.com/huggingface/diffusers/issues/6818

The current behavior of `unload_ip_adapter` is that it will unload `feature_extractor` as long as the pipeline has this component; however, it should only unload it when it is by default `None`. in SDXL pipelines, `feature_extractor` is None by default but not the case for SD pipelines

#### testing script
```python
import torch
from diffusers import AutoPipelineForText2Image

pipe = AutoPipelineForText2Image.from_pretrained(
    "runwayml/stable-diffusion-v1-5",
    variant="fp16",
    torch_dtype=torch.float16).to("cuda")

print(" ")
print("before load")
for k, v in pipe.components.items():
    print(f"{k},{type(v)}") 

pipe.load_ip_adapter("h94/IP-Adapter", subfolder="models", weight_name="ip-adapter-plus_sd15.bin")
print(f" ")
print(f" after load")
for k, v in pipe.components.items():
    print(f"{k},{type(v)}")

pipe.unload_ip_adapter()
print(" ")
print("after unload")
for k, v in pipe.components.items():
    print(f"{k},{type(v)}")
```

output

```
before load
vae,<class 'diffusers.models.autoencoders.autoencoder_kl.AutoencoderKL'>
text_encoder,<class 'transformers.models.clip.modeling_clip.CLIPTextModel'>
tokenizer,<class 'transformers.models.clip.tokenization_clip.CLIPTokenizer'>
unet,<class 'diffusers.models.unets.unet_2d_condition.UNet2DConditionModel'>
scheduler,<class 'diffusers.schedulers.scheduling_pndm.PNDMScheduler'>
safety_checker,<class 'diffusers.pipelines.stable_diffusion.safety_checker.StableDiffusionSafetyChecker'>
feature_extractor,<class 'transformers.models.clip.image_processing_clip.CLIPImageProcessor'>
image_encoder,<class 'NoneType'>
 
 after load
vae,<class 'diffusers.models.autoencoders.autoencoder_kl.AutoencoderKL'>
text_encoder,<class 'transformers.models.clip.modeling_clip.CLIPTextModel'>
tokenizer,<class 'transformers.models.clip.tokenization_clip.CLIPTokenizer'>
unet,<class 'diffusers.models.unets.unet_2d_condition.UNet2DConditionModel'>
scheduler,<class 'diffusers.schedulers.scheduling_pndm.PNDMScheduler'>
safety_checker,<class 'diffusers.pipelines.stable_diffusion.safety_checker.StableDiffusionSafetyChecker'>
feature_extractor,<class 'transformers.models.clip.image_processing_clip.CLIPImageProcessor'>
image_encoder,<class 'transformers.models.clip.modeling_clip.CLIPVisionModelWithProjection'>
 
after unload
vae,<class 'diffusers.models.autoencoders.autoencoder_kl.AutoencoderKL'>
text_encoder,<class 'transformers.models.clip.modeling_clip.CLIPTextModel'>
tokenizer,<class 'transformers.models.clip.tokenization_clip.CLIPTokenizer'>
unet,<class 'diffusers.models.unets.unet_2d_condition.UNet2DConditionModel'>
scheduler,<class 'diffusers.schedulers.scheduling_pndm.PNDMScheduler'>
safety_checker,<class 'diffusers.pipelines.stable_diffusion.safety_checker.StableDiffusionSafetyChecker'>
feature_extractor,<class 'transformers.models.clip.image_processing_clip.CLIPImageProcessor'>
image_encoder,<class 'NoneType'>
```