### PR TITLE
[CI] Set CLIP attn to "eager" on Fast PR Tests

### DIFF
--- a/tests/lora/test_lora_layers_sd3.py
+++ b/tests/lora/test_lora_layers_sd3.py
@@ -58,6 +58,7 @@ class SD3LoRATests(unittest.TestCase):
             out_channels=4,
         )
         clip_text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/amused/test_amused.py
+++ b/tests/pipelines/amused/test_amused.py
@@ -83,6 +83,7 @@ class AmusedPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=8,

--- a/tests/pipelines/amused/test_amused_img2img.py
+++ b/tests/pipelines/amused/test_amused_img2img.py
@@ -87,6 +87,7 @@ class AmusedImg2ImgPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=8,

--- a/tests/pipelines/amused/test_amused_inpaint.py
+++ b/tests/pipelines/amused/test_amused_inpaint.py
@@ -87,6 +87,7 @@ class AmusedInpaintPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=8,

--- a/tests/pipelines/animatediff/test_animatediff.py
+++ b/tests/pipelines/animatediff/test_animatediff.py
@@ -80,6 +80,7 @@ class AnimateDiffPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/animatediff/test_animatediff_sdxl.py
+++ b/tests/pipelines/animatediff/test_animatediff_sdxl.py
@@ -93,6 +93,7 @@ class AnimateDiffPipelineSDXLFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/animatediff/test_animatediff_video2video.py
+++ b/tests/pipelines/animatediff/test_animatediff_video2video.py
@@ -75,6 +75,7 @@ class AnimateDiffVideoToVideoPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/blipdiffusion/test_blipdiffusion.py
+++ b/tests/pipelines/blipdiffusion/test_blipdiffusion.py
@@ -63,6 +63,7 @@ class BlipDiffusionPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
     def get_dummy_components(self):
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             vocab_size=1000,
             hidden_size=8,
             intermediate_size=8,

