### PR TITLE
fix: Replaced deprecated `logger.warn` with `logger.warning`

### DIFF
--- a/src/diffusers/loaders/unet.py
+++ b/src/diffusers/loaders/unet.py
@@ -998,7 +998,7 @@ class FromOriginalUNetMixin:
         if is_accelerate_available():
             unexpected_keys = load_model_dict_into_meta(model, diffusers_format_checkpoint, dtype=torch_dtype)
             if len(unexpected_keys) > 0:
-                logger.warn(
+                logger.warning(
                     f"Some weights of the model checkpoint were not used when initializing {cls.__name__}: \n {[', '.join(unexpected_keys)]}"
                 )
 

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1816,7 +1816,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
                 ):
                     original_class_obj[name] = component
                 else:
-                    logger.warn(
+                    logger.warning(
                         f"component {name} is not switched over to new pipeline because type does not match the expected."
                         f" {name} is {type(component)} while the new pipeline expect {component_types[name]}."
                         f" please pass the component of the correct type to the new pipeline. `from_pipe(..., {name}={name})`"


### PR DESCRIPTION
# What does this PR do?
`logging.warn` and `logging.Logger.warn` are deprecated in favor of `logging.warning` and `logging.Logger.warning`, which are functionally equivalent. (https://docs.python.org/3/library/logging.html#logging.warning)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@sayakpaul