### PR TITLE
[LoRA] attempt at fixing onetrainer lora.

### DIFF
--- a/src/diffusers/loaders/lora.py
+++ b/src/diffusers/loaders/lora.py
@@ -597,6 +597,11 @@ class LoraLoaderMixin:
                         if is_peft_version("<", "0.9.0"):
                             lora_config_kwargs.pop("use_dora")
                 lora_config = LoraConfig(**lora_config_kwargs)
+                target_modules = lora_config_kwargs.get("target_modules")
+                print(f"{target_modules[:5]=}")
+                for k in target_modules:
+                    if "projection" in k:
+                        print(f"From load_lora_into_text_encoder: {k}")
 
                 # adapter_name
                 if adapter_name is None:

--- a/src/diffusers/loaders/lora.py
+++ b/src/diffusers/loaders/lora.py
@@ -597,11 +597,6 @@ class LoraLoaderMixin:
                         if is_peft_version("<", "0.9.0"):
                             lora_config_kwargs.pop("use_dora")
                 lora_config = LoraConfig(**lora_config_kwargs)
-                target_modules = lora_config_kwargs.get("target_modules")
-                print(f"{target_modules[:5]=}")
-                for k in target_modules:
-                    if "projection" in k:
-                        print(f"From load_lora_into_text_encoder: {k}")
 
                 # adapter_name
                 if adapter_name is None:

--- a/src/diffusers/loaders/lora_conversion_utils.py
+++ b/src/diffusers/loaders/lora_conversion_utils.py
@@ -247,7 +247,6 @@ def _convert_kohya_lora_to_diffusers(state_dict, unet_name="unet", text_encoder_
                     te2_state_dict[diffusers_name.replace(".down.", ".up.")] = state_dict.pop(lora_name_up)
             # OneTrainer specificity
             elif "text_projection" in diffusers_name and lora_name.startswith("lora_te2_"):
-                print(f"{diffusers_name=}, {key=}")
                 te2_state_dict[diffusers_name] = state_dict.pop(key)
                 te2_state_dict[diffusers_name.replace(".down.", ".up.")] = state_dict.pop(lora_name_up)
 
@@ -277,7 +276,7 @@ def _convert_kohya_lora_to_diffusers(state_dict, unet_name="unet", text_encoder_
             network_alphas.update({new_name: alpha})
 
     if len(state_dict) > 0:
-        raise ValueError(f"The following keys have not been correctly be renamed: \n\n {', '.join(state_dict.keys())}")
+        raise ValueError(f"The following keys have not been correctly renamed: \n\n {', '.join(state_dict.keys())}")
 
     logger.info("Kohya-style checkpoint detected.")
     unet_state_dict = {f"{unet_name}.{module_name}": params for module_name, params in unet_state_dict.items()}

--- a/src/diffusers/loaders/lora_conversion_utils.py
+++ b/src/diffusers/loaders/lora_conversion_utils.py
@@ -226,6 +226,8 @@ def _convert_kohya_lora_to_diffusers(state_dict, unet_name="unet", text_encoder_
             diffusers_name = diffusers_name.replace("k.proj.lora", "to_k_lora")
             diffusers_name = diffusers_name.replace("v.proj.lora", "to_v_lora")
             diffusers_name = diffusers_name.replace("out.proj.lora", "to_out_lora")
+            diffusers_name = diffusers_name.replace("text.projection", "text_projection")
+
             if "self_attn" in diffusers_name:
                 if lora_name.startswith(("lora_te_", "lora_te1_")):
                     te_state_dict[diffusers_name] = state_dict.pop(key)
@@ -243,6 +245,11 @@ def _convert_kohya_lora_to_diffusers(state_dict, unet_name="unet", text_encoder_
                 else:
                     te2_state_dict[diffusers_name] = state_dict.pop(key)
                     te2_state_dict[diffusers_name.replace(".down.", ".up.")] = state_dict.pop(lora_name_up)
+            # OneTrainer specificity
+            elif "text_projection" in diffusers_name and lora_name.startswith("lora_te2_"):
+                print(f"{diffusers_name=}, {key=}")
+                te2_state_dict[diffusers_name] = state_dict.pop(key)
+                te2_state_dict[diffusers_name.replace(".down.", ".up.")] = state_dict.pop(lora_name_up)
 
             if (is_te_dora_lora or is_te2_dora_lora) and lora_name.startswith(("lora_te_", "lora_te1_", "lora_te2_")):
                 dora_scale_key_to_replace_te = (

--- a/src/diffusers/utils/state_dict_utils.py
+++ b/src/diffusers/utils/state_dict_utils.py
@@ -62,6 +62,8 @@ DIFFUSERS_TO_PEFT = {
     ".out_proj.lora_linear_layer.down": ".out_proj.lora_A",
     ".lora_linear_layer.up": ".lora_B",
     ".lora_linear_layer.down": ".lora_A",
+    "text_projection.lora.down.weight": "text_projection.lora_A.weight",
+    "text_projection.lora.up.weight": "text_projection.lora_B.weight",
 }
 
 DIFFUSERS_OLD_TO_PEFT = {


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/diffusers/issues/8237.

```python
from diffusers import DiffusionPipeline
import torch

pipe_id = "stabilityai/stable-diffusion-xl-base-1.0"
pipe = DiffusionPipeline.from_pretrained(pipe_id, torch_dtype=torch.float16).to("cuda")
pipe.load_lora_weights("sayakpaul/diffusers-8237-lora", weight_name="lora.safetensors", adapter_name="engraving")

lora_scale= 0.9
prompt = "Engravings Henri Meyer"
image = pipe(
    prompt, num_inference_steps=30, cross_attention_kwargs={"scale": lora_scale}, generator=torch.manual_seed(0)
).images[0]
image
```

@BenjaminBossan I am seeing some unexpected warnings when running the above:

```bash
Loading adapter weights from None led to unexpected keys not found in the model:  ['text_projection.lora.down.weight', 'text_projection.lora.up.weight']. 
```

I have intentionally left some print statements for us to debug things in an easier manner. Here are the logs in an ordered fashion:

```bash
diffusers_name='text_projection.lora.down.weight', key='lora_te2_text_projection.lora_down.weight'

target_modules[:5]=['text_model.encoder.layers.3.self_attn.out_proj', 'text_model.encoder.layers.11.self_attn.v_proj', 'text_model.encoder.layers.6.self_attn.k_proj', 'text_model.encoder.layers.7.self_attn.k_proj', 'text_model.encoder.layers.6.mlp.fc1']

target_modules[:5]=['text_model.encoder.layers.16.mlp.fc1', 'text_model.encoder.layers.11.self_attn.v_proj', 'text_model.encoder.layers.7.self_attn.k_proj', 'text_model.encoder.layers.21.self_attn.v_proj', 'text_model.encoder.layers.26.mlp.fc2']

From load_lora_into_text_encoder: text_projection

Loading adapter weights from None led to unexpected keys not found in the model:  ['text_projection.lora.down.weight', 'text_projection.lora.up.weight'].
```

I am on `peft` 0.11.1 and `diffusers` from the latest `main`. What am I missing here? 