### PR TITLE
[Core] Support single file from `from_pretrained`

### DIFF
--- a/src/diffusers/loaders/autoencoder.py
+++ b/src/diffusers/loaders/autoencoder.py
@@ -144,4 +144,5 @@ class FromOriginalVAEMixin:
         if torch_dtype is not None:
             vae = vae.to(torch_dtype)
 
+        vae.eval()
         return vae

--- a/src/diffusers/loaders/controlnet.py
+++ b/src/diffusers/loaders/controlnet.py
@@ -134,4 +134,5 @@ class FromOriginalControlNetMixin:
         if torch_dtype is not None:
             controlnet = controlnet.to(torch_dtype)
 
+        controlnet.eval()
         return controlnet

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -780,7 +780,7 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
 
         # Set model in evaluation mode to deactivate DropOut modules by default
         model.eval()
-        if output_loading_info and not single_file_ckpt:
+        if not single_file_ckpt and output_loading_info:
             return model, loading_info
 
         return model

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -49,6 +49,8 @@ from ..utils.hub_utils import PushToHubMixin, load_or_create_model_card, populat
 logger = logging.get_logger(__name__)
 
 
+SINGLE_FILE_LOADABLE_CLASSES = {"ControlNetModel", "AutoencoderKL"}
+
 if is_torch_version(">=", "1.9.0"):
     _LOW_CPU_MEM_USAGE_DEFAULT = True
 else:
@@ -500,6 +502,10 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
         """
         single_file_ckpt = False
         if is_single_file_checkpoint(pretrained_model_name_or_path):
+            if cls.__name__ not in SINGLE_FILE_LOADABLE_CLASSES:
+                raise ValueError(
+                    f"{cls.__name__} is not supported. Supported classes are: {' '.join(list(SINGLE_FILE_LOADABLE_CLASSES))}."
+                )
             logger.info("Single file checkpoint detected...")
             model = cls.from_single_file(pretrained_model_name_or_path, **kwargs)
             single_file_ckpt = True

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -39,6 +39,7 @@ from ..utils import (
     _get_model_file,
     deprecate,
     is_accelerate_available,
+    is_single_file_checkpoint,
     is_torch_version,
     logging,
 )
@@ -497,102 +498,87 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
         You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.
         ```
         """
-        cache_dir = kwargs.pop("cache_dir", None)
-        ignore_mismatched_sizes = kwargs.pop("ignore_mismatched_sizes", False)
-        force_download = kwargs.pop("force_download", False)
-        from_flax = kwargs.pop("from_flax", False)
-        resume_download = kwargs.pop("resume_download", False)
-        proxies = kwargs.pop("proxies", None)
-        output_loading_info = kwargs.pop("output_loading_info", False)
-        local_files_only = kwargs.pop("local_files_only", None)
-        token = kwargs.pop("token", None)
-        revision = kwargs.pop("revision", None)
-        torch_dtype = kwargs.pop("torch_dtype", None)
-        subfolder = kwargs.pop("subfolder", None)
-        device_map = kwargs.pop("device_map", None)
-        max_memory = kwargs.pop("max_memory", None)
-        offload_folder = kwargs.pop("offload_folder", None)
-        offload_state_dict = kwargs.pop("offload_state_dict", False)
-        low_cpu_mem_usage = kwargs.pop("low_cpu_mem_usage", _LOW_CPU_MEM_USAGE_DEFAULT)
-        variant = kwargs.pop("variant", None)
-        use_safetensors = kwargs.pop("use_safetensors", None)
+        single_file_ckpt = False
+        if is_single_file_checkpoint(pretrained_model_name_or_path):
+            logger.info("Single file checkpoint detected...")
+            model = cls.from_single_file(pretrained_model_name_or_path, **kwargs)
+            single_file_ckpt = True
 
