### PR TITLE
Fix mirror_community_pipeline.yml name

### DIFF
--- a/.github/workflows/mirror_community_pipeline.yml
+++ b/.github/workflows/mirror_community_pipeline.yml
@@ -1,4 +1,4 @@
-name: Fast tests for PRs
+name: Mirror Community Pipeline
 
 on:
   # Push changes on the main branch


### PR DESCRIPTION
Merged https://github.com/huggingface/diffusers/pull/8417 without noticing. This PR updates the workflow name.