### PR TITLE
[Chore] allow auraflow latest to be torch compile compatible.

### DIFF
--- a/src/diffusers/models/transformers/auraflow_transformer_2d.py
+++ b/src/diffusers/models/transformers/auraflow_transformer_2d.py
@@ -75,7 +75,7 @@ class AuraFlowPatchEmbed(nn.Module):
         )
         latent = latent.permute(0, 2, 4, 1, 3, 5).flatten(-3).flatten(1, 2)
         latent = self.proj(latent)
-        return latent + self.pos_embed
+        return latent + self.pos_embed[:, : latent.size(1)]
 
 
 # Taken from the original Aura flow inference code.

--- a/src/diffusers/models/transformers/auraflow_transformer_2d.py
+++ b/src/diffusers/models/transformers/auraflow_transformer_2d.py
@@ -75,7 +75,7 @@ class AuraFlowPatchEmbed(nn.Module):
         )
         latent = latent.permute(0, 2, 4, 1, 3, 5).flatten(-3).flatten(1, 2)
         latent = self.proj(latent)
-        return latent + self.pos_embed[:, : latent.size(1)]
+        return latent + self.pos_embed
 
 
 # Taken from the original Aura flow inference code.

--- a/src/diffusers/pipelines/aura_flow/pipeline_aura_flow.py
+++ b/src/diffusers/pipelines/aura_flow/pipeline_aura_flow.py
@@ -391,8 +391,8 @@ class AuraFlowPipeline(DiffusionPipeline):
         sigmas: List[float] = None,
         guidance_scale: float = 3.5,
         num_images_per_prompt: Optional[int] = 1,
-        height: Optional[int] = 512,
-        width: Optional[int] = 512,
+        height: Optional[int] = 1024,
+        width: Optional[int] = 1024,
         generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
         latents: Optional[torch.Tensor] = None,
         prompt_embeds: Optional[torch.Tensor] = None,
@@ -415,9 +415,9 @@ class AuraFlowPipeline(DiffusionPipeline):
                 `negative_prompt_embeds` instead. Ignored when not using guidance (i.e., ignored if `guidance_scale` is
                 less than `1`).
             height (`int`, *optional*, defaults to self.transformer.config.sample_size * self.vae_scale_factor):
-                The height in pixels of the generated image. This is set to 512 by default.
+                The height in pixels of the generated image. This is set to 1024 by default for best results.
             width (`int`, *optional*, defaults to self.transformer.config.sample_size * self.vae_scale_factor):
-                The width in pixels of the generated image. This is set to 512 by default.
+                The width in pixels of the generated image. This is set to 1024 by default for best results.
             num_inference_steps (`int`, *optional*, defaults to 50):
                 The number of denoising steps. More denoising steps usually lead to a higher quality image at the
                 expense of slower inference.


### PR DESCRIPTION
# What does this PR do?

Otherwise, we run into a shape broadcasting problem during `torch.compile()`. Note that this doesn't happen when the internal [AuraDiffusion/auradiffusion-v0.1a0](https://huggingface.co/AuraDiffusion/auradiffusion-v0.1a0/) variant. 

<details>Benchmarking script
<summary><h2>Benchmarking script</h2></summary>

```python
import torch 

torch.set_float32_matmul_precision("high")

from diffusers import AuraFlowPipeline
import time

id = "fal/AuraFlow" # "AuraDiffusion/auradiffusion-v0.1a0"
pipeline = AuraFlowPipeline.from_pretrained(
    id, 
    torch_dtype=torch.float16
).to("cuda")
pipeline.set_progress_bar_config(disable=True)

torch._inductor.config.conv_1x1_as_mm = True
torch._inductor.config.coordinate_descent_tuning = True
torch._inductor.config.epilogue_fusion = False
torch._inductor.config.coordinate_descent_check_all_directions = True

pipeline.transformer.to(memory_format=torch.channels_last)
pipeline.vae.to(memory_format=torch.channels_last)
pipeline.transformer = torch.compile(pipeline.transformer, mode="max-autotune", fullgraph=True)
pipeline.vae.decode = torch.compile(pipeline.vae.decode, mode="max-autotune", fullgraph=True)

prompt = "a photo of a cat"
for _ in range(3):
    _ = pipeline(
        prompt=prompt,
        num_inference_steps=50, 
        guidance_scale=5.0,
        generator=torch.manual_seed(1),
    )

start = time.time()
for _ in range(10):
    _ = pipeline(
        prompt=prompt,
        num_inference_steps=50, 
        guidance_scale=5.0,
        generator=torch.manual_seed(1),
    )
end = time.time()
avg_inference_time = (end - start) / 10
print(f"Average inference time: {avg_inference_time:.3f} seconds.")
```
</details>

<details>Results
<summary><h2>Results</h2></summary>
| With `torch.compile()` | Without `torch.compile()` |
|----------|----------|
|   7.293 seconds   |   8.801 seconds  |
</details>

@apolinario FYI. 
