### PR TITLE
Update `version_range_max` in `setup.py` to support Python 12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -250,7 +250,7 @@ install_requires = [
     deps["Pillow"],
 ]
 
-version_range_max = max(sys.version_info[1], 10) + 1
+version_range_max = max(sys.version_info[1], 12) + 1
 
 setup(
     name="diffusers",


### PR DESCRIPTION
Just to align with [PyTorch](https://github.com/pytorch/pytorch/blob/7b029101636512038a3a09f4b4ae72fe931c7248/setup.py#L1151C50-L1151C52).
@sayakpaul @yiyixuxu