### PR TITLE
[LoRA] fix `cross_attention_kwargs` problems and tighten tests

### DIFF
--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
-import copy
 import torch.nn as nn
 import torch.utils.checkpoint
 

--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
+import copy
 import torch.nn as nn
 import torch.utils.checkpoint
 
@@ -1178,12 +1179,12 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin,
         # we're popping the `scale` instead of getting it because otherwise `scale` will be propagated
         # to the internal blocks and will raise deprecation warnings. this will be confusing for our users.
         if cross_attention_kwargs is not None:
+            cross_attention_kwargs = cross_attention_kwargs.copy()
             lora_scale = cross_attention_kwargs.pop("scale", 1.0)
         else:
             lora_scale = 1.0
 
         if USE_PEFT_BACKEND:
-            print(f"lora scale: {lora_scale}")
             # weight the lora layers by setting `lora_scale` for each PEFT layer
             scale_lora_layers(self, lora_scale)
 

--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -1178,7 +1178,7 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin,
         # we're popping the `scale` instead of getting it because otherwise `scale` will be propagated
         # to the internal blocks and will raise deprecation warnings. this will be confusing for our users.
         if cross_attention_kwargs is not None:
-            lora_scale = cross_attention_kwargs.pop("scale", 1.0)
+            lora_scale = cross_attention_kwargs.get("scale", 1.0)
         else:
             lora_scale = 1.0
 

--- a/src/diffusers/models/unets/unet_2d_condition.py
+++ b/src/diffusers/models/unets/unet_2d_condition.py
@@ -1178,11 +1178,12 @@ class UNet2DConditionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin,
         # we're popping the `scale` instead of getting it because otherwise `scale` will be propagated
         # to the internal blocks and will raise deprecation warnings. this will be confusing for our users.
         if cross_attention_kwargs is not None:
-            lora_scale = cross_attention_kwargs.get("scale", 1.0)
+            lora_scale = cross_attention_kwargs.pop("scale", 1.0)
         else:
             lora_scale = 1.0
 
         if USE_PEFT_BACKEND:
+            print(f"lora scale: {lora_scale}")
             # weight the lora layers by setting `lora_scale` for each PEFT layer
             scale_lora_layers(self, lora_scale)
 

--- a/tests/lora/test_lora_layers_peft.py
+++ b/tests/lora/test_lora_layers_peft.py
@@ -1301,6 +1301,11 @@ class StableDiffusionLoRATests(PeftLoraLoaderMixinTests, unittest.TestCase):
         pipe = pipe.to("cuda")
 
         self.assertTrue(
+            self.check_if_lora_correctly_set(pipe.unet),
+            "Lora not correctly set in UNet",
+        )
+
+        self.assertTrue(
             self.check_if_lora_correctly_set(pipe.text_encoder),
             "Lora not correctly set in text encoder 2",
         )

--- a/tests/lora/test_lora_layers_peft.py
+++ b/tests/lora/test_lora_layers_peft.py
@@ -589,7 +589,7 @@ class PeftLoraLoaderMixinTests:
                 **inputs, generator=torch.manual_seed(0), cross_attention_kwargs={"scale": 0.5}
             ).images
             self.assertTrue(
-                not np.allclose(output_lora, output_lora_scale, atol=1e-3, rtol=1e-3),
+                not np.allclose(output_lora, output_lora_scale, atol=1e-4, rtol=1e-4),
                 "Lora + scale should change the output",
             )
 

--- a/tests/lora/test_lora_layers_peft.py
+++ b/tests/lora/test_lora_layers_peft.py
@@ -1323,6 +1323,7 @@ class StableDiffusionLoRATests(PeftLoraLoaderMixinTests, unittest.TestCase):
         expected_slice_scale = np.array([0.307, 0.283, 0.310, 0.310, 0.300, 0.314, 0.336, 0.314, 0.321])
 
         predicted_slice = images[0, -3:, -3:, -1].flatten()
+        print(", ".join([str(x) for x in predicted_slice.tolist()]))
 
         self.assertTrue(np.allclose(expected_slice_scale, predicted_slice, atol=1e-3, rtol=1e-3))
 

--- a/tests/lora/test_lora_layers_peft.py
+++ b/tests/lora/test_lora_layers_peft.py
@@ -158,7 +158,7 @@ class PeftLoraLoaderMixinTests:
 
         pipeline_inputs = {
             "prompt": "A painting of a squirrel eating a burger",
-            "num_inference_steps": 2,
+            "num_inference_steps": 5,
             "guidance_scale": 6.0,
             "output_type": "np",
         }

--- a/tests/lora/test_lora_layers_peft.py
+++ b/tests/lora/test_lora_layers_peft.py
@@ -1323,7 +1323,6 @@ class StableDiffusionLoRATests(PeftLoraLoaderMixinTests, unittest.TestCase):
         expected_slice_scale = np.array([0.307, 0.283, 0.310, 0.310, 0.300, 0.314, 0.336, 0.314, 0.321])
 
         predicted_slice = images[0, -3:, -3:, -1].flatten()
-        print(", ".join([str(x) for x in predicted_slice.tolist()]))
 
         self.assertTrue(np.allclose(expected_slice_scale, predicted_slice, atol=1e-3, rtol=1e-3))
 


### PR DESCRIPTION
# What does this PR do?

First of all, I would like to apologize for not being rigorous enough with https://github.com/huggingface/diffusers/pull/7338/. This was actually breaking:

```bash
RUN_SLOW=1 pytest tests/lora/test_lora_layers_peft.py::StableDiffusionLoRATests::test_integration_logits_with_scale
```

This is because `pop()` pops the requested key forever from the underlying dictionary (for the first time) and uses the default value throughout the subsequent calls. Since `unet` within a `DiffusionPipeline` is iteratively called this phenomenon creates a lot of unexpected consequences. As a result, the above-mentioned test fails. Here are the `lora_scale` values:

```bash
lora scale: 0.5
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
lora scale: 1.0
```

Notice how it is defaulting to 1.0 after the first round of denoising step. 

A simple solution is to create a shallow copy of `cross_attention_kwargs` so that the original one is left untouched. This is what this PR does. 

Additionally, you may wonder why the below set of tests PASS?

```bash
pytest tests/lora/test_lora_layers_peft.py -k "test_simple_inference_with_text_unet_lora_and_scale"
```

My best guess is that because we use a little too few `num_inference_steps` to validate things. To see if my hunch was right, I increased the `num_inference_steps` to 5 [here](https://github.com/huggingface/diffusers/blob/ce9825b56bd8a6849e68b9590022e935400659e6/tests/lora/test_lora_layers_peft.py#L161), and run these tests WITHOUT the changes introduced in this PR (i.e., shallow copy). All of those tests failed. With the changes, they pass. 

Once this PR is merged, I will take care of making another patch release. 

Once again, I am genuinely sorry for the oversight on my end.  