### PR TITLE
fix compatability issue between PAG and IP-adapter

### DIFF
--- a/src/diffusers/loaders/unet.py
+++ b/src/diffusers/loaders/unet.py
@@ -928,9 +928,7 @@ class UNet2DConditionLoadersMixin:
                 hidden_size = self.config.block_out_channels[block_id]
 
             if cross_attention_dim is None or "motion_modules" in name:
-                attn_processor_class = (
-                    AttnProcessor2_0 if hasattr(F, "scaled_dot_product_attention") else AttnProcessor
-                )
+                attn_processor_class = self.attn_processors[name].__class__
                 attn_procs[name] = attn_processor_class()
 
             else:

--- a/src/diffusers/pipelines/pag_utils.py
+++ b/src/diffusers/pipelines/pag_utils.py
@@ -45,7 +45,7 @@ class PAGMixin:
         self._pag_applied_layers = pag_applied_layers
         self._pag_applied_layers_index = pag_applied_layers_index
         self._pag_cfg = pag_cfg
-
+        self._is_pag_enabled = True
         self._set_pag_attn_processor()
 
     def _get_self_attn_layers(self):
@@ -180,6 +180,7 @@ class PAGMixin:
         self._pag_applied_layers = None
         self._pag_applied_layers_index = None
         self._pag_cfg = None
+        self._is_pag_enabled = False
 
     @property
     def pag_adaptive_scaling(self):
@@ -191,4 +192,4 @@ class PAGMixin:
 
     @property
     def do_perturbed_attention_guidance(self):
-        return hasattr(self, "_pag_scale") and self._pag_scale is not None and self._pag_scale > 0
+        return self._is_pag_enabled

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -1172,6 +1172,10 @@ class StableDiffusionXLPipeline(
                 self.do_classifier_free_guidance,
             )
 
+        # expand the image embeddings if we are using perturbed-attention guidance
+        for i in range(len(image_embeds)):
+            image_embeds[i] = image_embeds[i].repeat(prompt_embeds.shape[0] // latents.shape[0], 1, 1)
+
         # 8. Denoising loop
         num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
 
@@ -1205,7 +1209,7 @@ class StableDiffusionXLPipeline(
                 if self.interrupt:
                     continue
 
-                # expand the latents if we are doing classifier free guidance
+                # expand the latents if we are doing classifier free guidance, perturbed-attention guidance, or both
                 latent_model_input = torch.cat([latents] * (prompt_embeds.shape[0] // latents.shape[0]))
 
                 latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)


### PR DESCRIPTION
## What does this PR do?

I fixed the IP-adapter compatibility issue of the proposed [PAG Mixin](https://github.com/huggingface/diffusers/pull/7944).

First, I found that `load_ip_adapter` overwrites the loaded `PAGIdentitySelfAttnProcessor2_0` with `AttnProcessor` or `AttnProcessor2_0` (see `uent.py`). So, I changed the code to keep the original processor if it is not a cross-attention processor.

Second, I also found that even if I use PAG only (not using CFG), the image embeddings of the IP-adapter are only applied to one of `noise_pred_uncond` or `noise_pred_perturb` (I can't remember the exact variable 😭). I checked this by changing `_apply_perturbed_attention_guidance` in `pag_utils.py` line 133 to use only `noise_pred_uncond` or `noise_pred_perturb`. If I do not use classifier-free guidance, the results should be the same, but the final results are completely different: one has the image condition applied, and the other does not. So, I copied `image_embeds` in `pipeline_stable_diffusion_xl.py` similar to how latents are copied when using CFG (`latent_model_input = torch.cat([latents] * (prompt_embeds.shape[0] // latents.shape[0]))`). I'm not sure this is the right approach because I couldn't identify the exact location where `image_embeds` are only applied to single latents.

Finally, I changed `do_perturbed_attention_guidance` of `PAGMixin` to work consistently even when `pag_scale` is 0. This is because if we use `enable_pag(...)`, the attention processor is changed to `PAGIdentitySelfAttnProcessor2_0` even though `pag_scale` is 0. This causes errors when a single latent passes through `PAGIdentitySelfAttnProcessor2_0`, which expects copied and concatenated latents.

## Example code and results
I attached the example code and the results. In the grid image, the IP adapter scale increases to the right, and the PAG scale increases downward.

IP-adapter + PAG (without CFG)
```
from diffusers import AutoPipelineForText2Image
from diffusers.utils import load_image
import torch

pipeline = AutoPipelineForText2Image.from_pretrained("stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float16).to("cuda")

pag_scales = [0.0, 1.5, 3.0, 5.0, 7.0]
ip_adapter_scales = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]

image = load_image("https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/ip_adapter_diner.png")
grid = []
for pag_scale in pag_scales:
    for ip_adapter_scale in ip_adapter_scales:
        pipeline.enable_pag(pag_scale=pag_scale, pag_applied_layers=["mid"], pag_cfg=False)
        pipeline.load_ip_adapter("h94/IP-Adapter", subfolder="sdxl_models", weight_name="ip-adapter_sdxl.bin")
        pipeline.set_ip_adapter_scale(ip_adapter_scale)

        generator = torch.Generator(device="cpu").manual_seed(0)
        images = pipeline(
            prompt="a polar bear sitting in a chair drinking a milkshake",
            ip_adapter_image=image,
            negative_prompt="deformed, ugly, wrong proportion, low res, bad anatomy, worst quality, low quality",
            num_inference_steps=25,
            guidance_scale=0,
            generator=generator,
        ).images
        images[0]

        grid.append(images[0])
        pipeline.disable_pag()

# save the grid
from diffusers.utils import make_image_grid
make_image_grid(grid, rows=len(pag_scales), cols=len(ip_adapter_scales)).save("finally.png")
```
![showcase_nocfg](https://github.com/huggingface/diffusers/assets/13927747/7e30f789-3380-4ecd-8c33-143b80db172f)

IP-adapter + PAG (with CFG)
```
from diffusers import AutoPipelineForText2Image
from diffusers.utils import load_image
import torch

pipeline = AutoPipelineForText2Image.from_pretrained("stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float16).to("cuda")

pag_scales = [0.0, 1.5, 3.0, 5.0, 7.0]
ip_adapter_scales = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]

image = load_image("https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/ip_adapter_diner.png")
grid = []
for pag_scale in pag_scales:
    for ip_adapter_scale in ip_adapter_scales:
        pipeline.enable_pag(pag_scale=pag_scale, pag_applied_layers=["mid"], pag_cfg=True)
        pipeline.load_ip_adapter("h94/IP-Adapter", subfolder="sdxl_models", weight_name="ip-adapter_sdxl.bin")
        pipeline.set_ip_adapter_scale(ip_adapter_scale)

        generator = torch.Generator(device="cpu").manual_seed(0)
        images = pipeline(
            prompt="a polar bear sitting in a chair drinking a milkshake",
            ip_adapter_image=image,
            negative_prompt="deformed, ugly, wrong proportion, low res, bad anatomy, worst quality, low quality",
            num_inference_steps=25,
            guidance_scale=3.0,
            generator=generator,
        ).images
        images[0]

        grid.append(images[0])
        pipeline.disable_pag()

# save the grid
from diffusers.utils import make_image_grid
make_image_grid(grid, rows=len(pag_scales), cols=len(ip_adapter_scales)).save("finally.png")
```
![showcase_cfg](https://github.com/huggingface/diffusers/assets/13927747/9da65f45-2e03-4c7d-a5a0-701d4e22e788)

In my opinion, using PAG reduces artifacts and improves the overall composition both with and without CFG. It is very encouraging to see that PAG works well with the IP-adapter.