### PR TITLE
[docs] Add note for float8

### DIFF
--- a/docs/source/en/api/pipelines/stable_diffusion/stable_diffusion_3.md
+++ b/docs/source/en/api/pipelines/stable_diffusion/stable_diffusion_3.md
@@ -251,6 +251,9 @@ image.save('sd3-single-file.png')
 
 ### Loading the single file checkpoint with T5
 
+> [!TIP]
+> The following example loads a checkpoint stored in a 8-bit floating point format which requires PyTorch 2.3 or later.
+
 ```python
 import torch
 from diffusers import StableDiffusion3Pipeline


### PR DESCRIPTION
Adds a `[!TIP]` in the SD3 single file code example to require using torch 2.3 as suggested [here](https://github.com/huggingface/diffusers/issues/8537#issuecomment-2171460924).