### PR TITLE
Support loading of other supported UNets from single file checkpoints

### DIFF
--- a/src/diffusers/loaders/__init__.py
+++ b/src/diffusers/loaders/__init__.py
@@ -57,7 +57,7 @@ if is_torch_available():
     _import_structure["autoencoder"] = ["FromOriginalVAEMixin"]
 
     _import_structure["controlnet"] = ["FromOriginalControlNetMixin"]
-    _import_structure["unet"] = ["UNet2DConditionLoadersMixin"]
+    _import_structure["unet"] = ["FromOriginalUNetMixin", "UNet2DConditionLoadersMixin"]
     _import_structure["utils"] = ["AttnProcsLayers"]
     if is_transformers_available():
         _import_structure["single_file"] = ["FromSingleFileMixin"]
@@ -72,7 +72,7 @@ if TYPE_CHECKING or DIFFUSERS_SLOW_IMPORT:
     if is_torch_available():
         from .autoencoder import FromOriginalVAEMixin
         from .controlnet import FromOriginalControlNetMixin
-        from .unet import UNet2DConditionLoadersMixin
+        from .unet import FromOriginalUNetMixin, UNet2DConditionLoadersMixin
         from .utils import AttnProcsLayers
 
         if is_transformers_available():

--- a/src/diffusers/loaders/unet.py
+++ b/src/diffusers/loaders/unet.py
@@ -1008,4 +1008,4 @@ class FromOriginalUNetMixin:
                 image_size=kwargs.get("image_size", None),
                 torch_dtype=torch_dtype,
                 model_type=kwargs.pop("model_type", None),
-            )
+            )["unet"]

--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -19,7 +19,7 @@ import torch.nn as nn
 import torch.utils.checkpoint
 
 from ...configuration_utils import ConfigMixin, register_to_config
-from ...loaders import PeftAdapterMixin, UNet2DConditionLoadersMixin
+from ...loaders import FromOriginalUNetMixin, PeftAdapterMixin, UNet2DConditionLoadersMixin
 from ...utils import USE_PEFT_BACKEND, BaseOutput, deprecate, logging, scale_lora_layers, unscale_lora_layers
 from ..activations import get_activation
 from ..attention_processor import (
@@ -66,7 +66,9 @@ class UNet2DConditionOutput(BaseOutput):
     sample: torch.FloatTensor = None
 
 
-class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin, PeftAdapterMixin):
+class UNet2DConditionModel(
+    ModelMixin, ConfigMixin, FromOriginalUNetMixin, UNet2DConditionLoadersMixin, PeftAdapterMixin
+):
     r"""
     A conditional 2D UNet model that takes a noisy sample, conditional state, and a timestep and returns a sample
     shaped output.


### PR DESCRIPTION
# What does this PR do?

Test:

```python
from diffusers import UNet2DConditionModel
import torch


def get_inputs():
    sample = torch.randn(1, 4, 64, 64).to("cuda")
    timestep = torch.randint(1, 1000, size=(1,)).to("cuda")
    encoder_hidden_states = torch.randn(1, 77, 2048).to("cuda")
    added_cond_kwargs = {"text_embeds": torch.randn(1, 1280).to("cuda"), "time_ids": torch.randn(1, 6).to("cuda")}
    return dict(
        sample=sample,
        timestep=timestep,
        encoder_hidden_states=encoder_hidden_states,
        added_cond_kwargs=added_cond_kwargs,
    )


repo_id = "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/sd_xl_base_1.0.safetensors"
single_file_unet = UNet2DConditionModel.from_single_file(repo_id, pipeline_class_name="StableDiffusionXLPipeline").to(
    "cuda"
)
diffusers_unet = UNet2DConditionModel.from_pretrained("stabilityai/stable-diffusion-xl-base-1.0", subfolder="unet").to(
    "cuda"
)

with torch.no_grad():
    inputs = get_inputs()
    single_file_outs = single_file_unet(**inputs, return_dict=False)[0]
    diffusers_outs = diffusers_unet(**inputs, return_dict=False)[0]

    assert torch.allclose(single_file_outs, diffusers_outs, atol=1e-4, rtol=1e-4)
```

Follow up of https://github.com/huggingface/diffusers/pull/7274. 