### PR TITLE
[Workflows] add a workflow that can be manually triggered on a PR.

### DIFF
--- a/.github/workflows/run_test_from_pr.yml
+++ b/.github/workflows/run_test_from_pr.yml
@@ -1,4 +1,4 @@
-name: Run (SLOW) desired tests on our runner from a PR
+name: Run (SLOW) desired tests on our runner from a PR (applicable to GPUs only at the moment)
 
 on:
   workflow_dispatch:
@@ -36,6 +36,7 @@ jobs:
         run: |
           nvidia-smi
 
+      - uses: actions/checkout@v3
       - name: Install `gh`
         run: | 
             : # see https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt 
@@ -47,10 +48,9 @@ jobs:
             && apt update \
             && apt install gh -y
       
-      - name: Clone diffusers and checkout the PR branch
+      - name: Checkout the PR branch
         run: |
-          git clone https://github.com/huggingface/diffusers
-          cd diffusers && gh pr checkout ${{ github.event.inputs.pr_number }}
+          gh pr checkout ${{ github.event.inputs.pr_number }}
       
       - name: Run tests
         run: ${{ github.event.inputs.test_command }}

--- a/.github/workflows/run_test_from_pr.yml
+++ b/.github/workflows/run_test_from_pr.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Install `gh`
         run: | 
+            : # see https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt 
             (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \
             && mkdir -p -m 755 /etc/apt/keyrings \
             && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \

--- a/.github/workflows/run_test_from_pr.yml
+++ b/.github/workflows/run_test_from_pr.yml
@@ -38,13 +38,13 @@ jobs:
 
       - name: Install `gh`
         run: | 
-            (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-            && sudo mkdir -p -m 755 /etc/apt/keyrings \
-            && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-            && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-            && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-            && sudo apt update \
-            && sudo apt install gh -y
+            (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \
+            && mkdir -p -m 755 /etc/apt/keyrings \
+            && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+            && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+            && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+            && apt update \
+            && apt install gh -y
       
       - name: Clone diffusers and checkout the PR branch
         run: |

--- a/.github/workflows/run_test_from_pr.yml
+++ b/.github/workflows/run_test_from_pr.yml
@@ -1,0 +1,55 @@
+name: Run (SLOW) desired tests on our runner from a PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number: 
+        description: 'PR number'
+        required: true
+      docker_image:
+        default: 'diffusers/diffusers-pytorch-cuda'
+        description: 'Name of the Docker image'
+        required: true
+      test_command:
+        description: 'Test command to run (e.g.: `pytest tests/pipelines/dit/`). Any valid pytest command can be provided.'
+        required: true
+
+env:
+  IS_GITHUB_CI: "1"
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  HF_HOME: /mnt/cache
+  DIFFUSERS_IS_CI: yes
+  OMP_NUM_THREADS: 8
+  MKL_NUM_THREADS: 8
+  RUN_SLOW: yes
+
+jobs:
+  run_tests:
+    name: "Run a test on our runner from a PR"
+    runs-on: [single-gpu, nvidia-gpu, "t4", ci]
+    container:
+      image: ${{ github.event.inputs.docker_image }}
+      options: --gpus all --privileged --ipc host -v /mnt/cache/.cache/huggingface:/mnt/cache/
+
+    steps:
+      - name: NVIDIA-SMI
+        run: |
+          nvidia-smi
+
+      - name: Install `gh`
+        run: | 
+            (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+            && sudo mkdir -p -m 755 /etc/apt/keyrings \
+            && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+            && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+            && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+            && sudo apt update \
+            && sudo apt install gh -y
+      
+      - name: Clone diffusers and checkout the PR branch
+        run: |
+          git clone https://github.com/huggingface/diffusers
+          cd diffusers && gh pr checkout ${{ github.event.inputs.pr_number }}
+      
+      - name: Run tests
+        run: ${{ github.event.inputs.test_command }}


### PR DESCRIPTION
# What does this PR do?

Currently, we manually run the SLOW tests for PRs where applicable to ensure the changed components are robust enough to merge. This is burdensome. 

How about a workflow that we can trigger with a few clicks and run the desired tests within our CI runner?

This PR adds such a workflow.  