### PR TITLE
[DPMSolverSinglestepScheduler] correct `get_order_list` for `solver_order=2`and `lower_order_final=True` 

### DIFF
--- a/src/diffusers/schedulers/scheduling_dpmsolver_singlestep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_singlestep.py
@@ -151,7 +151,7 @@ class DPMSolverSinglestepScheduler(SchedulerMixin, ConfigMixin):
         sample_max_value: float = 1.0,
         algorithm_type: str = "dpmsolver++",
         solver_type: str = "midpoint",
-        lower_order_final: bool = True,
+        lower_order_final: bool = False,
         use_karras_sigmas: Optional[bool] = False,
         final_sigmas_type: Optional[str] = "zero",  # "zero", "sigma_min"
         lambda_min_clipped: float = -float("inf"),

--- a/src/diffusers/schedulers/scheduling_dpmsolver_singlestep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_singlestep.py
@@ -233,7 +233,7 @@ class DPMSolverSinglestepScheduler(SchedulerMixin, ConfigMixin):
                     orders = [1, 2, 3] * (steps // 3) + [1, 2]
             elif order == 2:
                 if steps % 2 == 0:
-                    orders = [1, 2] * (steps // 2)
+                    orders = [1, 2] * (steps // 2 - 1) + [1, 1]
                 else:
                     orders = [1, 2] * (steps // 2) + [1]
             elif order == 1:
@@ -320,7 +320,7 @@ class DPMSolverSinglestepScheduler(SchedulerMixin, ConfigMixin):
 
         if not self.config.lower_order_final and num_inference_steps % self.config.solver_order != 0:
             logger.warn(
-                "Changing scheduler {self.config} to have `lower_order_final` set to True to handle uneven amount of inference steps. Please make sure to always use an even number of `num_inference steps when using `lower_order_final=True`."
+                "Changing scheduler {self.config} to have `lower_order_final` set to True to handle uneven amount of inference steps. Please make sure to always use an even number of `num_inference steps when using `lower_order_final=False`."
             )
             self.register_to_config(lower_order_final=True)
 


### PR DESCRIPTION
For `lower_order_final=True` and `solver_order=2`, we would expect the order for the last step to be `1`, currently in`DPMSolverSinglestepScheduler` it does not work as expected for an even number of steps 

this is the `get_order_list` method of DPMSolverSinglestepScheduler, (see my comments in code below) https://github.com/huggingface/diffusers/blob/0a1daadef865f179895b6a2a679bb9db9b0ee8f3/src/diffusers/schedulers/scheduling_dpmsolver_singlestep.py#L216

currently `lower_order_final=True` and `lower_order_final=False` have exactly same result

```python
    def get_order_list(self, num_inference_steps: int) -> List[int]:
        steps = num_inference_steps
        order = self.config.solver_order
        if self.config.lower_order_final:
            if order == 3:
                ...
            elif order == 2:
                if steps % 2 == 0:
                    # YiYi notes: for solver_order = 2, if the steps are even, it seems that we are not lowering the final order even when `config.lower_final_order=True`
                    orders = [1, 2] * (steps // 2) 
                else:
                    # YiYi notes: for uneven steps however, it lowers the final order as expected
                    orders = [1, 2] * (steps // 2) + [1]
            elif order == 1:
              ...
        else:
           ...
           elif order == 2:
              # YiYi notes: this is exactly same as lower_final_order=True
              orders = [1, 2] * (steps // 2)
           ...
        return orders
```
another option is just to not allow use even number of steps + solver_orde=2 + lower_final_order - I think it's more complicated that way, especially now we have the `last_sigmas_type='zero' argument that has to work with final_order ==1 


related PR /issue
https://github.com/huggingface/diffusers/issues/6949
https://github.com/huggingface/diffusers/issues/1866
https://github.com/huggingface/diffusers/pull/3413
https://github.com/huggingface/diffusers/pull/6477

