### PR TITLE
pin transformers to the latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ _deps = [
     "tensorboard",
     "torch>=1.4",
     "torchvision",
-    "transformers>=4.25.1",
+    "transformers>=4.41.2",
     "urllib3<=2.0.0",
     "black",
 ]


### PR DESCRIPTION
# What does this PR do?

Related to https://github.com/huggingface/diffusers/issues/8495. 

Upgrading `diffusers` should also upgrade `transformers` and in turn upgrade `tokenizers`. 