### PR TITLE
denormalize latents with the mean and std if available

### DIFF
--- a/src/diffusers/models/autoencoders/autoencoder_kl.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl.py
@@ -80,6 +80,8 @@ class AutoencoderKL(ModelMixin, ConfigMixin, FromOriginalVAEMixin):
         norm_num_groups: int = 32,
         sample_size: int = 32,
         scaling_factor: float = 0.18215,
+        latents_mean: Optional[Tuple[float]] = None,
+        latents_std: Optional[Tuple[float]] = None,
         force_upcast: float = True,
     ):
         super().__init__()

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -1315,12 +1315,9 @@ class StableDiffusionXLPipeline(
 
             # unscale/denormalize the latents
             # denormalize with the mean and std if available and not None
-            if (
-                hasattr(self.vae.config, "latents_mean")
-                and self.vae.config.latents_mean is not None
-                and hasattr(self.vae.config, "latents_std")
-                and self.vae.config.latents_std is not None
-            ):
+            has_latents_mean = hasattr(self.vae.config, "latents_mean") and self.vae.config.latents_mean is not None
+            has_latents_std = hasattr(self.vae.config, "latents_std") and self.vae.config.latents_std is not None
+            if has_latents_mean and has_latents_std:
                 latents_mean = (
                     torch.tensor(self.vae.config.latents_mean).view(1, 4, 1, 1).to(latents.device, latents.dtype)
                 )

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -1321,10 +1321,13 @@ class StableDiffusionXLPipeline(
                 and hasattr(self.vae.config, "latents_std")
                 and self.vae.config.latents_std is not None
             ):
-                latents = (
-                    latents * self.vae.config.latents_std / self.vae.config.scaling_factor
-                    + self.vae.config.latents_mean
+                latents_mean = (
+                    torch.tensor(self.vae.config.latents_mean).view(1, 4, 1, 1).to(latents.device, latents.dtype)
                 )
+                latents_std = (
+                    torch.tensor(self.vae.config.latents_std).view(1, 4, 1, 1).to(latents.device, latents.dtype)
+                )
+                latents = latents * latents_std / self.vae.config.scaling_factor + latents_mean
             else:
                 latents = latents / self.vae.config.scaling_factor
 

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -1314,13 +1314,19 @@ class StableDiffusionXLPipeline(
                 latents = latents.to(next(iter(self.vae.post_quant_conv.parameters())).dtype)
 
             # unscale/denormalize the latents
-            # denormalize with the mean and std if available
-            if hasattr(self.vae.config, "latents_mean") and hasattr(self.vae.config, "latents_std"):
+            # denormalize with the mean and std if available and not None
+            if (
+                hasattr(self.vae.config, "latents_mean")
+                and self.vae.config.latents_mean is not None
+                and hasattr(self.vae.config, "latents_std")
+                and self.vae.config.latents_std is not None
+            ):
                 latents = (
-                    latents * self.vae.config.latents_std / self.vae.config.scale_factor + self.vae.config.latents_mean
+                    latents * self.vae.config.latents_std / self.vae.config.scaling_factor
+                    + self.vae.config.latents_mean
                 )
             else:
-                latents = latents * self.vae.config.scale_factor
+                latents = latents / self.vae.config.scaling_factor
 
             image = self.vae.decode(latents, return_dict=False)[0]
 


### PR DESCRIPTION
# What does this PR do?

This PR adapts SDXL pipeline slightly to denormalize `latents` with mean and std if available in the vae config. We could also consider having these arguments in the vae `__init__` if more models starts doing this.