### PR TITLE
[df-if II] add additional input checks to ensure the input is divisible by 8

### DIFF
--- a/src/diffusers/pipelines/deepfloyd_if/pipeline_if_superresolution.py
+++ b/src/diffusers/pipelines/deepfloyd_if/pipeline_if_superresolution.py
@@ -543,12 +543,27 @@ class IFSuperResolutionPipeline(DiffusionPipeline, LoraLoaderMixin):
 
         if isinstance(image, list):
             image_batch_size = len(image)
+            # Check that each image is the same size:
+            if not all([i.size == image[0].size for i in image]):
+                raise ValueError("All images must be the same size")
+            # Check that the size is divisible by 8:
+            if (image[0].size[0] % 8 != 0 or image[0].size[1] % 8 != 0):
+                raise ValueError("Image size must be divisible by 8")
         elif isinstance(image, torch.Tensor):
             image_batch_size = image.shape[0]
+            # Check that the size is divisible by 8:
+            if (image.shape[2] % 8 != 0 or image.shape[3] % 8 != 0):
+                raise ValueError("Image size must be divisible by 8")
         elif isinstance(image, PIL.Image.Image):
             image_batch_size = 1
+            # Check that the size is divisible by 8:
+            if (image.size[0] % 8 != 0 or image.size[1] % 8 != 0):
+                raise ValueError("Image size must be divisible by 8")
         elif isinstance(image, np.ndarray):
             image_batch_size = image.shape[0]
+            # Check that the size is divisible by 8:
+            if (image.shape[1] % 8 != 0 or image.shape[2] % 8 != 0):
+                raise ValueError("Image size must be divisible by 8")
         else:
             assert False
 

--- a/tests/pipelines/deepfloyd_if/test_if_superresolution.py
+++ b/tests/pipelines/deepfloyd_if/test_if_superresolution.py
@@ -57,6 +57,13 @@ class IFSuperResolutionPipelineFastTests(PipelineTesterMixin, IFPipelineTesterMi
 
         return inputs
 
+    def test_incorrect_input_size(self):
+        # Put an image non-divisible by 8 into the pipeline and check that it throws an Exception.
+        image = floats_tensor((1, 3, 31, 31), rng=random.Random(0)).to(torch_device)
+        generator = torch.Generator(device="cpu").manual_seed(0)
+        with self.assertRaises(ValueError):
+            self.pipeline(prompt="elegant destruction", image=image, generator=generator, num_inference_steps=2, output_type="np")
+
     @unittest.skipIf(
         torch_device != "cuda" or not is_xformers_available(),
         reason="XFormers attention is only available with CUDA and `xformers` installed",


### PR DESCRIPTION
# What does this PR do?

Fixes #7842 

Adds logic to check_inputs for the IF SuperResolution pipeline so that the user receives a clear error when attempting to run the pipeline with invalid image sizes for the input.

This is possible to hit when using the super-resolution model for upscaling evaluation images during training, if eg. the target 256 pixel resolution is aligned to 8px intervals and then divided by 4 to obtain the input image size. The stage II **output** resolution will be okay, but the **input** resolution would be wrong.

I suppose there's other ways to hit the problem, but it's always been a bit murky which input is causing the problems.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

- Pipelines:  @sayakpaul @yiyixuxu @DN6
