### PR TITLE
Fix for "no lora weight found module" with some loras

### DIFF
--- a/src/diffusers/utils/peft_utils.py
+++ b/src/diffusers/utils/peft_utils.py
@@ -248,10 +248,11 @@ def set_weights_and_activate_adapters(model, adapter_names, weights):
                 return weight_
 
         parts = module_name.split(".")
+        # e.g. key = "down_blocks.1.attentions.0"
         key = f"{parts[0]}.{parts[1]}.attentions.{parts[3]}"
-        blocK_weight = weight_for_adapter.get(key, 1.0)
+        block_weight = weight_for_adapter.get(key, 1.0)
 
-        return blocK_weight
+        return block_weight
 
     # iterate over each adapter, make it active and set the corresponding scaling weight
     for adapter_name, weight in zip(adapter_names, weights):

--- a/src/diffusers/utils/peft_utils.py
+++ b/src/diffusers/utils/peft_utils.py
@@ -246,7 +246,12 @@ def set_weights_and_activate_adapters(model, adapter_names, weights):
         for layer_name, weight_ in weight_for_adapter.items():
             if layer_name in module_name:
                 return weight_
-        return weight_for_adapter[layer_name]
+
+        parts = module_name.split(".")
+        key = f"{parts[0]}.{parts[1]}.attentions.{parts[3]}"
+        blocK_weight = weight_for_adapter.get(key, 1.0)
+
+        return blocK_weight
 
     # iterate over each adapter, make it active and set the corresponding scaling weight
     for adapter_name, weight in zip(adapter_names, weights):

--- a/src/diffusers/utils/peft_utils.py
+++ b/src/diffusers/utils/peft_utils.py
@@ -246,7 +246,7 @@ def set_weights_and_activate_adapters(model, adapter_names, weights):
         for layer_name, weight_ in weight_for_adapter.items():
             if layer_name in module_name:
                 return weight_
-        raise RuntimeError(f"No LoRA weight found for module {module_name}.")
+        return weight_for_adapter[layer_name]
 
     # iterate over each adapter, make it active and set the corresponding scaling weight
     for adapter_name, weight in zip(adapter_names, weights):

--- a/tests/lora/test_lora_layers_sdxl.py
+++ b/tests/lora/test_lora_layers_sdxl.py
@@ -202,6 +202,36 @@ class LoraSDXLIntegrationTests(unittest.TestCase):
         pipe.unload_lora_weights()
         release_memory(pipe)
 
+    def test_sdxl_1_0_blockwise_lora(self):
+        generator = torch.Generator("cpu").manual_seed(0)
+
+        pipe = StableDiffusionXLPipeline.from_pretrained("stabilityai/stable-diffusion-xl-base-1.0")
+        pipe.enable_model_cpu_offload()
+        lora_model_id = "hf-internal-testing/sdxl-1.0-lora"
+        lora_filename = "sd_xl_offset_example-lora_1.0.safetensors"
+        pipe.load_lora_weights(lora_model_id, weight_name=lora_filename, adapter_name="offset")
+        scales = {
+            "unet": {
+                "down": {"block_1": [1.0, 1.0], "block_2": [1.0, 1.0]},
+                "mid": 1.0,
+                "up": {"block_0": [1.0, 1.0, 1.0], "block_1": [1.0, 1.0, 1.0]},
+            },
+        }
+        pipe.set_adapters(["offset"], [scales])
+
+        images = pipe(
+            "masterpiece, best quality, mountain", output_type="np", generator=generator, num_inference_steps=2
+        ).images
+
+        images = images[0, -3:, -3:, -1].flatten()
+        expected = np.array([0.4468, 0.4087, 0.4134, 0.366, 0.3202, 0.3505, 0.3786, 0.387, 0.3535])
+
+        max_diff = numpy_cosine_similarity_distance(expected, images)
+        assert max_diff < 1e-4
+
+        pipe.unload_lora_weights()
+        release_memory(pipe)
+
     def test_sdxl_lcm_lora(self):
         pipe = StableDiffusionXLPipeline.from_pretrained(
             "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float16


### PR DESCRIPTION
# What does this PR do?

When using some LoRAs, for example [sd_xl_offset_example-lora_1.0.safetensors](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/blob/main/sd_xl_offset_example-lora_1.0.safetensors) with blockwise scales we get this error:

```
RuntimeError: No LoRA weight found for module down_blocks.0.resnets.0.conv1
```

This PR makes it so if the layer is not found, it returns the weight (scale) of the block enabling the use of these LoRAs with blockwise scales.

e.g.,

```python
offset_scales = {
    "unet": {
        "down": {"block_1": [0.0, 0.5], "block_2": [1.0, 1.0]},
        "mid": 1.0,
        "up": {"block_0": [1.0, 1.0, 1.0], "block_1": [1.0, 1.0, 1.0]},
    },
    "text_encoder": 1.0,
    "text_encoder_2": 1.0,
}
```

- If `down_blocks.0.resnets.0.conv1` is not found, returns the `scale` of `1.0` as a default.
- If `down_blocks.1.resnets.0.conv1`  is not found, returns the `scale` of `0.0`
- If `down_blocks.1.resnets.1.conv1`  is not found, returns the `scale` of `0.5`
- If `down_blocks.2.resnets.0.conv1`  is not found, returns the `scale` of `1.0`

Fixes #7871

## Who can review?

@sayakpaul @yiyixuxu @DN6
