### PR TITLE
FIX [`PEFT` / `Core`] Copy the state dict when passing it to `load_lora_weights`

### DIFF
--- a/src/diffusers/loaders/lora.py
+++ b/src/diffusers/loaders/lora.py
@@ -106,6 +106,10 @@ class LoraLoaderMixin:
         if not USE_PEFT_BACKEND:
             raise ValueError("PEFT backend is required for this method.")
 
+        # if a dict is passed, copy it instead of modifying it inplace
+        if isinstance(pretrained_model_name_or_path_or_dict, dict):
+            pretrained_model_name_or_path_or_dict = pretrained_model_name_or_path_or_dict.copy()
+
         # First, ensure that the checkpoint is a compatible one and can be successfully loaded.
         state_dict, network_alphas = self.lora_state_dict(pretrained_model_name_or_path_or_dict, **kwargs)
 
@@ -1228,6 +1232,10 @@ class StableDiffusionXLLoraLoaderMixin(LoraLoaderMixin):
         # We could have accessed the unet config from `lora_state_dict()` too. We pass
         # it here explicitly to be able to tell that it's coming from an SDXL
         # pipeline.
+
+        # if a dict is passed, copy it instead of modifying it inplace
+        if isinstance(pretrained_model_name_or_path_or_dict, dict):
+            pretrained_model_name_or_path_or_dict = pretrained_model_name_or_path_or_dict.copy()
 
         # First, ensure that the checkpoint is a compatible one and can be successfully loaded.
         state_dict, network_alphas = self.lora_state_dict(


### PR DESCRIPTION
# What does this PR do?

As per title 

Fixes: https://github.com/huggingface/diffusers/issues/7054

There should be no reason to not copy the state dict of the lora layers if one passes a dict into `load_lora_weights`, therefore avoiding to sliently modifying the passed state_dict in-place. Added also a nice test with a state dict pushed under hf-internal-testing

cc @yiyixuxu @sayakpaul @pacman100 