### PR TITLE
[Fix] attention processor is wrong if we run many times

### DIFF
--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -119,7 +119,7 @@ class JointTransformerBlock(nn.Module):
                 f"Unknown context_norm_type: {context_norm_type}, currently only support `ada_norm_continous`, `ada_norm_zero`"
             )
         if hasattr(F, "scaled_dot_product_attention"):
-            processor = JointAttnProcessor2_0()
+            self.processor = JointAttnProcessor2_0()
         else:
             raise ValueError(
                 "The current PyTorch version does not support the `scaled_dot_product_attention` function."
@@ -133,7 +133,7 @@ class JointTransformerBlock(nn.Module):
             out_dim=attention_head_dim,
             context_pre_only=context_pre_only,
             bias=True,
-            processor=processor,
+            processor=self.processor,
         )
 
         self.norm2 = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
@@ -169,6 +169,7 @@ class JointTransformerBlock(nn.Module):
             )
 
         # Attention.
+        self.attn.set_processor(self.processor)
         attn_output, context_attn_output = self.attn(
             hidden_states=norm_hidden_states, encoder_hidden_states=norm_encoder_hidden_states
         )


### PR DESCRIPTION
Fixes # (issue) SD3

SD3 JointTransformerBlock attention processor is wrong if we run many times 

## Test code
'''
import torch
from diffusers import StableDiffusion3Pipeline

pipe = StableDiffusion3Pipeline.from_pretrained("stable-diffusion-3-medium-diffusers", torch_dtype=torch.float16)
pipe = pipe.to("cuda")

prompt = "A cat holding a sign that says hello world"
for i in range(2):
    image = pipe(prompt, negative_prompt="", num_inference_steps=28, guidance_scale=7.0,).images[0]
'''

## issue
It will be wrong while running the second times:
  File "/usr/local/lib/python3.10/site-packages/diffusers/models/transformers/transformer_sd3.py", line 317, in forward
    encoder_hidden_states, hidden_states = block(
  File "/usr/local/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/diffusers/models/attention.py", line 196, in forward
    encoder_hidden_states = encoder_hidden_states + context_attn_output
RuntimeError: The size of tensor a (154) must match the size of tensor b (4096) at non-singleton dimension 1

The reason is the attention processor become AttnProcessor2_0 instead of JointAttnProcessor2_0, so set_processor before run attn.

Please help to review it, thanks.
