### PR TITLE
Use scheduler strength option for set_timesteps

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -181,6 +181,7 @@ def retrieve_timesteps(
     device: Optional[Union[str, torch.device]] = None,
     timesteps: Optional[List[int]] = None,
     sigmas: Optional[List[float]] = None,
+    strength: Optional[float] = None,
     **kwargs,
 ):
     """
@@ -229,7 +230,10 @@ def retrieve_timesteps(
         timesteps = scheduler.timesteps
         num_inference_steps = len(timesteps)
     else:
-        scheduler.set_timesteps(num_inference_steps, device=device, **kwargs)
+        if "strength" in set(inspect.signature(scheduler.set_timesteps).parameters.keys()):
+            scheduler.set_timesteps(num_inference_steps, strength=strength, device=device, **kwargs)
+        else:
+            scheduler.set_timesteps(num_inference_steps, device=device, **kwargs)
         timesteps = scheduler.timesteps
     return timesteps, num_inference_steps
 
@@ -1246,12 +1250,11 @@ class StableDiffusionInpaintPipeline(
             )
 
         # 4. set timesteps
-        timesteps, num_inference_steps = retrieve_timesteps(
-            self.scheduler, num_inference_steps, device, timesteps, sigmas
-        )
-        timesteps, num_inference_steps = self.get_timesteps(
-            num_inference_steps=num_inference_steps, strength=strength, device=device
-        )
+        timesteps, num_inference_steps = retrieve_timesteps(self.scheduler, num_inference_steps, device, timesteps, strength=strength)
+        if "strength" not in set(inspect.signature(self.scheduler.set_timesteps).parameters.keys()):
+            timesteps, num_inference_steps = self.get_timesteps(
+                num_inference_steps=num_inference_steps, strength=strength, device=device
+            )
         # check that number of inference steps is not < 1 - as this doesn't make sense
         if num_inference_steps < 1:
             raise ValueError(

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -271,6 +271,7 @@ def retrieve_timesteps(
     device: Optional[Union[str, torch.device]] = None,
     timesteps: Optional[List[int]] = None,
     sigmas: Optional[List[float]] = None,
+    strength: Optional[float] = None,
     **kwargs,
 ):
     """
@@ -319,7 +320,10 @@ def retrieve_timesteps(
         timesteps = scheduler.timesteps
         num_inference_steps = len(timesteps)
     else:
-        scheduler.set_timesteps(num_inference_steps, device=device, **kwargs)
+        if "strength" in set(inspect.signature(scheduler.set_timesteps).parameters.keys()):
+            scheduler.set_timesteps(num_inference_steps, strength=strength, device=device, **kwargs)
+        else:
+            scheduler.set_timesteps(num_inference_steps, device=device, **kwargs)
         timesteps = scheduler.timesteps
     return timesteps, num_inference_steps
 
@@ -1524,15 +1528,14 @@ class StableDiffusionXLInpaintPipeline(
         def denoising_value_valid(dnv):
             return isinstance(dnv, float) and 0 < dnv < 1
 
-        timesteps, num_inference_steps = retrieve_timesteps(
-            self.scheduler, num_inference_steps, device, timesteps, sigmas
-        )
-        timesteps, num_inference_steps = self.get_timesteps(
-            num_inference_steps,
-            strength,
-            device,
-            denoising_start=self.denoising_start if denoising_value_valid(self.denoising_start) else None,
-        )
+        timesteps, num_inference_steps = retrieve_timesteps(self.scheduler, num_inference_steps, device, timesteps, strength=strength)
+        if "strength" not in set(inspect.signature(self.scheduler.set_timesteps).parameters.keys()):
+            timesteps, num_inference_steps = self.get_timesteps(
+                num_inference_steps,
+                strength,
+                device,
+                denoising_start=self.denoising_start if denoising_value_valid(self.denoising_start) else None,
+            )
         # check that number of inference steps is not < 1 - as this doesn't make sense
         if num_inference_steps < 1:
             raise ValueError(


### PR DESCRIPTION
# Conflicts:
#	src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py #	src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py #	src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py #	src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py

# What does this PR do?

Changes the SD and SDXL pipelines to use the strength parameter of the scheduler when possible

Fixes # (issue)

#7651

## Who can review?

@yiyixuxu @DN6 @sayakpaul 