### PR TITLE
Fix LCM benchmark test

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,7 @@
 name: Benchmarking tests
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "30 1 1,15 * *" # every 2 weeks on the 1st and the 15th of every month at 1:30 AM
 

--- a/benchmarks/base_classes.py
+++ b/benchmarks/base_classes.py
@@ -141,6 +141,7 @@ class LCMLoRATextToImageBenchmark(TextToImageBenchmark):
         super().__init__(args)
         self.pipe.load_lora_weights(self.lora_id)
         self.pipe.fuse_lora()
+        self.pipe.unload_lora_weights()
         self.pipe.scheduler = LCMScheduler.from_config(self.pipe.scheduler.config)
 
     def get_result_filepath(self, args):


### PR DESCRIPTION
# What does this PR do?

The LCM LoRA benchmark test current fails: https://github.com/huggingface/diffusers/actions/runs/8105285148/job/22153378360#step:8:52. This PR fixes that. Additionally, makes benchmarking workflow dispatchable. 