### PR TITLE
Fix `PATH_IN_REPO` on new release in mirror_community_pipeline.yaml 

### DIFF
--- a/.github/workflows/mirror_community_pipeline.yml
+++ b/.github/workflows/mirror_community_pipeline.yml
@@ -54,7 +54,7 @@ jobs:
           else
             # e.g. refs/tags/v0.28.1 -> v0.28.1
             echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
-            echo "PATH_IN_REPO=${${{ github.ref }}#refs/tags/}" >> $GITHUB_ENV
+            echo "PATH_IN_REPO=$(echo ${{ github.ref }} | sed 's/^refs\/tags\///')" >> $GITHUB_ENV
           fi
       - name: Print env vars
         run: |


### PR DESCRIPTION
Follow-up PR after https://github.com/huggingface/diffusers/pull/8417.

When `github.ref` is a tag (e.g. `refs/tags/v0.29.0`), the logic to determine `PATH_IN_REPO` (e.g. `v0.29.0`) is incorrect. See [example](https://github.com/huggingface/diffusers/actions/runs/9489094498/job/26149588467) where files have been hosted at the root of the folder. This PR fixes this. Sorry about that, I did not realize how github action inject values in the bash command. This time I tested it properly and it should work correctly.


**EDIT:** in parallel I also opened a PR to clean the mess in the dataset repo: https://huggingface.co/datasets/diffusers/community-pipelines-mirror/discussions/2

**EDIT 2:**:  I also triggered a manual deployment to correctly push `v0.29.0` (see [CI](https://github.com/huggingface/diffusers/actions/runs/9495944132/job/26169275902)) . Files have correctly been uploaded to `v0.29.0/` folder: https://huggingface.co/datasets/diffusers/community-pipelines-mirror/tree/main/v0.29.0