--- a/tests/pipelines/controlnet/test_controlnet.py
+++ b/tests/pipelines/controlnet/test_controlnet.py
@@ -167,6 +167,7 @@ class ControlNetPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -354,6 +355,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -574,6 +576,7 @@ class StableDiffusionMultiControlNetOneModelPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/controlnet/test_controlnet_blip_diffusion.py
+++ b/tests/pipelines/controlnet/test_controlnet_blip_diffusion.py
@@ -71,6 +71,7 @@ class BlipDiffusionControlNetPipelineFastTests(PipelineTesterMixin, unittest.Tes
     def get_dummy_components(self):
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             vocab_size=1000,
             hidden_size=16,
             intermediate_size=16,

--- a/tests/pipelines/controlnet/test_controlnet_img2img.py
+++ b/tests/pipelines/controlnet/test_controlnet_img2img.py
@@ -117,6 +117,7 @@ class ControlNetImg2ImgPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -261,6 +262,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/controlnet/test_controlnet_inpaint.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint.py
@@ -106,6 +106,7 @@ class ControlNetInpaintPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -223,6 +224,7 @@ class ControlNetSimpleInpaintPipelineFastTests(ControlNetInpaintPipelineFastTest
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -316,6 +318,7 @@ class MultiControlNetInpaintPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
@@ -126,6 +126,7 @@ class ControlNetPipelineSDXLFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/controlnet/test_controlnet_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_sdxl.py
@@ -130,6 +130,7 @@ class StableDiffusionXLControlNetPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -568,6 +569,7 @@ class StableDiffusionXLMultiControlNetPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -755,6 +757,7 @@ class StableDiffusionXLMultiControlNetOneModelPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -1080,6 +1083,7 @@ class StableDiffusionSSD1BControlNetPipelineFastTests(StableDiffusionXLControlNe
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/controlnet/test_controlnet_sdxl_img2img.py
+++ b/tests/pipelines/controlnet/test_controlnet_sdxl_img2img.py
@@ -118,6 +118,7 @@ class ControlNetPipelineSDXLImg2ImgFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/controlnet_sd3/test_controlnet_sd3.py
+++ b/tests/pipelines/controlnet_sd3/test_controlnet_sd3.py
@@ -86,6 +86,7 @@ class StableDiffusion3ControlNetPipelineFastTests(unittest.TestCase, PipelineTes
             out_channels=8,
         )
         clip_text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/controlnet_xs/test_controlnetxs.py
+++ b/tests/pipelines/controlnet_xs/test_controlnetxs.py
@@ -180,6 +180,7 @@ class ControlNetXSPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=8,

--- a/tests/pipelines/controlnet_xs/test_controlnetxs_sdxl.py
+++ b/tests/pipelines/controlnet_xs/test_controlnetxs_sdxl.py
@@ -119,6 +119,7 @@ class StableDiffusionXLControlNetXSPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=4,

--- a/tests/pipelines/i2vgen_xl/test_i2vgenxl.py
+++ b/tests/pipelines/i2vgen_xl/test_i2vgenxl.py
@@ -98,6 +98,7 @@ class I2VGenXLPipelineFastTests(SDFunctionTesterMixin, PipelineTesterMixin, unit
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=4,

--- a/tests/pipelines/kandinsky/test_kandinsky_prior.py
+++ b/tests/pipelines/kandinsky/test_kandinsky_prior.py
@@ -66,6 +66,7 @@ class Dummies:
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=self.text_embedder_hidden_size,

--- a/tests/pipelines/kandinsky2_2/test_kandinsky_prior.py
+++ b/tests/pipelines/kandinsky2_2/test_kandinsky_prior.py
@@ -67,6 +67,7 @@ class Dummies:
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=self.text_embedder_hidden_size,

--- a/tests/pipelines/kandinsky2_2/test_kandinsky_prior_emb2emb.py
+++ b/tests/pipelines/kandinsky2_2/test_kandinsky_prior_emb2emb.py
@@ -83,6 +83,7 @@ class KandinskyV22PriorEmb2EmbPipelineFastTests(PipelineTesterMixin, unittest.Te
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=self.text_embedder_hidden_size,

--- a/tests/pipelines/latent_consistency_models/test_latent_consistency_models.py
+++ b/tests/pipelines/latent_consistency_models/test_latent_consistency_models.py
@@ -68,6 +68,7 @@ class LatentConsistencyModelPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/latent_consistency_models/test_latent_consistency_models_img2img.py
+++ b/tests/pipelines/latent_consistency_models/test_latent_consistency_models_img2img.py
@@ -76,6 +76,7 @@ class LatentConsistencyModelImg2ImgPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/latent_diffusion/test_latent_diffusion.py
+++ b/tests/pipelines/latent_diffusion/test_latent_diffusion.py
@@ -81,6 +81,7 @@ class LDMTextToImagePipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/ledits_pp/test_ledits_pp_stable_diffusion.py
+++ b/tests/pipelines/ledits_pp/test_ledits_pp_stable_diffusion.py
@@ -70,6 +70,7 @@ class LEditsPPPipelineStableDiffusionFastTests(unittest.TestCase):
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/ledits_pp/test_ledits_pp_stable_diffusion_xl.py
+++ b/tests/pipelines/ledits_pp/test_ledits_pp_stable_diffusion_xl.py
@@ -112,6 +112,7 @@ class LEditsPPPipelineStableDiffusionXLFastTests(unittest.TestCase):
 
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/marigold/test_marigold_depth.py
+++ b/tests/pipelines/marigold/test_marigold_depth.py
@@ -96,6 +96,7 @@ class MarigoldDepthPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/marigold/test_marigold_normals.py
+++ b/tests/pipelines/marigold/test_marigold_normals.py
@@ -96,6 +96,7 @@ class MarigoldNormalsPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/pag/test_pag_controlnet_sd.py
+++ b/tests/pipelines/pag/test_pag_controlnet_sd.py
@@ -109,6 +109,7 @@ class StableDiffusionControlNetPAGPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=8,

--- a/tests/pipelines/pag/test_pag_controlnet_sdxl.py
+++ b/tests/pipelines/pag/test_pag_controlnet_sdxl.py
@@ -122,6 +122,7 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/pag/test_pag_sd.py
+++ b/tests/pipelines/pag/test_pag_sd.py
@@ -104,6 +104,7 @@ class StableDiffusionPAGPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=cross_attention_dim,

--- a/tests/pipelines/pag/test_pag_sdxl.py
+++ b/tests/pipelines/pag/test_pag_sdxl.py
@@ -110,6 +110,7 @@ class StableDiffusionXLPAGPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/pag/test_pag_sdxl_img2img.py
+++ b/tests/pipelines/pag/test_pag_sdxl_img2img.py
@@ -149,6 +149,7 @@ class StableDiffusionXLPAGImg2ImgPipelineFastTests(
 
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/pag/test_pag_sdxl_inpaint.py
+++ b/tests/pipelines/pag/test_pag_sdxl_inpaint.py
@@ -124,6 +124,7 @@ class StableDiffusionXLPAGInpaintPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/pia/test_pia.py
+++ b/tests/pipelines/pia/test_pia.py
@@ -83,6 +83,7 @@ class PIAPipelineFastTests(IPAdapterTesterMixin, PipelineTesterMixin, PipelineFr
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/semantic_stable_diffusion/test_semantic_diffusion.py
+++ b/tests/pipelines/semantic_stable_diffusion/test_semantic_diffusion.py
@@ -90,6 +90,7 @@ class SafeDiffusionPipelineFastTests(unittest.TestCase):
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/shap_e/test_shap_e.py
+++ b/tests/pipelines/shap_e/test_shap_e.py
@@ -67,6 +67,7 @@ class ShapEPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=self.text_embedder_hidden_size,

--- a/tests/pipelines/stable_cascade/test_stable_cascade_combined.py
+++ b/tests/pipelines/stable_cascade/test_stable_cascade_combined.py
@@ -81,6 +81,7 @@ class StableCascadeCombinedPipelineFastTests(PipelineTesterMixin, unittest.TestC
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             projection_dim=self.text_embedder_hidden_size,

--- a/tests/pipelines/stable_cascade/test_stable_cascade_decoder.py
+++ b/tests/pipelines/stable_cascade/test_stable_cascade_decoder.py
@@ -82,6 +82,7 @@ class StableCascadeDecoderPipelineFastTests(PipelineTesterMixin, unittest.TestCa
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             projection_dim=self.text_embedder_hidden_size,

--- a/tests/pipelines/stable_cascade/test_stable_cascade_prior.py
+++ b/tests/pipelines/stable_cascade/test_stable_cascade_prior.py
@@ -87,6 +87,7 @@ class StableCascadePriorPipelineFastTests(PipelineTesterMixin, unittest.TestCase
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=self.text_embedder_hidden_size,

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion.py
@@ -159,6 +159,7 @@ class StableDiffusionPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=cross_attention_dim,

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_img2img.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_img2img.py
@@ -138,6 +138,7 @@ class StableDiffusionImg2ImgPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_inpaint.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_inpaint.py
@@ -140,6 +140,7 @@ class StableDiffusionInpaintPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -427,6 +428,7 @@ class StableDiffusionSimpleInpaintPipelineFastTests(StableDiffusionInpaintPipeli
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion_instruction_pix2pix.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion_instruction_pix2pix.py
@@ -91,6 +91,7 @@ class StableDiffusionInstructPix2PixPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion.py
@@ -111,6 +111,7 @@ class StableDiffusion2PipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_attend_and_excite.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_attend_and_excite.py
@@ -109,6 +109,7 @@ class StableDiffusionAttendAndExcitePipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_depth.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_depth.py
@@ -104,6 +104,7 @@ class StableDiffusionDepth2ImgPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_diffedit.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_diffedit.py
@@ -101,6 +101,7 @@ class StableDiffusionDiffEditPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_inpaint.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_inpaint.py
@@ -84,6 +84,7 @@ class StableDiffusion2InpaintPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_latent_upscale.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_latent_upscale.py
@@ -120,6 +120,7 @@ class StableDiffusionLatentUpscalePipelineFastTests(
         )
         scheduler = EulerDiscreteScheduler(prediction_type="sample")
         text_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_upscale.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_upscale.py
@@ -97,6 +97,7 @@ class StableDiffusionUpscalePipelineFastTests(unittest.TestCase):
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_v_pred.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_v_pred.py
@@ -92,6 +92,7 @@ class StableDiffusion2VPredictionPipelineFastTests(unittest.TestCase):
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3.py
+++ b/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3.py
@@ -50,6 +50,7 @@ class StableDiffusion3PipelineFastTests(unittest.TestCase, PipelineTesterMixin):
             out_channels=4,
         )
         clip_text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3_img2img.py
+++ b/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3_img2img.py
@@ -52,6 +52,7 @@ class StableDiffusion3Img2ImgPipelineFastTests(PipelineLatentTesterMixin, unitte
             out_channels=4,
         )
         clip_text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3_inpaint.py
+++ b/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3_inpaint.py
@@ -54,6 +54,7 @@ class StableDiffusion3InpaintPipelineFastTests(PipelineLatentTesterMixin, unitte
             out_channels=16,
         )
         clip_text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_adapter/test_stable_diffusion_adapter.py
+++ b/tests/pipelines/stable_diffusion_adapter/test_stable_diffusion_adapter.py
@@ -82,6 +82,7 @@ class AdapterTests:
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -169,6 +170,7 @@ class AdapterTests:
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_gligen/test_stable_diffusion_gligen.py
+++ b/tests/pipelines/stable_diffusion_gligen/test_stable_diffusion_gligen.py
@@ -90,6 +90,7 @@ class GligenPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_gligen_text_image/test_stable_diffusion_gligen_text_image.py
+++ b/tests/pipelines/stable_diffusion_gligen_text_image/test_stable_diffusion_gligen_text_image.py
@@ -99,6 +99,7 @@ class GligenTextImagePipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_ldm3d/test_stable_diffusion_ldm3d.py
+++ b/tests/pipelines/stable_diffusion_ldm3d/test_stable_diffusion_ldm3d.py
@@ -72,6 +72,7 @@ class StableDiffusionLDM3DPipelineFastTests(unittest.TestCase):
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_panorama/test_stable_diffusion_panorama.py
+++ b/tests/pipelines/stable_diffusion_panorama/test_stable_diffusion_panorama.py
@@ -81,6 +81,7 @@ class StableDiffusionPanoramaPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_safe/test_safe_diffusion.py
+++ b/tests/pipelines/stable_diffusion_safe/test_safe_diffusion.py
@@ -81,6 +81,7 @@ class SafeDiffusionPipelineFastTests(unittest.TestCase):
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_sag/test_stable_diffusion_sag.py
+++ b/tests/pipelines/stable_diffusion_sag/test_stable_diffusion_sag.py
@@ -88,6 +88,7 @@ class StableDiffusionSAGPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=8,

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -116,6 +116,7 @@ class StableDiffusionXLPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
@@ -96,6 +96,7 @@ class StableDiffusionXLAdapterPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -203,6 +204,7 @@ class StableDiffusionXLAdapterPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py
@@ -141,6 +141,7 @@ class StableDiffusionXLImg2ImgPipelineFastTests(
 
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,
@@ -563,6 +564,7 @@ class StableDiffusionXLImg2ImgRefinerOnlyPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
@@ -111,6 +111,7 @@ class StableDiffusionXLInpaintPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_instruction_pix2pix.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_instruction_pix2pix.py
@@ -99,6 +99,7 @@ class StableDiffusionXLInstructPix2PixPipelineFastTests(
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/stable_unclip/test_stable_unclip.py
+++ b/tests/pipelines/stable_unclip/test_stable_unclip.py
@@ -51,6 +51,7 @@ class StableUnCLIPPipelineFastTests(
         torch.manual_seed(0)
         prior_text_encoder = CLIPTextModelWithProjection(
             CLIPTextConfig(
+                attn_implementation="eager",
                 bos_token_id=0,
                 eos_token_id=2,
                 hidden_size=embedder_hidden_size,
@@ -94,6 +95,7 @@ class StableUnCLIPPipelineFastTests(
         torch.manual_seed(0)
         text_encoder = CLIPTextModel(
             CLIPTextConfig(
+                attn_implementation="eager",
                 bos_token_id=0,
                 eos_token_id=2,
                 hidden_size=embedder_hidden_size,

--- a/tests/pipelines/stable_unclip/test_stable_unclip_img2img.py
+++ b/tests/pipelines/stable_unclip/test_stable_unclip_img2img.py
@@ -84,6 +84,7 @@ class StableUnCLIPImg2ImgPipelineFastTests(
         torch.manual_seed(0)
         text_encoder = CLIPTextModel(
             CLIPTextConfig(
+                attn_implementation="eager",
                 bos_token_id=0,
                 eos_token_id=2,
                 hidden_size=embedder_hidden_size,

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -1124,6 +1124,7 @@ class PipelineFastTests(unittest.TestCase):
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -1905,6 +1905,7 @@ class PipelinePushToHubTester(unittest.TestCase):
         )
 
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/text_to_video_synthesis/test_text_to_video.py
+++ b/tests/pipelines/text_to_video_synthesis/test_text_to_video.py
@@ -95,6 +95,7 @@ class TextToVideoSDPipelineFastTests(PipelineTesterMixin, SDFunctionTesterMixin,
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=4,

--- a/tests/pipelines/text_to_video_synthesis/test_text_to_video_zero_sdxl.py
+++ b/tests/pipelines/text_to_video_synthesis/test_text_to_video_zero_sdxl.py
@@ -100,6 +100,7 @@ class TextToVideoZeroSDXLPipelineFastTests(PipelineTesterMixin, PipelineFromPipe
         )
         torch.manual_seed(seed)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/text_to_video_synthesis/test_video_to_video.py
+++ b/tests/pipelines/text_to_video_synthesis/test_video_to_video.py
@@ -105,6 +105,7 @@ class VideoToVideoSDPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         )
         torch.manual_seed(0)
         text_encoder_config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=32,

--- a/tests/pipelines/unclip/test_unclip.py
+++ b/tests/pipelines/unclip/test_unclip.py
@@ -88,6 +88,7 @@ class UnCLIPPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=self.text_embedder_hidden_size,

--- a/tests/pipelines/unclip/test_unclip_image_variation.py
+++ b/tests/pipelines/unclip/test_unclip_image_variation.py
@@ -96,6 +96,7 @@ class UnCLIPImageVariationPipelineFastTests(PipelineTesterMixin, unittest.TestCa
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=self.text_embedder_hidden_size,

--- a/tests/pipelines/wuerstchen/test_wuerstchen_combined.py
+++ b/tests/pipelines/wuerstchen/test_wuerstchen_combined.py
@@ -69,6 +69,7 @@ class WuerstchenCombinedPipelineFastTests(PipelineTesterMixin, unittest.TestCase
     def dummy_prior_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=self.text_embedder_hidden_size,
@@ -85,6 +86,7 @@ class WuerstchenCombinedPipelineFastTests(PipelineTesterMixin, unittest.TestCase
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             projection_dim=self.text_embedder_hidden_size,

--- a/tests/pipelines/wuerstchen/test_wuerstchen_decoder.py
+++ b/tests/pipelines/wuerstchen/test_wuerstchen_decoder.py
@@ -70,6 +70,7 @@ class WuerstchenDecoderPipelineFastTests(PipelineTesterMixin, unittest.TestCase)
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             projection_dim=self.text_embedder_hidden_size,

--- a/tests/pipelines/wuerstchen/test_wuerstchen_prior.py
+++ b/tests/pipelines/wuerstchen/test_wuerstchen_prior.py
@@ -77,6 +77,7 @@ class WuerstchenPriorPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
     def dummy_text_encoder(self):
         torch.manual_seed(0)
         config = CLIPTextConfig(
+            attn_implementation="eager",
             bos_token_id=0,
             eos_token_id=2,
             hidden_size=self.text_embedder_hidden_size,


### PR DESCRIPTION
# What does this PR do?
The latest version for transformers 4.43.1 sets the default attention mechanism in CLIP models to SDPA. This is causing our PR tests to fail. 

This PR updates all our CLIP models in the fast tests to use `attn_implementation="eager"` 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
