### PR TITLE
[Tests] fix things after #7013/

### DIFF
--- a/src/diffusers/loaders/lora.py
+++ b/src/diffusers/loaders/lora.py
@@ -1294,7 +1294,7 @@ class LoraLoaderMixin:
                         text_encoder_module.lora_B[adapter_name].to(device)
                         # this is a param, not a module, so device placement is not in-place -> re-assign
                         if (
-                            hasattr(text_encoder, "lora_magnitude_vector")
+                            hasattr(text_encoder_module, "lora_magnitude_vector")
                             and text_encoder_module.lora_magnitude_vector is not None
                         ):
                             text_encoder_module.lora_magnitude_vector[

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -1269,6 +1269,7 @@ class StableDiffusionXLPipeline(
         if not output_type == "latent":
             # apply watermark if available
             if self.watermark is not None:
+                print("Applying watermarking.")
                 image = self.watermark.apply_watermark(image)
 
             image = self.image_processor.postprocess(image, output_type=output_type)

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -1269,7 +1269,6 @@ class StableDiffusionXLPipeline(
         if not output_type == "latent":
             # apply watermark if available
             if self.watermark is not None:
-                print("Applying watermarking.")
                 image = self.watermark.apply_watermark(image)
 
             image = self.image_processor.postprocess(image, output_type=output_type)

--- a/tests/lora/test_lora_layers_sd.py
+++ b/tests/lora/test_lora_layers_sd.py
@@ -192,7 +192,6 @@ class StableDiffusionLoRATests(PeftLoraLoaderMixinTests, unittest.TestCase):
 
         for name, param in pipe.unet.named_parameters():
             if "lora_" in name:
-                print(f"{param.device=}")
                 self.assertNotEqual(param.device, torch.device("cpu"))
 
         for name, param in pipe.text_encoder.named_parameters():

--- a/tests/lora/test_lora_layers_sd.py
+++ b/tests/lora/test_lora_layers_sd.py
@@ -192,10 +192,12 @@ class StableDiffusionLoRATests(PeftLoraLoaderMixinTests, unittest.TestCase):
 
         for name, param in pipe.unet.named_parameters():
             if "lora_" in name:
+                print(f"{param.device=}")
                 self.assertNotEqual(param.device, torch.device("cpu"))
 
         for name, param in pipe.text_encoder.named_parameters():
             if "lora_" in name:
+                print(f"{name=}")
                 self.assertNotEqual(param.device, torch.device("cpu"))
 
 

--- a/tests/lora/test_lora_layers_sdxl.py
+++ b/tests/lora/test_lora_layers_sdxl.py
@@ -194,6 +194,7 @@ class LoraSDXLIntegrationTests(unittest.TestCase):
         ).images
 
         images = images[0, -3:, -3:, -1].flatten()
+        print(", ".join([str(round(x, 4)) for x in images]))
         expected = np.array([0.4468, 0.4087, 0.4134, 0.366, 0.3202, 0.3505, 0.3786, 0.387, 0.3535])
 
         max_diff = numpy_cosine_similarity_distance(expected, images)
@@ -283,8 +284,7 @@ class LoraSDXLIntegrationTests(unittest.TestCase):
 
         images = images[0, -3:, -3:, -1].flatten()
         # This way we also test equivalence between LoRA fusion and the non-fusion behaviour.
-        print(", ".join([str(round(x, 4)) for x in images]))
-        expected = np.array([0.4468, 0.4087, 0.4134, 0.366, 0.3202, 0.3505, 0.3786, 0.387, 0.3535])
+        expected = np.array([0.4468, 0.4061, 0.4134, 0.3637, 0.3202, 0.365, 0.3786, 0.3725, 0.3535])
 
         max_diff = numpy_cosine_similarity_distance(expected, images)
         assert max_diff < 1e-4

--- a/tests/lora/test_lora_layers_sdxl.py
+++ b/tests/lora/test_lora_layers_sdxl.py
@@ -248,6 +248,7 @@ class LoraSDXLIntegrationTests(unittest.TestCase):
         image = pipe(
             "masterpiece, best quality, mountain", generator=generator, num_inference_steps=4, guidance_scale=0.5
         ).images[0]
+        image.save("/root/diffusers/sdxl_lcm_lora.png")
 
         expected_image = load_image(
             "https://huggingface.co/datasets/hf-internal-testing/diffusers-images/resolve/main/lcm_lora/sdxl_lcm_lora.png"

--- a/tests/lora/test_lora_layers_sdxl.py
+++ b/tests/lora/test_lora_layers_sdxl.py
@@ -194,8 +194,7 @@ class LoraSDXLIntegrationTests(unittest.TestCase):
         ).images
 
         images = images[0, -3:, -3:, -1].flatten()
-        print(", ".join([str(round(x, 4)) for x in images]))
-        expected = np.array([0.4468, 0.4087, 0.4134, 0.366, 0.3202, 0.3505, 0.3786, 0.387, 0.3535])
+        expected = np.array([0.4468, 0.4061, 0.4134, 0.3637, 0.3202, 0.365, 0.3786, 0.3725, 0.3535])
 
         max_diff = numpy_cosine_similarity_distance(expected, images)
         assert max_diff < 1e-4

--- a/tests/lora/test_lora_layers_sdxl.py
+++ b/tests/lora/test_lora_layers_sdxl.py
@@ -255,7 +255,6 @@ class LoraSDXLIntegrationTests(unittest.TestCase):
 
         image_np = pipe.image_processor.pil_to_numpy(image)
         expected_image_np = pipe.image_processor.pil_to_numpy(expected_image)
-        expected_image_np = expected_image_np[:, :, :, ::-1]
 
         max_diff = numpy_cosine_similarity_distance(image_np.flatten(), expected_image_np.flatten())
         assert max_diff < 1e-4
@@ -284,6 +283,7 @@ class LoraSDXLIntegrationTests(unittest.TestCase):
 
         images = images[0, -3:, -3:, -1].flatten()
         # This way we also test equivalence between LoRA fusion and the non-fusion behaviour.
+        print(", ".join([str(round(x, 4)) for x in images]))
         expected = np.array([0.4468, 0.4087, 0.4134, 0.366, 0.3202, 0.3505, 0.3786, 0.387, 0.3535])
 
         max_diff = numpy_cosine_similarity_distance(expected, images)

--- a/tests/lora/test_lora_layers_sdxl.py
+++ b/tests/lora/test_lora_layers_sdxl.py
@@ -248,7 +248,6 @@ class LoraSDXLIntegrationTests(unittest.TestCase):
         image = pipe(
             "masterpiece, best quality, mountain", generator=generator, num_inference_steps=4, guidance_scale=0.5
         ).images[0]
-        image.save("/root/diffusers/sdxl_lcm_lora.png")
 
         expected_image = load_image(
             "https://huggingface.co/datasets/hf-internal-testing/diffusers-images/resolve/main/lcm_lora/sdxl_lcm_lora.png"
@@ -256,6 +255,7 @@ class LoraSDXLIntegrationTests(unittest.TestCase):
 
         image_np = pipe.image_processor.pil_to_numpy(image)
         expected_image_np = pipe.image_processor.pil_to_numpy(expected_image)
+        expected_image_np = expected_image_np[:, :, :, ::-1]
 
         max_diff = numpy_cosine_similarity_distance(image_np.flatten(), expected_image_np.flatten())
         assert max_diff < 1e-4


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/diffusers/pull/7013/ changed the order of channels in the watermarked which is used in our CI. This led to some assertion failures, as seen here: https://github.com/huggingface/diffusers/actions/runs/8943160603/job/24567270848#step:7:3396. 

For `FAILED tests/lora/test_lora_layers_sdxl.py::LoraSDXLIntegrationTests::test_sdxl_lcm_lora`, I did https://huggingface.co/datasets/hf-internal-testing/diffusers-images/discussions/39. 

Additionally, I fixed the reason why `tests/lora/test_lora_layers_sd.py::StableDiffusionLoRATests::test_integration_move_lora_dora_cpu` was failing. 

Other failing tests are likely because of caching issues. Once that is resolved and if we observe assertion problems, I will fix them as we go. 