### PR TITLE
[Hunyuan] allow Hunyuan DiT to run under 6GB for GPU VRAM

### DIFF
--- a/docs/source/en/api/pipelines/hunyuandit.md
+++ b/docs/source/en/api/pipelines/hunyuandit.md
@@ -29,6 +29,10 @@ HunyuanDiT has the following components:
 * It combines two text encoders, a bilingual CLIP and a multilingual T5 encoder
 
 
+## Memory optimization
+
+By loading the T5 text encoder in 8 bits, you can run the pipeline in just under 6 GBs of GPU VRAM. Refer to [this script](https://gist.github.com/sayakpaul/3154605f6af05b98a41081aaba5ca43e) for details. 
+
 ## HunyuanDiTPipeline
 
 [[autodoc]] HunyuanDiTPipeline


### PR DESCRIPTION
# What does this PR do?

This PR adds the changes necessary to help run Hunyuan DiT under 6GB for GPU VRAM. 

Code:

```python
from diffusers import HunyuanDiTPipeline
from transformers import T5EncoderModel
import torch 
import gc 


def flush():
    gc.collect()
    torch.cuda.empty_cache()

def bytes_to_giga_bytes(bytes):
    return bytes / 1024 / 1024 / 1024


id = "Tencent-Hunyuan/HunyuanDiT-Diffusers"
text_encoder_2 = T5EncoderModel.from_pretrained(
    id,
    subfolder="text_encoder_2",
    load_in_8bit=True,
    device_map="auto",
)
pipeline = HunyuanDiTPipeline.from_pretrained(
    id, 
    text_encoder_2=text_encoder_2,
    transformer=None,
    vae=None,
    torch_dtype=torch.float16,
    device_map="balanced",
)

with torch.no_grad():
    prompt = "一个宇航员在骑马"
    prompt_embeds, negative_prompt_embeds, prompt_attention_mask, negative_prompt_attention_mask = pipeline.encode_prompt(prompt)
    (
        prompt_embeds_2,
        negative_prompt_embeds_2,
        prompt_attention_mask_2,
        negative_prompt_attention_mask_2,
    ) = pipeline.encode_prompt(
        prompt=prompt,
        negative_prompt=None,
        prompt_embeds=None,
        negative_prompt_embeds=None,
        prompt_attention_mask=None,
        negative_prompt_attention_mask=None,
        max_sequence_length=256,
        text_encoder_index=1,
    )


del text_encoder_2
del pipeline
flush()

pipe = HunyuanDiTPipeline.from_pretrained(
    id,
    text_encoder=None,
    text_encoder_2=None,
    torch_dtype=torch.float16,
).to("cuda")

image = pipe(
    negative_prompt=None, 
    prompt_embeds=prompt_embeds,
    prompt_embeds_2=prompt_embeds_2,
    negative_prompt_embeds=negative_prompt_embeds,
    negative_prompt_embeds_2=negative_prompt_embeds_2,
    prompt_attention_mask=prompt_attention_mask,
    prompt_attention_mask_2=prompt_attention_mask_2,
    negative_prompt_attention_mask=negative_prompt_attention_mask,
    negative_prompt_attention_mask_2=negative_prompt_attention_mask_2,
    num_images_per_prompt=1,
).images[0]

print(
    f"Max memory allocated: {bytes_to_giga_bytes(torch.cuda.max_memory_allocated())} GB"
)
image.save("memory_optimized.png")
```

Result:
![memory_optimized](https://github.com/huggingface/diffusers/assets/22957388/be6c06bf-fa1f-4e14-969c-13811423e2ba)

Once I have an initial approval, I will add documentation for it. 

Cc: @gnobitab 
