### PR TITLE
Experimental feature to use tokens not in <s\d> format

### DIFF
--- a/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
+++ b/examples/advanced_diffusion_training/train_dreambooth_lora_sdxl_advanced.py
@@ -86,6 +86,7 @@ def save_model_card(
     base_model=str,
     train_text_encoder=False,
     train_text_encoder_ti=False,
+    base_new_tokens_off_token_abstractions=False,
     token_abstraction_dict=None,
     instance_prompt=str,
     validation_prompt=str,
@@ -107,8 +108,15 @@ def save_model_card(
         - text: '{instance_prompt}'
         """
     embeddings_filename = f"{repo_folder}_emb"
-    instance_prompt_webui = re.sub(r"<s\d+>", "", re.sub(r"<s\d+>", embeddings_filename, instance_prompt, count=1))
-    ti_keys = ", ".join(f'"{match}"' for match in re.findall(r"<s\d+>", instance_prompt))
+    if base_new_tokens_off_token_abstractions and token_abstraction_dict:
+        ti_keys = []
+        for key in token_abstraction_dict.keys():
+            instance_prompt_webui = re.sub(rf"<{key}_\d+>", "", re.sub(rf"<{key}_\d+>", embeddings_filename, instance_prompt, count=1))
+            ti_keys += [f'"{match}"' for match in re.findall(rf"<{key}_\d+>", instance_prompt)]
+        ti_keys = ", ".join(ti_keys)
+    else:
+        instance_prompt_webui = re.sub(r"<s\d+>", "", re.sub(r"<s\d+>", embeddings_filename, instance_prompt, count=1))
+        ti_keys = ", ".join(f'"{match}"' for match in re.findall(r"<s\d+>", instance_prompt))
     if instance_prompt_webui != embeddings_filename:
         instance_prompt_sentence = f"For example, `{instance_prompt_webui}`"
     else:
@@ -332,6 +340,13 @@ def parse_args(input_args=None):
         help="identifier specifying the instance(or instances) as used in instance_prompt, validation prompt, "
         "captions - e.g. TOK. To use multiple identifiers, please specify them in a comma seperated string - e.g. "
         "'TOK,TOK2,TOK3' etc.",
+    )
+
+    parser.add_argument(
+        "--base_new_tokens_off_token_abstractions",
+        default=False,
+        action="store_true",
+        help="utilize <TOK_0><TOK_1>... per each token instead of the default <si><si+1>..."
     )
 
     parser.add_argument(
@@ -1266,9 +1281,14 @@ def main(args):
         token_abstraction_dict = {}
         token_idx = 0
         for i, token in enumerate(token_abstraction_list):
-            token_abstraction_dict[token] = [
-                f"<s{token_idx + i + j}>" for j in range(args.num_new_tokens_per_abstraction)
-            ]
+            if args.base_new_tokens_off_token_abstractions:
+                token_abstraction_dict[token] = [
+                    f"<{token}_{j}>" for j in range(args.num_new_tokens_per_abstraction)
+                ]
+            else: 
+                token_abstraction_dict[token] = [
+                    f"<s{token_idx + i + j}>" for j in range(args.num_new_tokens_per_abstraction)
+                ]
             token_idx += args.num_new_tokens_per_abstraction - 1
 
         # replace instances of --token_abstraction in --instance_prompt with the new tokens: "<si><si+1>" etc.
@@ -2211,6 +2231,7 @@ def main(args):
             base_model=args.pretrained_model_name_or_path,
             train_text_encoder=args.train_text_encoder,
             train_text_encoder_ti=args.train_text_encoder_ti,
+            base_new_tokens_off_token_abstractions=args.base_new_tokens_off_token_abstractions,
             token_abstraction_dict=train_dataset.token_abstraction_dict,
             instance_prompt=args.instance_prompt,
             validation_prompt=args.validation_prompt,


### PR DESCRIPTION
Create a new flag that will incorporate provided tokens abstraction into model tokens to prevent multiple LoRAs clashing.

# What does this PR do?

Creates an experimental flag that will rename the default <s0><s1> to <TOK_0><TOK_1>. 

Fixes # 7298


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?