### PR TITLE
SDXL Inpainting VAE Normalization

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -1776,9 +1776,9 @@ class StableDiffusionXLInpaintPipeline(
         has_latents_std = hasattr(self.vae.config, "latents_std") and self.vae.config.latents_std is not None
         if has_latents_mean and has_latents_std:
             latents_mean = torch.tensor(self.vae.config.latents_mean).view(1, 4, 1, 1)
-            latents_mean.to(image_latents.device, image_latents.dtype)
+            latents_mean.to(latents.device, latents.dtype)
             latents_std = torch.tensor(self.vae.config.latents_std).view(1, 4, 1, 1)
-            latents_std.to(image_latents.device, image_latents.dtype)
+            latents_std.to(latents.device, latents.dtype)
             latents = latents * latents_std + latents_mean
 
         if not output_type == "latent":

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -308,6 +308,25 @@ def retrieve_timesteps(
     return timesteps, num_inference_steps
 
 
+def requires_vae_latents_normalization(vae):
+    return hasattr(vae.config, "latents_mean") and vae.config.latents_mean is not None and \
+           hasattr(vae.config, "latents_std") and vae.config.latents_std is not None
+
+
+def normalize_vae_latents(latents, latents_mean, latents_std):
+    latents_mean = latents_mean.to(device=latents.device, dtype=latents.dtype)
+    latents_std = latents_std.to(device=latents.device, dtype=latents.dtype)
+    latents = (latents - latents_mean) / latents_std
+    return latents
+
+
+def denormalize_vae_latents(latents, latents_mean, latents_std):
+    latents_mean = latents_mean.to(device=latents.device, dtype=latents.dtype)
+    latents_std = latents_std.to(device=latents.device, dtype=latents.dtype)
+    latents = latents * latents_std + latents_mean
+    return latents
+
+
 class StableDiffusionXLInpaintPipeline(
     DiffusionPipeline,
     StableDiffusionMixin,
@@ -939,6 +958,12 @@ class StableDiffusionXLInpaintPipeline(
         else:
             image_latents = retrieve_latents(self.vae.encode(image), generator=generator)
 
+        if requires_vae_latents_normalization(self.vae):
+            image_latents = normalize_vae_latents(
+                image_latents,
+                latents_mean=torch.tensor(self.vae.config.latents_mean).view(1, 4, 1, 1),
+                latents_std=torch.tensor(self.vae.config.latents_std).view(1, 4, 1, 1),
+            )
         if self.vae.config.force_upcast:
             self.vae.to(dtype)
 
@@ -1762,6 +1787,13 @@ class StableDiffusionXLInpaintPipeline(
 
                 if XLA_AVAILABLE:
                     xm.mark_step()
+
+        if requires_vae_latents_normalization(self.vae):
+            latents = denormalize_vae_latents(
+                latents,
+                latents_mean=torch.tensor(self.vae.config.latents_mean).view(1, 4, 1, 1),
+                latents_std=torch.tensor(self.vae.config.latents_std).view(1, 4, 1, 1),
+            )
 
         if not output_type == "latent":
             # make sure the VAE is in float32 mode, as it overflows in float16


### PR DESCRIPTION
# What does this PR do?

Since the release of Playground V2.5 with "custom" VAE we should normalize and denormalize latents. 
This is already implemented in `StableDiffusionXLPipeline`: https://github.com/huggingface/diffusers/blob/687bc2772721af584d649129f8d2a28ca56a9ad8/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py#L1230-L1243


## Who can review?

cc: @sayakpaul @patil-suraj 
