### PR TITLE
add conv_in_channels in def save_motion_modules

### DIFF
--- a/src/diffusers/models/unets/unet_motion_model.py
+++ b/src/diffusers/models/unets/unet_motion_model.py
@@ -613,6 +613,7 @@ class UNetMotionModel(ModelMixin, ConfigMixin, UNet2DConditionLoadersMixin):
             motion_num_attention_heads=self.config["motion_num_attention_heads"],
             motion_max_seq_length=self.config["motion_max_seq_length"],
             use_motion_mid_block=self.config["use_motion_mid_block"],
+            conv_in_channels=self.config["conv_in_channels"],
         )
         adapter.load_state_dict(motion_state_dict)
         adapter.save_pretrained(


### PR DESCRIPTION


# What does this PR do?

In [save_motion_modules](https://github.com/huggingface/diffusers/blob/7ebd359446c2cb31bfbbbd98046cd916de8bdc7b/src/diffusers/models/unets/unet_motion_model.py#L592), current implementation doesn't pass `conv_in_channels` to the MotionAdapter constructor. This would incorrectly result into `"conv_in_channels": null` in the saved `config.json`, disregarding the actual `conv_in_channels`. This commit fixes the issue.

**However, more actions may be required.**

If a instance is constructed from `from_unet2d` with a `motion_adapter`, one can simply copy `motion_adapter.config` to the `UNetMotionModel` instance ([like this](https://github.com/huggingface/diffusers/blob/7ebd359446c2cb31bfbbbd98046cd916de8bdc7b/src/diffusers/models/unets/unet_motion_model.py#L464-L471)) and use the config to construct the [MotionAdapter instance](https://github.com/huggingface/diffusers/blob/7ebd359446c2cb31bfbbbd98046cd916de8bdc7b/src/diffusers/models/unets/unet_motion_model.py#L609) to be saved.

If an instance is **NOT** constructed from `from_unet2d`, there has to be a way to identify the correct config that describes the motion_adapter in the instance, but it is beyond my bandwidth for the moment.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu 
- Pipelines:  @sayakpaul @yiyixuxu @DN6
- Training examples: @sayakpaul 
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @pacman100

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
