### PR TITLE
sentencepiece was missing in requirements_sd3.txt

### DIFF
--- a/examples/dreambooth/requirements_sd3.txt
+++ b/examples/dreambooth/requirements_sd3.txt
@@ -5,3 +5,4 @@ ftfy
 tensorboard
 Jinja2
 peft== 0.11.1
+sentencepiece==0.2.0


### PR DESCRIPTION
sentencepiece package is missing, because of this giving this error while running the train_dreambooth_sd3.py. this PR just add this package into requirements_sd3.txt

The Error:

Traceback (most recent call last):
  File "/home/harshb/workspace/ml-dev/sd3/diffusers/examples/dreambooth/train_dreambooth_sd3.py", line 1760, in <module>
    main(args)
  File "/home/harshb/workspace/ml-dev/sd3/diffusers/examples/dreambooth/train_dreambooth_sd3.py", line 1058, in main
    tokenizer_three = T5TokenizerFast.from_pretrained(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/harshb/miniconda3/envs/sd3/lib/python3.11/site-packages/transformers/tokenization_utils_base.py", line 2110, in from_pretrained
    return cls._from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/harshb/miniconda3/envs/sd3/lib/python3.11/site-packages/transformers/tokenization_utils_base.py", line 2336, in _from_pretrained
    tokenizer = cls(*init_inputs, **init_kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/harshb/miniconda3/envs/sd3/lib/python3.11/site-packages/transformers/models/t5/tokenization_t5_fast.py", line 120, in __init__
    super().__init__(
  File "/home/harshb/miniconda3/envs/sd3/lib/python3.11/site-packages/transformers/tokenization_utils_fast.py", line 105, in __init__
    raise ValueError(
ValueError: Cannot instantiate this tokenizer from a slow version. If it's based on sentencepiece, make sure you have sentencepiece installed.
Traceback (most recent call last):
  File "/home/harshb/miniconda3/envs/sd3/bin/accelerate", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/harshb/miniconda3/envs/sd3/lib/python3.11/site-packages/accelerate/commands/accelerate_cli.py", line 48, in main
    args.func(args)
  File "/home/harshb/miniconda3/envs/sd3/lib/python3.11/site-packages/accelerate/commands/launch.py", line 1097, in launch_command
    simple_launcher(args)
  File "/home/harshb/miniconda3/envs/sd3/lib/python3.11/site-packages/accelerate/commands/launch.py", line 703, in simple_launcher
    raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)



@sayakpaul @yiyixuxu


