### PR TITLE
Update deprecated code and fix warnings

### DIFF
--- a/src/diffusers/training_utils.py
+++ b/src/diffusers/training_utils.py
@@ -321,11 +321,11 @@ class EMAModel:
         one_minus_decay = 1 - decay
 
         context_manager = contextlib.nullcontext
-        if is_transformers_available() and transformers.deepspeed.is_deepspeed_zero3_enabled():
+        if is_transformers_available() and transformers.integrations.is_deepspeed_zero3_enabled():
             import deepspeed
 
         for s_param, param in zip(self.shadow_params, parameters):
-            if is_transformers_available() and transformers.deepspeed.is_deepspeed_zero3_enabled():
+            if is_transformers_available() and transformers.integrations.is_deepspeed_zero3_enabled():
                 context_manager = deepspeed.zero.GatheredParameters(param, modifier_rank=None)
 
             with context_manager():

--- a/tests/models/test_layers_utils.py
+++ b/tests/models/test_layers_utils.py
@@ -376,6 +376,7 @@ class Transformer2DModelTests(unittest.TestCase):
             dropout=0.0,
             cross_attention_dim=64,
             num_embeds_ada_norm=num_embeds_ada_norm,
+            norm_type="ada_norm",
         ).to(torch_device)
         with torch.no_grad():
             timestep_1 = torch.tensor(1, dtype=torch.long).to(torch_device)
@@ -467,6 +468,7 @@ class Transformer2DModelTests(unittest.TestCase):
             attention_head_dim=32,
             in_channels=32,
             num_embeds_ada_norm=5,
+            norm_type="ada_norm",
         )
 
         assert spatial_transformer_block.transformer_blocks[0].norm1.__class__ == AdaLayerNorm

--- a/tests/schedulers/test_schedulers.py
+++ b/tests/schedulers/test_schedulers.py
@@ -463,11 +463,19 @@ class SchedulerCommonTest(unittest.TestCase):
 
             if "generator" in set(inspect.signature(scheduler.step).parameters.keys()):
                 kwargs["generator"] = torch.manual_seed(0)
-            output = scheduler.step(residual, time_step, sample, **kwargs).prev_sample
+            if scheduler_class == LMSDiscreteScheduler:
+                sample_scheduler = scheduler.scale_model_input(sample, time_step)
+                output = scheduler.step(residual, time_step, sample_scheduler, **kwargs).prev_sample
+            else:
+                output = scheduler.step(residual, time_step, sample, **kwargs).prev_sample
 
             if "generator" in set(inspect.signature(scheduler.step).parameters.keys()):
                 kwargs["generator"] = torch.manual_seed(0)
-            new_output = new_scheduler.step(residual, time_step, sample, **kwargs).prev_sample
+            if scheduler_class == LMSDiscreteScheduler:
+                sample_new_scheduler = new_scheduler.scale_model_input(sample, time_step)
+                new_output = new_scheduler.step(residual, time_step, sample_new_scheduler, **kwargs).prev_sample
+            else:
+                new_output = new_scheduler.step(residual, time_step, sample, **kwargs).prev_sample
 
             assert torch.sum(torch.abs(output - new_output)) < 1e-5, "Scheduler outputs are not identical"
 
@@ -509,11 +517,19 @@ class SchedulerCommonTest(unittest.TestCase):
 
             if "generator" in set(inspect.signature(scheduler.step).parameters.keys()):
                 kwargs["generator"] = torch.manual_seed(0)
-            output = scheduler.step(residual, timestep, sample, **kwargs).prev_sample
+            if scheduler_class == LMSDiscreteScheduler:
+                sample_scheduler = scheduler.scale_model_input(sample, timestep)
+                output = scheduler.step(residual, timestep, sample_scheduler, **kwargs).prev_sample
+            else:
+                output = scheduler.step(residual, timestep, sample, **kwargs).prev_sample
 
             if "generator" in set(inspect.signature(scheduler.step).parameters.keys()):
                 kwargs["generator"] = torch.manual_seed(0)
