### PR TITLE
[draft2]correct the attn naming for UNet2DConditionModel

### DIFF
--- a/src/diffusers/models/controlnet.py
+++ b/src/diffusers/models/controlnet.py
@@ -266,18 +266,17 @@ class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlNetMixin):
                 f"Must provide the same number of `only_cross_attention` as `down_block_types`. `only_cross_attention`: {only_cross_attention}. `down_block_types`: {down_block_types}."
             )
 
-        if isinstance(num_attention_heads, int) and len(num_attention_heads) != len(down_block_types):
+        if not isinstance(num_attention_heads, int) and len(num_attention_heads) != len(down_block_types):
             raise ValueError(
                 f"Must provide the same number of `num_attention_heads` as `down_block_types`. `num_attention_heads`: {num_attention_heads}. `down_block_types`: {down_block_types}."
             )
+        if isinstance(num_attention_heads, int):
+            num_attention_heads = (num_attention_heads,) * len(down_block_types)
 
         # we use num_attention_heads to calculate attention_head_dim
-        if isinstance(num_attention_heads, int):
-            attention_head_dim = [out_channels // num_attention_heads for out_channels in block_out_channels]
-        else:
-            attention_head_dim = [
-                out_channels // num_heads for out_channels, num_heads in zip(block_out_channels, num_attention_heads)
-            ]
+        attention_head_dim = [
+            out_channels // num_heads for out_channels, num_heads in zip(block_out_channels, num_attention_heads)
+        ]
 
         if isinstance(transformer_layers_per_block, int):
             transformer_layers_per_block = [transformer_layers_per_block] * len(down_block_types)
@@ -386,9 +385,6 @@ class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlNetMixin):
 
         if isinstance(only_cross_attention, bool):
             only_cross_attention = [only_cross_attention] * len(down_block_types)
-
-        if isinstance(num_attention_heads, int):
-            num_attention_heads = (num_attention_heads,) * len(down_block_types)
 
         # down
         output_channel = block_out_channels[0]

