### PR TITLE
Refactor save_model_card function to handle images and repo_folder parameters

### DIFF
--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -68,10 +68,10 @@ def save_model_card(
     args,
     repo_id: str,
     images: list = None,
-    repo_folder: str = None,
+    repo_folder: str = ".",
 ):
     img_str = ""
-    if len(images) > 0:
+    if images is not None:
         image_grid = make_image_grid(images, 1, len(args.validation_prompts))
         image_grid.save(os.path.join(repo_folder, "val_imgs_grid.png"))
         img_str += "![val_imgs_grid](./val_imgs_grid.png)\n"

--- a/examples/text_to_image/train_text_to_image_lora.py
+++ b/examples/text_to_image/train_text_to_image_lora.py
@@ -57,12 +57,17 @@ logger = get_logger(__name__, log_level="INFO")
 
 
 def save_model_card(
-    repo_id: str, images: list = None, base_model: str = None, dataset_name: str = None, repo_folder: str = None
+    repo_id: str,
+    images: list = None,
+    base_model: str = None,
+    dataset_name: str = None,
+    repo_folder: str = ".",
 ):
     img_str = ""
-    for i, image in enumerate(images):
-        image.save(os.path.join(repo_folder, f"image_{i}.png"))
-        img_str += f"![img_{i}](./image_{i}.png)\n"
+    if images is not None:
+        for i, image in enumerate(images):
+            image.save(os.path.join(repo_folder, f"image_{i}.png"))
+            img_str += f"![img_{i}](./image_{i}.png)\n"
 
     model_description = f"""
 # LoRA text2image fine-tuning - {repo_id}

--- a/examples/text_to_image/train_text_to_image_lora_sdxl.py
+++ b/examples/text_to_image/train_text_to_image_lora_sdxl.py
@@ -75,7 +75,7 @@ def save_model_card(
     base_model: str = None,
     dataset_name: str = None,
     train_text_encoder: bool = False,
-    repo_folder: str = None,
+    repo_folder: str = ".",
     vae_path: str = None,
 ):
     img_str = ""

--- a/examples/text_to_image/train_text_to_image_sdxl.py
+++ b/examples/text_to_image/train_text_to_image_sdxl.py
@@ -70,13 +70,14 @@ def save_model_card(
     validation_prompt: str = None,
     base_model: str = None,
     dataset_name: str = None,
-    repo_folder: str = None,
+    repo_folder: str = ".",
     vae_path: str = None,
 ):
     img_str = ""
-    for i, image in enumerate(images):
-        image.save(os.path.join(repo_folder, f"image_{i}.png"))
-        img_str += f"![img_{i}](./image_{i}.png)\n"
+    if images is not None:
+        for i, image in enumerate(images):
+            image.save(os.path.join(repo_folder, f"image_{i}.png"))
+            img_str += f"![img_{i}](./image_{i}.png)\n"
 
     model_description = f"""
 # Text-to-image finetuning - {repo_id}


### PR DESCRIPTION
This pull request refactors the save_model_card function to handle the `images` and `repo_folder` parameters. It ensures that the function can handle both cases when images are provided and when they are not. `len(images)` was not proper for images' default None value. Also, None was not proper as a default for `os.path.join` in terms of `repo_folder`.