### PR TITLE
[Utility] feat: add utilities to notify slack about a new library release.

### DIFF
--- a/.github/workflows/notify_slack_about_new_release.yml
+++ b/.github/workflows/notify_slack_about_new_release.yml
@@ -1,0 +1,23 @@
+name: Notify Slack on Library Update
+
+on:
+  schedule:
+    # Runs at 12:00 UTC every day
+    - cron: '0 12 * * *'
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: pip install requests
+    - name: Run the Slack notification script
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      run: python scripts/notify_slack.py

--- a/scripts/notify_slack.py
+++ b/scripts/notify_slack.py
@@ -1,0 +1,60 @@
+import os
+
+import requests
+
+
+# Configuration
+LIBRARY_NAME = "diffusers"
+GITHUB_REPO = "huggingface/diffusers"
+SLACK_WEBHOOK_URL = os.getenv["SLACK_WEBHOOK_URL"]
+
+
+def check_pypi_for_latest_release(library_name):
+    """Check PyPI for the latest release of the library."""
+    response = requests.get(f"https://pypi.org/pypi/{library_name}/json")
+    if response.status_code == 200:
+        data = response.json()
+        return data["info"]["version"]
+    else:
+        print("Failed to fetch library details from PyPI.")
+        return None
+
+
+def get_github_release_info(github_repo):
+    """Fetch the latest release info from GitHub."""
+    url = f"https://api.github.com/repos/{github_repo}/releases/latest"
+    response = requests.get(url)
+    if response.status_code == 200:
+        data = response.json()
+        return {"tag_name": data["tag_name"], "url": data["html_url"]}
+    else:
+        print("Failed to fetch release info from GitHub.")
+        return None
+
+
+def notify_slack(webhook_url, library_name, version, release_info):
+    """Send a notification to a Slack channel."""
+    message = (
+        f"🚀 New release for {library_name} available: version **{version}** 🎉\n"
+        f"📜 Release Notes: {release_info['url']}\n"
+    )
+    payload = {"text": message}
+    response = requests.post(webhook_url, json=payload)
+
+    if response.status_code == 200:
+        print("Notification sent to Slack successfully.")
+    else:
+        print("Failed to send notification to Slack.")
+
+
+def main():
+    latest_version = check_pypi_for_latest_release(LIBRARY_NAME)
+    release_info = get_github_release_info(GITHUB_REPO)
+    parsed_version = release_info["tag_name"].replace("v", "")
+
+    if latest_version and release_info and latest_version == parsed_version:
+        notify_slack(SLACK_WEBHOOK_URL, LIBRARY_NAME, latest_version, release_info)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# What does this PR do?

This is how such an automatic notification would look like (internal link): https://huggingface.slack.com/archives/C03HBN1C8CW/p1707889851090899.

<img width="582" alt="image" src="https://github.com/huggingface/diffusers/assets/22957388/115af6d6-d76f-4d2d-a979-4a15379c1489">

Steps to create the webhook-enabled Slack Bot (documenting in case someone else finds it useful):

* Go to the Slack API website and create a new app.
* Choose the workspace you want to install your app to.
* In the 'Add features and functionality' section, choose 'Incoming Webhooks'.
* Activate incoming webhooks and create a new webhook for the channel you want to post messages to.
* Copy the webhook URL; you'll use it in your Python script to send messages to Slack.