### PR TITLE
Multi-image masking for single IP Adapter

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -948,14 +948,16 @@ class IPAdapterMaskProcessor(VaeImageProcessor):
                 The downsampled mask tensor.
 
         """
-        o_h = mask.shape[1]
-        o_w = mask.shape[2]
+        if mask.ndim == 3:
+            mask = mask.unsqueeze(0)
+        o_h = mask.shape[2]
+        o_w = mask.shape[3]
         ratio = o_w / o_h
         mask_h = int(math.sqrt(num_queries / ratio))
         mask_h = int(mask_h) + int((num_queries % int(mask_h)) != 0)
         mask_w = num_queries // mask_h
 
-        mask_downsample = F.interpolate(mask.unsqueeze(0), size=(mask_h, mask_w), mode="bicubic").squeeze(0)
+        mask_downsample = F.interpolate(mask, size=(mask_h, mask_w), mode="bicubic").squeeze(0)
 
         # Repeat batch_size times
         if mask_downsample.shape[0] < batch_size:

--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -948,16 +948,14 @@ class IPAdapterMaskProcessor(VaeImageProcessor):
                 The downsampled mask tensor.
 
         """
-        if mask.ndim == 3:
-            mask = mask.unsqueeze(0)
-        o_h = mask.shape[2]
-        o_w = mask.shape[3]
+        o_h = mask.shape[1]
+        o_w = mask.shape[2]
         ratio = o_w / o_h
         mask_h = int(math.sqrt(num_queries / ratio))
         mask_h = int(mask_h) + int((num_queries % int(mask_h)) != 0)
         mask_w = num_queries // mask_h
 
-        mask_downsample = F.interpolate(mask, size=(mask_h, mask_w), mode="bicubic").squeeze(0)
+        mask_downsample = F.interpolate(mask.unsqueeze(0), size=(mask_h, mask_w), mode="bicubic").squeeze(0)
 
         # Repeat batch_size times
         if mask_downsample.shape[0] < batch_size:

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -2200,7 +2200,7 @@ class IPAdapterAttnProcessor(nn.Module):
         if ip_adapter_masks is not None:
             if len(ip_adapter_masks) != len(self.scale):
                 raise ValueError(
-                    f"Lenght of ip_adapter_masks array ({len(ip_adapter_masks)}) must match "
+                    f"Length of ip_adapter_masks array ({len(ip_adapter_masks)}) must match "
                     f"number of IP-Adapters ({len(self.scale)})"
                 )
         else:

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -2206,7 +2206,7 @@ class IPAdapterAttnProcessor(nn.Module):
                     f"Length of ip_adapter_masks array ({len(ip_adapter_masks)}) must match "
                     f"length of self.scale array ({len(self.scale)}) and number of ip_hidden_states "
                     f"({len(ip_hidden_states)})"
-                    )
+                )
             else:
                 for index, (mask, scale, ip_state) in enumerate(zip(ip_adapter_masks, self.scale, ip_hidden_states)):
                     if not isinstance(mask, torch.Tensor) or mask.ndim != 4:
@@ -2233,7 +2233,6 @@ class IPAdapterAttnProcessor(nn.Module):
             ip_hidden_states, self.scale, self.to_k_ip, self.to_v_ip, ip_adapter_masks
         ):
             if mask is not None:
-
                 if not isinstance(scale, list):
                     scale = [scale]
 
@@ -2417,7 +2416,7 @@ class IPAdapterAttnProcessor2_0(torch.nn.Module):
                     f"Length of ip_adapter_masks array ({len(ip_adapter_masks)}) must match "
                     f"length of self.scale array ({len(self.scale)}) and number of ip_hidden_states "
                     f"({len(ip_hidden_states)})"
-                    )
+                )
             else:
                 for index, (mask, scale, ip_state) in enumerate(zip(ip_adapter_masks, self.scale, ip_hidden_states)):
                     if not isinstance(mask, torch.Tensor) or mask.ndim != 4:
@@ -2444,7 +2443,6 @@ class IPAdapterAttnProcessor2_0(torch.nn.Module):
             ip_hidden_states, self.scale, self.to_k_ip, self.to_v_ip, ip_adapter_masks
         ):
             if mask is not None:
-
                 if not isinstance(scale, list):
                     scale = [scale]
 

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -2198,6 +2198,19 @@ class IPAdapterAttnProcessor(nn.Module):
         hidden_states = attn.batch_to_head_dim(hidden_states)
 
         if ip_adapter_masks is not None:
