### PR TITLE
Controlnet: return zero tensors if scale is zero

### DIFF
--- a/src/diffusers/models/controlnet.py
+++ b/src/diffusers/models/controlnet.py
@@ -663,6 +663,49 @@ class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlNetMixin):
         if isinstance(module, (CrossAttnDownBlock2D, DownBlock2D)):
             module.gradient_checkpointing = value
 
+    def zeros_res_samples(
+        self, sample: torch.FloatTensor, return_dict: bool
+    ) -> Union[ControlNetOutput, Tuple[Tuple[torch.FloatTensor, ...], torch.FloatTensor]]:
+        b, c, h, w = sample.shape
+        down_block_res_samples = []
+        block_out_channels = self.config.block_out_channels
+        output_channel = block_out_channels[0]
+        for i, block in enumerate(self.down_blocks):
+            input_channel = output_channel
+            output_channel = block_out_channels[i]
+            num_states = len(block.resnets)
+            for j in range(num_states):
+                down_block_res_samples.append(
+                    torch.zeros(
+                        (b, input_channel if j == 0 else output_channel, h, w),
+                        device=sample.device,
+                        dtype=sample.dtype,
+                    )
+                )
+            down_block_res_samples.append(
+                torch.zeros(
+                    (b, output_channel, h, w),
+                    device=sample.device,
+                    dtype=sample.dtype,
+                )
+            )
+            h, w = h // 2, w // 2
+
+        b, c, h, w = sample.shape
+        mid_block_channel = block_out_channels[-1]
+        mid_block_res_sample = torch.zeros(
+            (b, mid_block_channel, h // 8, w // 8),
+            device=sample.device,
+            dtype=sample.dtype,
+        )
+
+        if not return_dict:
+            return (down_block_res_samples, mid_block_res_sample)
+        return ControlNetOutput(
+            down_block_res_samples=down_block_res_samples,
+            mid_block_res_sample=mid_block_res_sample,
+        )
+
     def forward(
         self,
         sample: torch.FloatTensor,
@@ -717,6 +760,10 @@ class ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlNetMixin):
                 If `return_dict` is `True`, a [`~models.controlnet.ControlNetOutput`] is returned, otherwise a tuple is
                 returned where the first element is the sample tensor.
         """
+        # check if conditioning_scale is zero
+        if conditioning_scale == 0:
+            return self.zeros_res_samples(sample=sample, return_dict=return_dict)
+
         # check channel order
         channel_order = self.config.controlnet_conditioning_channel_order
 


### PR DESCRIPTION
# What does this PR do?

Return zero tensors when the scale for ControlNet is set to zero.

Example use case: Consider a pipeline that incorporates multiple ControlNets (e.g., 2) and aims to generate images using the same pipeline but with variations: a) using only the 1st ControlNet; b) using only the 2nd ControlNet; c) using both ControlNets. In such scenarios, you can configure the scales as [..., 0] for option a) and [0, ...] for option b). This pull request addresses the issue of unnecessary inference of ControlNet model blocks when the scale is set to zero, optimizing performance for these cases.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sayakpaul