### PR TITLE
Cleaning up warnings in MotionAdapter and UNetMotionModel

### DIFF
--- a/src/diffusers/models/unets/unet_motion_model.py
+++ b/src/diffusers/models/unets/unet_motion_model.py
@@ -84,6 +84,9 @@ class MotionAdapter(ModelMixin, ConfigMixin):
     def __init__(
         self,
         block_out_channels: Tuple[int, ...] = (320, 640, 1280, 1280),
+        motion_activation_fn: str = "geglu",
+        motion_attention_bias: bool = False,
+        motion_cross_attention_dim: Optional[int] = None,
         motion_layers_per_block: int = 2,
         motion_mid_block_layers_per_block: int = 1,
         motion_num_attention_heads: int = 8,
@@ -92,11 +95,17 @@ class MotionAdapter(ModelMixin, ConfigMixin):
         use_motion_mid_block: bool = True,
         conv_in_channels: Optional[int] = None,
     ):
-        """Container to store AnimateDiff Motion Modules
+        r"""Container to store AnimateDiff Motion Modules
 
         Args:
             block_out_channels (`Tuple[int]`, *optional*, defaults to `(320, 640, 1280, 1280)`):
-            The tuple of output channels for each UNet block.
+                The tuple of output channels for each UNet block.
+            motion_activation_fn (`str`, *optional*, defaults to "geglu"):
+                The activation function to use in the motion module.
+            motion_attention_bias (`bool`, *optional*, defaults to False):
+                Whether to use bias in the attention layers of the motion module.
+            motion_cross_attention_dim (`int`, *optional*, defaults to None):
+                The dimension of the cross attention layer in the motion module.
             motion_layers_per_block (`int`, *optional*, defaults to 2):
                 The number of motion layers per UNet block.
             motion_mid_block_layers_per_block (`int`, *optional*, defaults to 1):
@@ -127,9 +136,9 @@ class MotionAdapter(ModelMixin, ConfigMixin):
                 MotionModules(
                     in_channels=output_channel,
                     norm_num_groups=motion_norm_num_groups,
-                    cross_attention_dim=None,
-                    activation_fn="geglu",
-                    attention_bias=False,
+                    cross_attention_dim=motion_cross_attention_dim,
+                    activation_fn=motion_activation_fn,
+                    attention_bias=motion_attention_bias,
                     num_attention_heads=motion_num_attention_heads,
                     max_seq_length=motion_max_seq_length,
                     layers_per_block=motion_layers_per_block,
@@ -140,9 +149,9 @@ class MotionAdapter(ModelMixin, ConfigMixin):
             self.mid_block = MotionModules(
                 in_channels=block_out_channels[-1],
                 norm_num_groups=motion_norm_num_groups,
-                cross_attention_dim=None,
-                activation_fn="geglu",
-                attention_bias=False,
+                cross_attention_dim=motion_cross_attention_dim,
+                activation_fn=motion_activation_fn,
+                attention_bias=motion_attention_bias,
                 num_attention_heads=motion_num_attention_heads,
                 layers_per_block=motion_mid_block_layers_per_block,
                 max_seq_length=motion_max_seq_length,
@@ -158,9 +167,9 @@ class MotionAdapter(ModelMixin, ConfigMixin):
                 MotionModules(
                     in_channels=output_channel,
                     norm_num_groups=motion_norm_num_groups,
-                    cross_attention_dim=None,
-                    activation_fn="geglu",
-                    attention_bias=False,
+                    cross_attention_dim=motion_cross_attention_dim,
+                    activation_fn=motion_activation_fn,
+                    attention_bias=motion_attention_bias,
                     num_attention_heads=motion_num_attention_heads,
                     max_seq_length=motion_max_seq_length,
                     layers_per_block=motion_layers_per_block + 1,


### PR DESCRIPTION
# What does this PR do?

Loading a MotionAdapter currently throws the following warning:

```
The config attributes {'motion_activation_fn': 'geglu', 'motion_attention_bias': False, 'motion_cross_attention_dim': None} were passed to MotionAdapter, but are not expected and will be ignored. Please verify your config.json configuration file.
```

For UNetMotionModel:

```
The config attributes {'center_input_sample': False, 'flip_sin_to_cos': True, 'freq_shift': 0, 'mid_block_type': 'UNetMidBlock2DCrossAttn', 'only_cross_attention': False, 'attention_head_dim': 8, 'dual_cross_attention': False, 'class_embed_type': None, 'addition_embed_type': None, 'num_class_embeds': None, 'upcast_attention': False, 'resnet_time_scale_shift': 'default', 'resnet_skip_time_act': False, 'resnet_out_scale_factor': 1.0, 'time_embedding_type': 'positional', 'time_embedding_dim': None, 'time_embedding_act_fn': None, 'timestep_post_act': None, 'conv_in_kernel': 3, 'conv_out_kernel': 3, 'projection_class_embeddings_input_dim': None, 'class_embeddings_concat': False, 'mid_block_only_cross_attention': None, 'cross_attention_norm': None, 'addition_embed_type_num_heads': 64} were passed to UNetMotionModel, but are not expected and will be ignored. Please verify your config.json configuration file.
```

I think it's unnecessary for this warning to be thrown and should be handled in the `__init__` function for the sake of completeness. Is there a reason why the parameters are hardcoded? It just limits the controllability, no? For example, in AnimateDiff SDXL/SparseCntrl, we're going to have to bring in some of the missing init params to correctly initialize the model in UNetMotionModel (for which I'll take it up in the SDXL PR).

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@DN6 