### PR TITLE
[Tests] Speed up fast pipelines part II

### DIFF
--- a/tests/pipelines/animatediff/test_animatediff.py
+++ b/tests/pipelines/animatediff/test_animatediff.py
@@ -166,6 +166,12 @@ class AnimateDiffPipelineFastTests(
                 ]
             )
         return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
+    
+    def test_dict_tuple_outputs_equivalent(self):
+        expected_slice = None 
+        if torch_device == "cpu":
+            expected_slice = np.array([0.4051, 0.4495, 0.4480, 0.5845, 0.4172, 0.6066, 0.4205, 0.3786, 0.5323])
+        return super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
 
     def test_inference_batch_single_identical(
         self,

--- a/tests/pipelines/animatediff/test_animatediff.py
+++ b/tests/pipelines/animatediff/test_animatediff.py
@@ -166,9 +166,9 @@ class AnimateDiffPipelineFastTests(
                 ]
             )
         return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
-    
+
     def test_dict_tuple_outputs_equivalent(self):
-        expected_slice = None 
+        expected_slice = None
         if torch_device == "cpu":
             expected_slice = np.array([0.4051, 0.4495, 0.4480, 0.5845, 0.4172, 0.6066, 0.4205, 0.3786, 0.5323])
         return super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)

--- a/tests/pipelines/controlnet/test_controlnet_blip_diffusion.py
+++ b/tests/pipelines/controlnet/test_controlnet_blip_diffusion.py
@@ -28,7 +28,7 @@ from diffusers import (
     PNDMScheduler,
     UNet2DConditionModel,
 )
-from diffusers.utils.testing_utils import enable_full_determinism
+from diffusers.utils.testing_utils import enable_full_determinism, torch_device
 from src.diffusers.pipelines.blip_diffusion.blip_image_processing import BlipImageProcessor
 from src.diffusers.pipelines.blip_diffusion.modeling_blip2 import Blip2QFormerModel
 from src.diffusers.pipelines.blip_diffusion.modeling_ctx_clip import ContextCLIPTextModel
@@ -195,6 +195,12 @@ class BlipDiffusionControlNetPipelineFastTests(PipelineTesterMixin, unittest.Tes
             "output_type": "np",
         }
         return inputs
+
+    def test_dict_tuple_outputs_equivalent(self):
+        expected_slice = None
+        if torch_device == "cpu":
+            expected_slice = np.array([0.4803, 0.3865, 0.1422, 0.6119, 0.2283, 0.6365, 0.5453, 0.5205, 0.3581])
+        super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
 
     def test_blipdiffusion_controlnet(self):
         device = "cpu"

