### PR TITLE
Update _get_prev_sample function in PNDMScheduler to be better supported by fx

### DIFF
--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -419,6 +419,8 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         # prev_sample -> x_(t−δ)
         if not isinstance(timestep, torch.Tensor):
             timestep = torch.tensor(timestep)
+        if not isinstance(prev_timestep, torch.Tensor):
+            prev_timestep = torch.tensor(prev_timestep)
         alpha_prod_t = self.alphas_cumprod.index_select(0, timestep)
         updated_prev_timestep = torch.where(
             prev_timestep >= 0, prev_timestep, self.alphas_cumprod.size(dim=0) + prev_timestep

--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -417,8 +417,17 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         # sample -> x_t
         # model_output -> e_θ(x_t, t)
         # prev_sample -> x_(t−δ)
+        if not isinstance(timestep, torch.Tensor):
+            timestep = torch.tensor(timestep)
         alpha_prod_t = self.alphas_cumprod.index_select(0, timestep)
-        alpha_prod_t_prev = torch.where(prev_timestep >= 0, torch.index_select(self.alphas_cumprod, 0, abs(prev_timestep)), self.final_alpha_cumprod)
+        updated_prev_timestep = torch.where(
+            prev_timestep >= 0, prev_timestep, self.alphas_cumprod.size(dim=0) + prev_timestep
+        )
+        alpha_prod_t_prev = torch.where(
+            prev_timestep >= 0,
+            torch.index_select(self.alphas_cumprod, 0, updated_prev_timestep),
+            self.final_alpha_cumprod,
+        )
         beta_prod_t = 1 - alpha_prod_t
         beta_prod_t_prev = 1 - alpha_prod_t_prev
 

--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -417,8 +417,8 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         # sample -> x_t
         # model_output -> e_θ(x_t, t)
         # prev_sample -> x_(t−δ)
-        alpha_prod_t = self.alphas_cumprod[timestep]
-        alpha_prod_t_prev = self.alphas_cumprod[prev_timestep] if prev_timestep >= 0 else self.final_alpha_cumprod
+        alpha_prod_t = self.alphas_cumprod.index_select(0, timestep)
+        alpha_prod_t_prev = torch.where(prev_timestep >= 0, torch.index_select(self.alphas_cumprod, 0, abs(prev_timestep)), self.final_alpha_cumprod)
         beta_prod_t = 1 - alpha_prod_t
         beta_prod_t_prev = 1 - alpha_prod_t_prev
 

--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -424,9 +424,7 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
             prev_timestep >= 0, prev_timestep, self.alphas_cumprod.size(dim=0) + prev_timestep
         )
         alpha_prod_t_prev = torch.where(
-            prev_timestep >= 0,
-            torch.index_select(self.alphas_cumprod, 0, updated_prev_timestep),
-            self.final_alpha_cumprod,
+            prev_timestep >= 0, self.alphas_cumprod.index_select(0, updated_prev_timestep), self.final_alpha_cumprod
         )
         beta_prod_t = 1 - alpha_prod_t
         beta_prod_t_prev = 1 - alpha_prod_t_prev


### PR DESCRIPTION

# What does this PR do?
Updates the `alpha_prod_t` and `alpha_prod_t_prev` variables in the `_get_prev_sample` function in PNDMScheduler, so that it can be traced through torch fx. Torch fx does not support Python control flow over tensors as stated in this Pytorch issue (https://github.com/pytorch/pytorch/issues/116690#issuecomment-1883661346) as well as indexing a tensor, such as, `x[i]`, causes a guard on `i` directly, and using `index_select` it won't be subject to this as stated here (https://github.com/pytorch/pytorch/issues/116690#issuecomment-1883886156). The results of  `alpha_prod_t` and `alpha_prod_t_prev` are the same, this change just makes it so it can be traced through torch fx.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu and @patrickvonplaten
- Pipelines:  @patrickvonplaten and @sayakpaul
- Training examples: @sayakpaul and @patrickvonplaten
- Docs: @stevhliu and @yiyixuxu
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @patrickvonplaten and @sayakpaul

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
