### PR TITLE
[stalebot] don't close the issue if the stale label is removed

### DIFF
--- a/utils/stale.py
+++ b/utils/stale.py
@@ -39,25 +39,22 @@ def main():
     open_issues = repo.get_issues(state="open")
 
     for issue in open_issues:
-        comments = sorted(issue.get_comments(), key=lambda i: i.created_at, reverse=True)
-        last_comment = comments[0] if len(comments) > 0 else None
-        if (
-            last_comment is not None
-            and last_comment.user.login == "github-actions[bot]"
-            and (dt.now(timezone.utc) - issue.updated_at).days > 7
-            and (dt.now(timezone.utc) - issue.created_at).days >= 30
-            and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
-        ):
-            # Closes the issue after 7 days of inactivity since the Stalebot notification.
-            issue.edit(state="closed")
-        elif (
-            "stale" in issue.get_labels()
-            and last_comment is not None
-            and last_comment.user.login != "github-actions[bot]"
-        ):
-            # Opens the issue if someone other than Stalebot commented.
-            issue.edit(state="open")
-            issue.remove_from_labels("stale")
+        if "stale" in issue.get_labels():
+            comments = sorted(issue.get_comments(), key=lambda i: i.created_at, reverse=True)
+            last_comment = comments[0] if len(comments) > 0 else None
+            if (
+                last_comment is not None
+                and last_comment.user.login == "github-actions[bot]"
+                and (dt.now(timezone.utc) - issue.updated_at).days > 7
+                and (dt.now(timezone.utc) - issue.created_at).days >= 30
+                and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
+            ):
+                # Closes the issue after 7 days of inactivity since the Stalebot notification.
+                issue.edit(state="closed")
+            elif last_comment is not None and last_comment.user.login != "github-actions[bot]":
+                # Opens the issue if someone other than Stalebot commented.
+                issue.edit(state="open")
+                issue.remove_from_labels("stale")
         elif (
             (dt.now(timezone.utc) - issue.updated_at).days > 23
             and (dt.now(timezone.utc) - issue.created_at).days >= 30

--- a/utils/stale.py
+++ b/utils/stale.py
@@ -43,16 +43,7 @@ def main():
         if "stale" in labels:
             comments = sorted(issue.get_comments(), key=lambda i: i.created_at, reverse=True)
             last_comment = comments[0] if len(comments) > 0 else None
-            if (
-                last_comment is not None
-                and last_comment.user.login == "github-actions[bot]"
-                and (dt.now(timezone.utc) - issue.updated_at).days > 7
-                and (dt.now(timezone.utc) - issue.created_at).days >= 30
-                and not any(label.name.lower() in LABELS_TO_EXEMPT for label in labels)
-            ):
-                # Closes the issue after 7 days of inactivity since the Stalebot notification.
-                issue.edit(state="closed")
-            elif last_comment is not None and last_comment.user.login != "github-actions[bot]":
+            if last_comment is not None and last_comment.user.login != "github-actions[bot]":
                 # Opens the issue if someone other than Stalebot commented.
                 issue.edit(state="open")
                 issue.remove_from_labels("stale")

--- a/utils/stale.py
+++ b/utils/stale.py
@@ -39,7 +39,8 @@ def main():
     open_issues = repo.get_issues(state="open")
 
     for issue in open_issues:
-        if "stale" in issue.get_labels():
+        labels = [label.name for label in issue.get_labels()]
+        if "stale" in labels:
             comments = sorted(issue.get_comments(), key=lambda i: i.created_at, reverse=True)
             last_comment = comments[0] if len(comments) > 0 else None
             if (
@@ -47,7 +48,7 @@ def main():
                 and last_comment.user.login == "github-actions[bot]"
                 and (dt.now(timezone.utc) - issue.updated_at).days > 7
                 and (dt.now(timezone.utc) - issue.created_at).days >= 30
-                and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
+                and not any(label.name.lower() in LABELS_TO_EXEMPT for label in labels)
             ):
                 # Closes the issue after 7 days of inactivity since the Stalebot notification.
                 issue.edit(state="closed")
@@ -58,7 +59,7 @@ def main():
         elif (
             (dt.now(timezone.utc) - issue.updated_at).days > 23
             and (dt.now(timezone.utc) - issue.created_at).days >= 30
-            and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
+            and not any(label.name.lower() in LABELS_TO_EXEMPT for label in labels)
         ):
             # Post a Stalebot notification after 23 days of inactivity.
             issue.create_comment(


### PR DESCRIPTION
currently, our StaleBot isn't working as expected:
1. it does not re-open issues - it is supposed to open the issue if someone other than Stalebot commented but it does not do that
   * if you go through our staled PR you can find lots of examples https://github.com/huggingface/diffusers/pull/6595
3. it will close an issue even if we had remove the "stale" label manually, e.g https://github.com/huggingface/diffusers/issues/6248#issuecomment-1964390412

However, I think the expected behavior of the StaleBot to automatically re-open an issue after someone comments is a little bit questionable. e.g., if we leave a comment asking, "Can we close this now?" - it will trigger the StaleBot to reopen the issue. for example, here https://github.com/huggingface/diffusers/issues/6695

Maybe we should come up with a special spell (instead of any comments) for the StableBot to go away? cc @sayakpaul think you might be interested as a harry potter fan 