### PR TITLE
Remove extra newline in warning message to install the transformers module

### DIFF
--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -422,8 +422,7 @@ installation page: https://librosa.org/doc/latest/install.html and follow the on
 
 # docstyle-ignore
 TRANSFORMERS_IMPORT_ERROR = """
-{0} requires the transformers library but it was not found in your environment. You can install it with pip: `pip
-install transformers`
+{0} requires the transformers library but it was not found in your environment. You can install it with pip: `pip install transformers`
 """
 
 # docstyle-ignore


### PR DESCRIPTION
# What does this PR do?

When calling the **from_pretrained** method without the transformers module installed, an error message is outputted with a message stating to install the transformers module. The issue is that the pip command is split accross multiple lines, so it is displayed as:
```
    raise ImportError("".join(failed))
ImportError:
StableDiffusionPipeline requires the transformers library but it was not found in your environment. You can install it with pip: `pip
install transformers`
```
with a newline between "pip" and "install transformers". This change removes the newline.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
