### PR TITLE
[draft1]correct the attn naming for `UNet2DConditionModel`

### DIFF
--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -322,8 +322,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin,
                 attention_head_dimension = [out_channels // num_attention_heads for out_channels in block_out_channels]
             else:
                 attention_head_dimension = [
-                    out_channels // num_heads
-                    for out_channel, num_heads in zip(block_out_channels, num_attention_heads)
+                    out_channel // num_heads for out_channel, num_heads in zip(block_out_channels, num_attention_heads)
                 ]
         # input
         conv_in_padding = (conv_in_kernel - 1) // 2

--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -314,7 +314,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin,
             else:
                 num_attention_heads = [
                     out_channels // attn_dim
-                    for out_channel, attn_dim in zip(block_out_channels, attention_head_dimension)
+                    for out_channels, attn_dim in zip(block_out_channels, attention_head_dimension)
                 ]
         # we use num_attention_heads to calculate attention_head_dimension
         elif num_attention_heads is not None:

--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -322,7 +322,8 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin,
                 attention_head_dimension = [out_channels // num_attention_heads for out_channels in block_out_channels]
             else:
                 attention_head_dimension = [
-                    out_channel // num_heads for out_channel, num_heads in zip(block_out_channels, num_attention_heads)
+                    out_channels // num_heads
+                    for out_channels, num_heads in zip(block_out_channels, num_attention_heads)
                 ]
         # input
         conv_in_padding = (conv_in_kernel - 1) // 2


### PR DESCRIPTION
In this PR, we:
1. deprecate `attention_head_dim` and introduced a new variable `attention_head_dimension`
2.  the user to use `num_attention_heads`or `attention_head_dimension` in the configuration file for UNet2DConditionModel
3. make sure all the blocks accept both `num_attention_heads` and `attention_head_dim` arguments
4. when the deprecated `attention_head_dim` argument is passed to UNet2DConditionModel: we use `correct_incorrect_names()` function to calculate `num_attention_heads` and `attention_head_dimension`
5. in UNet2DConditionModel, after taking the above steps, calculate `attention_head_dim` based on `num_attention_head`, or calculate `num_attention_head` based on `attention_head_dimension` 
6. pass both arguments to all the blocks

I updated `ControlNetModel` with the same logic and also removed the `#Copied from` from the deprecated modeling_text_unet.py 

related to this PR https://github.com/huggingface/diffusers/pull/6983, which I like more because code is easier to understand



### quick sanity test
```python
import torch
from diffusers import UNet2DConditionModel
from diffusers.models.attention_processor import Attention

print(" ")
print(" SD1.5 (current mode configure file)")
repo = "runwayml/stable-diffusion-v1-5"
unet = UNet2DConditionModel.from_pretrained(repo, subfolder="unet", torch_dtype=torch.float16, variant="fp16")
for name, module in unet.named_modules():
    if isinstance(module, Attention):
        print(f"  module.inner_dim/module_heads:{module.inner_dim/module.heads}, module.heads:{module.heads}")
        print(f" module.scale: {module.scale}")

print(" ")
print(" SD1.5 (correct configure)")
repo = "runwayml/stable-diffusion-v1-5"
unet = UNet2DConditionModel.from_pretrained(repo, subfolder="unet", torch_dtype=torch.float16, variant="fp16", attention_head_dim=None, num_attention_heads=8, attention_head_dimension=None)
for name, module in unet.named_modules():
    if isinstance(module, Attention):
        print(f"  module.inner_dim/module_heads:{module.inner_dim/module.heads}, module.heads:{module.heads}")
        print(f" module.scale: {module.scale}")

print(f" ")
print(f" IF (current model configuration file)")
repo = "DeepFloyd/IF-I-XL-v1.0"
unet = UNet2DConditionModel.from_pretrained(repo, subfolder="unet", torch_dtype=torch.float16, variant="fp16")
for name, module in unet.named_modules():
    if isinstance(module, Attention):
        print(f"  module.inner_dim/module_heads:{module.inner_dim/module.heads}, module.heads:{module.heads}")
        print(f" module.scale: {module.scale}")

print(f" ")
print(f" IF (correct configure)")
repo = "DeepFloyd/IF-I-XL-v1.0"
unet = UNet2DConditionModel.from_pretrained(repo, subfolder="unet", torch_dtype=torch.float16, variant="fp16", attention_head_dim=None, num_attention_heads=None, attention_head_dimension=64)
for name, module in unet.named_modules():
    if isinstance(module, Attention):
        print(f"  module.inner_dim/module_heads:{module.inner_dim/module.heads}, module.heads:{module.heads}")
        print(f" module.scale: {module.scale}")
```

```
 SD1.5 (current mode configure file)
/home/yiyi_huggingface_co/diffusers/src/diffusers/models/unets/unet_2d_condition.py:249: FutureWarning:  `attention_head_dim` is deprecated and will be removed in a future version. Use `num_attention_heads` and `attention_head_dimension` instead.
  deprecate("attention_head_dim not None", "1.0.0", deprecation_message, standard_warn=False)
corrected potentially incorrect arguments, the model will be configured with `num_attention_heads` 8 and `attention_head_dimension` None.
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
 
 SD1.5 (correct configure)
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
 
 IF (current model configuration file)
corrected potentially incorrect arguments, the model will be configured with `num_attention_heads` None and `attention_head_dimension` 64.
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
 
 IF (correct configure)
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
```