### PR TITLE
fix a bug in `from_config`

### DIFF
--- a/src/diffusers/configuration_utils.py
+++ b/src/diffusers/configuration_utils.py
@@ -262,8 +262,7 @@ class ConfigMixin:
         # update _class_name and _diffusers_versionl
         if "_class_name" in hidden_dict:
             hidden_dict["_class_name"] = cls.__name__
-        if "_diffusers_version" in hidden_dict:
-            hidden_dict["_diffusers_version"] = __version__
+
         model.register_to_config(**hidden_dict)
 
         # add hidden kwargs of compatible classes to unused_kwargs

--- a/src/diffusers/configuration_utils.py
+++ b/src/diffusers/configuration_utils.py
@@ -259,6 +259,11 @@ class ConfigMixin:
         model = cls(**init_dict)
 
         # make sure to also save config parameters that might be used for compatible classes
+        # update _class_name and _diffusers_versionl
+        if "_class_name" in hidden_dict:
+            hidden_dict["_class_name"] = cls.__name__
+        if "_diffusers_version" in hidden_dict:
+            hidden_dict["_diffusers_version"] = __version__
         model.register_to_config(**hidden_dict)
 
         # add hidden kwargs of compatible classes to unused_kwargs

--- a/src/diffusers/configuration_utils.py
+++ b/src/diffusers/configuration_utils.py
@@ -259,7 +259,7 @@ class ConfigMixin:
         model = cls(**init_dict)
 
         # make sure to also save config parameters that might be used for compatible classes
-        # update _class_name and _diffusers_versionl
+        # update _class_name
         if "_class_name" in hidden_dict:
             hidden_dict["_class_name"] = cls.__name__
 


### PR DESCRIPTION
fix https://github.com/huggingface/diffusers/issues/7183

this script now runs expected

```pythn
from diffusers import DiffusionPipeline, EulerAncestralDiscreteScheduler, LCMScheduler, AutoencoderKL
import torch

model_id = "stabilityai/stable-diffusion-xl-base-1.0"

pipe = DiffusionPipeline.from_pretrained(model_id, variant="fp16", torch_dtype=torch.float16)

#print correct value
print(f" test1: should print EulerAncestralDiscreteScheduler")
print(pipe.scheduler.config._class_name)
print(pipe.scheduler)
print(pipe.scheduler.config._class_name)

pipe.scheduler = LCMScheduler.from_config(pipe.scheduler.config)

#gives Euler not LCM
print(f" test2: shuld print LCMScheduler")
print(pipe.scheduler.config._class_name)
print(pipe.scheduler)
print(pipe.scheduler.config._class_name)

pipe.scheduler = EulerAncestralDiscreteScheduler.from_config(pipe.scheduler.config)

#prints LCM not EulerA
print(f" test3: shuld print EulerAncestralDiscreteScheduler")
print(pipe.scheduler.config._class_name)
print(pipe.scheduler)
print(pipe.scheduler.config._class_name)
 ```
output
```
Loading pipeline components...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:02<00:00,  3.33it/s]
 test1: should print EulerAncestralDiscreteScheduler
EulerDiscreteScheduler
EulerDiscreteScheduler {
  "_class_name": "EulerDiscreteScheduler",
  "_diffusers_version": "0.27.0.dev0",
  "beta_end": 0.012,
  "beta_schedule": "scaled_linear",
  "beta_start": 0.00085,
  "clip_sample": false,
  "interpolation_type": "linear",
  "num_train_timesteps": 1000,
  "prediction_type": "epsilon",
  "rescale_betas_zero_snr": false,
  "sample_max_value": 1.0,
  "set_alpha_to_one": false,
  "sigma_max": null,
  "sigma_min": null,
  "skip_prk_steps": true,
  "steps_offset": 1,
  "timestep_spacing": "leading",
  "timestep_type": "discrete",
  "trained_betas": null,
  "use_karras_sigmas": false
}

EulerDiscreteScheduler
The config attributes {'skip_prk_steps': True} were passed to LCMScheduler, but are not expected and will be ignored. Please verify your scheduler_config.json configuration file.
 hidden_dict: {'interpolation_type': 'linear', 'use_karras_sigmas': False, '_class_name': 'LCMScheduler', '_diffusers_version': '0.27.0.dev0', 'skip_prk_steps': True}
 test2: shuld print LCMScheduler
LCMScheduler
LCMScheduler {
  "_class_name": "LCMScheduler",
  "_diffusers_version": "0.27.0.dev0",
  "beta_end": 0.012,
  "beta_schedule": "scaled_linear",
  "beta_start": 0.00085,
  "clip_sample": false,
  "clip_sample_range": 1.0,
  "dynamic_thresholding_ratio": 0.995,
  "interpolation_type": "linear",
  "num_train_timesteps": 1000,
  "original_inference_steps": 50,
  "prediction_type": "epsilon",
  "rescale_betas_zero_snr": false,
  "sample_max_value": 1.0,
  "set_alpha_to_one": false,
  "skip_prk_steps": true,
  "steps_offset": 1,
  "thresholding": false,
  "timestep_scaling": 10.0,
  "timestep_spacing": "leading",
  "trained_betas": null,
  "use_karras_sigmas": false
}

LCMScheduler
 hidden_dict: {'clip_sample': False, 'set_alpha_to_one': False, 'sample_max_value': 1.0, 'interpolation_type': 'linear', 'use_karras_sigmas': False, '_class_name': 'EulerAncestralDiscreteScheduler', '_diffusers_version': '0.27.0.dev0', 'skip_prk_steps': True}
 test3: shuld print EulerAncestralDiscreteScheduler
EulerAncestralDiscreteScheduler
EulerAncestralDiscreteScheduler {
  "_class_name": "EulerAncestralDiscreteScheduler",
  "_diffusers_version": "0.27.0.dev0",
  "beta_end": 0.012,
  "beta_schedule": "scaled_linear",
  "beta_start": 0.00085,
  "clip_sample": false,
  "interpolation_type": "linear",
  "num_train_timesteps": 1000,
  "prediction_type": "epsilon",
  "rescale_betas_zero_snr": false,
  "sample_max_value": 1.0,
  "set_alpha_to_one": false,
  "skip_prk_steps": true,
  "steps_offset": 1,
  "timestep_spacing": "leading",
  "trained_betas": null,
  "use_karras_sigmas": false
}

EulerAncestralDiscreteScheduler
```