-            new_output = new_scheduler.step(residual, timestep, sample, **kwargs).prev_sample
+            if scheduler_class == LMSDiscreteScheduler:
+                sample_new_scheduler = new_scheduler.scale_model_input(sample, timestep)
+                new_output = new_scheduler.step(residual, timestep, sample_new_scheduler, **kwargs).prev_sample
+            else:
+                new_output = new_scheduler.step(residual, timestep, sample, **kwargs).prev_sample
 
             assert torch.sum(torch.abs(output - new_output)) < 1e-5, "Scheduler outputs are not identical"
 
@@ -587,8 +603,13 @@ class SchedulerCommonTest(unittest.TestCase):
             elif num_inference_steps is not None and not hasattr(scheduler, "set_timesteps"):
                 kwargs["num_inference_steps"] = num_inference_steps
 
-            output_0 = scheduler.step(residual, timestep_0, sample, **kwargs).prev_sample
-            output_1 = scheduler.step(residual, timestep_1, sample, **kwargs).prev_sample
+            if scheduler_class == LMSDiscreteScheduler:
+                sample_scheduler = scheduler.scale_model_input(sample, timestep_0)
+                output_0 = scheduler.step(residual, timestep_0, sample_scheduler, **kwargs).prev_sample
+                output_1 = scheduler.step(residual, timestep_1, sample_scheduler, **kwargs).prev_sample
+            else:
+                output_0 = scheduler.step(residual, timestep_0, sample, **kwargs).prev_sample
+                output_1 = scheduler.step(residual, timestep_1, sample, **kwargs).prev_sample
 
             self.assertEqual(output_0.shape, sample.shape)
             self.assertEqual(output_0.shape, output_1.shape)
@@ -655,7 +676,11 @@ class SchedulerCommonTest(unittest.TestCase):
             # Set the seed before state as some schedulers are stochastic like EulerAncestralDiscreteScheduler, EulerDiscreteScheduler
             if "generator" in set(inspect.signature(scheduler.step).parameters.keys()):
                 kwargs["generator"] = torch.manual_seed(0)
-            outputs_dict = scheduler.step(residual, timestep, sample, **kwargs)
+            if scheduler_class == LMSDiscreteScheduler:
+                sample_scheduler = scheduler.scale_model_input(sample, timestep)
+                outputs_dict = scheduler.step(residual, timestep, sample_scheduler, **kwargs)
+            else:
+                outputs_dict = scheduler.step(residual, timestep, sample, **kwargs)
 
             if num_inference_steps is not None and hasattr(scheduler, "set_timesteps"):
                 scheduler.set_timesteps(num_inference_steps)
@@ -665,7 +690,11 @@ class SchedulerCommonTest(unittest.TestCase):
             # Set the seed before state as some schedulers are stochastic like EulerAncestralDiscreteScheduler, EulerDiscreteScheduler
             if "generator" in set(inspect.signature(scheduler.step).parameters.keys()):
                 kwargs["generator"] = torch.manual_seed(0)
-            outputs_tuple = scheduler.step(residual, timestep, sample, return_dict=False, **kwargs)
+            if scheduler_class == LMSDiscreteScheduler:
+                sample_new_scheduler = scheduler.scale_model_input(sample, timestep)
+                outputs_tuple = scheduler.step(residual, timestep, sample_new_scheduler, return_dict=False, **kwargs)
+            else:
+                outputs_tuple = scheduler.step(residual, timestep, sample, return_dict=False, **kwargs)
 
             recursive_check(outputs_tuple, outputs_dict)
 


### PR DESCRIPTION
This pull request updates the code to replace the deprecated `transformers.deepspeed` with `transformers.integrations`. It also adds a `norm_type` parameter to the `Transformer2DModel` constructor to remove a warning. Additionally, it fixes issues with the `LMSDiscreteScheduler` by running `scale_model_input()` before calling `.step()`.

@stevhliu