--- a/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
@@ -57,6 +57,7 @@ class ControlNetPipelineSDXLFastTests(
     image_latents_params = TEXT_TO_IMAGE_IMAGE_PARAMS
 
     def get_dummy_components(self):
+        torch.manual_seed(0)
         unet = UNet2DConditionModel(
             block_out_channels=(32, 64),
             layers_per_block=2,
@@ -74,6 +75,7 @@ class ControlNetPipelineSDXLFastTests(
             projection_class_embeddings_input_dim=80,  # 6 * 8 + 32
             cross_attention_dim=64,
         )
+        torch.manual_seed(0)
         controlnet = ControlNetModel(
             block_out_channels=(32, 64),
             layers_per_block=2,
@@ -123,6 +125,7 @@ class ControlNetPipelineSDXLFastTests(
         text_encoder = CLIPTextModel(text_encoder_config)
         tokenizer = CLIPTokenizer.from_pretrained("hf-internal-testing/tiny-random-clip")
 
+        torch.manual_seed(0)
         text_encoder_2 = CLIPTextModelWithProjection(text_encoder_config)
         tokenizer_2 = CLIPTokenizer.from_pretrained("hf-internal-testing/tiny-random-clip")
 
@@ -185,6 +188,7 @@ class ControlNetPipelineSDXLFastTests(
     # def test_dict_tuple_outputs_equivalent(self):
     #     expected_slice = None
     #     if torch_device == "cpu":
+                # 0.5433, 0.4865, 0.4654, 0.5596, 0.5238, 0.4869, 0.5809, 0.5657, 0.4339
     #         expected_slice = np.array([0.5362, 0.4936, 0.4656, 0.5778, 0.5256, 0.4790, 0.6009, 0.5727, 0.4301])
     #     super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
 

--- a/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
@@ -298,6 +298,7 @@ class ControlNetPipelineSDXLFastTests(
 
         output = sd_pipe(**inputs)
         image_slice = output.images[0, -3:, -3:, -1]
+        print(", ".join([str(round(x, 4)) for x in image_slice.flatten().tolist()]))
         expected_slice = np.array(
             [0.5381963, 0.4836803, 0.45821992, 0.5577731, 0.51210403, 0.4794795, 0.59282357, 0.5647199, 0.43100584]
         )

--- a/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
@@ -182,11 +182,11 @@ class ControlNetPipelineSDXLFastTests(
     def test_attention_slicing_forward_pass(self):
         return self._test_attention_slicing_forward_pass(expected_max_diff=2e-3)
 
-    def test_dict_tuple_outputs_equivalent(self):
-        expected_slice = None
-        if torch_device == "cpu":
-            expected_slice = np.array([0.5362, 0.4936, 0.4656, 0.5778, 0.5256, 0.4790, 0.6009, 0.5727, 0.4301])
-        super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
+    # def test_dict_tuple_outputs_equivalent(self):
+    #     expected_slice = None
+    #     if torch_device == "cpu":
+    #         expected_slice = np.array([0.5362, 0.4936, 0.4656, 0.5778, 0.5256, 0.4790, 0.6009, 0.5727, 0.4301])
+    #     super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
 
     @unittest.skipIf(
         torch_device != "cuda" or not is_xformers_available(),

--- a/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
@@ -298,10 +298,7 @@ class ControlNetPipelineSDXLFastTests(
 
         output = sd_pipe(**inputs)
         image_slice = output.images[0, -3:, -3:, -1]
-        print(", ".join([str(round(x, 4)) for x in image_slice.flatten().tolist()]))
-        expected_slice = np.array(
-            [0.5381963, 0.4836803, 0.45821992, 0.5577731, 0.51210403, 0.4794795, 0.59282357, 0.5647199, 0.43100584]
-        )
+        expected_slice = np.array([0.549, 0.5053, 0.4676, 0.5816, 0.5364, 0.483, 0.5937, 0.5719, 0.4318])
 
         # make sure that it's equal
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-4

--- a/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
@@ -185,12 +185,11 @@ class ControlNetPipelineSDXLFastTests(
     def test_attention_slicing_forward_pass(self):
         return self._test_attention_slicing_forward_pass(expected_max_diff=2e-3)
 
-    # def test_dict_tuple_outputs_equivalent(self):
-    #     expected_slice = None
-    #     if torch_device == "cpu":
-                # 0.5433, 0.4865, 0.4654, 0.5596, 0.5238, 0.4869, 0.5809, 0.5657, 0.4339
-    #         expected_slice = np.array([0.5362, 0.4936, 0.4656, 0.5778, 0.5256, 0.4790, 0.6009, 0.5727, 0.4301])
-    #     super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
+    def test_dict_tuple_outputs_equivalent(self):
+        expected_slice = None
+        if torch_device == "cpu":
+            expected_slice = np.array([0.5490, 0.5053, 0.4676, 0.5816, 0.5364, 0.4830, 0.5937, 0.5719, 0.4318])
+        super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
 
     @unittest.skipIf(
         torch_device != "cuda" or not is_xformers_available(),

--- a/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
@@ -182,6 +182,12 @@ class ControlNetPipelineSDXLFastTests(
     def test_attention_slicing_forward_pass(self):
         return self._test_attention_slicing_forward_pass(expected_max_diff=2e-3)
 
+    def test_dict_tuple_outputs_equivalent(self):
+        expected_slice = None
+        if torch_device == "cpu":
+            expected_slice = np.array([0.5362, 0.4936, 0.4656, 0.5778, 0.5256, 0.4790, 0.6009, 0.5727, 0.4301])
+        super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
+
     @unittest.skipIf(
         torch_device != "cuda" or not is_xformers_available(),
         reason="XFormers attention is only available with CUDA and `xformers` installed",

--- a/tests/pipelines/kandinsky3/test_kandinsky3_img2img.py
+++ b/tests/pipelines/kandinsky3/test_kandinsky3_img2img.py
@@ -36,6 +36,7 @@ from diffusers.utils.testing_utils import (
     load_image,
     require_torch_gpu,
     slow,
+    torch_device,
 )
 
 from ..pipeline_params import (
@@ -151,6 +152,12 @@ class Kandinsky3Img2ImgPipelineFastTests(PipelineTesterMixin, unittest.TestCase)
             "output_type": "np",
         }
         return inputs
+
+    def test_dict_tuple_outputs_equivalent(self):
+        expected_slice = None
+        if torch_device == "cpu":
+            expected_slice = np.array([0.5762, 0.6112, 0.4150, 0.6018, 0.6167, 0.4626, 0.5426, 0.5641, 0.6536])
+        super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
 
     def test_kandinsky3_img2img(self):
         device = "cpu"

--- a/tests/pipelines/pia/test_pia.py
+++ b/tests/pipelines/pia/test_pia.py
@@ -174,9 +174,9 @@ class PIAPipelineFastTests(IPAdapterTesterMixin, PipelineTesterMixin, unittest.T
                 ]
             )
         return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
-    
+
     def test_dict_tuple_outputs_equivalent(self):
-        expected_slice = None 
+        expected_slice = None
         if torch_device == "cpu":
             expected_slice = np.array([0.3740, 0.4284, 0.4038, 0.5417, 0.4405, 0.5521, 0.4273, 0.4124, 0.4997])
         return super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)

--- a/tests/pipelines/pia/test_pia.py
+++ b/tests/pipelines/pia/test_pia.py
@@ -174,6 +174,12 @@ class PIAPipelineFastTests(IPAdapterTesterMixin, PipelineTesterMixin, unittest.T
                 ]
             )
         return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
+    
+    def test_dict_tuple_outputs_equivalent(self):
+        expected_slice = None 
+        if torch_device == "cpu":
+            expected_slice = np.array([0.3740, 0.4284, 0.4038, 0.5417, 0.4405, 0.5521, 0.4273, 0.4124, 0.4997])
+        return super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
 
     @unittest.skip("Attention slicing is not enabled in this pipeline")
     def test_attention_slicing_forward_pass(self):

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_attend_and_excite.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_attend_and_excite.py
@@ -32,6 +32,7 @@ from diffusers.utils.testing_utils import (
     numpy_cosine_similarity_distance,
     require_torch_gpu,
     skip_mps,
+    torch_device,
 )
 
 from ..pipeline_params import TEXT_TO_IMAGE_BATCH_PARAMS, TEXT_TO_IMAGE_IMAGE_PARAMS, TEXT_TO_IMAGE_PARAMS
@@ -144,6 +145,12 @@ class StableDiffusionAttendAndExcitePipelineFastTests(
         }
         return inputs
 
+    def test_dict_tuple_outputs_equivalent(self):
+        expected_slice = None
+        if torch_device == "cpu":
+            expected_slice = np.array([0.6391, 0.6290, 0.4860, 0.5134, 0.5550, 0.4577, 0.5033, 0.5023, 0.4538])
+        super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice, expected_max_difference=3e-3)
+
     def test_inference(self):
         device = "cpu"
 
@@ -172,9 +179,6 @@ class StableDiffusionAttendAndExcitePipelineFastTests(
 
     def test_inference_batch_single_identical(self):
         self._test_inference_batch_single_identical(batch_size=2, expected_max_diff=7e-4)
-
-    def test_dict_tuple_outputs_equivalent(self):
-        super().test_dict_tuple_outputs_equivalent(expected_max_difference=3e-3)
 
     def test_pt_np_pil_outputs_equivalent(self):
         super().test_pt_np_pil_outputs_equivalent(expected_max_diff=5e-4)

--- a/tests/pipelines/stable_diffusion_gligen_text_image/test_stable_diffusion_gligen_text_image.py
+++ b/tests/pipelines/stable_diffusion_gligen_text_image/test_stable_diffusion_gligen_text_image.py
@@ -35,7 +35,7 @@ from diffusers import (
 )
 from diffusers.pipelines.stable_diffusion import CLIPImageProjection
 from diffusers.utils import load_image
-from diffusers.utils.testing_utils import enable_full_determinism
+from diffusers.utils.testing_utils import enable_full_determinism, torch_device
 
 from ..pipeline_params import (
     TEXT_TO_IMAGE_BATCH_PARAMS,
@@ -150,6 +150,12 @@ class GligenTextImagePipelineFastTests(
             "output_type": "np",
         }
         return inputs
+
+    def test_dict_tuple_outputs_equivalent(self):
+        expected_slice = None
+        if torch_device == "cpu":
+            expected_slice = np.array([0.5052, 0.5546, 0.4567, 0.4770, 0.5195, 0.4085, 0.5026, 0.4909, 0.4495])
+        super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
 
     def test_stable_diffusion_gligen_text_image_default_case(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -874,6 +874,7 @@ class PipelineTesterMixin:
             else:
                 max_diff = np.abs(to_np(output) - to_np(output_tuple)[0, -3:, -3:, -1, -1].flatten()).max()
         
+        assert output is None
         self.assertLess(max_diff, expected_max_difference)
 
     def test_components_function(self):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -862,7 +862,7 @@ class PipelineTesterMixin:
             output = pipe(**self.get_dummy_inputs(generator_device))[0]
         else:
             output = expected_slice
-        print_tensor_test(output, limit_to_slices=True, max_torch_print=True)
+            
         output_tuple = pipe(**self.get_dummy_inputs(generator_device), return_dict=False)[0]
 
         if expected_slice is None:

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -874,7 +874,6 @@ class PipelineTesterMixin:
             else:
                 max_diff = np.abs(to_np(output) - to_np(output_tuple)[0, -3:, -3:, -1, -1].flatten()).max()
         
-        assert output is None
         self.assertLess(max_diff, expected_max_difference)
 
     def test_components_function(self):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -860,6 +860,7 @@ class PipelineTesterMixin:
         generator_device = "cpu"
         if expected_slice is None:
             output = pipe(**self.get_dummy_inputs(generator_device))[0]
+            print_tensor_test(output, limit_to_slices=True, max_torch_print=True)
         else:
             output = expected_slice
 

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -860,6 +860,7 @@ class PipelineTesterMixin:
         generator_device = "cpu"
         if expected_slice is None:
             output = pipe(**self.get_dummy_inputs(generator_device))[0]
+            print(output[0, -3:, -3:, -1, -1].flatten())
             print(output.shape)
         else:
             output = expected_slice

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -860,8 +860,6 @@ class PipelineTesterMixin:
         generator_device = "cpu"
         if expected_slice is None:
             output = pipe(**self.get_dummy_inputs(generator_device))[0]
-            print(output[0, -3:, -3:, -1, -1].flatten())
-            print(output.shape)
         else:
             output = expected_slice
 
@@ -870,9 +868,11 @@ class PipelineTesterMixin:
         if expected_slice is None:
             max_diff = np.abs(to_np(output) - to_np(output_tuple)).max()
         else:
-            max_diff = np.abs(to_np(output) - to_np(output_tuple)[0, -3:, -3:, -1].flatten()).max()
+            if output_tuple.ndim != 5:
+                max_diff = np.abs(to_np(output) - to_np(output_tuple)[0, -3:, -3:, -1].flatten()).max()
+            else:
+                max_diff = np.abs(to_np(output) - to_np(output_tuple)[0, -3:, -3:, -1, -1].flatten()).max()
         
-        assert output is None
         self.assertLess(max_diff, expected_max_difference)
 
     def test_components_function(self):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -862,13 +862,13 @@ class PipelineTesterMixin:
             output = pipe(**self.get_dummy_inputs(generator_device))[0]
         else:
             output = expected_slice
-            
+
         output_tuple = pipe(**self.get_dummy_inputs(generator_device), return_dict=False)[0]
 
         if expected_slice is None:
             max_diff = np.abs(to_np(output) - to_np(output_tuple)).max()
         else:
-            max_diff = np.abs(to_np(output) - to_np(output_tuple)[0, -3:, -3:, -1]).max()
+            max_diff = np.abs(to_np(output) - to_np(output_tuple)[0, -3:, -3:, -1].flatten()).max()
         self.assertLess(max_diff, expected_max_difference)
 
     def test_components_function(self):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -860,7 +860,6 @@ class PipelineTesterMixin:
         generator_device = "cpu"
         if expected_slice is None:
             output = pipe(**self.get_dummy_inputs(generator_device))[0]
-            print_tensor_test(output, limit_to_slices=True, max_torch_print=True)
         else:
             output = expected_slice
 

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -37,7 +37,7 @@ from diffusers.pipelines.pipeline_utils import StableDiffusionMixin
 from diffusers.schedulers import KarrasDiffusionSchedulers
 from diffusers.utils import logging
 from diffusers.utils.import_utils import is_accelerate_available, is_accelerate_version, is_xformers_available
-from diffusers.utils.testing_utils import CaptureLogger, require_torch, torch_device
+from diffusers.utils.testing_utils import CaptureLogger, require_torch, torch_device, print_tensor_test
 
 from ..models.autoencoders.test_models_vae import (
     get_asym_autoencoder_kl_config,
@@ -859,6 +859,7 @@ class PipelineTesterMixin:
 
         generator_device = "cpu"
         output = pipe(**self.get_dummy_inputs(generator_device))[0]
+        print_tensor_test(output)
         output_tuple = pipe(**self.get_dummy_inputs(generator_device), return_dict=False)[0]
 
         max_diff = np.abs(to_np(output) - to_np(output_tuple)).max()

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -860,6 +860,7 @@ class PipelineTesterMixin:
         generator_device = "cpu"
         if expected_slice is None:
             output = pipe(**self.get_dummy_inputs(generator_device))[0]
+            print(output[0, -3:, -3:, -1, -1].flatten())
         else:
             output = expected_slice
 
@@ -873,6 +874,7 @@ class PipelineTesterMixin:
             else:
                 max_diff = np.abs(to_np(output) - to_np(output_tuple)[0, -3:, -3:, -1, -1].flatten()).max()
         
+        assert output is None
         self.assertLess(max_diff, expected_max_difference)
 
     def test_components_function(self):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -859,7 +859,7 @@ class PipelineTesterMixin:
 
         generator_device = "cpu"
         output = pipe(**self.get_dummy_inputs(generator_device))[0]
-        print_tensor_test(output)
+        print_tensor_test(output, limit_to_slices=True, max_torch_print=True)
         output_tuple = pipe(**self.get_dummy_inputs(generator_device), return_dict=False)[0]
 
         max_diff = np.abs(to_np(output) - to_np(output_tuple)).max()

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -860,6 +860,7 @@ class PipelineTesterMixin:
         generator_device = "cpu"
         if expected_slice is None:
             output = pipe(**self.get_dummy_inputs(generator_device))[0]
+            print(output.shape)
         else:
             output = expected_slice
 
@@ -869,6 +870,8 @@ class PipelineTesterMixin:
             max_diff = np.abs(to_np(output) - to_np(output_tuple)).max()
         else:
             max_diff = np.abs(to_np(output) - to_np(output_tuple)[0, -3:, -3:, -1].flatten()).max()
+        
+        assert output is None
         self.assertLess(max_diff, expected_max_difference)
 
     def test_components_function(self):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -860,7 +860,6 @@ class PipelineTesterMixin:
         generator_device = "cpu"
         if expected_slice is None:
             output = pipe(**self.get_dummy_inputs(generator_device))[0]
-            print(output[0, -3:, -3:, -1, -1].flatten())
         else:
             output = expected_slice
 
@@ -873,8 +872,7 @@ class PipelineTesterMixin:
                 max_diff = np.abs(to_np(output) - to_np(output_tuple)[0, -3:, -3:, -1].flatten()).max()
             else:
                 max_diff = np.abs(to_np(output) - to_np(output_tuple)[0, -3:, -3:, -1, -1].flatten()).max()
-        
-        assert output is None
+
         self.assertLess(max_diff, expected_max_difference)
 
     def test_components_function(self):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -37,7 +37,7 @@ from diffusers.pipelines.pipeline_utils import StableDiffusionMixin
 from diffusers.schedulers import KarrasDiffusionSchedulers
 from diffusers.utils import logging
 from diffusers.utils.import_utils import is_accelerate_available, is_accelerate_version, is_xformers_available
-from diffusers.utils.testing_utils import CaptureLogger, print_tensor_test, require_torch, torch_device
+from diffusers.utils.testing_utils import CaptureLogger, require_torch, torch_device
 
 from ..models.autoencoders.test_models_vae import (
     get_asym_autoencoder_kl_config,

--- a/tests/pipelines/text_to_video_synthesis/test_text_to_video.py
+++ b/tests/pipelines/text_to_video_synthesis/test_text_to_video.py
@@ -134,7 +134,7 @@ class TextToVideoSDPipelineFastTests(PipelineTesterMixin, SDFunctionTesterMixin,
         return inputs
 
     def test_dict_tuple_outputs_equivalent(self):
-        expected_slice = None 
+        expected_slice = None
         if torch_device == "cpu":
             expected_slice = np.array([0.4903, 0.5649, 0.5504, 0.5179, 0.4821, 0.5466, 0.4131, 0.5052, 0.5077])
         return super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)

--- a/tests/pipelines/text_to_video_synthesis/test_text_to_video.py
+++ b/tests/pipelines/text_to_video_synthesis/test_text_to_video.py
@@ -133,6 +133,12 @@ class TextToVideoSDPipelineFastTests(PipelineTesterMixin, SDFunctionTesterMixin,
         }
         return inputs
 
+    def test_dict_tuple_outputs_equivalent(self):
+        expected_slice = None 
+        if torch_device == "cpu":
+            expected_slice = np.array([0.4903, 0.5649, 0.5504, 0.5179, 0.4821, 0.5466, 0.4131, 0.5052, 0.5077])
+        return super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
+
     def test_text_to_video_default_case(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
         components = self.get_dummy_components()

--- a/tests/pipelines/unidiffuser/test_unidiffuser.py
+++ b/tests/pipelines/unidiffuser/test_unidiffuser.py
@@ -206,6 +206,12 @@ class UniDiffuserPipelineFastTests(
         }
         return inputs
 
+    def test_dict_tuple_outputs_equivalent(self):
+        expected_slice = None
+        if torch_device == "cpu":
+            expected_slice = np.array([0.7489, 0.3722, 0.4475, 0.5630, 0.5923, 0.4992, 0.3936, 0.5844, 0.4975])
+        super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
+
     def test_unidiffuser_default_joint_v0(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
         components = self.get_dummy_components()


### PR DESCRIPTION
# What does this PR do?

Follow-up of https://github.com/huggingface/diffusers/pull/7477. 

This PR targets the `test_dict_tuple_outputs_equivalent()` method we run for all pipelines. I took the top 10 time-consuming tests from the lot and decided to use static slices ONLY for them. This is because of the rest of the tests, it's under a second. So, it doesn't matter that much. 

The next PR will be similar to this but for `test_inference_batch_single_identical()`. 