### PR TITLE
Fix object has no attribute 'flush' when using without a console

### DIFF
--- a/src/diffusers/utils/logging.py
+++ b/src/diffusers/utils/logging.py
@@ -82,7 +82,9 @@ def _configure_library_root_logger() -> None:
             # This library has already configured the library root logger.
             return
         _default_handler = logging.StreamHandler()  # Set sys.stderr as stream.
-        _default_handler.flush = sys.stderr.flush
+
+        if sys.stderr:  # only if sys.stderr exists, e.g. when not using pythonw in windows
+            _default_handler.flush = sys.stderr.flush
 
         # Apply our default configuration to the library root logger.
         library_root_logger = _get_library_root_logger()


### PR DESCRIPTION
# What does this PR do?

Fix a recurring problem when using diffusers without console, e.g. using `pythonw.exe` in windows, since there's no `sys.stderr`.

I can make a more advanced solution like using a `FileHandler` instead if there's no `sys.stderr` but don't know if it's worth the effort here. Users should implement their own error handling for this.

Fixes #3290

## Who can review?
@sayakpaul @yiyixuxu @DN6
