### PR TITLE
[WIP]correct the attn naming for `UNet3DConditionModel`

### DIFF
--- a/src/diffusers/models/unets/unet_3d_condition.py
+++ b/src/diffusers/models/unets/unet_3d_condition.py
@@ -214,6 +214,7 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
             resnet_act_fn=act_fn,
             output_scale_factor=mid_block_scale_factor,
             cross_attention_dim=cross_attention_dim,
+            num_attention_heads=None,
             attention_head_dim=attention_head_dim[-1],
             resnet_groups=norm_num_groups,
             dual_cross_attention=False,

--- a/src/diffusers/models/unets/unet_3d_condition.py
+++ b/src/diffusers/models/unets/unet_3d_condition.py
@@ -132,14 +132,6 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 "At the moment it is not possible to define the number of attention heads via `num_attention_heads` because of a naming issue as described in https://github.com/huggingface/diffusers/issues/2011#issuecomment-1547958131. Passing `num_attention_heads` will only be supported in diffusers v0.19."
             )
 
-        # If `num_attention_heads` is not defined (which is the case for most models)
-        # it will default to `attention_head_dim`. This looks weird upon first reading it and it is.
-        # The reason for this behavior is to correct for incorrectly named variables that were introduced
-        # when this library was created. The incorrect naming was only discovered much later in https://github.com/huggingface/diffusers/issues/2011#issuecomment-1547958131
-        # Changing `attention_head_dim` to `num_attention_heads` for 40,000+ configurations is too backwards breaking
-        # which is why we correct for the naming here.
-        num_attention_heads = num_attention_heads or attention_head_dim
-
         # Check inputs
         if len(down_block_types) != len(up_block_types):
             raise ValueError(
@@ -151,9 +143,9 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 f"Must provide the same number of `block_out_channels` as `down_block_types`. `block_out_channels`: {block_out_channels}. `down_block_types`: {down_block_types}."
             )
 
-        if not isinstance(num_attention_heads, int) and len(num_attention_heads) != len(down_block_types):
+        if not isinstance(attention_head_dim, int) and len(attention_head_dim) != len(down_block_types):
             raise ValueError(
-                f"Must provide the same number of `num_attention_heads` as `down_block_types`. `num_attention_heads`: {num_attention_heads}. `down_block_types`: {down_block_types}."
+                f"Must provide the same number of `attention_head_dim` as `down_block_types`. `attention_head_dim`: {attention_head_dim}. `down_block_types`: {down_block_types}."
             )
 
         # input
@@ -187,8 +179,8 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
         self.down_blocks = nn.ModuleList([])
         self.up_blocks = nn.ModuleList([])
 
-        if isinstance(num_attention_heads, int):
-            num_attention_heads = (num_attention_heads,) * len(down_block_types)
+        if isinstance(attention_head_dim, int):
+            attention_head_dim = (attention_head_dim,) * len(down_block_types)
 
         # down
         output_channel = block_out_channels[0]
@@ -208,7 +200,7 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 resnet_act_fn=act_fn,
                 resnet_groups=norm_num_groups,
                 cross_attention_dim=cross_attention_dim,
-                num_attention_heads=num_attention_heads[i],
+                attention_head_dim=attention_head_dim[i],
                 downsample_padding=downsample_padding,
                 dual_cross_attention=False,
             )
@@ -222,7 +214,7 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
             resnet_act_fn=act_fn,
             output_scale_factor=mid_block_scale_factor,
             cross_attention_dim=cross_attention_dim,
-            num_attention_heads=num_attention_heads[-1],
+            attention_head_dim=attention_head_dim[-1],
             resnet_groups=norm_num_groups,
             dual_cross_attention=False,
         )
@@ -232,7 +224,7 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
 
         # up
         reversed_block_out_channels = list(reversed(block_out_channels))
-        reversed_num_attention_heads = list(reversed(num_attention_heads))
+        reversed_attention_head_dim = list(reversed(attention_head_dim))
 
         output_channel = reversed_block_out_channels[0]
         for i, up_block_type in enumerate(up_block_types):
@@ -261,7 +253,7 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin)
                 resnet_act_fn=act_fn,
                 resnet_groups=norm_num_groups,
                 cross_attention_dim=cross_attention_dim,
-                num_attention_heads=reversed_num_attention_heads[i],
+                attention_head_dim=reversed_attention_head_dim[i],
                 dual_cross_attention=False,
                 resolution_idx=i,
             )


### PR DESCRIPTION
## why do I open this PR? 
The motivation for this PR is that I find it impossible to reason about how to config a 3D Unet using `CrossAttnDownBlock3D`, `CrossAttnUpBlock3D` and `UNetMidBlock3DCrossAttn` - these 3 blocks all have an argument `num_attention_heads` which expects the value of `attention_head_dim`. 