-        allow_pickle = False
-        if use_safetensors is None:
-            use_safetensors = True
-            allow_pickle = True
+        else:
+            cache_dir = kwargs.pop("cache_dir", None)
+            ignore_mismatched_sizes = kwargs.pop("ignore_mismatched_sizes", False)
+            force_download = kwargs.pop("force_download", False)
+            from_flax = kwargs.pop("from_flax", False)
+            resume_download = kwargs.pop("resume_download", False)
+            proxies = kwargs.pop("proxies", None)
+            output_loading_info = kwargs.pop("output_loading_info", False)
+            local_files_only = kwargs.pop("local_files_only", None)
+            token = kwargs.pop("token", None)
+            revision = kwargs.pop("revision", None)
+            torch_dtype = kwargs.pop("torch_dtype", None)
+            subfolder = kwargs.pop("subfolder", None)
+            device_map = kwargs.pop("device_map", None)
+            max_memory = kwargs.pop("max_memory", None)
+            offload_folder = kwargs.pop("offload_folder", None)
+            offload_state_dict = kwargs.pop("offload_state_dict", False)
+            low_cpu_mem_usage = kwargs.pop("low_cpu_mem_usage", _LOW_CPU_MEM_USAGE_DEFAULT)
+            variant = kwargs.pop("variant", None)
+            use_safetensors = kwargs.pop("use_safetensors", None)
 
-        if low_cpu_mem_usage and not is_accelerate_available():
-            low_cpu_mem_usage = False
-            logger.warning(
-                "Cannot initialize model with low cpu memory usage because `accelerate` was not found in the"
-                " environment. Defaulting to `low_cpu_mem_usage=False`. It is strongly recommended to install"
-                " `accelerate` for faster and less memory-intense model loading. You can do so with: \n```\npip"
-                " install accelerate\n```\n."
-            )
+            allow_pickle = False
+            if use_safetensors is None:
+                use_safetensors = True
+                allow_pickle = True
 
-        if device_map is not None and not is_accelerate_available():
-            raise NotImplementedError(
-                "Loading and dispatching requires `accelerate`. Please make sure to install accelerate or set"
-                " `device_map=None`. You can install accelerate with `pip install accelerate`."
-            )
+            if low_cpu_mem_usage and not is_accelerate_available():
+                low_cpu_mem_usage = False
+                logger.warning(
+                    "Cannot initialize model with low cpu memory usage because `accelerate` was not found in the"
+                    " environment. Defaulting to `low_cpu_mem_usage=False`. It is strongly recommended to install"
+                    " `accelerate` for faster and less memory-intense model loading. You can do so with: \n```\npip"
+                    " install accelerate\n```\n."
+                )
 
-        # Check if we can handle device_map and dispatching the weights
-        if device_map is not None and not is_torch_version(">=", "1.9.0"):
-            raise NotImplementedError(
-                "Loading and dispatching requires torch >= 1.9.0. Please either update your PyTorch version or set"
-                " `device_map=None`."
-            )
+            if device_map is not None and not is_accelerate_available():
+                raise NotImplementedError(
+                    "Loading and dispatching requires `accelerate`. Please make sure to install accelerate or set"
+                    " `device_map=None`. You can install accelerate with `pip install accelerate`."
+                )
 
-        if low_cpu_mem_usage is True and not is_torch_version(">=", "1.9.0"):
-            raise NotImplementedError(
-                "Low memory initialization requires torch >= 1.9.0. Please either update your PyTorch version or set"
-                " `low_cpu_mem_usage=False`."
-            )
+            # Check if we can handle device_map and dispatching the weights
+            if device_map is not None and not is_torch_version(">=", "1.9.0"):
+                raise NotImplementedError(
+                    "Loading and dispatching requires torch >= 1.9.0. Please either update your PyTorch version or set"
+                    " `device_map=None`."
+                )
 
-        if low_cpu_mem_usage is False and device_map is not None:
-            raise ValueError(
-                f"You cannot set `low_cpu_mem_usage` to `False` while using device_map={device_map} for loading and"
-                " dispatching. Please make sure to set `low_cpu_mem_usage=True`."
-            )
+            if low_cpu_mem_usage is True and not is_torch_version(">=", "1.9.0"):
+                raise NotImplementedError(
+                    "Low memory initialization requires torch >= 1.9.0. Please either update your PyTorch version or set"
+                    " `low_cpu_mem_usage=False`."
+                )
 
-        # Load config if we don't provide a configuration
-        config_path = pretrained_model_name_or_path
+            if low_cpu_mem_usage is False and device_map is not None:
+                raise ValueError(
+                    f"You cannot set `low_cpu_mem_usage` to `False` while using device_map={device_map} for loading and"
+                    " dispatching. Please make sure to set `low_cpu_mem_usage=True`."
+                )
 
