### PR TITLE
add `sentencepiece` to requirements.txt for SD3 dreambooth

### DIFF
--- a/examples/dreambooth/requirements_sd3.txt
+++ b/examples/dreambooth/requirements_sd3.txt
@@ -5,3 +5,4 @@ ftfy
 tensorboard
 Jinja2
 peft== 0.11.1
+sentencepiece


### PR DESCRIPTION
add `sentencepiece` to requirements.txt for SD3 dreambooth

# What does this PR do?

sd3 dreambooth requires `sentencepiece` but it's not in the requirements.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul
