### PR TITLE
fix `_optional_components` in `StableCascadeCombinedPipeline`

### DIFF
--- a/src/diffusers/pipelines/stable_cascade/pipeline_stable_cascade_combined.py
+++ b/src/diffusers/pipelines/stable_cascade/pipeline_stable_cascade_combined.py
@@ -71,6 +71,7 @@ class StableCascadeCombinedPipeline(DiffusionPipeline):
     """
 
     _load_connected_pipes = True
+    _optional_components = ["prior_feature_extractor", "prior_image_encoder"]
 
     def __init__(
         self,

--- a/tests/pipelines/stable_cascade/test_stable_cascade_combined.py
+++ b/tests/pipelines/stable_cascade/test_stable_cascade_combined.py
@@ -153,6 +153,8 @@ class StableCascadeCombinedPipelineFastTests(PipelineTesterMixin, unittest.TestC
             "prior_tokenizer": prior_tokenizer,
             "prior_prior": prior,
             "prior_scheduler": scheduler,
+            "prior_feature_extractor": None,
+            "prior_image_encoder": None,
         }
 
         return components


### PR DESCRIPTION
currently, `StableCascadeCombinedPipeline` is missing  `_optional_components` so the combined pipeline is not able to get the correct list of expected modules, i.e. `_get_signature_keys` (https://github.com/huggingface/diffusers/blob/c1c42698c955959d7ef34af129428f64c6e363bf/src/diffusers/pipelines/pipeline_utils.py#L1555) will not include the optional components in `expected_modules`, which will then cause  errors in methods using this methods, such as `components` and `to`

this fix https://github.com/huggingface/diffusers/issues/7598