-        user_agent = {
-            "diffusers": __version__,
-            "file_type": "model",
-            "framework": "pytorch",
-        }
+            # Load config if we don't provide a configuration
+            config_path = pretrained_model_name_or_path
 
-        # load config
-        config, unused_kwargs, commit_hash = cls.load_config(
-            config_path,
-            cache_dir=cache_dir,
-            return_unused_kwargs=True,
-            return_commit_hash=True,
-            force_download=force_download,
-            resume_download=resume_download,
-            proxies=proxies,
-            local_files_only=local_files_only,
-            token=token,
-            revision=revision,
-            subfolder=subfolder,
-            device_map=device_map,
-            max_memory=max_memory,
-            offload_folder=offload_folder,
-            offload_state_dict=offload_state_dict,
-            user_agent=user_agent,
-            **kwargs,
-        )
+            user_agent = {
+                "diffusers": __version__,
+                "file_type": "model",
+                "framework": "pytorch",
+            }
 
-        # load model
-        model_file = None
-        if from_flax:
-            model_file = _get_model_file(
-                pretrained_model_name_or_path,
-                weights_name=FLAX_WEIGHTS_NAME,
+            # load config
+            config, unused_kwargs, commit_hash = cls.load_config(
+                config_path,
                 cache_dir=cache_dir,
+                return_unused_kwargs=True,
+                return_commit_hash=True,
                 force_download=force_download,
                 resume_download=resume_download,
                 proxies=proxies,
@@ -600,40 +586,20 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
                 token=token,
                 revision=revision,
                 subfolder=subfolder,
+                device_map=device_map,
+                max_memory=max_memory,
+                offload_folder=offload_folder,
+                offload_state_dict=offload_state_dict,
                 user_agent=user_agent,
-                commit_hash=commit_hash,
+                **kwargs,
             )
-            model = cls.from_config(config, **unused_kwargs)
 
-            # Convert the weights
-            from .modeling_pytorch_flax_utils import load_flax_checkpoint_in_pytorch_model
-
-            model = load_flax_checkpoint_in_pytorch_model(model, model_file)
-        else:
-            if use_safetensors:
-                try:
-                    model_file = _get_model_file(
-                        pretrained_model_name_or_path,
-                        weights_name=_add_variant(SAFETENSORS_WEIGHTS_NAME, variant),
-                        cache_dir=cache_dir,
-                        force_download=force_download,
-                        resume_download=resume_download,
-                        proxies=proxies,
-                        local_files_only=local_files_only,
-                        token=token,
-                        revision=revision,
-                        subfolder=subfolder,
-                        user_agent=user_agent,
-                        commit_hash=commit_hash,
-                    )
-                except IOError as e:
-                    if not allow_pickle:
-                        raise e
-                    pass
-            if model_file is None:
+            # load model
+            model_file = None
+            if from_flax:
                 model_file = _get_model_file(
                     pretrained_model_name_or_path,
-                    weights_name=_add_variant(WEIGHTS_NAME, variant),
+                    weights_name=FLAX_WEIGHTS_NAME,
                     cache_dir=cache_dir,
                     force_download=force_download,
                     resume_download=resume_download,
@@ -645,76 +611,90 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
                     user_agent=user_agent,
                     commit_hash=commit_hash,
                 )
+                model = cls.from_config(config, **unused_kwargs)
 
-            if low_cpu_mem_usage:
-                # Instantiate model with empty weights
-                with accelerate.init_empty_weights():
-                    model = cls.from_config(config, **unused_kwargs)
+                # Convert the weights
+                from .modeling_pytorch_flax_utils import load_flax_checkpoint_in_pytorch_model
 
-                # if device_map is None, load the state dict and move the params from meta device to the cpu
-                if device_map is None:
-                    param_device = "cpu"
-                    state_dict = load_state_dict(model_file, variant=variant)
-                    model._convert_deprecated_attention_blocks(state_dict)
-                    # move the params from meta device to cpu
-                    missing_keys = set(model.state_dict().keys()) - set(state_dict.keys())
-                    if len(missing_keys) > 0:
-                        raise ValueError(
-                            f"Cannot load {cls} from {pretrained_model_name_or_path} because the following keys are"
-                            f" missing: \n {', '.join(missing_keys)}. \n Please make sure to pass"
-                            " `low_cpu_mem_usage=False` and `device_map=None` if you want to randomly initialize"
-                            " those weights or else make sure your checkpoint file is correct."
+                model = load_flax_checkpoint_in_pytorch_model(model, model_file)
+            else:
+                if use_safetensors:
+                    try:
+                        model_file = _get_model_file(
+                            pretrained_model_name_or_path,
+                            weights_name=_add_variant(SAFETENSORS_WEIGHTS_NAME, variant),
+                            cache_dir=cache_dir,
+                            force_download=force_download,
+                            resume_download=resume_download,
+                            proxies=proxies,
+                            local_files_only=local_files_only,
+                            token=token,
+                            revision=revision,
+                            subfolder=subfolder,
+                            user_agent=user_agent,
+                            commit_hash=commit_hash,
                         )
-
-                    unexpected_keys = load_model_dict_into_meta(
-                        model,
-                        state_dict,
-                        device=param_device,
-                        dtype=torch_dtype,
-                        model_name_or_path=pretrained_model_name_or_path,
+                    except IOError as e:
+                        if not allow_pickle:
+                            raise e
+                        pass
+                if model_file is None:
+                    model_file = _get_model_file(
+                        pretrained_model_name_or_path,
+                        weights_name=_add_variant(WEIGHTS_NAME, variant),
+                        cache_dir=cache_dir,
+                        force_download=force_download,
+                        resume_download=resume_download,
+                        proxies=proxies,
+                        local_files_only=local_files_only,
+                        token=token,
+                        revision=revision,
+                        subfolder=subfolder,
+                        user_agent=user_agent,
+                        commit_hash=commit_hash,
                     )
 
-                    if cls._keys_to_ignore_on_load_unexpected is not None:
-                        for pat in cls._keys_to_ignore_on_load_unexpected:
-                            unexpected_keys = [k for k in unexpected_keys if re.search(pat, k) is None]
+                if low_cpu_mem_usage:
+                    # Instantiate model with empty weights
+                    with accelerate.init_empty_weights():
+                        model = cls.from_config(config, **unused_kwargs)
 
-                    if len(unexpected_keys) > 0:
-                        logger.warn(
-                            f"Some weights of the model checkpoint were not used when initializing {cls.__name__}: \n {[', '.join(unexpected_keys)]}"
-                        )
-
-                else:  # else let accelerate handle loading and dispatching.
-                    # Load weights and dispatch according to the device_map
-                    # by default the device_map is None and the weights are loaded on the CPU
-                    try:
-                        accelerate.load_checkpoint_and_dispatch(
-                            model,
-                            model_file,
-                            device_map,
-                            max_memory=max_memory,
-                            offload_folder=offload_folder,
-                            offload_state_dict=offload_state_dict,
-                            dtype=torch_dtype,
-                        )
-                    except AttributeError as e:
-                        # When using accelerate loading, we do not have the ability to load the state
-                        # dict and rename the weight names manually. Additionally, accelerate skips
-                        # torch loading conventions and directly writes into `module.{_buffers, _parameters}`
-                        # (which look like they should be private variables?), so we can't use the standard hooks
-                        # to rename parameters on load. We need to mimic the original weight names so the correct
-                        # attributes are available. After we have loaded the weights, we convert the deprecated
-                        # names to the new non-deprecated names. Then we _greatly encourage_ the user to convert
-                        # the weights so we don't have to do this again.
-
-                        if "'Attention' object has no attribute" in str(e):
-                            logger.warn(
-                                f"Taking `{str(e)}` while using `accelerate.load_checkpoint_and_dispatch` to mean {pretrained_model_name_or_path}"
-                                " was saved with deprecated attention block weight names. We will load it with the deprecated attention block"
-                                " names and convert them on the fly to the new attention block format. Please re-save the model after this conversion,"
-                                " so we don't have to do the on the fly renaming in the future. If the model is from a hub checkpoint,"
-                                " please also re-upload it or open a PR on the original repository."
+                    # if device_map is None, load the state dict and move the params from meta device to the cpu
+                    if device_map is None:
+                        param_device = "cpu"
+                        state_dict = load_state_dict(model_file, variant=variant)
+                        model._convert_deprecated_attention_blocks(state_dict)
+                        # move the params from meta device to cpu
+                        missing_keys = set(model.state_dict().keys()) - set(state_dict.keys())
+                        if len(missing_keys) > 0:
+                            raise ValueError(
+                                f"Cannot load {cls} from {pretrained_model_name_or_path} because the following keys are"
+                                f" missing: \n {', '.join(missing_keys)}. \n Please make sure to pass"
+                                " `low_cpu_mem_usage=False` and `device_map=None` if you want to randomly initialize"
+                                " those weights or else make sure your checkpoint file is correct."
                             )
-                            model._temp_convert_self_to_deprecated_attention_blocks()
+
+                        unexpected_keys = load_model_dict_into_meta(
+                            model,
+                            state_dict,
+                            device=param_device,
+                            dtype=torch_dtype,
+                            model_name_or_path=pretrained_model_name_or_path,
+                        )
+
+                        if cls._keys_to_ignore_on_load_unexpected is not None:
+                            for pat in cls._keys_to_ignore_on_load_unexpected:
+                                unexpected_keys = [k for k in unexpected_keys if re.search(pat, k) is None]
+
+                        if len(unexpected_keys) > 0:
+                            logger.warn(
+                                f"Some weights of the model checkpoint were not used when initializing {cls.__name__}: \n {[', '.join(unexpected_keys)]}"
+                            )
+
+                    else:  # else let accelerate handle loading and dispatching.
+                        # Load weights and dispatch according to the device_map
+                        # by default the device_map is None and the weights are loaded on the CPU
+                        try:
                             accelerate.load_checkpoint_and_dispatch(
                                 model,
                                 model_file,
@@ -724,49 +704,77 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
                                 offload_state_dict=offload_state_dict,
                                 dtype=torch_dtype,
                             )
-                            model._undo_temp_convert_self_to_deprecated_attention_blocks()
-                        else:
-                            raise e
+                        except AttributeError as e:
+                            # When using accelerate loading, we do not have the ability to load the state
+                            # dict and rename the weight names manually. Additionally, accelerate skips
+                            # torch loading conventions and directly writes into `module.{_buffers, _parameters}`
+                            # (which look like they should be private variables?), so we can't use the standard hooks
+                            # to rename parameters on load. We need to mimic the original weight names so the correct
+                            # attributes are available. After we have loaded the weights, we convert the deprecated
+                            # names to the new non-deprecated names. Then we _greatly encourage_ the user to convert
+                            # the weights so we don't have to do this again.
 
-                loading_info = {
-                    "missing_keys": [],
-                    "unexpected_keys": [],
-                    "mismatched_keys": [],
-                    "error_msgs": [],
-                }
-            else:
-                model = cls.from_config(config, **unused_kwargs)
+                            if "'Attention' object has no attribute" in str(e):
+                                logger.warn(
+                                    f"Taking `{str(e)}` while using `accelerate.load_checkpoint_and_dispatch` to mean {pretrained_model_name_or_path}"
+                                    " was saved with deprecated attention block weight names. We will load it with the deprecated attention block"
+                                    " names and convert them on the fly to the new attention block format. Please re-save the model after this conversion,"
+                                    " so we don't have to do the on the fly renaming in the future. If the model is from a hub checkpoint,"
+                                    " please also re-upload it or open a PR on the original repository."
+                                )
+                                model._temp_convert_self_to_deprecated_attention_blocks()
+                                accelerate.load_checkpoint_and_dispatch(
+                                    model,
+                                    model_file,
+                                    device_map,
+                                    max_memory=max_memory,
+                                    offload_folder=offload_folder,
+                                    offload_state_dict=offload_state_dict,
+                                    dtype=torch_dtype,
+                                )
+                                model._undo_temp_convert_self_to_deprecated_attention_blocks()
+                            else:
+                                raise e
 
-                state_dict = load_state_dict(model_file, variant=variant)
-                model._convert_deprecated_attention_blocks(state_dict)
+                    loading_info = {
+                        "missing_keys": [],
+                        "unexpected_keys": [],
+                        "mismatched_keys": [],
+                        "error_msgs": [],
+                    }
+                else:
+                    model = cls.from_config(config, **unused_kwargs)
 
-                model, missing_keys, unexpected_keys, mismatched_keys, error_msgs = cls._load_pretrained_model(
-                    model,
-                    state_dict,
-                    model_file,
-                    pretrained_model_name_or_path,
-                    ignore_mismatched_sizes=ignore_mismatched_sizes,
+                    state_dict = load_state_dict(model_file, variant=variant)
+                    model._convert_deprecated_attention_blocks(state_dict)
+
+                    model, missing_keys, unexpected_keys, mismatched_keys, error_msgs = cls._load_pretrained_model(
+                        model,
+                        state_dict,
+                        model_file,
+                        pretrained_model_name_or_path,
+                        ignore_mismatched_sizes=ignore_mismatched_sizes,
+                    )
+
+                    loading_info = {
+                        "missing_keys": missing_keys,
+                        "unexpected_keys": unexpected_keys,
+                        "mismatched_keys": mismatched_keys,
+                        "error_msgs": error_msgs,
+                    }
+
+            if torch_dtype is not None and not isinstance(torch_dtype, torch.dtype):
+                raise ValueError(
+                    f"{torch_dtype} needs to be of type `torch.dtype`, e.g. `torch.float16`, but is {type(torch_dtype)}."
                 )
+            elif torch_dtype is not None:
+                model = model.to(torch_dtype)
 
-                loading_info = {
-                    "missing_keys": missing_keys,
-                    "unexpected_keys": unexpected_keys,
-                    "mismatched_keys": mismatched_keys,
-                    "error_msgs": error_msgs,
-                }
-
-        if torch_dtype is not None and not isinstance(torch_dtype, torch.dtype):
-            raise ValueError(
-                f"{torch_dtype} needs to be of type `torch.dtype`, e.g. `torch.float16`, but is {type(torch_dtype)}."
-            )
-        elif torch_dtype is not None:
-            model = model.to(torch_dtype)
-
-        model.register_to_config(_name_or_path=pretrained_model_name_or_path)
+            model.register_to_config(_name_or_path=pretrained_model_name_or_path)
 
         # Set model in evaluation mode to deactivate DropOut modules by default
         model.eval()
-        if output_loading_info:
+        if output_loading_info and not single_file_ckpt:
             return model, loading_info
 
         return model

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -109,6 +109,20 @@ LOADABLE_CLASSES = {
     },
 }
 
+SINGLE_FILE_LOADABLE_CLASSES = {
+    "StableDiffusionPipeline",
+    "StableDiffusionImg2ImgPipeline",
+    "StableDiffusionInpaintPipeline",
+    "StableDiffusionUpscalePipeline",
+    "StableDiffusionControlNetPipeline",
+    "StableDiffusionControlNetImg2ImgPipeline",
+    "StableDiffusionControlNetInpaintPipeline",
+    "StableDiffusionXLPipeline",
+    "StableDiffusionXLImg2ImgPipeline",
+    "StableDiffusionXLInpaintPipeline",
+    "StableDiffusionXLControlNetImg2ImgPipeline",
+}
+
 ALL_IMPORTABLE_CLASSES = {}
 for library in LOADABLE_CLASSES:
     ALL_IMPORTABLE_CLASSES.update(LOADABLE_CLASSES[library])
@@ -1056,6 +1070,10 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         ```
         """
         if is_single_file_checkpoint(pretrained_model_name_or_path):
+            if cls.__name__ not in SINGLE_FILE_LOADABLE_CLASSES:
+                raise ValueError(
+                    f"{cls.__name__} is not supported. Supported classes are: {' '.join(list(SINGLE_FILE_LOADABLE_CLASSES))}."
+                )
             logger.info("Single file checkpoint detected...")
             model = cls.from_single_file(pretrained_model_name_or_path, **kwargs)
         else:

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -23,7 +23,6 @@ import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
-from urllib.parse import urlparse
 
 import numpy as np
 import PIL.Image
@@ -46,7 +45,6 @@ from ..configuration_utils import ConfigMixin
 from ..models.modeling_utils import _LOW_CPU_MEM_USAGE_DEFAULT
 from ..schedulers.scheduling_utils import SCHEDULER_CONFIG_NAME
 from ..utils import (
-    _ACCEPTED_SINGLE_FILE_FORMATS,
     CONFIG_NAME,
     DEPRECATED_REVISION_ARGS,
     SAFETENSORS_WEIGHTS_NAME,
@@ -57,6 +55,7 @@ from ..utils import (
     is_accelerate_available,
     is_accelerate_version,
     is_peft_available,
+    is_single_file_checkpoint,
     is_torch_version,
     is_transformers_available,
     logging,
@@ -566,21 +565,6 @@ def _fetch_class_library_tuple(module):
     class_name = not_compiled_module.__class__.__name__
 
     return (library, class_name)
-
-
-def is_valid_url(url):
-    result = urlparse(url)
-    if result.scheme and result.netloc:
-        return True
-
-
-def is_single_file_checkpoint(filepath):
-    if filepath.endswith(_ACCEPTED_SINGLE_FILE_FORMATS):
-        if is_valid_url(filepath):
-            return True
-        elif os.path.isfile(filepath):
-            return True
-    return False
 
 
 class DiffusionPipeline(ConfigMixin, PushToHubMixin):

--- a/src/diffusers/utils/__init__.py
+++ b/src/diffusers/utils/__init__.py
@@ -19,6 +19,7 @@ from packaging import version
 
 from .. import __version__
 from .constants import (
+    _ACCEPTED_SINGLE_FILE_FORMATS,
     CONFIG_NAME,
     DEPRECATED_REVISION_ARGS,
     DIFFUSERS_DYNAMIC_MODULE_NAME,

--- a/src/diffusers/utils/__init__.py
+++ b/src/diffusers/utils/__init__.py
@@ -84,7 +84,7 @@ from .import_utils import (
     is_xformers_available,
     requires_backends,
 )
-from .loading_utils import load_image
+from .loading_utils import is_single_file_checkpoint, load_image
 from .logging import get_logger
 from .outputs import BaseOutput
 from .peft_utils import (

--- a/src/diffusers/utils/constants.py
+++ b/src/diffusers/utils/constants.py
@@ -37,6 +37,7 @@ HUGGINGFACE_CO_RESOLVE_ENDPOINT = os.environ.get("HF_ENDPOINT", "https://hugging
 DIFFUSERS_DYNAMIC_MODULE_NAME = "diffusers_modules"
 HF_MODULES_CACHE = os.getenv("HF_MODULES_CACHE", os.path.join(HF_HOME, "modules"))
 DEPRECATED_REVISION_ARGS = ["fp16", "non-ema"]
+_ACCEPTED_SINGLE_FILE_FORMATS = (".safetensors", ".ckpt", ".bin", ".pth", ".pt")
 
 # Below should be `True` if the current version of `peft` and `transformers` are compatible with
 # PEFT backend. Will automatically fall back to PEFT backend if the correct versions of the libraries are

--- a/src/diffusers/utils/loading_utils.py
+++ b/src/diffusers/utils/loading_utils.py
@@ -1,9 +1,26 @@
 import os
 from typing import Callable, Union
+from urllib.parse import urlparse
 
 import PIL.Image
 import PIL.ImageOps
 import requests
+
+from ..utils.constants import _ACCEPTED_SINGLE_FILE_FORMATS
+
+
+def is_single_file_checkpoint(filepath):
+    def is_valid_url(url):
+        result = urlparse(url)
+        if result.scheme and result.netloc:
+            return True
+
+    if filepath.endswith(_ACCEPTED_SINGLE_FILE_FORMATS):
+        if is_valid_url(filepath):
+            return True
+        elif os.path.isfile(filepath):
+            return True
+    return False
 
 
 def load_image(


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/diffusers/issues/6461. 

@DN6, some considerations I kept in mind:

* I didn't introduce `from_single_file` kwarg in `from_pretrained()`. 
* My reasoning is as follows: users are already familiar with the `from_single_file()` method and they know that they can either pass the local filepath or a URL. This workflow is quite well-known at this point in time. 
* So, I don't think it makes sense to deviate from this and tackle it with a combination of `repo_id` and `weight_name` like how it's done in `load_lora_weights()`. `load_lora_weights()` also supports passing a direct local path of the LoRA file, though. 

So, in a sense, `from_pretrained()`'s behavior is not deviating from `from_single_file()` in terms of how `from_pretrained()` is being called. WDYT? 

## TODO

- [ ] Add deprecation cycle to `from_single_file()`
- [ ] Tests
- [ ] Documentation