### PR TITLE
[Core] refactor `transformer_2d` forward logic into meaningful conditions.

### DIFF
--- a/src/diffusers/models/transformers/transformer_2d.py
+++ b/src/diffusers/models/transformers/transformer_2d.py
@@ -402,7 +402,19 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
 
         # 1. Input
         if self.is_input_continuous:
-            batch_size, _, height, width = hidden_states.shape
+        batch_size, _, height, width = hidden_states.shape
+
+        if self.is_input_continuous:
+            residual = hidden_states
+            hidden_states, inner_dim = self._operate_on_continuous_inputs(hidden_states)
+        elif self.is_input_vectorized:
+            hidden_states = self.latent_image_embedding(hidden_states)
+        elif self.is_input_patches:
+            height, width = height // self.patch_size, width // self.patch_size
+            hidden_states, encoder_hidden_states, timestep, embedded_timestep = self._operate_on_patched_inputs(
+                hidden_states, encoder_hidden_states, timestep, added_cond_kwargs
+            )
+
             residual = hidden_states
             hidden_states, inner_dim = self._operate_on_continuous_inputs(hidden_states)
         elif self.is_input_vectorized:

--- a/src/diffusers/models/transformers/transformer_2d.py
+++ b/src/diffusers/models/transformers/transformer_2d.py
@@ -351,6 +351,7 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
             encoder_hidden_states = self.caption_projection(encoder_hidden_states)
             encoder_hidden_states = encoder_hidden_states.view(batch_size, -1, hidden_states.shape[-1])
 
+        print(f"hidden_states before going to transformer block: {hidden_states.shape}")
         for block in self.transformer_blocks:
             if self.training and self.gradient_checkpointing:
 

--- a/src/diffusers/models/transformers/transformer_2d.py
+++ b/src/diffusers/models/transformers/transformer_2d.py
@@ -341,7 +341,7 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
             hidden_states = self.latent_image_embedding(hidden_states)
         elif self.is_input_patches:
             height, width = hidden_states.shape[-2] // self.patch_size, hidden_states.shape[-1] // self.patch_size
-            hidden_states, embedded_timestep = self._operate_on_patched_inputs(
+            hidden_states, timestep, embedded_timestep = self._operate_on_patched_inputs(
                 hidden_states, timestep, added_cond_kwargs
             )
 
@@ -439,7 +439,7 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
                 timestep, added_cond_kwargs, batch_size=batch_size, hidden_dtype=hidden_states.dtype
             )
 
-        return hidden_states, embedded_timestep
+        return hidden_states, timestep, embedded_timestep
 
     def _get_output_for_continuous_inputs(self, hidden_states, residual, batch_size, height, width, inner_dim):
         if not self.use_linear_projection:

--- a/src/diffusers/models/transformers/transformer_2d.py
+++ b/src/diffusers/models/transformers/transformer_2d.py
@@ -401,7 +401,9 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
             output = F.log_softmax(logits.double(), dim=1).float()
 
         if self.is_input_patches:
-            output = self._get_output_for_patched_inputs(hidden_states, timestep, class_labels, embedded_timestep)
+            output = self._get_output_for_patched_inputs(
+                hidden_states, timestep, class_labels, embedded_timestep, height=height, width=width
+            )
 
         if not return_dict:
             return (output,)
@@ -454,7 +456,9 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
         output = hidden_states + residual
         return output
 
