### PR TITLE
Fix vae_encodings_fn hash in train_text_to_image_sdxl.py

### DIFF
--- a/examples/text_to_image/train_text_to_image_sdxl.py
+++ b/examples/text_to_image/train_text_to_image_sdxl.py
@@ -895,7 +895,7 @@ def main(args):
         # fingerprint used by the cache for the other processes to load the result
         # details: https://github.com/huggingface/diffusers/pull/4038#discussion_r1266078401
         new_fingerprint = Hasher.hash(args)
-        new_fingerprint_for_vae = Hasher.hash("vae")
+        new_fingerprint_for_vae = Hasher.hash(vae_path)
         train_dataset = train_dataset.map(compute_embeddings_fn, batched=True, new_fingerprint=new_fingerprint)
         train_dataset = train_dataset.map(
             compute_vae_encodings_fn,


### PR DESCRIPTION
The hash used as new fingerprint when computing the VAE encodings in train_text_to_image_sdxl.py should change if the VAE changes.

Previously if someone used different VAEs using this script, it would always reload the first result in the dataset cache instead of recomputing using the different VAE.

I haven't checked in other examples for similar cases, maybe it can be worth checking.

@sayakpaul 