### PR TITLE
[ip-adapter] make sure length of `scale` is same as number of ip-adapters when using  `set_ip_adapter_scale`

### DIFF
--- a/src/diffusers/loaders/ip_adapter.py
+++ b/src/diffusers/loaders/ip_adapter.py
@@ -181,11 +181,16 @@ class IPAdapterMixin:
         unet._load_ip_adapter_weights(state_dicts)
 
     def set_ip_adapter_scale(self, scale):
-        if not isinstance(scale, list):
-            scale = [scale]
         unet = getattr(self, self.unet_name) if not hasattr(self, "unet") else self.unet
         for attn_processor in unet.attn_processors.values():
             if isinstance(attn_processor, (IPAdapterAttnProcessor, IPAdapterAttnProcessor2_0)):
+                if not isinstance(scale, list):
+                    scale = [scale] * len(attn_processor.scale)
+                if len(attn_processor.scale) != len(scale):
+                    raise ValueError(
+                        f"`scale` should be a list of same length as the number if ip-adapters "
+                        f"Expected {len(attn_processor.scale)} but got {len(scale)}."
+                    )
                 attn_processor.scale = scale
 
     def unload_ip_adapter(self):


### PR DESCRIPTION
```python
import torch
from diffusers import AutoPipelineForText2Image

pipeline = AutoPipelineForText2Image.from_pretrained(
    "stabilityai/stable-diffusion-xl-base-1.0",
    torch_dtype=torch.float16
)
pipeline.load_ip_adapter(
  "h94/IP-Adapter", 
  subfolder="sdxl_models", 
  weight_name=["ip-adapter-plus_sdxl_vit-h.safetensors", "ip-adapter-plus-face_sdxl_vit-h.safetensors"]
)

print(f" testing scale = 0.7")
try:
    pipeline.set_ip_adapter_scale(0.7)
except Exception as e:
    print(f"Error: {e}")

print(f" testing scale = [0.7]")
try:
    pipeline.set_ip_adapter_scale([0.7])
except Exception as e:
    print(f"Error: {e}")

print(f" testing scale = [0.7, 0.6]")
try:
    pipeline.set_ip_adapter_scale([0.7, 0.6])
except Exception as e:
    print(f"Error: {e}"
    )
print(f" testing scale = [0.7, 0.5, 0.6]")
try:
    pipeline.set_ip_adapter_scale([0.7, 0.5, 0.6])
except Exception as e:
    print(f"Error: {e}")
    
```


outputs are expected 

```
 testing scale = 0.7
 testing scale = [0.7]
Error: `scale` should be a list of same length as the number if ip-adapters Expected 2 but got 1.
 testing scale = [0.7, 0.6]
 testing scale = [0.7, 0.5, 0.6]
Error: `scale` should be a list of same length as the number if ip-adapters Expected 2 but got 3.
```