--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -322,8 +322,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin,
                 attention_head_dimension = [out_channels // num_attention_heads for out_channels in block_out_channels]
             else:
                 attention_head_dimension = [
-                    out_channels // num_heads
-                    for out_channel, num_heads in zip(block_out_channels, num_attention_heads)
+                    out_channel // num_heads for out_channel, num_heads in zip(block_out_channels, num_attention_heads)
                 ]
         # input
         conv_in_padding = (conv_in_kernel - 1) // 2

--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -314,7 +314,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin,
             else:
                 num_attention_heads = [
                     out_channels // attn_dim
-                    for out_channel, attn_dim in zip(block_out_channels, attention_head_dimension)
+                    for out_channels, attn_dim in zip(block_out_channels, attention_head_dimension)
                 ]
         # we use num_attention_heads to calculate attention_head_dimension
         elif num_attention_heads is not None:

--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -296,13 +296,14 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin,
                 if isinstance(layer_number_per_block, list):
                     raise ValueError("Must provide 'reverse_transformer_layers_per_block` if using asymmetrical UNet.")
 
-        # we use num_attention_heads to calculate attention_head_dim
+        #  make sure num_attention_heads is a tuple
         if isinstance(num_attention_heads, int):
-            attention_head_dim = [out_channels // num_attention_heads for out_channels in block_out_channels]
-        else:
-            attention_head_dim = [
-                out_channels // num_heads for out_channels, num_heads in zip(block_out_channels, num_attention_heads)
-            ]
+            num_attention_heads = (num_attention_heads,) * len(down_block_types)
+
+        # we use num_attention_heads to calculate attention_head_dim
+        attention_head_dim = [
+            out_channels // num_heads for out_channels, num_heads in zip(block_out_channels, num_attention_heads)
+        ]
         # input
         conv_in_padding = (conv_in_kernel - 1) // 2
         self.conv_in = nn.Conv2d(
@@ -443,9 +444,6 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin,
 
         if mid_block_only_cross_attention is None:
             mid_block_only_cross_attention = False
-
-        if isinstance(num_attention_heads, int):
-            num_attention_heads = (num_attention_heads,) * len(down_block_types)
 
         if isinstance(cross_attention_dim, int):
             cross_attention_dim = (cross_attention_dim,) * len(down_block_types)

--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -322,7 +322,8 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin,
                 attention_head_dimension = [out_channels // num_attention_heads for out_channels in block_out_channels]
             else:
                 attention_head_dimension = [
-                    out_channel // num_heads for out_channel, num_heads in zip(block_out_channels, num_attention_heads)
+                    out_channels // num_heads
+                    for out_channels, num_heads in zip(block_out_channels, num_attention_heads)
                 ]
         # input
         conv_in_padding = (conv_in_kernel - 1) // 2

--- a/src/diffusers/pipelines/deprecated/versatile_diffusion/modeling_text_unet.py
+++ b/src/diffusers/pipelines/deprecated/versatile_diffusion/modeling_text_unet.py
@@ -268,7 +268,6 @@ class GLIGENTextBoundingboxProjection(nn.Module):
         return objs
 
 
-# Copied from diffusers.models.unets.unet_2d_condition.UNet2DConditionModel with UNet2DConditionModel->UNetFlatConditionModel, nn.Conv2d->LinearMultiDim, Block2D->BlockFlat
 class UNetFlatConditionModel(ModelMixin, ConfigMixin):
     r"""
     A conditional 2D UNet model that takes a noisy sample, conditional state, and a timestep and returns a sample
@@ -1786,7 +1785,6 @@ class CrossAttnDownBlockFlat(nn.Module):
         return hidden_states, output_states
 
 
-# Copied from diffusers.models.unets.unet_2d_blocks.UpBlock2D with UpBlock2D->UpBlockFlat, ResnetBlock2D->ResnetBlockFlat, Upsample2D->LinearMultiDim
 class UpBlockFlat(nn.Module):
     def __init__(
         self,
@@ -1897,7 +1895,6 @@ class UpBlockFlat(nn.Module):
         return hidden_states
 
 
-# Copied from diffusers.models.unets.unet_2d_blocks.CrossAttnUpBlock2D with CrossAttnUpBlock2D->CrossAttnUpBlockFlat, ResnetBlock2D->ResnetBlockFlat, Upsample2D->LinearMultiDim
 class CrossAttnUpBlockFlat(nn.Module):
     def __init__(
         self,
@@ -2071,7 +2068,6 @@ class CrossAttnUpBlockFlat(nn.Module):
         return hidden_states
 
 
-# Copied from diffusers.models.unets.unet_2d_blocks.UNetMidBlock2D with UNetMidBlock2D->UNetMidBlockFlat, ResnetBlock2D->ResnetBlockFlat
 class UNetMidBlockFlat(nn.Module):
     """
     A 2D UNet mid-block [`UNetMidBlockFlat`] with multiple residual blocks and optional attention blocks.
@@ -2227,7 +2223,6 @@ class UNetMidBlockFlat(nn.Module):
         return hidden_states
 
 
-# Copied from diffusers.models.unets.unet_2d_blocks.UNetMidBlock2DCrossAttn with UNetMidBlock2DCrossAttn->UNetMidBlockFlatCrossAttn, ResnetBlock2D->ResnetBlockFlat
 class UNetMidBlockFlatCrossAttn(nn.Module):
     def __init__(
         self,
@@ -2374,7 +2369,6 @@ class UNetMidBlockFlatCrossAttn(nn.Module):
         return hidden_states
 
 
-# Copied from diffusers.models.unets.unet_2d_blocks.UNetMidBlock2DSimpleCrossAttn with UNetMidBlock2DSimpleCrossAttn->UNetMidBlockFlatSimpleCrossAttn, ResnetBlock2D->ResnetBlockFlat
 class UNetMidBlockFlatSimpleCrossAttn(nn.Module):
     def __init__(
         self,


### PR DESCRIPTION
In this PR, we:
1. deprecate `attention_head_dim` and allow the user to only use `num_attention_heads` in the configuration file for UNet2DConditionModel
2. make sure all the blocks accept both `num_attention_heads` and `attention_head_dim` arguments
3. when the deprecated `attention_head_dim` argument is passed to UNet2DConditionModel: we use `correct_incorrect_names()` function to calculate `num_attention_heads`
4. in UNet2DConditionModel, after taking above steps, calculate `attention_head_dim` based on `num_attention_head` and pass both arguments to all the blocks

I updated `ControlNetModel` with the same logic and also removed the `#Copied from` from the deprecated modeling_text_unet.py 

I did a quick sanity test below; I also tested our popular checkpoints here, results expected  https://github.com/huggingface/diffusers/pull/6983#issuecomment-1945340299 

all fast tests passes too, the one fails are remote code tests, it fails as expected of the code change

### quick sanity test

```python
import torch
from diffusers import UNet2DConditionModel
from diffusers.models.attention_processor import Attention

print(" ")
print(" SD1.5 (current mode configure file)")
repo = "runwayml/stable-diffusion-v1-5"
unet = UNet2DConditionModel.from_pretrained(repo, subfolder="unet", torch_dtype=torch.float16, variant="fp16")
for name, module in unet.named_modules():
    if isinstance(module, Attention):
        print(f"  module.inner_dim/module_heads:{module.inner_dim/module.heads}, module.heads:{module.heads}")
        print(f" module.scale: {module.scale}")

print(" ")
print(" SD1.5 (correct configure)")
repo = "runwayml/stable-diffusion-v1-5"
unet = UNet2DConditionModel.from_pretrained(repo, subfolder="unet", torch_dtype=torch.float16, variant="fp16", attention_head_dim=None, num_attention_heads=8)
for name, module in unet.named_modules():
    if isinstance(module, Attention):
        print(f"  module.inner_dim/module_heads:{module.inner_dim/module.heads}, module.heads:{module.heads}")
        print(f" module.scale: {module.scale}")

print(f" ")
print(f" IF (current model configuration file)")
repo = "DeepFloyd/IF-I-XL-v1.0"
unet = UNet2DConditionModel.from_pretrained(repo, subfolder="unet", torch_dtype=torch.float16, variant="fp16")
for name, module in unet.named_modules():
    if isinstance(module, Attention):
        print(f"  module.inner_dim/module_heads:{module.inner_dim/module.heads}, module.heads:{module.heads}")
        print(f" module.scale: {module.scale}")

print(f" ")
print(f" IF (correct configure)")
repo = "DeepFloyd/IF-I-XL-v1.0"
unet = UNet2DConditionModel.from_pretrained(repo, subfolder="unet", torch_dtype=torch.float16, variant="fp16", attention_head_dim=None, num_attention_heads=(11, 22, 33, 44), )
for name, module in unet.named_modules():
    if isinstance(module, Attention):
        print(f"  module.inner_dim/module_heads:{module.inner_dim/module.heads}, module.heads:{module.heads}")
        print(f" module.scale: {module.scale}")
```

output
```
SD1.5 (current mode configure file)
/home/yiyi_huggingface_co/diffusers/src/diffusers/models/unets/unet_2d_condition.py:252: FutureWarning:  `attention_head_dim` is deprecated and will be removed in a future version. Use `num_attention_heads` instead.
  deprecate("attention_head_dim not None", "1.0.0", deprecation_message, standard_warn=False)
corrected potentially incorrect arguments attention_head_dim 8.the model will be configured with `num_attention_heads` 8.
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
 
 SD1.5 (correct configure)
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:80.0, module.heads:8
 module.scale: 0.11180339887498948
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:40.0, module.heads:8
 module.scale: 0.15811388300841897
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
  module.inner_dim/module_heads:160.0, module.heads:8
 module.scale: 0.07905694150420949
 
 IF (current model configuration file)
corrected potentially incorrect arguments attention_head_dim 64.the model will be configured with `num_attention_heads` [11, 22, 33, 44].
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
 
 IF (correct configure)
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:33
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:22
 module.scale: 0.125
  module.inner_dim/module_heads:64.0, module.heads:44
 module.scale: 0.125
```