### PR TITLE
Fix minor bug in SD3 img2img test

### DIFF
--- a/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3_img2img.py
+++ b/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3_img2img.py
@@ -108,7 +108,6 @@ class StableDiffusion3Img2ImgPipelineFastTests(PipelineLatentTesterMixin, unitte
 
     def get_dummy_inputs(self, device, seed=0):
         image = floats_tensor((1, 3, 32, 32), rng=random.Random(seed)).to(device)
-        image = image / 2 + 0.5
         if str(device).startswith("mps"):
             generator = torch.manual_seed(seed)
         else:


### PR DESCRIPTION
# What does this PR do?

vae image processor takes inputs in range [0, 1] for images. previously, we had an additional line that makes the range [0.5, 1]. while that works, i think this is the more correct thing to do.

context: https://github.com/huggingface/diffusers/pull/8709#discussion_r1661780194

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yiyixuxu 