### PR TITLE
fix: metadata token

### DIFF
--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -25,6 +25,6 @@ jobs:
 
       - name: Update metadata
         env:
-          HUGGING_FACE_HUB_TOKEN: ${{ secrets.DIFFUSERS_BOT_TOKEN }}
+          HUGGING_FACE_HUB_TOKEN: ${{ secrets.SAYAK_HF_TOKEN }}
         run: |
           python utils/update_metadata.py --commit_sha ${{ github.sha }}


### PR DESCRIPTION
# What does this PR do?

In our `update_metadata.yml` workflow, we're using the token of a user that's not a part of the `huggingface` org on the Hub. So, this PR updates it with my token. 

Will merge once the CI is green. 