### PR TITLE
fix(training): lr scheduler doesn't work properly in distributed scenarios

### DIFF
--- a/examples/text_to_image/train_text_to_image_lora.py
+++ b/examples/text_to_image/train_text_to_image_lora.py
@@ -697,17 +697,22 @@ def main():
     )
 
     # Scheduler and math around the number of training steps.
-    overrode_max_train_steps = False
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    # Check the PR https://github.com/huggingface/diffusers/pull/8312 for detailed explanation.
+    num_warmup_steps_for_scheduler = args.lr_warmup_steps * accelerator.num_processes
     if args.max_train_steps is None:
-        args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
-        overrode_max_train_steps = True
+        len_train_dataloader_after_sharding = math.ceil(len(train_dataloader) / accelerator.num_processes)
+        num_update_steps_per_epoch = math.ceil(len_train_dataloader_after_sharding / args.gradient_accumulation_steps)
+        num_training_steps_for_scheduler = (
+            args.num_train_epochs * num_update_steps_per_epoch * accelerator.num_processes
+        )
+    else:
+        num_training_steps_for_scheduler = args.max_train_steps * accelerator.num_processes
 
     lr_scheduler = get_scheduler(
         args.lr_scheduler,
         optimizer=optimizer,
-        num_warmup_steps=args.lr_warmup_steps * accelerator.num_processes,
-        num_training_steps=args.max_train_steps * accelerator.num_processes,
+        num_warmup_steps=num_warmup_steps_for_scheduler,
+        num_training_steps=num_training_steps_for_scheduler,
     )
 
     # Prepare everything with our `accelerator`.
@@ -717,8 +722,14 @@ def main():
 
     # We need to recalculate our total training steps as the size of the training dataloader may have changed.
     num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
-    if overrode_max_train_steps:
+    if args.max_train_steps is None:
         args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
+        if num_training_steps_for_scheduler != args.max_train_steps * accelerator.num_processes:
+            logger.warning(
+                f"The length of the 'train_dataloader' after 'accelerator.prepare' ({len(train_dataloader)}) does not match "
+                f"the expected length ({len_train_dataloader_after_sharding}) when the learning rate scheduler was created. "
+                f"This inconsistency may result in the learning rate scheduler not functioning properly."
+            )
     # Afterwards we recalculate our number of training epochs
     args.num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
 


### PR DESCRIPTION
# What does this PR do?

### TL;DR

In a distributed training scenario, passing the argument `--num_train_epochs` to any of the training scripts disrupts the functioning of the learning rate scheduler. Essentially, the learning rate decays `num_processes` times slower than expected. Related issues #8236, #3954, and PR #3983 shed further light on this.

### Explanation

In our training setup, we utilize `accelerator` instead of PyTorch's native [DistributedSampler](https://pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler) when creating the `train_dataloader`. This means we create the `train_dataloader` directly as if for standalone training and subsequently employ `accelerator.prepare` to shard the samples across different processes.

When referencing `step` in training scripts such as `lr_warmup_steps`, `max_train_steps`, etc., we're indicating the  optimizing step. In essence, each step consumes `num_processes * gradient_accumulation_steps` batches of data. In the script, the learning rate scheduler is initialized before `accelerator.prepare` is called. At this stage, the `train_dataloader` hasn't yet sharded the samples, specifically the batched samples.

To accurately calculate `num_update_steps_per_epoch`, we need the length of the `train_dataloader` after distributed sharding. How do we achieve this? Typically, `accelerator.prepare` replaces `train_dataloader.batch_sampler` with [BatchSamplerShard](https://github.com/huggingface/accelerate/blob/b24a0ef5dbb4e0408074f92f84683608eab474af/src/accelerate/data_loader.py#L100). The length of the distributed sharded `train_dataloader` (still a [DataLoader](https://github.com/pytorch/pytorch/blob/92bc444ee32f578ee9ebc2ecb76b283881f806a8/torch/utils/data/dataloader.py#L124) instance) becomes the length of `BatchSamplerShard`. Hence, we derive a formula for estimating the length of the sharded `train_dataloader`, which aligns with current training scripts (where `accelerator.prepare` is called with no extra arguments).

As per `accelerator` principles, the **_prepared_** scheduler calls the `step()` of the **_unprepared_** scheduler `num_processes` times at each optimizing step (once gradient accumulation is completed). This necessitates dividing `num_*_steps_for_scheduler` by `gradient_accumulation_steps` and multiplying it by `num_processes`.

Feeling a bit confused? Not to worry, let's visualize it.

### Experiments

We utilize [Fine-tuning for text2image with LoRA](https://github.com/huggingface/diffusers/blob/main/examples/text_to_image/train_text_to_image_lora.py) as an example. Below is the training command:

```bash
export MODEL_NAME="CompVis/stable-diffusion-v1-4"
export DATASET_NAME="lambdalabs/naruto-blip-captions"

# Example of --num_train_epochs
accelerate launch examples/text_to_image/train_text_to_image_lora.py \
  --pretrained_model_name_or_path=$MODEL_NAME \
  --dataset_name=$DATASET_NAME \
  --resolution=128 --random_flip --max_train_samples=171 \
  --train_batch_size=4 \
  --num_train_epochs=6 \
  --learning_rate=1e-04 --lr_scheduler="cosine_with_restarts" --lr_warmup_steps=3 \
  --gradient_accumulation_steps=5 \
  --seed=42 \
  --output_dir="sd-pokemon-model-lora-epoch"

# Example of --max_train_steps
accelerate launch examples/text_to_image/train_text_to_image_lora.py \
  --pretrained_model_name_or_path=$MODEL_NAME \
  --dataset_name=$DATASET_NAME \
  --resolution=128 --random_flip --max_train_samples=171 \
  --train_batch_size=4 \
  --max_train_steps=30 \
  --learning_rate=1e-04 --lr_scheduler="cosine_with_restarts" --lr_warmup_steps=3 \
  --gradient_accumulation_steps=5 \
  --seed=42 \
  --output_dir="sd-pokemon-model-lora-step"
```

The hyper-parameters are:

- Batch size: 4
- Number of processes (n_gpus): 2
- Dataset length: 171
- Gradient accumulation steps: 5

Thus,
```python
len_dataloader_standalone = ceil(171/4) = 43
len_dataloader_distribute = ceil(43/2) = 22
num_update_steps_per_epoch = ceil(22/5) = 5
```
And `epochs=6` is equivalent to `steps=30`.

Additionally, introducing the argument `num_cycles=2` to the function `get_scheduler` exacerbates the error.

#### Before the PR
`--num_train_epochs`
<img width="1088" alt="截屏2024-05-29 18 32 08" src="https://github.com/huggingface/diffusers/assets/74176172/fd2179e4-0e39-4ab2-9401-a1c06088ecca">

`--max_train_steps`
<img width="1088" alt="截屏2024-05-29 18 34 14" src="https://github.com/huggingface/diffusers/assets/74176172/df5589aa-7480-4c92-8001-2e0335598b0e">

#### After the PR
`--num_train_epochs`
<img width="1088" alt="截屏2024-05-29 18 34 26" src="https://github.com/huggingface/diffusers/assets/74176172/862f8dc6-9e7e-4edc-8771-89b55e038a93">

`--max_train_steps`
<img width="1088" alt="截屏2024-05-29 18 34 40" src="https://github.com/huggingface/diffusers/assets/74176172/dabdf649-aec3-4980-b85c-89e013be4fd6">

Fixes #8236

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul @eliphatfs