### PR TITLE
 Preserve Original Tensor Model Output in RepaintPipeline

### DIFF
--- a/src/diffusers/pipelines/deprecated/repaint/pipeline_repaint.py
+++ b/src/diffusers/pipelines/deprecated/repaint/pipeline_repaint.py
@@ -132,7 +132,7 @@ class RePaintPipeline(DiffusionPipeline):
                 A [`torch.Generator`](https://pytorch.org/docs/stable/generated/torch.Generator.html) to make
                 generation deterministic.
             output_type (`str`, `optional`, defaults to `"pil"`):
-                The output format of the generated image. Choose between `PIL.Image` or `np.array`.
+                The output format of the generated image. Choose between `PIL.Image`,`np.array`, or 'Torch.tensor' cast as numpy.
             return_dict (`bool`, *optional*, defaults to `True`):
                 Whether or not to return a [`ImagePipelineOutput`] instead of a plain tuple.
 
@@ -219,10 +219,14 @@ class RePaintPipeline(DiffusionPipeline):
                 image = self.scheduler.undo_step(image, t_last, generator)
             t_last = t
 
-        image = (image / 2 + 0.5).clamp(0, 1)
+        if output_type != "tensor":
+            image = (image / 2 + 0.5).clamp(0, 1)
+        
         image = image.cpu().permute(0, 2, 3, 1).numpy()
+        
         if output_type == "pil":
             image = self.numpy_to_pil(image)
+
 
         if not return_dict:
             return (image,)


### PR DESCRIPTION
This PR adds an extra case for the original, non-rescaled tensor output passed to ImagePipelineOutput in repaint_pipeline.py. By not rescaling between 0 and 1 (as opposed to say -1 and 1), it doesn't make assumptions about the original normalization used for the model. The changes preserve the logic of the original implementation but add a case to prevent this rescaling. The tensor output is still cast to numpy for compatibility with ImageOutputPipeline. I have also added this change to the documentation.

Fixes #7545


## Before submitting
This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
 Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
 Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
 Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul @yiyixuxu @DN6