### PR TITLE
Add `final_sigma_zero` to UniPCMultistep

### DIFF
--- a/src/diffusers/schedulers/scheduling_unipc_multistep.py
+++ b/src/diffusers/schedulers/scheduling_unipc_multistep.py
@@ -127,8 +127,9 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
             Sample Steps are Flawed](https://huggingface.co/papers/2305.08891) for more information.
         steps_offset (`int`, defaults to 0):
             An offset added to the inference steps, as required by some model families.
-        final_sigma_zero (`bool`, defaults to `False`):
-            Overrides the final sigma to be zero, ensuring that sampling covers the full timestep period.
+        final_sigmas_type (`str`, defaults to `"zero"`):
+            The final `sigma` value for the noise schedule during the sampling process. If `"sigma_min"`, the final sigma
+            is the same as the last sigma in the training schedule. If `zero`, the final sigma is set to 0.
     """
 
     _compatibles = [e.name for e in KarrasDiffusionSchedulers]
@@ -155,7 +156,7 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
         use_karras_sigmas: Optional[bool] = False,
         timestep_spacing: str = "linspace",
         steps_offset: int = 0,
-        final_sigma_zero: bool = False,
+        final_sigmas_type: Optional[str] = "zero",  # "zero", "sigma_min"
     ):
         if trained_betas is not None:
             self.betas = torch.tensor(trained_betas, dtype=torch.float32)
@@ -268,12 +269,25 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_karras(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas]).round()
-            sigmas = np.concatenate([sigmas, [0] if self.config.final_sigma_zero else sigmas[-1:]]).astype(np.float32)
+            if self.config.final_sigmas_type == "sigma_min":
+                sigma_last = sigmas[-1]
+            elif self.config.final_sigmas_type == "zero":
+                sigma_last = 0
+            else:
+                raise ValueError(
+                    f"`final_sigmas_type` must be one of 'zero', or 'sigma_min', but got {self.config.final_sigmas_type}"
+                )
+            sigmas = np.concatenate([sigmas, [sigma_last]]).astype(np.float32)
         else:
             sigmas = np.interp(timesteps, np.arange(0, len(sigmas)), sigmas)
-            sigma_last = (
-                0 if self.config.final_sigma_zero else ((1 - self.alphas_cumprod[0]) / self.alphas_cumprod[0]) ** 0.5
-            )
+            if self.config.final_sigmas_type == "sigma_min":
+                sigma_last = ((1 - self.alphas_cumprod[0]) / self.alphas_cumprod[0]) ** 0.5
+            elif self.config.final_sigmas_type == "zero":
+                sigma_last = 0
+            else:
+                raise ValueError(
+                    f"`final_sigmas_type` must be one of 'zero', or 'sigma_min', but got {self.config.final_sigmas_type}"
+                )
             sigmas = np.concatenate([sigmas, [sigma_last]]).astype(np.float32)
 
         self.sigmas = torch.from_numpy(sigmas)

--- a/tests/schedulers/test_scheduler_unipc.py
+++ b/tests/schedulers/test_scheduler_unipc.py
@@ -24,6 +24,7 @@ class UniPCMultistepSchedulerTest(SchedulerCommonTest):
             "beta_schedule": "linear",
             "solver_order": 2,
             "solver_type": "bh2",
+            "final_sigmas_type": "sigma_min",
         }
 
         config.update(**kwargs)


### PR DESCRIPTION
Effectively the same trick as DDIM's `set_alpha_to_one` and DPM's `final_sigma_type='zero'` where the extra concatenated sigma is simply zero instead of the prior sigma. Completely fixes the goofy residual noise, particularly with lower step counts.

1st and 2nd order UniPC without the patch
![unipc_base](https://github.com/huggingface/diffusers/assets/39478211/592c43b0-c811-4c8f-accb-bfd49169127f)
1st and 2nd order UniPC with `final_sigma_zero=True`
![unipc_sig0](https://github.com/huggingface/diffusers/assets/39478211/154bf61d-6fb3-4f5c-944b-eb7efe6ec127)
Third order errors out for me even on a clean `main` branch so that's fun. I'll monkey with it later...

Currently `False` by default but maybe this should be `True` like DDIM/DPM?

This could also be represented as the same `final_sigma_type='zero'|'sig_min'` that DPM uses, but I don't really see why it needs to be a string with only two options. *Personally* I find this scheme much more intuitive.

No UT right now as I didn't see anything for `final_sigma_type='zero'` in DPM's UTs.

@yiyixuxu