### PR TITLE
[Community] Fix Scalings for Boundary Conditions for Consistency Training Script

### DIFF
--- a/examples/research_projects/consistency_training/train_cm_ct_unconditional.py
+++ b/examples/research_projects/consistency_training/train_cm_ct_unconditional.py
@@ -188,10 +188,10 @@ def get_input_preconditioning(sigmas, sigma_data=0.5, input_precond_type: str = 
         )
 
 
-def scalings_for_boundary_conditions(timestep, sigma_data=0.5, timestep_scaling=1.0):
+def scalings_for_boundary_conditions(timestep, sigma_min, sigma_data=0.5, timestep_scaling=1.0):
     scaled_timestep = timestep_scaling * timestep
-    c_skip = sigma_data**2 / (scaled_timestep**2 + sigma_data**2)
-    c_out = scaled_timestep / (scaled_timestep**2 + sigma_data**2) ** 0.5
+    c_skip = sigma_data**2 / ((scaled_timestep - sigma_min)**2 + sigma_data**2)
+    c_out = (scaled_timestep - sigma_min) * sigma_data / (scaled_timestep**2 + sigma_data**2) ** 0.5
     return c_skip, c_out
 
 
@@ -1255,8 +1255,8 @@ def main(args):
             c_in_teacher = get_input_preconditioning(teacher_timesteps, input_precond_type=args.input_precond_type)
             c_in_student = get_input_preconditioning(student_timesteps, input_precond_type=args.input_precond_type)
 
-            c_skip_teacher, c_out_teacher = scalings_for_boundary_conditions(teacher_timesteps)
-            c_skip_student, c_out_student = scalings_for_boundary_conditions(student_timesteps)
+            c_skip_teacher, c_out_teacher = scalings_for_boundary_conditions(teacher_timesteps, args.sigma_min)
+            c_skip_student, c_out_student = scalings_for_boundary_conditions(student_timesteps, args.sigma_min)
 
             c_skip_teacher, c_out_teacher, c_in_teacher = [
                 append_dims(x, clean_images.ndim) for x in [c_skip_teacher, c_out_teacher, c_in_teacher]

--- a/examples/research_projects/consistency_training/train_cm_ct_unconditional.py
+++ b/examples/research_projects/consistency_training/train_cm_ct_unconditional.py
@@ -190,7 +190,7 @@ def get_input_preconditioning(sigmas, sigma_data=0.5, input_precond_type: str = 
 
 def scalings_for_boundary_conditions(timestep, sigma_min, sigma_data=0.5, timestep_scaling=1.0):
     scaled_timestep = timestep_scaling * timestep
-    c_skip = sigma_data**2 / ((scaled_timestep - sigma_min)**2 + sigma_data**2)
+    c_skip = sigma_data**2 / ((scaled_timestep - sigma_min) ** 2 + sigma_data**2)
     c_out = (scaled_timestep - sigma_min) * sigma_data / (scaled_timestep**2 + sigma_data**2) ** 0.5
     return c_skip, c_out
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes a bug in `examples/research_projects/consistency_training/train_cm_ct_unconditional.py` where the `scalings_for_boundary_conditions` function does not take into account `sigma_min` ($`= \epsilon`$ in the [original CM paper](https://arxiv.org/pdf/2303.01469.pdf)) when calculating `c_skip` and `c_out` and thus does not satisfy the consistency model boundary condition $`c_{\mbox{skip}}(\epsilon) = 1`$ and $`c_{\mbox{out}}(\epsilon) = 0`$. The implementation should now correctly follow the parameterization given in Appendix C of the [original Consistency Models paper](https://arxiv.org/pdf/2303.01469.pdf).


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@patrickvonplaten
@sayakpaul
@patil-suraj
