### PR TITLE
Quick-Fix for #7352 block-lora

### DIFF
--- a/src/diffusers/loaders/lora.py
+++ b/src/diffusers/loaders/lora.py
@@ -1111,7 +1111,7 @@ class LoraLoaderMixin:
                 # warn if adapter doesn't have parts specified by adapter_weights
                 for part_weight, part_name in zip(
                     [unet_lora_weight, text_encoder_lora_weight, text_encoder_2_lora_weight],
-                    ["uent", "text_encoder", "text_encoder_2"],
+                    ["unet", "text_encoder", "text_encoder_2"],
                 ):
                     if part_weight is not None and part_name not in invert_list_adapters[adapter_name]:
                         logger.warning(


### PR DESCRIPTION
Due to a typo in the merged PR #7352, an error will always be logged. Currently, the validation code expects a "uent" parameter, which is a typo for unet.

(But the unet scale dict is still handled correctly.)

Thanks @asomoza for spotting!

cc @sayakpaul