+            if not isinstance(ip_adapter_mask, List):
+                # for backward compatibility, we accept `ip_adapter_mask` as a tensor of shape [num_ip_adapter, 1, height, width]
+                ip_adapter_mask = list(ip_adapter_mask.unsqueeze(1))
+            if not (len(ip_adapter_masks) == len(self.scale) == len(ip_hidden_states) == len(self.to_k_ip) == len(self.to_v_ip)):
+                raise ValueError(...)
+             else:
+                 for mask, scale, ip_state in zip(ip_adapter_masks, self.scale, ip_hidden_states):
+                     if not isinstance(mask, torch.Tensor) or mask.ndim != 4:
+                         raise ValueError("each ip_adapter_mask should be a tensor with shape [1, num_images, height, width] ..." )
+                     if mask.shape[1] != current_ip_hidden_states.shape[1]:
+                         raise ValueError(...)
+                     if isinstance(scale, list) and not len(scale) == len(mask.shape[1]:
+                         raise ValueError(...) 
             if len(ip_adapter_masks) != len(self.scale):
                 raise ValueError(
                     f"Length of ip_adapter_masks array ({len(ip_adapter_masks)}) must match "
@@ -2211,28 +2224,13 @@ class IPAdapterAttnProcessor(nn.Module):
             ip_hidden_states, self.scale, self.to_k_ip, self.to_v_ip, ip_adapter_masks
         ):
             if mask is not None:
-                if not isinstance(mask, torch.Tensor) or mask.ndim != 4:
-                    raise ValueError(
-                        "Each element of the ip_adapter_masks array should be a tensor with shape "
-                        "[1, num_images, height, width]."
-                        " Please use `IPAdapterMaskProcessor` to preprocess your mask"
-                    )
-
-                if mask.shape[1] != current_ip_hidden_states.shape[1]:
-                    raise ValueError(
-                        f"Number of masks in ip_adapter_masks ({mask.shape[1]}) must match "
-                        f"number of input images ({current_ip_hidden_states.shape[1]})"
-                    )
 
                 if not isinstance(scale, list):
                     scale = [scale]
 
-                if mask.shape[1] != len(scale):
-                    raise ValueError(
-                        f"Number of masks in ip_adapter_masks ({mask.shape[1]}) must match number of scales ({len(scale)})"
-                    )
 
-                for i in range(mask.shape[1]):
+                current_num_images = mask.shape[1]
+                for i in range(current_num_images):
                     ip_key = to_k_ip(current_ip_hidden_states[:, i, :, :])
                     ip_value = to_v_ip(current_ip_hidden_states[:, i, :, :])
 

--- a/tests/pipelines/ip_adapters/test_ip_adapter_stable_diffusion.py
+++ b/tests/pipelines/ip_adapters/test_ip_adapter_stable_diffusion.py
@@ -551,8 +551,8 @@ class IPAdapterSDXLIntegrationTests(IPAdapterNightlyTestsMixin):
             "stabilityai/stable-diffusion-xl-base-1.0",
             image_encoder=image_encoder,
             torch_dtype=self.dtype,
-            variant="fp16",
         )
+        pipeline.enable_model_cpu_offload()
         pipeline.load_ip_adapter(
             "h94/IP-Adapter", subfolder="sdxl_models", weight_name=["ip-adapter-plus-face_sdxl_vit-h.safetensors"]
         )

--- a/tests/pipelines/ip_adapters/test_ip_adapter_stable_diffusion.py
+++ b/tests/pipelines/ip_adapters/test_ip_adapter_stable_diffusion.py
@@ -544,3 +544,33 @@ class IPAdapterSDXLIntegrationTests(IPAdapterNightlyTestsMixin):
 
         max_diff = numpy_cosine_similarity_distance(image_slice, expected_slice)
         assert max_diff < 5e-4
+
+    def test_ip_adapter_multiple_masks_one_adapter(self):
+        image_encoder = self.get_image_encoder(repo_id="h94/IP-Adapter", subfolder="models/image_encoder")
+        pipeline = StableDiffusionXLPipeline.from_pretrained(
+            "stabilityai/stable-diffusion-xl-base-1.0",
+            image_encoder=image_encoder,
+            torch_dtype=self.dtype,
+            variant="fp16",
+        )
+        pipeline.load_ip_adapter(
+            "h94/IP-Adapter", subfolder="sdxl_models", weight_name=["ip-adapter-plus-face_sdxl_vit-h.safetensors"]
+        )
+        pipeline.set_ip_adapter_scale([[0.7, 0.7]])
+
+        inputs = self.get_dummy_inputs(for_masks=True)
+        masks = inputs["cross_attention_kwargs"]["ip_adapter_masks"]
+        processor = IPAdapterMaskProcessor()
+        masks = processor.preprocess(masks)
+        masks = masks.reshape(1, masks.shape[0], masks.shape[2], masks.shape[3])
+        inputs["cross_attention_kwargs"]["ip_adapter_masks"] = [masks]
+        ip_images = inputs["ip_adapter_image"]
+        inputs["ip_adapter_image"] = [[image[0] for image in ip_images]]
+        images = pipeline(**inputs).images
+        image_slice = images[0, :3, :3, -1].flatten()
+        expected_slice = np.array(
+            [0.79474676, 0.7977683, 0.8013954, 0.7988008, 0.7970615, 0.8029355, 0.80614823, 0.8050743, 0.80627424]
+        )
+
+        max_diff = numpy_cosine_similarity_distance(image_slice, expected_slice)
+        assert max_diff < 5e-4

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -400,7 +400,7 @@ class IPAdapterTesterMixin:
             "Output without ip-adapter must be same as normal inference",
         )
         self.assertGreater(
-            max_diff_with_adapter_scale, 1e-2, "Output with ip-adapter must be different from normal inference"
+            max_diff_with_adapter_scale, 1e-3, "Output with ip-adapter must be different from normal inference"
         )
 
 

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -226,6 +226,11 @@ class IPAdapterTesterMixin:
     def _get_dummy_image_embeds(self, cross_attention_dim: int = 32):
         return torch.randn((2, 1, cross_attention_dim), device=torch_device)
 
