### PR TITLE
Added .to internal method call for DiffusionPipelines included in another DiffusionPipelines

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -865,7 +865,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
 
         module_names, _ = self._get_signature_keys(self)
         modules = [getattr(self, n, None) for n in module_names]
-        modules = [m for m in modules if isinstance(m, torch.nn.Module)]
+        modules = [m for m in modules if isinstance(m, (torch.nn.Module, DiffusionPipeline))]
 
         is_offloaded = pipeline_is_offloaded or pipeline_is_sequentially_offloaded
         for module in modules:


### PR DESCRIPTION
# What does this PR do?

This PR increases compatibility for DiffusionPipelines in a situation where one DiffusionPipeline includes another DiffusionPipeline as part of it.

Currently, the `.to` method is not called for the included DiffusionPipeline, so it is not transferred to another dtype or another device. I think that it would be convenient to also transfer those parts of pipelines along with the root pipeline.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@patrickvonplaten, @sayakpaul your review is kindly appreciated.