-    def _get_output_for_patched_inputs(self, hidden_states, timestep, class_labels, embedded_timestep):
+    def _get_output_for_patched_inputs(
+        self, hidden_states, timestep, class_labels, embedded_timestep, height=None, width=None
+    ):
         if self.config.norm_type != "ada_norm_single":
             conditioning = self.transformer_blocks[0].norm1.emb(
                 timestep, class_labels, hidden_dtype=hidden_states.dtype

--- a/src/diffusers/models/transformers/transformer_2d.py
+++ b/src/diffusers/models/transformers/transformer_2d.py
@@ -419,7 +419,6 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
             encoder_hidden_states = self.caption_projection(encoder_hidden_states)
             encoder_hidden_states = encoder_hidden_states.view(batch_size, -1, hidden_states.shape[-1])
 
-        print(f"hidden_states before going to transformer block: {hidden_states.shape}")
         for block in self.transformer_blocks:
             if self.training and self.gradient_checkpointing:
 

--- a/src/diffusers/models/transformers/transformer_2d.py
+++ b/src/diffusers/models/transformers/transformer_2d.py
@@ -402,19 +402,7 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
 
         # 1. Input
         if self.is_input_continuous:
-        batch_size, _, height, width = hidden_states.shape
-
-        if self.is_input_continuous:
-            residual = hidden_states
-            hidden_states, inner_dim = self._operate_on_continuous_inputs(hidden_states)
-        elif self.is_input_vectorized:
-            hidden_states = self.latent_image_embedding(hidden_states)
-        elif self.is_input_patches:
-            height, width = height // self.patch_size, width // self.patch_size
-            hidden_states, encoder_hidden_states, timestep, embedded_timestep = self._operate_on_patched_inputs(
-                hidden_states, encoder_hidden_states, timestep, added_cond_kwargs
-            )
-
+            batch_size, _, height, width = hidden_states.shape
             residual = hidden_states
             hidden_states, inner_dim = self._operate_on_continuous_inputs(hidden_states)
         elif self.is_input_vectorized:

--- a/src/diffusers/models/transformers/transformer_2d.py
+++ b/src/diffusers/models/transformers/transformer_2d.py
@@ -341,12 +341,9 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
             hidden_states = self.latent_image_embedding(hidden_states)
         elif self.is_input_patches:
             height, width = hidden_states.shape[-2] // self.patch_size, hidden_states.shape[-1] // self.patch_size
-            if self.adaln_single is not None:
-                hidden_states, embedded_timestep = self._operate_on_patched_inputs(
-                    hidden_states, timestep, added_cond_kwargs
-                )
-            else:
-                hidden_states = self._operate_on_patched_inputs(hidden_states, timestep, added_cond_kwargs)
+            hidden_states, embedded_timestep = self._operate_on_patched_inputs(
+                hidden_states, timestep, added_cond_kwargs
+            )
 
         # 2. Blocks
         if self.caption_projection is not None:
@@ -427,6 +424,7 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
 
     def _operate_on_patched_inputs(self, hidden_states, timestep, added_cond_kwargs):
         hidden_states = self.pos_embed(hidden_states)
+        embedded_timestep = None
 
         if self.adaln_single is not None:
             if self.use_additional_conditions and added_cond_kwargs is None:
@@ -438,9 +436,7 @@ class Transformer2DModel(ModelMixin, ConfigMixin):
                 timestep, added_cond_kwargs, batch_size=batch_size, hidden_dtype=hidden_states.dtype
             )
 
-            return hidden_states, embedded_timestep
-
-        return hidden_states
+        return hidden_states, embedded_timestep
 
     def _get_output_for_continuous_inputs(self, hidden_states, residual, batch_size, height, width, inner_dim):
         if not self.use_linear_projection:


### PR DESCRIPTION
# What does this PR do?

Refactors the `forward()` of `Transformers2DModel` for easier readability. 

More specifically, the PR refactors the `forward()` method of `Transformers2DModel` to have the following unified structure:

```python
def forward(self):
    # handle attention masking. 
    ...

    # 1. input-level operations.
    if self.is_input_continuous:
        ... = self._operate_on_continuous_inputs(...)
    elif self.is_input_vectorized:
    	... = self.latent_image_embedding(...) # for vectorized inputs only this is needed.
    elif self.is_input_patches:
        ... = self._operate_on_patched_inputs(...)

    # 2. Blocks (common across all the variants)
    for block in self.transformer_blocks:
    	...

    # 3. Outputs.
    if self.is_input_continuous:
        ... = self._get_output_for_continuous_inputs(...)
    elif self.is_input_vectorized:
        output = self._get_output_for_vectorized_inputs(...)
    elif self.is_input_patches:
        output = self._get_output_for_patched_inputs(...)

    return output
```

About the possibility of spinning out separate transformer classes for patched and vectorized inputs, what's the consensus? Currently, we have DiT and PixArt-Alpha that use patched inputs. So, for those checkpoints ([DiT](https://huggingface.co/facebook/DiT-XL-2-256) and [PixArt-Alpha](https://huggingface.co/PixArt-alpha/PixArt-XL-2-1024-MS)), are we thinking of just updating the configs to use `PatchedTransformer2DModel`? (Same could be done for the `VectorizedTransformer2DModel`)

If that's the case I think it could be quite breaking of a change. Many folks use the DiT and PixArt models especially in the light of many Open SoRA initiative. Introducing a change like this could be problematic. Should we consider throwing a deprecation warning, instead? 

@yiyixuxu @DN6 please let me know your thoughts. 