### PR TITLE
Fix gradient checkpointing issue for Stable Diffusion 3

### DIFF
--- a/src/diffusers/models/transformers/transformer_sd3.py
+++ b/src/diffusers/models/transformers/transformer_sd3.py
@@ -306,7 +306,7 @@ class SD3Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
                     return custom_forward
 
                 ckpt_kwargs: Dict[str, Any] = {"use_reentrant": False} if is_torch_version(">=", "1.11.0") else {}
-                hidden_states = torch.utils.checkpoint.checkpoint(
+                encoder_hidden_states, hidden_states = torch.utils.checkpoint.checkpoint(
                     create_custom_forward(block),
                     hidden_states,
                     encoder_hidden_states,


### PR DESCRIPTION
When gradient checkpointing is enabled for SD3, in the example dreambooth script with default arguments, various modules fail with "expected Tensor, not tuple". This is because the gradient checkpointing codepath doesn't deconstruct the hidden states tuple. This fixes that issue.

@sayakpaul