for example this is the `__init__` method of `CrossAttnDownBlock3D` 
```python
class CrossAttnDownBlock3D(nn.Module):
    def __init__(self, ..., num_attention_heads, ...):
              ...
              attentions.append(
                Transformer2DModel(
                    out_channels // num_attention_heads,
                    num_attention_heads,
                    in_channels=out_channels,
                    num_layers=1,
                    cross_attention_dim=cross_attention_dim,
                    norm_num_groups=resnet_groups,
                    use_linear_projection=use_linear_projection,
                    only_cross_attention=only_cross_attention,
                    upcast_attention=upcast_attention,
                )
            )
```
It is not really obvious that the `num_attention_heads` are supposed to be `attention_head_dim`. Only if you look closely at how it creates `Transformer2DModel` and then check against `Transformer2DModel`'s [signature](https://github.com/huggingface/diffusers/blob/17612de451244c4c169b1498f1333401dfd3106f/src/diffusers/models/transformers/transformer_2d.py#L78), you will notice that the `num_attention_heads` here are passed as `attention_head_dim` to `Transformer2DModel` and then passed all the way down to `Attention` as `head_dim`

All our text-to-video UNets are configured with `attention_head_dim`, for example [this one](https://huggingface.co/ali-vilab/text-to-video-ms-1.7b/blob/8227dddca75a8561bf858d604cc5dae52b954d01/unet/config.json#L6) has `attention_head_dim = 64`

so what we did in `UNet3DConditionModel` is 
1. we immediately assign `attention_head_dim` to `num_attention_head`, i.e. inside`UNet3DConditionModel.__init__`, we do `num_attention_head=attention_head_dim`
2. we pass the `64` around in the name of `num_attention_heads`:
    * call `get_down_block(num_attention_heads = num_attention_heads)`
    * `get_down_block` then call `CrossAttnDownBlock3D(num_attention_heads=num_attention_heads`)
3. we swap these two arguments back when `CrossAttnDownBlock3D` calls `Transformer2DModel` and `TransformerTemporalModel`

It took me so much efforts to figure out what's going on and and I'm still confused. I know this is introduced in this PR https://github.com/huggingface/diffusers/pull/3797 but I'm not sure why. 

Unlike Unet2D models, 3D models never really have the "wrong configuration" problem - they are configured with `attention_head_dim`  instead of `num_attention_heads`, but it wan't "wrong".  i.e. `attention_head_dim = 64` actually means `attention_head_dim = 64`. This is different from Unet2D models, I'm aware that the Unet2D has the wrong configuration issue: the `attention_head_dim` in their config file should be `num_attention_heads`; and I'm aware that's why we had to assign `attention_head_dim` to `num_attention_heads` for Unet2D. But this is not the case for 3D though

Did we do it this way so that all the cross-attention blocks can only accept one argument, `num_attention_heads`, instead of two different arguments? If so, I would argue that even though it is not ideal, it is still better than the current arrangement: with current arrangement I find it very difficult to reason about it and even harder to explain to other people 😭😭😭

So, I tried to correct the argument names and deprecate things in this PR. I'm curious why we did it this way (I think it's very likely I missed something). And I'm very much open to any other solution that can make this confusion go away:) 














## test

I will run the slow test, but here is a quick sanity check to make sure that we are able to config the `heads` and `head_dim` parameters in `Attention` class correctly.

```python
import torch
from diffusers import DiffusionPipeline
from diffusers.models.attention_processor import Attention

print(" ")
print(" unet2d")
repo = "runwayml/stable-diffusion-v1-5"
pipe = DiffusionPipeline.from_pretrained(repo, torch_dtype=torch.float16, variant="fp16")
for name, module in pipe.unet.named_modules():
    if isinstance(module, Attention):
        print(f"  module.inner_dim/module_heads:{module.inner_dim/module.heads}, module.heads:{module.heads}")
        print(f" module.scale: {module.scale}")

print(f" ")
print(f" unet3d")
repo = "damo-vilab/text-to-video-ms-1.7b"
pipe = DiffusionPipeline.from_pretrained(repo, torch_dtype=torch.float16, variant="fp16")

for name, module in pipe.unet.named_modules():
    if isinstance(module, Attention):
        print(f"  module.inner_dim/module_heads:{module.inner_dim/module.heads}, module.heads:{module.heads}")
        print(f" module.scale: {module.scale}")

```

for 2d unet model, we config with `num_attention_heads = 8`
```
unet2d
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
```

for 3d unet models, we config with `attention_head_dim=64`, results are expected 

```python
unet3d
Loading pipeline components...:  20%|██████████████████▌                                                                          | 1/5 [00:00<00:01,  2.89it/s]/home/yiyi_huggingface_co/diffusers/src/diffusers/models/unets/unet_3d_blocks.py:355: 
Loading pipeline components...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:01<00:00,  3.75it/s]
  module.inner_dim/module_heads:64.0, module.heads:8
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:8
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:10
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:5
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:20
 module.scale: 0.125
```
