### PR TITLE
Stable Cascade fix INT8 compression with NNCF

### DIFF
--- a/src/diffusers/pipelines/stable_cascade/pipeline_stable_cascade_prior.py
+++ b/src/diffusers/pipelines/stable_cascade/pipeline_stable_cascade_prior.py
@@ -460,7 +460,10 @@ class StableCascadePriorPipeline(DiffusionPipeline):
 
         # 0. Define commonly used variables
         device = self._execution_device
-        dtype = next(self.prior.parameters()).dtype
+        if getattr(self, "_autocast_dtype", None) is not None:
+            dtype = self._autocast_dtype
+        else:
+            dtype = next(self.prior.parameters()).dtype
         self._guidance_scale = guidance_scale
         if prompt is not None and isinstance(prompt, str):
             batch_size = 1


### PR DESCRIPTION
# What does this PR do?
Fixes NNCF compression with Stable Cascade.

NNCF compresses model weight to 8 bit and reduces the model footprint by half.
Full Stable Cascade model can run with 6-8 GB GPUs using NNCF compression and model cpu offload.


# Fixed Issues:

NNCF compression uses uint8 and Stable Cascade Prior Pipeline tries to use the dtype from the model weights.
This behavior makes it unable to run since most stuff doesn't support Byte types.

This PR checks for uint8 and int8 uses BF16 or FP32 depending on the GPU support.

# Notes

CUDA is using torch.cuda.is_bf16_supported().
IPEX (Intel ARC) is only checking the device since every XPU device does support BF16.

I don't know if there is a way to get the original dtype used before the NNCF compression step.
Current method i implemented ignores the user inputted torch dtype.


# Example use of NNCF compression

```
pip install nncf==2.7.0
```

```py
import copy
import nncf
device = "cuda"

def nncf_compress_model(model):
    return_device = model.device
    model.eval()
    if hasattr(model, "get_input_embeddings"):
        backup_embeddings = copy.deepcopy(model.get_input_embeddings())
    model = nncf.compress_weights(model.to(device)).to(return_device)
    if hasattr(model, "set_input_embeddings"):
        model.set_input_embeddings(backup_embeddings)
    return model

pipe.prior_prior = pipe.prior_pipe.prior = nncf_compress_model(pipe.prior_pipe.prior)
```


# BF16
<details>

![image](https://github.com/huggingface/diffusers/assets/47277141/8b5c472e-b02f-4961-bd92-d5b0dba21273)


</details>

# UINT8
<details>

![image](https://github.com/huggingface/diffusers/assets/47277141/956469b8-b013-4eb0-8157-73ecf2ae94f3)

</details>

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- Pipelines:  @sayakpaul @yiyixuxu @DN6
