### PR TITLE
Fixed a return value handling bug for SD3 transformer blocks during training

### DIFF
--- a/src/diffusers/models/transformers/transformer_sd3.py
+++ b/src/diffusers/models/transformers/transformer_sd3.py
@@ -306,7 +306,7 @@ class SD3Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
                     return custom_forward
 
                 ckpt_kwargs: Dict[str, Any] = {"use_reentrant": False} if is_torch_version(">=", "1.11.0") else {}
-                hidden_states = torch.utils.checkpoint.checkpoint(
+                encoder_hidden_states, hidden_states = torch.utils.checkpoint.checkpoint(
                     create_custom_forward(block),
                     hidden_states,
                     encoder_hidden_states,


### PR DESCRIPTION
# What does this PR do?

When training SD3 with gradient checkpointing enabled, the return value of the transformer blocks are not split into two variables. This is different from the non checkpointed handling.

## Who can review?

@DN6 