### PR TITLE
fix: Attribute error in Logger object (logger.warning)

### DIFF
--- a/src/diffusers/loaders/single_file_utils.py
+++ b/src/diffusers/loaders/single_file_utils.py
@@ -826,8 +826,8 @@ def convert_ldm_unet_checkpoint(checkpoint, config, extract_ema=False, **kwargs)
 
     # at least a 100 parameters have to start with `model_ema` in order for the checkpoint to be EMA
     if sum(k.startswith("model_ema") for k in keys) > 100 and extract_ema:
-        logger.warninging("Checkpoint has both EMA and non-EMA weights.")
-        logger.warninging(
+        logger.warning("Checkpoint has both EMA and non-EMA weights.")
+        logger.warning(
             "In this conversion only the EMA weights are extracted. If you want to instead extract the non-EMA"
             " weights (useful to continue fine-tuning), please make sure to remove the `--extract_ema` flag."
         )
@@ -837,7 +837,7 @@ def convert_ldm_unet_checkpoint(checkpoint, config, extract_ema=False, **kwargs)
                 unet_state_dict[key.replace(unet_key, "")] = checkpoint.get(flat_ema_key)
     else:
         if sum(k.startswith("model_ema") for k in keys) > 100:
-            logger.warninging(
+            logger.warning(
                 "In this conversion only the non-EMA weights are extracted. If you want to instead extract the EMA"
                 " weights (usually better for inference), please make sure to add the `--extract_ema` flag."
             )


### PR DESCRIPTION
# This PR fixes a minor spelling error in the logger object. The traceback is as follows: 

Traceback (most recent call last):
  File "/workspace/hbot-backend-anime/src/main.py", line 7, in <module>
    from core import generate_anime_image
  File "/workspace/hbot-backend-anime/src/core.py", line 18, in <module>
    pipe = StableDiffusionPipeline.from_single_file("./anime/anyhentai.safetensors", torch_dtype=torch.float16, safety_checker=None,text_encoder=text_encoder)
  File "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/diffusers/loaders/single_file.py", line 491, in from_single_file
    loaded_sub_model = load_single_file_sub_model(
  File "/usr/local/lib/python3.10/dist-packages/diffusers/loaders/single_file.py", line 100, in load_single_file_sub_model
    loaded_sub_model = load_method(
  File "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/diffusers/loaders/single_file_model.py", line 260, in from_single_file
    diffusers_format_checkpoint = checkpoint_mapping_fn(
  File "/usr/local/lib/python3.10/dist-packages/diffusers/loaders/single_file_utils.py", line 840, in convert_ldm_unet_checkpoint
    logger.warninging(
AttributeError: 'Logger' object has no attribute 'warninging'. Did you mean: 'warning'?


<!-- Remove if not applicable -->

Fixes #8182 
@sayakpaul @yiyixuxu @DN6