+    def _get_dummy_masks(self, input_size: int = 64):
+        _masks = torch.zeros((1, 1, input_size, input_size), device=torch_device)
+        _masks[0, :, :, :int(input_size / 2)] = 1
+        return _masks
+
     def _modify_inputs_for_ip_adapter_test(self, inputs: Dict[str, Any]):
         parameters = inspect.signature(self.pipeline_class.__call__).parameters
         if "image" in parameters.keys() and "strength" in parameters.keys():
@@ -353,6 +358,55 @@ class IPAdapterTesterMixin:
 
         assert out_cfg.shape == out_no_cfg.shape
 
+    def test_ip_adapter_masks(self, expected_max_diff: float = 1e-4):
+
+        components = self.get_dummy_components()
+        pipe = self.pipeline_class(**components).to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
+        cross_attention_dim = pipe.unet.config.get("cross_attention_dim", 32)
+        sample_size = pipe.unet.config.get("sample_size", 32)
+        block_out_channels = pipe.vae.config.get("block_out_channels", [128, 256, 512, 512])
+        input_size =  sample_size * (2 ** (len(block_out_channels) - 1))
+
+        # forward pass without ip adapter
+        inputs = self._modify_inputs_for_ip_adapter_test(self.get_dummy_inputs(torch_device))
+        output_without_adapter = pipe(**inputs)[0]
+        output_without_adapter = output_without_adapter[0, -3:, -3:, -1].flatten()
+
+        adapter_state_dict = create_ip_adapter_state_dict(pipe.unet)
+        pipe.unet._load_ip_adapter_weights(adapter_state_dict)
+
+        # forward pass with single ip adapter and masks, but scale=0 which should have no effect
+        inputs = self._modify_inputs_for_ip_adapter_test(self.get_dummy_inputs(torch_device))
+        inputs["ip_adapter_image_embeds"] = [self._get_dummy_image_embeds(cross_attention_dim)]
+        inputs["cross_attention_kwargs"] = {
+            "ip_adapter_masks": [self._get_dummy_masks(input_size)]
+        }
+        pipe.set_ip_adapter_scale(0.0)
+        output_without_adapter_scale = pipe(**inputs)[0]
+        output_without_adapter_scale = output_without_adapter_scale[0, -3:, -3:, -1].flatten()
+
+        # forward pass with single ip adapter and masks, but with scale of adapter weights
+        inputs = self._modify_inputs_for_ip_adapter_test(self.get_dummy_inputs(torch_device))
+        inputs["ip_adapter_image_embeds"] = [self._get_dummy_image_embeds(cross_attention_dim)]
+        inputs["cross_attention_kwargs"] = {
+            "ip_adapter_masks": [self._get_dummy_masks(input_size)]
+        }
+        pipe.set_ip_adapter_scale(42.0)
+        output_with_adapter_scale = pipe(**inputs)[0]
+        output_with_adapter_scale = output_with_adapter_scale[0, -3:, -3:, -1].flatten()
+
+        max_diff_without_adapter_scale = np.abs(output_without_adapter_scale - output_without_adapter).max()
+        max_diff_with_adapter_scale = np.abs(output_with_adapter_scale - output_without_adapter).max()
+
+        self.assertLess(
+            max_diff_without_adapter_scale,
+            expected_max_diff,
+            "Output without ip-adapter must be same as normal inference",
+        )
+        self.assertGreater(
+            max_diff_with_adapter_scale, 1e-2, "Output with ip-adapter must be different from normal inference"
+        )
 
 class PipelineLatentTesterMixin:
     """


### PR DESCRIPTION
# What does this PR do?
Image masking is currently supported by passing a mask and an image for each IP Adapter in the pipeline.

This PR extends this usage by allowing multiple masks and images to be passed to a single IP Adapter. Scales must be passed accordingly.

Discussed in #7419 

@sayakpaul @yiyixuxu 