### PR TITLE
fix `DeprecatedAttentionBlockTests`

### DIFF
--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -711,7 +711,6 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
                     )
                     model._undo_temp_convert_self_to_deprecated_attention_blocks()
 
-
                 loading_info = {
                     "missing_keys": [],
                     "unexpected_keys": [],
@@ -968,12 +967,12 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
 
         recursive_find_attn_block(self)
         if len(deprecated_attention_block_modules) > 0:
-                logger.warning(
-                    f"{pretrained_model_name_or_path} was saved with deprecated attention block weight names."
-                    " We will load it with the deprecated attention block names and convert them on the fly to the new attention block format."
-                    " Please re-save the model after this conversion so we don't have to do the on the fly renaming in the future. "
-                    "If the model is from a hub checkpoint, please also re-upload it or open a PR on the original repository."
-                )
+            logger.warning(
+                f"{pretrained_model_name_or_path} was saved with deprecated attention block weight names."
+                " We will load it with the deprecated attention block names and convert them on the fly to the new attention block format."
+                " Please re-save the model after this conversion so we don't have to do the on the fly renaming in the future. "
+                "If the model is from a hub checkpoint, please also re-upload it or open a PR on the original repository."
+            )
 
         for module in deprecated_attention_block_modules:
             module.query = module.to_q


### PR DESCRIPTION
This test is failing https://github.com/huggingface/diffusers/actions/runs/8586533839/job/23529105209?pr=7580#step:8:3269 due to this PR in accelerate https://github.com/huggingface/accelerate/pull/2588, which breaks the model loading behavior in diffusers when:
1. `accelerate.load_checkpoint_and_dispatch` is used
2. the checkpoint contains deprecated weight names 

As you can see [here](https://github.com/huggingface/diffusers/blob/7e808e768a7305b3f8f9e981ad14f2de3598e9a6/src/diffusers/models/modeling_utils.py#L703), we rely on `accelerate.load_checkpoint_and_dispatch` to throw an `AttributeError` when there are unmatched keys in state_dict; we use this info to (1) rename the deprecated weights (2) inform user that they should convert the weights. The PR https://github.com/huggingface/accelerate/pull/2588 changed the default loading behavior in accelerate to be `strict=False` and will not throw an error by default 

I'm trying to handle this in diffusers in this PR; the alternative is to open an issue in accelerate that allows us to pass a `strict=True` from `load_checkpoint_and_dispatch`; 



