### PR TITLE
[Release tests] make nightly workflow dispatchable.

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -1,6 +1,7 @@
 name: Nightly tests on main
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # every day at midnight
 
@@ -245,6 +246,8 @@ jobs:
   run_flax_tpu_tests:
     name: Nightly Flax TPU Tests
     runs-on: docker-tpu
+    if: github.event_name == 'schedule'
+    
     container:
       image: diffusers/diffusers-flax-tpu
       options: --shm-size "16gb" --ipc host -v /mnt/hf_cache:/mnt/cache/ --privileged
@@ -355,6 +358,7 @@ jobs:
   run_nightly_tests_apple_m1:
     name: Nightly PyTorch MPS tests on MacOS
     runs-on: [ self-hosted, apple-m1 ]
+    if: github.event_name == 'schedule'
 
     steps:
       - name: Checkout diffusers

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -1,4 +1,4 @@
-name: Nightly tests on main
+name: Nightly and release tests on main/release branch
 
 on:
   workflow_dispatch:

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,13 @@ To create the package for PyPI.
    If releasing on a special branch, copy the updated README.md on the main branch for the commit you will make
    for the post-release and run `make fix-copies` on the main branch as well.
 
-2. Run Tests for Amazon Sagemaker. The documentation is located in `./tests/sagemaker/README.md`, otherwise @philschmid.
+2. Unpin specific versions from setup.py that use a git install.
 
-3. Unpin specific versions from setup.py that use a git install.
-
-4. Checkout the release branch (v<RELEASE>-release, for example v4.19-release), and commit these changes with the
+3. Checkout the release branch (v<RELEASE>-release, for example v4.19-release), and commit these changes with the
    message: "Release: <RELEASE>" and push.
+
+4. Manually trigger the "Nightly and release tests on main/release branch" workflow from the release branch. Wait for
+   the tests to complete. We can safely ignore the known test failures.
 
 5. Wait for the tests on main to be completed and be green (otherwise revert and fix bugs).
 


### PR DESCRIPTION
# What does this PR do?

This PR makes the nightly tests workflow dispatchable. The idea is to manually trigger the torch nightly tests before making a release. The tests that are known to fail at the moment (https://github.com/huggingface/diffusers/issues/7334, for example) will be ignored during this check. 

For releases, @DN6 and I think it's okay to just stick to the torch tests. 

Once the PR is approved, will add a note in our setup.py about running this test.

Cc: @yiyixuxu for awareness. 