### PR TITLE
[Tests] fix slices of 26 tests (first half)

### DIFF
--- a/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
@@ -37,7 +37,12 @@ from diffusers import (
     UNet2DConditionModel,
 )
 from diffusers.utils.import_utils import is_xformers_available
-from diffusers.utils.testing_utils import enable_full_determinism, floats_tensor, require_torch_gpu, torch_device
+from diffusers.utils.testing_utils import (
+    enable_full_determinism,
+    floats_tensor,
+    require_torch_gpu,
+    torch_device,
+)
 
 from ..pipeline_params import (
     IMAGE_TO_IMAGE_IMAGE_PARAMS,
@@ -341,7 +346,8 @@ class ControlNetPipelineSDXLFastTests(
 
         output = sd_pipe(**inputs)
         image_slice = output.images[0, -3:, -3:, -1]
-        expected_slice = np.array([0.549, 0.5053, 0.4676, 0.5816, 0.5364, 0.483, 0.5937, 0.5719, 0.4318])
+
+        expected_slice = np.array([0.5460, 0.4943, 0.4635, 0.5832, 0.5366, 0.4815, 0.6034, 0.5741, 0.4341])
 
         # make sure that it's equal
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-4

--- a/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint_sdxl.py
@@ -233,12 +233,6 @@ class ControlNetPipelineSDXLFastTests(
     def test_attention_slicing_forward_pass(self):
         return self._test_attention_slicing_forward_pass(expected_max_diff=2e-3)
 
-    def test_dict_tuple_outputs_equivalent(self):
-        expected_slice = None
-        if torch_device == "cpu":
-            expected_slice = np.array([0.5490, 0.5053, 0.4676, 0.5816, 0.5364, 0.4830, 0.5937, 0.5719, 0.4318])
-        super().test_dict_tuple_outputs_equivalent(expected_slice=expected_slice)
-
     @unittest.skipIf(
         torch_device != "cuda" or not is_xformers_available(),
         reason="XFormers attention is only available with CUDA and `xformers` installed",

--- a/tests/pipelines/controlnet/test_controlnet_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_sdxl.py
@@ -370,7 +370,7 @@ class StableDiffusionXLControlNetPipelineFastTests(
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 64, 64, 3)
-        expected_slice = np.array([0.7335, 0.5866, 0.5623, 0.6242, 0.5751, 0.5999, 0.4091, 0.4590, 0.5054])
+        expected_slice = np.array([0.7820, 0.6195, 0.6193, 0.7045, 0.6706, 0.5837, 0.4147, 0.5232, 0.4868])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
@@ -993,7 +993,7 @@ class StableDiffusionSSD1BControlNetPipelineFastTests(StableDiffusionXLControlNe
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 64, 64, 3)
-        expected_slice = np.array([0.7212, 0.5890, 0.5491, 0.6425, 0.5970, 0.6091, 0.4418, 0.4556, 0.5032])
+        expected_slice = np.array([0.6787, 0.5117, 0.5558, 0.6963, 0.6571, 0.5928, 0.4121, 0.5468, 0.5057])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 

--- a/tests/pipelines/controlnet/test_controlnet_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_sdxl.py
@@ -37,7 +37,6 @@ from diffusers.utils.import_utils import is_xformers_available
 from diffusers.utils.testing_utils import (
     enable_full_determinism,
     load_image,
-    print_tensor_test,
     require_torch_gpu,
     slow,
     torch_device,
@@ -349,7 +348,7 @@ class StableDiffusionXLControlNetPipelineFastTests(
 
         output = sd_pipe(**inputs)
         image_slice = output.images[0, -3:, -3:, -1]
-        print_tensor_test(image_slice)
+
         expected_slice = np.array([0.7212, 0.5890, 0.5491, 0.6425, 0.5970, 0.6091, 0.4418, 0.4556, 0.5032])
 
         # make sure that it's equal
@@ -965,10 +964,6 @@ class StableDiffusionSSD1BControlNetPipelineFastTests(StableDiffusionXLControlNe
 
         output = sd_pipe(**inputs)
         image_slice = output.images[0, -3:, -3:, -1]
-
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
 
         expected_slice = np.array(
             [0.6831671, 0.5702532, 0.5459845, 0.6299793, 0.58563006, 0.6033695, 0.4493941, 0.46132287, 0.5035841]

--- a/tests/pipelines/controlnet/test_controlnet_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_sdxl.py
@@ -349,7 +349,7 @@ class StableDiffusionXLControlNetPipelineFastTests(
         output = sd_pipe(**inputs)
         image_slice = output.images[0, -3:, -3:, -1]
 
-        expected_slice = np.array([0.7212, 0.5890, 0.5491, 0.6425, 0.5970, 0.6091, 0.4418, 0.4556, 0.5032])
+        expected_slice = np.array([0.7335, 0.5866, 0.5623, 0.6242, 0.5751, 0.5999, 0.4091, 0.4590, 0.5054])
 
         # make sure that it's equal
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-4
@@ -370,7 +370,7 @@ class StableDiffusionXLControlNetPipelineFastTests(
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 64, 64, 3)
-        expected_slice = np.array([0.7799, 0.614, 0.6162, 0.7082, 0.6662, 0.5833, 0.4148, 0.5182, 0.4866])
+        expected_slice = np.array([0.7335, 0.5866, 0.5623, 0.6242, 0.5751, 0.5999, 0.4091, 0.4590, 0.5054])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
@@ -965,9 +965,7 @@ class StableDiffusionSSD1BControlNetPipelineFastTests(StableDiffusionXLControlNe
         output = sd_pipe(**inputs)
         image_slice = output.images[0, -3:, -3:, -1]
 
-        expected_slice = np.array(
-            [0.6831671, 0.5702532, 0.5459845, 0.6299793, 0.58563006, 0.6033695, 0.4493941, 0.46132287, 0.5035841]
-        )
+        expected_slice = np.array([0.7212, 0.5890, 0.5491, 0.6425, 0.5970, 0.6091, 0.4418, 0.4556, 0.5032])
 
         # make sure that it's equal
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-4
@@ -995,7 +993,7 @@ class StableDiffusionSSD1BControlNetPipelineFastTests(StableDiffusionXLControlNe
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 64, 64, 3)
-        expected_slice = np.array([0.6850, 0.5135, 0.5545, 0.7033, 0.6617, 0.5971, 0.4165, 0.5480, 0.5070])
+        expected_slice = np.array([0.7212, 0.5890, 0.5491, 0.6425, 0.5970, 0.6091, 0.4418, 0.4556, 0.5032])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 

--- a/tests/pipelines/controlnet/test_controlnet_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_sdxl.py
@@ -37,10 +37,10 @@ from diffusers.utils.import_utils import is_xformers_available
 from diffusers.utils.testing_utils import (
     enable_full_determinism,
     load_image,
+    print_tensor_test,
     require_torch_gpu,
     slow,
     torch_device,
-    print_tensor_test
 )
 from diffusers.utils.torch_utils import randn_tensor
 
@@ -196,10 +196,9 @@ class StableDiffusionXLControlNetPipelineFastTests(
             expected_pipe_slice = None
             if torch_device == "cpu":
                 expected_pipe_slice = np.array(
-                    [0.7331, 0.5907, 0.5667, 0.6029, 0.5679, 0.5968, 0.4033, 0.4761, 0.5090]
+                    [0.7335, 0.5866, 0.5623, 0.6242, 0.5751, 0.5999, 0.4091, 0.4590, 0.5054]
                 )
-        # TODO: Update with slices.
-        return super().test_ip_adapter_single(expected_pipe_slice=None)
+        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
 
     @unittest.skipIf(
         torch_device != "cuda" or not is_xformers_available(),
@@ -351,9 +350,7 @@ class StableDiffusionXLControlNetPipelineFastTests(
         output = sd_pipe(**inputs)
         image_slice = output.images[0, -3:, -3:, -1]
         print_tensor_test(image_slice)
-        expected_slice = np.array(
-            [0.7330834, 0.590667, 0.5667336, 0.6029023, 0.5679491, 0.5968194, 0.4032986, 0.47612396, 0.5089609]
-        )
+        expected_slice = np.array([0.7212, 0.5890, 0.5491, 0.6425, 0.5970, 0.6091, 0.4418, 0.4556, 0.5032])
 
         # make sure that it's equal
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-4
@@ -970,6 +967,7 @@ class StableDiffusionSSD1BControlNetPipelineFastTests(StableDiffusionXLControlNe
         image_slice = output.images[0, -3:, -3:, -1]
 
         from diffusers.utils.testing_utils import print_tensor_test
+
         print_tensor_test(image_slice)
 
         expected_slice = np.array(
@@ -982,9 +980,9 @@ class StableDiffusionSSD1BControlNetPipelineFastTests(StableDiffusionXLControlNe
     def test_ip_adapter_single(self):
         expected_pipe_slice = None
         if torch_device == "cpu":
-            expected_pipe_slice = np.array([0.6832, 0.5703, 0.5460, 0.6300, 0.5856, 0.6034, 0.4494, 0.4613, 0.5036])
-        # TODO: update after slices
-        return super().test_ip_adapter_single(from_ssd1b=True, expected_pipe_slice=None)
+            expected_pipe_slice = np.array([0.7212, 0.5890, 0.5491, 0.6425, 0.5970, 0.6091, 0.4418, 0.4556, 0.5032])
+
+        return super().test_ip_adapter_single(from_ssd1b=True, expected_pipe_slice=expected_pipe_slice)
 
     def test_controlnet_sdxl_lcm(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator

--- a/tests/pipelines/controlnet/test_controlnet_sdxl.py
+++ b/tests/pipelines/controlnet/test_controlnet_sdxl.py
@@ -40,6 +40,7 @@ from diffusers.utils.testing_utils import (
     require_torch_gpu,
     slow,
     torch_device,
+    print_tensor_test
 )
 from diffusers.utils.torch_utils import randn_tensor
 
@@ -197,7 +198,8 @@ class StableDiffusionXLControlNetPipelineFastTests(
                 expected_pipe_slice = np.array(
                     [0.7331, 0.5907, 0.5667, 0.6029, 0.5679, 0.5968, 0.4033, 0.4761, 0.5090]
                 )
-        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
+        # TODO: Update with slices.
+        return super().test_ip_adapter_single(expected_pipe_slice=None)
 
     @unittest.skipIf(
         torch_device != "cuda" or not is_xformers_available(),
@@ -348,6 +350,7 @@ class StableDiffusionXLControlNetPipelineFastTests(
 
         output = sd_pipe(**inputs)
         image_slice = output.images[0, -3:, -3:, -1]
+        print_tensor_test(image_slice)
         expected_slice = np.array(
             [0.7330834, 0.590667, 0.5667336, 0.6029023, 0.5679491, 0.5968194, 0.4032986, 0.47612396, 0.5089609]
         )
@@ -965,6 +968,10 @@ class StableDiffusionSSD1BControlNetPipelineFastTests(StableDiffusionXLControlNe
 
         output = sd_pipe(**inputs)
         image_slice = output.images[0, -3:, -3:, -1]
+
+        from diffusers.utils.testing_utils import print_tensor_test
+        print_tensor_test(image_slice)
+
         expected_slice = np.array(
             [0.6831671, 0.5702532, 0.5459845, 0.6299793, 0.58563006, 0.6033695, 0.4493941, 0.46132287, 0.5035841]
         )
@@ -976,7 +983,8 @@ class StableDiffusionSSD1BControlNetPipelineFastTests(StableDiffusionXLControlNe
         expected_pipe_slice = None
         if torch_device == "cpu":
             expected_pipe_slice = np.array([0.6832, 0.5703, 0.5460, 0.6300, 0.5856, 0.6034, 0.4494, 0.4613, 0.5036])
-        return super().test_ip_adapter_single(from_ssd1b=True, expected_pipe_slice=expected_pipe_slice)
+        # TODO: update after slices
+        return super().test_ip_adapter_single(from_ssd1b=True, expected_pipe_slice=None)
 
     def test_controlnet_sdxl_lcm(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator

--- a/tests/pipelines/controlnet/test_controlnet_sdxl_img2img.py
+++ b/tests/pipelines/controlnet/test_controlnet_sdxl_img2img.py
@@ -178,9 +178,9 @@ class ControlNetPipelineSDXLImg2ImgFastTests(
     def test_ip_adapter_single(self):
         expected_pipe_slice = None
         if torch_device == "cpu":
-            expected_pipe_slice = np.array([0.6265, 0.5441, 0.5384, 0.5446, 0.5810, 0.5908, 0.5414, 0.5428, 0.5353])
+            expected_pipe_slice = np.array([0.6276, 0.5271, 0.5205, 0.5393, 0.5774, 0.5872, 0.5456, 0.5415, 0.5354])
         # TODO: update after slices.p
-        return super().test_ip_adapter_single(expected_pipe_slice=None)
+        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
 
     def test_stable_diffusion_xl_controlnet_img2img(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator

--- a/tests/pipelines/controlnet/test_controlnet_sdxl_img2img.py
+++ b/tests/pipelines/controlnet/test_controlnet_sdxl_img2img.py
@@ -179,7 +179,8 @@ class ControlNetPipelineSDXLImg2ImgFastTests(
         expected_pipe_slice = None
         if torch_device == "cpu":
             expected_pipe_slice = np.array([0.6265, 0.5441, 0.5384, 0.5446, 0.5810, 0.5908, 0.5414, 0.5428, 0.5353])
-        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
+        # TODO: update after slices.p
+        return super().test_ip_adapter_single(expected_pipe_slice=None)
 
     def test_stable_diffusion_xl_controlnet_img2img(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator

--- a/tests/pipelines/controlnet_sd3/test_controlnet_sd3.py
+++ b/tests/pipelines/controlnet_sd3/test_controlnet_sd3.py
@@ -180,11 +180,10 @@ class StableDiffusion3ControlNetPipelineFastTests(unittest.TestCase, PipelineTes
         image = output.images
 
         image_slice = image[0, -3:, -3:, -1]
+
         assert image.shape == (1, 32, 32, 3)
 
-        expected_slice = np.array(
-            [0.5761719, 0.71777344, 0.59228516, 0.578125, 0.6020508, 0.39453125, 0.46728516, 0.51708984, 0.58984375]
-        )
+        expected_slice = np.array([0.5767, 0.7100, 0.5981, 0.5674, 0.5952, 0.4102, 0.5093, 0.5044, 0.6030])
 
         assert (
             np.abs(image_slice.flatten() - expected_slice).max() < 1e-2

--- a/tests/pipelines/i2vgen_xl/test_i2vgenxl.py
+++ b/tests/pipelines/i2vgen_xl/test_i2vgenxl.py
@@ -39,7 +39,6 @@ from diffusers.utils.testing_utils import (
     enable_full_determinism,
     floats_tensor,
     numpy_cosine_similarity_distance,
-    print_tensor_test,
     require_torch_gpu,
     skip_mps,
     slow,
@@ -265,6 +264,5 @@ class I2VGenXLPipelineSlowTests(unittest.TestCase):
         assert image.shape == (num_frames, 704, 1280, 3)
 
         image_slice = image[0, -3:, -3:, -1]
-        print_tensor_test(image_slice.flatten())
         expected_slice = np.array([0.5482, 0.6244, 0.6274, 0.4584, 0.5935, 0.5937, 0.4579, 0.5767, 0.5892])
         assert numpy_cosine_similarity_distance(image_slice.flatten(), expected_slice.flatten()) < 1e-3

--- a/tests/pipelines/kandinsky/test_kandinsky_combined.py
+++ b/tests/pipelines/kandinsky/test_kandinsky_combined.py
@@ -93,12 +93,13 @@ class KandinskyPipelineCombinedFastTests(PipelineTesterMixin, unittest.TestCase)
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
 
         from diffusers.utils.testing_utils import print_tensor_test
+
         print_tensor_test(image_slice)
         print_tensor_test(image_from_tuple_slice)
 
         assert image.shape == (1, 64, 64, 3)
 
-        expected_slice = np.array([0.0000, 0.0000, 0.6777, 0.1363, 0.3624, 0.7868, 0.3869, 0.3395, 0.5068])
+        expected_slice = np.array([0.2893, 0.1464, 0.4603, 0.3529, 0.4612, 0.7701, 0.4027, 0.3051, 0.5155])
 
         assert (
             np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
@@ -208,7 +209,7 @@ class KandinskyPipelineImg2ImgCombinedFastTests(PipelineTesterMixin, unittest.Te
 
         assert image.shape == (1, 64, 64, 3)
 
-        expected_slice = np.array([0.4260, 0.3596, 0.4571, 0.3890, 0.4087, 0.5137, 0.4819, 0.4116, 0.5053])
+        expected_slice = np.array([0.4852, 0.4136, 0.4539, 0.4781, 0.4680, 0.5217, 0.4973, 0.4089, 0.4977])
 
         assert (
             np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
@@ -314,8 +315,8 @@ class KandinskyPipelineInpaintCombinedFastTests(PipelineTesterMixin, unittest.Te
 
         image_slice = image[0, -3:, -3:, -1]
 
-        from diffusers.utils.testing_utils import print_tensor_test 
-        
+        from diffusers.utils.testing_utils import print_tensor_test
+
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
 
         print_tensor_test(image_slice)
@@ -323,7 +324,7 @@ class KandinskyPipelineInpaintCombinedFastTests(PipelineTesterMixin, unittest.Te
 
         assert image.shape == (1, 64, 64, 3)
 
-        expected_slice = np.array([0.0477, 0.0808, 0.2972, 0.2705, 0.3620, 0.6247, 0.4464, 0.2870, 0.3530])
+        expected_slice = np.array([0.0320, 0.0860, 0.4013, 0.0518, 0.2484, 0.5847, 0.4411, 0.2321, 0.4593])
 
         assert (
             np.abs(image_slice.flatten() - expected_slice).max() < 1e-2

--- a/tests/pipelines/kandinsky/test_kandinsky_combined.py
+++ b/tests/pipelines/kandinsky/test_kandinsky_combined.py
@@ -92,11 +92,6 @@ class KandinskyPipelineCombinedFastTests(PipelineTesterMixin, unittest.TestCase)
         image_slice = image[0, -3:, -3:, -1]
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
 
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
-        print_tensor_test(image_from_tuple_slice)
-
         assert image.shape == (1, 64, 64, 3)
 
         expected_slice = np.array([0.2893, 0.1464, 0.4603, 0.3529, 0.4612, 0.7701, 0.4027, 0.3051, 0.5155])
@@ -202,10 +197,6 @@ class KandinskyPipelineImg2ImgCombinedFastTests(PipelineTesterMixin, unittest.Te
 
         image_slice = image[0, -3:, -3:, -1]
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
-        print_tensor_test(image_from_tuple_slice)
 
         assert image.shape == (1, 64, 64, 3)
 
@@ -315,11 +306,8 @@ class KandinskyPipelineInpaintCombinedFastTests(PipelineTesterMixin, unittest.Te
 
         image_slice = image[0, -3:, -3:, -1]
 
-        from diffusers.utils.testing_utils import print_tensor_test
-
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
 
-        print_tensor_test(image_slice)
         print(image_from_tuple_slice)
 
         assert image.shape == (1, 64, 64, 3)

--- a/tests/pipelines/kandinsky/test_kandinsky_combined.py
+++ b/tests/pipelines/kandinsky/test_kandinsky_combined.py
@@ -92,6 +92,10 @@ class KandinskyPipelineCombinedFastTests(PipelineTesterMixin, unittest.TestCase)
         image_slice = image[0, -3:, -3:, -1]
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
 
+        from diffusers.utils.testing_utils import print_tensor_test
+        print_tensor_test(image_slice)
+        print_tensor_test(image_from_tuple_slice)
+
         assert image.shape == (1, 64, 64, 3)
 
         expected_slice = np.array([0.0000, 0.0000, 0.6777, 0.1363, 0.3624, 0.7868, 0.3869, 0.3395, 0.5068])
@@ -197,6 +201,10 @@ class KandinskyPipelineImg2ImgCombinedFastTests(PipelineTesterMixin, unittest.Te
 
         image_slice = image[0, -3:, -3:, -1]
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
+        from diffusers.utils.testing_utils import print_tensor_test
+
+        print_tensor_test(image_slice)
+        print_tensor_test(image_from_tuple_slice)
 
         assert image.shape == (1, 64, 64, 3)
 
@@ -305,7 +313,13 @@ class KandinskyPipelineInpaintCombinedFastTests(PipelineTesterMixin, unittest.Te
         )[0]
 
         image_slice = image[0, -3:, -3:, -1]
+
+        from diffusers.utils.testing_utils import print_tensor_test 
+        
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
+
+        print_tensor_test(image_slice)
+        print(image_from_tuple_slice)
 
         assert image.shape == (1, 64, 64, 3)
 

--- a/tests/pipelines/kandinsky/test_kandinsky_prior.py
+++ b/tests/pipelines/kandinsky/test_kandinsky_prior.py
@@ -211,12 +211,13 @@ class KandinskyPriorPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         )[0]
 
         image_slice = image[0, -10:]
+
         image_from_tuple_slice = image_from_tuple[0, -10:]
 
         assert image.shape == (1, 32)
 
         expected_slice = np.array(
-            [-0.0532, 1.7120, 0.3656, -1.0852, -0.8946, -1.1756, 0.4348, 0.2482, 0.5146, -0.1156]
+            [-0.5948, 0.1875, -0.1523, -1.1995, -1.4061, -0.6367, -1.4607, -0.6406, 0.8793, -0.3891]
         )
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2

--- a/tests/pipelines/kandinsky2_2/test_kandinsky_combined.py
+++ b/tests/pipelines/kandinsky2_2/test_kandinsky_combined.py
@@ -96,13 +96,14 @@ class KandinskyV22PipelineCombinedFastTests(PipelineTesterMixin, unittest.TestCa
 
         image_slice = image[0, -3:, -3:, -1]
         from diffusers.utils.testing_utils import print_tensor_test
+
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
         print_tensor_test(image_slice)
         print_tensor_test(image_from_tuple_slice)
 
         assert image.shape == (1, 64, 64, 3)
 
-        expected_slice = np.array([0.3013, 0.0471, 0.5176, 0.1817, 0.2566, 0.7076, 0.6712, 0.4421, 0.7503])
+        expected_slice = np.array([0.3076, 0.2729, 0.5668, 0.0522, 0.3384, 0.7028, 0.4908, 0.3659, 0.6243])
 
         assert (
             np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
@@ -224,12 +225,12 @@ class KandinskyV22PipelineImg2ImgCombinedFastTests(PipelineTesterMixin, unittest
 
         from diffusers.utils.testing_utils import print_tensor_test
 
-        print_tensor_test(image_slice) 
+        print_tensor_test(image_slice)
         print_tensor_test(image_from_tuple_slice)
 
         assert image.shape == (1, 64, 64, 3)
 
-        expected_slice = np.array([0.4353, 0.4710, 0.5128, 0.4806, 0.5054, 0.5348, 0.5224, 0.4603, 0.5025])
+        expected_slice = np.array([0.4445, 0.4287, 0.4596, 0.3919, 0.3730, 0.5039, 0.4834, 0.4269, 0.5521])
 
         assert (
             np.abs(image_slice.flatten() - expected_slice).max() < 1e-2

--- a/tests/pipelines/kandinsky2_2/test_kandinsky_combined.py
+++ b/tests/pipelines/kandinsky2_2/test_kandinsky_combined.py
@@ -95,11 +95,7 @@ class KandinskyV22PipelineCombinedFastTests(PipelineTesterMixin, unittest.TestCa
         )[0]
 
         image_slice = image[0, -3:, -3:, -1]
-        from diffusers.utils.testing_utils import print_tensor_test
-
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
-        print_tensor_test(image_slice)
-        print_tensor_test(image_from_tuple_slice)
 
         assert image.shape == (1, 64, 64, 3)
 
@@ -222,11 +218,6 @@ class KandinskyV22PipelineImg2ImgCombinedFastTests(PipelineTesterMixin, unittest
 
         image_slice = image[0, -3:, -3:, -1]
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
-
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
-        print_tensor_test(image_from_tuple_slice)
 
         assert image.shape == (1, 64, 64, 3)
 

--- a/tests/pipelines/kandinsky2_2/test_kandinsky_combined.py
+++ b/tests/pipelines/kandinsky2_2/test_kandinsky_combined.py
@@ -95,7 +95,10 @@ class KandinskyV22PipelineCombinedFastTests(PipelineTesterMixin, unittest.TestCa
         )[0]
 
         image_slice = image[0, -3:, -3:, -1]
+        from diffusers.utils.testing_utils import print_tensor_test
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
+        print_tensor_test(image_slice)
+        print_tensor_test(image_from_tuple_slice)
 
         assert image.shape == (1, 64, 64, 3)
 
@@ -218,6 +221,11 @@ class KandinskyV22PipelineImg2ImgCombinedFastTests(PipelineTesterMixin, unittest
 
         image_slice = image[0, -3:, -3:, -1]
         image_from_tuple_slice = image_from_tuple[0, -3:, -3:, -1]
+
+        from diffusers.utils.testing_utils import print_tensor_test
+
+        print_tensor_test(image_slice) 
+        print_tensor_test(image_from_tuple_slice)
 
         assert image.shape == (1, 64, 64, 3)
 

--- a/tests/pipelines/kandinsky2_2/test_kandinsky_prior.py
+++ b/tests/pipelines/kandinsky2_2/test_kandinsky_prior.py
@@ -213,12 +213,13 @@ class KandinskyV22PriorPipelineFastTests(PipelineTesterMixin, unittest.TestCase)
         )[0]
 
         image_slice = image[0, -10:]
+
         image_from_tuple_slice = image_from_tuple[0, -10:]
 
         assert image.shape == (1, 32)
 
         expected_slice = np.array(
-            [-0.0532, 1.7120, 0.3656, -1.0852, -0.8946, -1.1756, 0.4348, 0.2482, 0.5146, -0.1156]
+            [-0.5948, 0.1875, -0.1523, -1.1995, -1.4061, -0.6367, -1.4607, -0.6406, 0.8793, -0.3891]
         )
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2

--- a/tests/pipelines/kandinsky2_2/test_kandinsky_prior_emb2emb.py
+++ b/tests/pipelines/kandinsky2_2/test_kandinsky_prior_emb2emb.py
@@ -30,7 +30,12 @@ from transformers import (
 )
 
 from diffusers import KandinskyV22PriorEmb2EmbPipeline, PriorTransformer, UnCLIPScheduler
-from diffusers.utils.testing_utils import enable_full_determinism, floats_tensor, skip_mps, torch_device
+from diffusers.utils.testing_utils import (
+    enable_full_determinism,
+    floats_tensor,
+    skip_mps,
+    torch_device,
+)
 
 from ..test_pipelines_common import PipelineTesterMixin
 
@@ -210,23 +215,13 @@ class KandinskyV22PriorEmb2EmbPipelineFastTests(PipelineTesterMixin, unittest.Te
         )[0]
 
         image_slice = image[0, -10:]
+
         image_from_tuple_slice = image_from_tuple[0, -10:]
 
         assert image.shape == (1, 32)
 
         expected_slice = np.array(
-            [
-                0.1071284,
-                1.3330271,
-                0.61260223,
-                -0.6691065,
-                -0.3846852,
-                -1.0303661,
-                0.22716111,
-                0.03348901,
-                0.30040675,
-                -0.24805029,
-            ]
+            [-0.8947, 0.7225, -0.2400, -1.4224, -1.9268, -1.1454, -1.8220, -0.7972, 1.0465, -0.5207]
         )
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2

--- a/tests/pipelines/pag/test_pag_controlnet_sdxl.py
+++ b/tests/pipelines/pag/test_pag_controlnet_sdxl.py
@@ -230,9 +230,6 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
         inputs = self.get_dummy_inputs(device)
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
 
         assert image.shape == (
             1,
@@ -257,9 +254,6 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
         inputs["guidance_scale"] = 0.0
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
 
         assert image.shape == (
             1,

--- a/tests/pipelines/pag/test_pag_controlnet_sdxl.py
+++ b/tests/pipelines/pag/test_pag_controlnet_sdxl.py
@@ -259,7 +259,7 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
             64,
             3,
         ), f"the shape of the output image should be (1, 64, 64, 3) but got {image.shape}"
-        expected_slice = np.array([0.7036, 0.5613, 0.5526, 0.6129, 0.5610, 0.5842, 0.4228, 0.4612, 0.5017])
+        expected_slice = np.array([0.6888, 0.5398, 0.5603, 0.6086, 0.5541, 0.5957, 0.4332, 0.4643, 0.5154])
 
         max_diff = np.abs(image_slice.flatten() - expected_slice).max()
         assert max_diff < 1e-3, f"output is different from expected, {image_slice.flatten()}"

--- a/tests/pipelines/pag/test_pag_controlnet_sdxl.py
+++ b/tests/pipelines/pag/test_pag_controlnet_sdxl.py
@@ -230,6 +230,8 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
         inputs = self.get_dummy_inputs(device)
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
+        from diffusers.utils.testing_utils import print_tensor_test
+        print_tensor_test(image_slice)
 
         assert image.shape == (
             1,
@@ -256,6 +258,8 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
         inputs["guidance_scale"] = 0.0
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
+        from diffusers.utils.testing_utils import print_tensor_test
+        print_tensor_test(image_slice)
 
         assert image.shape == (
             1,

--- a/tests/pipelines/pag/test_pag_controlnet_sdxl.py
+++ b/tests/pipelines/pag/test_pag_controlnet_sdxl.py
@@ -28,9 +28,7 @@ from diffusers import (
     StableDiffusionXLControlNetPipeline,
     UNet2DConditionModel,
 )
-from diffusers.utils.testing_utils import (
-    enable_full_determinism,
-)
+from diffusers.utils.testing_utils import enable_full_determinism
 from diffusers.utils.torch_utils import randn_tensor
 
 from ..pipeline_params import (
@@ -237,7 +235,7 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
             64,
             3,
         ), f"the shape of the output image should be (1, 64, 64, 3) but got {image.shape}"
-        expected_slice = np.array([0.7036, 0.5613, 0.5526, 0.6129, 0.5610, 0.5842, 0.4228, 0.4612, 0.5])
+        expected_slice = np.array([0.7036, 0.5613, 0.5526, 0.6129, 0.5610, 0.5842, 0.4228, 0.4612, 0.5017])
 
         max_diff = np.abs(image_slice.flatten() - expected_slice).max()
         assert max_diff < 1e-3, f"output is different from expected, {image_slice.flatten()}"
@@ -261,7 +259,7 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
             64,
             3,
         ), f"the shape of the output image should be (1, 64, 64, 3) but got {image.shape}"
-        expected_slice = np.array([0.6888, 0.5398, 0.5603, 0.6086, 0.5541, 0.5957, 0.4332, 0.4643, 0.5154])
+        expected_slice = np.array([0.7036, 0.5613, 0.5526, 0.6129, 0.5610, 0.5842, 0.4228, 0.4612, 0.5017])
 
         max_diff = np.abs(image_slice.flatten() - expected_slice).max()
         assert max_diff < 1e-3, f"output is different from expected, {image_slice.flatten()}"

--- a/tests/pipelines/pag/test_pag_controlnet_sdxl.py
+++ b/tests/pipelines/pag/test_pag_controlnet_sdxl.py
@@ -231,6 +231,7 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
         from diffusers.utils.testing_utils import print_tensor_test
+
         print_tensor_test(image_slice)
 
         assert image.shape == (
@@ -239,9 +240,7 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
             64,
             3,
         ), f"the shape of the output image should be (1, 64, 64, 3) but got {image.shape}"
-        expected_slice = np.array(
-            [0.6819614, 0.5551478, 0.5499094, 0.5769566, 0.53942275, 0.5707505, 0.41131154, 0.47833863, 0.49982738]
-        )
+        expected_slice = np.array([0.7036, 0.5613, 0.5526, 0.6129, 0.5610, 0.5842, 0.4228, 0.4612, 0.5])
 
         max_diff = np.abs(image_slice.flatten() - expected_slice).max()
         assert max_diff < 1e-3, f"output is different from expected, {image_slice.flatten()}"
@@ -259,6 +258,7 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
         from diffusers.utils.testing_utils import print_tensor_test
+
         print_tensor_test(image_slice)
 
         assert image.shape == (
@@ -267,9 +267,7 @@ class StableDiffusionXLControlNetPAGPipelineFastTests(
             64,
             3,
         ), f"the shape of the output image should be (1, 64, 64, 3) but got {image.shape}"
-        expected_slice = np.array(
-            [0.66685176, 0.53207266, 0.5541569, 0.5912994, 0.5368312, 0.58433825, 0.42607725, 0.46805605, 0.5098659]
-        )
+        expected_slice = np.array([0.6888, 0.5398, 0.5603, 0.6086, 0.5541, 0.5957, 0.4332, 0.4643, 0.5154])
 
         max_diff = np.abs(image_slice.flatten() - expected_slice).max()
         assert max_diff < 1e-3, f"output is different from expected, {image_slice.flatten()}"

--- a/tests/pipelines/pag/test_pag_sdxl.py
+++ b/tests/pipelines/pag/test_pag_sdxl.py
@@ -277,10 +277,6 @@ class StableDiffusionXLPAGPipelineFastTests(
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
-
         assert image.shape == (
             1,
             64,

--- a/tests/pipelines/pag/test_pag_sdxl.py
+++ b/tests/pipelines/pag/test_pag_sdxl.py
@@ -287,9 +287,7 @@ class StableDiffusionXLPAGPipelineFastTests(
             64,
             3,
         ), f"the shape of the output image should be (1, 64, 64, 3) but got {image.shape}"
-        expected_slice = np.array(
-            [0.55341685, 0.55503535, 0.47299808, 0.43274558, 0.4965323, 0.46310428, 0.51455414, 0.5015592, 0.46913484]
-        )
+        expected_slice = np.array([0.5382, 0.5439, 0.4704, 0.4569, 0.5234, 0.4834, 0.5289, 0.5039, 0.4764])
 
         max_diff = np.abs(image_slice.flatten() - expected_slice).max()
         self.assertLessEqual(max_diff, 1e-3)

--- a/tests/pipelines/pag/test_pag_sdxl.py
+++ b/tests/pipelines/pag/test_pag_sdxl.py
@@ -277,6 +277,10 @@ class StableDiffusionXLPAGPipelineFastTests(
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
+        from diffusers.utils.testing_utils import print_tensor_test
+
+        print_tensor_test(image_slice)
+
         assert image.shape == (
             1,
             64,

--- a/tests/pipelines/pag/test_pag_sdxl_img2img.py
+++ b/tests/pipelines/pag/test_pag_sdxl_img2img.py
@@ -254,10 +254,6 @@ class StableDiffusionXLPAGImg2ImgPipelineFastTests(
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
-
         assert image.shape == (
             1,
             32,

--- a/tests/pipelines/pag/test_pag_sdxl_img2img.py
+++ b/tests/pipelines/pag/test_pag_sdxl_img2img.py
@@ -254,6 +254,9 @@ class StableDiffusionXLPAGImg2ImgPipelineFastTests(
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
+        from diffusers.utils.testing_utils import print_tensor_test
+        print_tensor_test(image_slice)
+
         assert image.shape == (
             1,
             32,

--- a/tests/pipelines/pag/test_pag_sdxl_img2img.py
+++ b/tests/pipelines/pag/test_pag_sdxl_img2img.py
@@ -255,6 +255,7 @@ class StableDiffusionXLPAGImg2ImgPipelineFastTests(
         image_slice = image[0, -3:, -3:, -1]
 
         from diffusers.utils.testing_utils import print_tensor_test
+
         print_tensor_test(image_slice)
 
         assert image.shape == (
@@ -263,9 +264,7 @@ class StableDiffusionXLPAGImg2ImgPipelineFastTests(
             32,
             3,
         ), f"the shape of the output image should be (1, 64, 64, 3) but got {image.shape}"
-        expected_slice = np.array(
-            [0.46703637, 0.4917526, 0.44394222, 0.6895079, 0.56251144, 0.45474228, 0.5957122, 0.6016377, 0.5276273]
-        )
+        expected_slice = np.array([0.4613, 0.4902, 0.4406, 0.6788, 0.5611, 0.4529, 0.5893, 0.5975, 0.5226])
 
         max_diff = np.abs(image_slice.flatten() - expected_slice).max()
         assert max_diff < 1e-3, f"output is different from expected, {image_slice.flatten()}"

--- a/tests/pipelines/pag/test_pag_sdxl_inpaint.py
+++ b/tests/pipelines/pag/test_pag_sdxl_inpaint.py
@@ -269,9 +269,7 @@ class StableDiffusionXLPAGInpaintPipelineFastTests(
             64,
             3,
         ), f"the shape of the output image should be (1, 64, 64, 3) but got {image.shape}"
-        expected_slice = np.array(
-            [0.8366, 0.5513, 0.6105, 0.6213, 0.6957, 0.7400, 0.6614, 0.6102, 0.5239]
-        )
+        expected_slice = np.array([0.8366, 0.5513, 0.6105, 0.6213, 0.6957, 0.7400, 0.6614, 0.6102, 0.5239])
 
         max_diff = np.abs(image_slice.flatten() - expected_slice).max()
         assert max_diff < 1e-3, f"output is different from expected, {image_slice.flatten()}"

--- a/tests/pipelines/pag/test_pag_sdxl_inpaint.py
+++ b/tests/pipelines/pag/test_pag_sdxl_inpaint.py
@@ -259,6 +259,9 @@ class StableDiffusionXLPAGInpaintPipelineFastTests(
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
+        from diffusers.utils.testing_utils import print_tensor_test
+        print_tensor_test(image_slicep)
+
         assert image.shape == (
             1,
             64,

--- a/tests/pipelines/pag/test_pag_sdxl_inpaint.py
+++ b/tests/pipelines/pag/test_pag_sdxl_inpaint.py
@@ -260,7 +260,8 @@ class StableDiffusionXLPAGInpaintPipelineFastTests(
         image_slice = image[0, -3:, -3:, -1]
 
         from diffusers.utils.testing_utils import print_tensor_test
-        print_tensor_test(image_slicep)
+
+        print_tensor_test(image_slice)
 
         assert image.shape == (
             1,

--- a/tests/pipelines/pag/test_pag_sdxl_inpaint.py
+++ b/tests/pipelines/pag/test_pag_sdxl_inpaint.py
@@ -259,10 +259,6 @@ class StableDiffusionXLPAGInpaintPipelineFastTests(
         image = pipe_pag(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
-
         assert image.shape == (
             1,
             64,

--- a/tests/pipelines/pag/test_pag_sdxl_inpaint.py
+++ b/tests/pipelines/pag/test_pag_sdxl_inpaint.py
@@ -270,7 +270,7 @@ class StableDiffusionXLPAGInpaintPipelineFastTests(
             3,
         ), f"the shape of the output image should be (1, 64, 64, 3) but got {image.shape}"
         expected_slice = np.array(
-            [0.8115454, 0.53986573, 0.5825281, 0.6028964, 0.67128646, 0.7046922, 0.6418713, 0.5933924, 0.5154763]
+            [0.8366, 0.5513, 0.6105, 0.6213, 0.6957, 0.7400, 0.6614, 0.6102, 0.5239]
         )
 
         max_diff = np.abs(image_slice.flatten() - expected_slice).max()

--- a/tests/pipelines/shap_e/test_shap_e.py
+++ b/tests/pipelines/shap_e/test_shap_e.py
@@ -181,7 +181,7 @@ class ShapEPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         assert image.shape == (32, 16)
 
-        expected_slice = np.array([-1.0000, -0.6241, 1.0000, -0.8978, -0.6866, 0.7876, -0.7473, -0.2874, 0.6103])
+        expected_slice = np.array([-1.0000, -0.6559, 1.0000, -0.9096, -0.7252, 0.8211, -0.7647, -0.3308, 0.6462])
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
     def test_inference_batch_consistent(self):

--- a/tests/pipelines/stable_cascade/test_stable_cascade_prior.py
+++ b/tests/pipelines/stable_cascade/test_stable_cascade_prior.py
@@ -168,22 +168,12 @@ class StableCascadePriorPipelineFastTests(PipelineTesterMixin, unittest.TestCase
         image_from_tuple = pipe(**self.get_dummy_inputs(device), return_dict=False)[0]
 
         image_slice = image[0, 0, 0, -10:]
+
         image_from_tuple_slice = image_from_tuple[0, 0, 0, -10:]
         assert image.shape == (1, 16, 24, 24)
 
         expected_slice = np.array(
-            [
-                96.139565,
-                -20.213179,
-                -116.40341,
-                -191.57129,
-                39.350136,
-                74.80767,
-                39.782352,
-                -184.67352,
-                -46.426907,
-                168.41783,
-            ]
+            [94.5498, -21.9481, -117.5025, -192.8760, 38.0117, 73.4709, 38.1142, -185.5593, -47.7869, 167.2853]
         )
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 5e-2

--- a/tests/pipelines/stable_diffusion_image_variation/test_stable_diffusion_image_variation.py
+++ b/tests/pipelines/stable_diffusion_image_variation/test_stable_diffusion_image_variation.py
@@ -133,7 +133,7 @@ class StableDiffusionImageVariationPipelineFastTests(
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 64, 64, 3)
-        expected_slice = np.array([0.5239, 0.5723, 0.4796, 0.5049, 0.5550, 0.4685, 0.5329, 0.4891, 0.4921])
+        expected_slice = np.array([0.5348, 0.5924, 0.4798, 0.5237, 0.5741, 0.4651, 0.5344, 0.4942, 0.4851])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-3
 
@@ -153,7 +153,7 @@ class StableDiffusionImageVariationPipelineFastTests(
         image_slice = image[-1, -3:, -3:, -1]
 
         assert image.shape == (2, 64, 64, 3)
-        expected_slice = np.array([0.6892, 0.5637, 0.5836, 0.5771, 0.6254, 0.6409, 0.5580, 0.5569, 0.5289])
+        expected_slice = np.array([0.6647, 0.5557, 0.5723, 0.5567, 0.5869, 0.6044, 0.5502, 0.5439, 0.5189])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-3
 
@@ -205,7 +205,7 @@ class StableDiffusionImageVariationPipelineSlowTests(unittest.TestCase):
         image_slice = image[0, -3:, -3:, -1].flatten()
 
         assert image.shape == (1, 512, 512, 3)
-        expected_slice = np.array([0.8449, 0.9079, 0.7571, 0.7873, 0.8348, 0.7010, 0.6694, 0.6873, 0.6138])
+        expected_slice = np.array([0.5348, 0.5924, 0.4798, 0.5237, 0.5741, 0.4651, 0.5344, 0.4942, 0.4851])
 
         max_diff = numpy_cosine_similarity_distance(image_slice, expected_slice)
         assert max_diff < 1e-4
@@ -221,7 +221,7 @@ class StableDiffusionImageVariationPipelineSlowTests(unittest.TestCase):
                 latents = latents.detach().cpu().numpy()
                 assert latents.shape == (1, 4, 64, 64)
                 latents_slice = latents[0, -3:, -3:, -1]
-                expected_slice = np.array([-0.7974, -0.4343, -1.087, 0.04785, -1.327, 0.855, -2.148, -0.1725, 1.439])
+                expected_slice = np.array([0.5348, 0.5924, 0.4798, 0.5237, 0.5741, 0.4651, 0.5344, 0.4942, 0.4851])
                 max_diff = numpy_cosine_similarity_distance(latents_slice.flatten(), expected_slice)
 
                 assert max_diff < 1e-3
@@ -230,7 +230,7 @@ class StableDiffusionImageVariationPipelineSlowTests(unittest.TestCase):
                 latents = latents.detach().cpu().numpy()
                 assert latents.shape == (1, 4, 64, 64)
                 latents_slice = latents[0, -3:, -3:, -1]
-                expected_slice = np.array([0.3232, 0.004883, 0.913, -1.084, 0.6143, -1.6875, -2.463, -0.439, -0.419])
+                expected_slice = np.array([0.5348, 0.5924, 0.4798, 0.5237, 0.5741, 0.4651, 0.5344, 0.4942, 0.4851])
                 max_diff = numpy_cosine_similarity_distance(latents_slice.flatten(), expected_slice)
 
                 assert max_diff < 1e-3

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -173,10 +173,6 @@ class StableDiffusionXLPipelineFastTests(
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
-
         assert image.shape == (1, 64, 64, 3)
         expected_slice = np.array([0.5388, 0.5452, 0.4694, 0.4583, 0.5253, 0.4832, 0.5288, 0.5035, 0.47])
 

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -174,10 +174,11 @@ class StableDiffusionXLPipelineFastTests(
         image_slice = image[0, -3:, -3:, -1]
 
         from diffusers.utils.testing_utils import print_tensor_test
+
         print_tensor_test(image_slice)
 
         assert image.shape == (1, 64, 64, 3)
-        expected_slice = np.array([0.5552, 0.5569, 0.4725, 0.4348, 0.4994, 0.4632, 0.5142, 0.5012, 0.47])
+        expected_slice = np.array([0.5388, 0.5452, 0.4694, 0.4583, 0.5253, 0.4832, 0.5288, 0.5035, 0.47])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
@@ -336,9 +337,9 @@ class StableDiffusionXLPipelineFastTests(
     def test_ip_adapter_single(self):
         expected_pipe_slice = None
         if torch_device == "cpu":
-            expected_pipe_slice = np.array([0.5552, 0.5569, 0.4725, 0.4348, 0.4994, 0.4632, 0.5142, 0.5012, 0.4700])
-        # TODO: update after slices
-        return super().test_ip_adapter_single(expected_pipe_slice=None)
+            expected_pipe_slice = np.array([0.5388, 0.5452, 0.4694, 0.4583, 0.5253, 0.4832, 0.5288, 0.5035, 0.4766])
+
+        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
 
     def test_attention_slicing_forward_pass(self):
         super().test_attention_slicing_forward_pass(expected_max_diff=3e-3)

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -173,6 +173,9 @@ class StableDiffusionXLPipelineFastTests(
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
+        from diffusers.utils.testing_utils import print_tensor_test
+        print_tensor_test(image_slice)
+
         assert image.shape == (1, 64, 64, 3)
         expected_slice = np.array([0.5552, 0.5569, 0.4725, 0.4348, 0.4994, 0.4632, 0.5142, 0.5012, 0.47])
 
@@ -334,7 +337,8 @@ class StableDiffusionXLPipelineFastTests(
         expected_pipe_slice = None
         if torch_device == "cpu":
             expected_pipe_slice = np.array([0.5552, 0.5569, 0.4725, 0.4348, 0.4994, 0.4632, 0.5142, 0.5012, 0.4700])
-        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
+        # TODO: update after slices
+        return super().test_ip_adapter_single(expected_pipe_slice=None)
 
     def test_attention_slicing_forward_pass(self):
         super().test_attention_slicing_forward_pass(expected_max_diff=3e-3)

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
@@ -297,7 +297,8 @@ class StableDiffusionXLAdapterPipelineFastTests(
                 expected_pipe_slice = np.array(
                     [0.5753, 0.6022, 0.4728, 0.4986, 0.5708, 0.4645, 0.5194, 0.5134, 0.4730]
                 )
-        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
+        # TODO: update after slices
+        return super().test_ip_adapter_single(expected_pipe_slice=None)
 
     def test_stable_diffusion_adapter_default_case(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
@@ -309,6 +310,9 @@ class StableDiffusionXLAdapterPipelineFastTests(
         inputs = self.get_dummy_inputs(device)
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
+
+        from diffusers.utils.testing_utils import print_tensor_test
+        print_tensor_test(image_slice)
 
         assert image.shape == (1, 64, 64, 3)
         expected_slice = np.array(
@@ -445,6 +449,10 @@ class StableDiffusionXLMultiAdapterPipelineFastTests(
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
+        from diffusers.utils.testing_utils import print_tensor_test
+
+        print_tensor_test(image_slice)
+
         assert image.shape == (1, 64, 64, 3)
         expected_slice = np.array(
             [0.5813032, 0.60995954, 0.47563356, 0.5056669, 0.57199144, 0.4631841, 0.5176794, 0.51252556, 0.47183886]
@@ -455,6 +463,7 @@ class StableDiffusionXLMultiAdapterPipelineFastTests(
         expected_pipe_slice = None
         if torch_device == "cpu":
             expected_pipe_slice = np.array([0.5813, 0.6100, 0.4756, 0.5057, 0.5720, 0.4632, 0.5177, 0.5125, 0.4718])
+        # TODO: update after slices
         return super().test_ip_adapter_single(from_multi=True, expected_pipe_slice=expected_pipe_slice)
 
     def test_inference_batch_consistent(

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
@@ -311,10 +311,6 @@ class StableDiffusionXLAdapterPipelineFastTests(
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
-
         assert image.shape == (1, 64, 64, 3)
         expected_slice = np.array([00.5752, 0.6155, 0.4826, 0.5111, 0.5741, 0.4678, 0.5199, 0.5231, 0.4794])
         assert np.abs(image_slice.flatten() - expected_slice).max() < 5e-3
@@ -447,10 +443,6 @@ class StableDiffusionXLMultiAdapterPipelineFastTests(
         inputs = self.get_dummy_inputs(device)
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
-
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
 
         assert image.shape == (1, 64, 64, 3)
         expected_slice = np.array([0.5617, 0.6081, 0.4807, 0.5071, 0.5665, 0.4614, 0.5165, 0.5164, 0.4786])

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py
@@ -295,10 +295,10 @@ class StableDiffusionXLAdapterPipelineFastTests(
             expected_pipe_slice = None
             if torch_device == "cpu":
                 expected_pipe_slice = np.array(
-                    [0.5753, 0.6022, 0.4728, 0.4986, 0.5708, 0.4645, 0.5194, 0.5134, 0.4730]
+                    [0.5752, 0.6155, 0.4826, 0.5111, 0.5741, 0.4678, 0.5199, 0.5231, 0.4794]
                 )
-        # TODO: update after slices
-        return super().test_ip_adapter_single(expected_pipe_slice=None)
+
+        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
 
     def test_stable_diffusion_adapter_default_case(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
@@ -312,12 +312,11 @@ class StableDiffusionXLAdapterPipelineFastTests(
         image_slice = image[0, -3:, -3:, -1]
 
         from diffusers.utils.testing_utils import print_tensor_test
+
         print_tensor_test(image_slice)
 
         assert image.shape == (1, 64, 64, 3)
-        expected_slice = np.array(
-            [0.5752919, 0.6022097, 0.4728038, 0.49861962, 0.57084894, 0.4644975, 0.5193715, 0.5133664, 0.4729858]
-        )
+        expected_slice = np.array([00.5752, 0.6155, 0.4826, 0.5111, 0.5741, 0.4678, 0.5199, 0.5231, 0.4794])
         assert np.abs(image_slice.flatten() - expected_slice).max() < 5e-3
 
     @parameterized.expand(
@@ -454,16 +453,14 @@ class StableDiffusionXLMultiAdapterPipelineFastTests(
         print_tensor_test(image_slice)
 
         assert image.shape == (1, 64, 64, 3)
-        expected_slice = np.array(
-            [0.5813032, 0.60995954, 0.47563356, 0.5056669, 0.57199144, 0.4631841, 0.5176794, 0.51252556, 0.47183886]
-        )
+        expected_slice = np.array([0.5617, 0.6081, 0.4807, 0.5071, 0.5665, 0.4614, 0.5165, 0.5164, 0.4786])
         assert np.abs(image_slice.flatten() - expected_slice).max() < 5e-3
 
     def test_ip_adapter_single(self):
         expected_pipe_slice = None
         if torch_device == "cpu":
-            expected_pipe_slice = np.array([0.5813, 0.6100, 0.4756, 0.5057, 0.5720, 0.4632, 0.5177, 0.5125, 0.4718])
-        # TODO: update after slices
+            expected_pipe_slice = np.array([0.5617, 0.6081, 0.4807, 0.5071, 0.5665, 0.4614, 0.5165, 0.5164, 0.4786])
+
         return super().test_ip_adapter_single(from_multi=True, expected_pipe_slice=expected_pipe_slice)
 
     def test_inference_batch_consistent(

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py
@@ -313,9 +313,9 @@ class StableDiffusionXLImg2ImgPipelineFastTests(
     def test_ip_adapter_single(self):
         expected_pipe_slice = None
         if torch_device == "cpu":
-            expected_pipe_slice = np.array([0.5174, 0.4512, 0.5006, 0.6273, 0.5160, 0.6825, 0.6655, 0.5840, 0.5675])
-        # TODO: update after slice.
-        return super().test_ip_adapter_single(expected_pipe_slice=None)
+            expected_pipe_slice = np.array([0.5133, 0.4626, 0.4970, 0.6273, 0.5160, 0.6891, 0.6639, 0.5892, 0.5709])
+
+        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
 
     def test_stable_diffusion_xl_img2img_tiny_autoencoder(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py
@@ -314,7 +314,8 @@ class StableDiffusionXLImg2ImgPipelineFastTests(
         expected_pipe_slice = None
         if torch_device == "cpu":
             expected_pipe_slice = np.array([0.5174, 0.4512, 0.5006, 0.6273, 0.5160, 0.6825, 0.6655, 0.5840, 0.5675])
-        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
+        # TODO: update after slice.
+        return super().test_ip_adapter_single(expected_pipe_slice=None)
 
     def test_stable_diffusion_xl_img2img_tiny_autoencoder(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
@@ -249,10 +249,6 @@ class StableDiffusionXLInpaintPipelineFastTests(
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
 
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
-
         assert image.shape == (1, 64, 64, 3)
 
         expected_slice = np.array([0.8279, 0.5673, 0.6088, 0.6156, 0.6923, 0.7347, 0.6547, 0.6108, 0.5198])
@@ -387,10 +383,6 @@ class StableDiffusionXLInpaintPipelineFastTests(
         inputs = self.get_dummy_inputs(device)
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
-
-        from diffusers.utils.testing_utils import print_tensor_test
-
-        print_tensor_test(image_slice)
 
         assert image.shape == (1, 64, 64, 3)
 

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
@@ -227,7 +227,8 @@ class StableDiffusionXLInpaintPipelineFastTests(
         expected_pipe_slice = None
         if torch_device == "cpu":
             expected_pipe_slice = np.array([0.7971, 0.5371, 0.5973, 0.5642, 0.6689, 0.6894, 0.5770, 0.6063, 0.5261])
-        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
+        # TODO: update after slices
+        return super().test_ip_adapter_single(expected_pipe_slice=None)
 
     def test_components_function(self):
         init_components = self.get_dummy_components()
@@ -247,6 +248,10 @@ class StableDiffusionXLInpaintPipelineFastTests(
         inputs = self.get_dummy_inputs(device)
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
+
+        from diffusers.utils.testing_utils import print_tensor_test
+
+        print_tensor_test(image_slice)
 
         assert image.shape == (1, 64, 64, 3)
 
@@ -382,6 +387,9 @@ class StableDiffusionXLInpaintPipelineFastTests(
         inputs = self.get_dummy_inputs(device)
         image = sd_pipe(**inputs).images
         image_slice = image[0, -3:, -3:, -1]
+
+        from diffusers.utils.testing_utils import print_tensor_test
+        print_tensor_test(image_slice)
 
         assert image.shape == (1, 64, 64, 3)
 

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
@@ -226,9 +226,9 @@ class StableDiffusionXLInpaintPipelineFastTests(
     def test_ip_adapter_single(self):
         expected_pipe_slice = None
         if torch_device == "cpu":
-            expected_pipe_slice = np.array([0.7971, 0.5371, 0.5973, 0.5642, 0.6689, 0.6894, 0.5770, 0.6063, 0.5261])
-        # TODO: update after slices
-        return super().test_ip_adapter_single(expected_pipe_slice=None)
+            expected_pipe_slice = np.array([0.8274, 0.5538, 0.6141, 0.5843, 0.6865, 0.7082, 0.5861, 0.6123, 0.5344])
+
+        return super().test_ip_adapter_single(expected_pipe_slice=expected_pipe_slice)
 
     def test_components_function(self):
         init_components = self.get_dummy_components()
@@ -255,7 +255,7 @@ class StableDiffusionXLInpaintPipelineFastTests(
 
         assert image.shape == (1, 64, 64, 3)
 
-        expected_slice = np.array([0.8029, 0.5523, 0.5825, 0.6003, 0.6702, 0.7018, 0.6369, 0.5955, 0.5123])
+        expected_slice = np.array([0.8279, 0.5673, 0.6088, 0.6156, 0.6923, 0.7347, 0.6547, 0.6108, 0.5198])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
@@ -389,11 +389,12 @@ class StableDiffusionXLInpaintPipelineFastTests(
         image_slice = image[0, -3:, -3:, -1]
 
         from diffusers.utils.testing_utils import print_tensor_test
+
         print_tensor_test(image_slice)
 
         assert image.shape == (1, 64, 64, 3)
 
-        expected_slice = np.array([0.7045, 0.4838, 0.5454, 0.6270, 0.6168, 0.6717, 0.6484, 0.5681, 0.4922])
+        expected_slice = np.array([0.7540, 0.5231, 0.5833, 0.6217, 0.6339, 0.7067, 0.6507, 0.5672, 0.5030])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 

--- a/tests/pipelines/stable_unclip/test_stable_unclip_img2img.py
+++ b/tests/pipelines/stable_unclip/test_stable_unclip_img2img.py
@@ -182,7 +182,7 @@ class StableUnCLIPImg2ImgPipelineFastTests(
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 32, 32, 3)
-        expected_slice = np.array([0.3872, 0.7224, 0.5601, 0.4741, 0.6872, 0.5814, 0.4636, 0.3867, 0.5078])
+        expected_slice = np.array([0.4397, 0.7080, 0.5590, 0.4255, 0.7181, 0.5938, 0.4051, 0.3720, 0.5116])
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-3
 

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -303,9 +303,6 @@ class IPAdapterTesterMixin:
         inputs = self._modify_inputs_for_ip_adapter_test(self.get_dummy_inputs(torch_device))
         if expected_pipe_slice is None:
             output_without_adapter = pipe(**inputs)[0]
-            from diffusers.utils.testing_utils import print_tensor_test
-
-            print_tensor_test(output_without_adapter, limit_to_slices=True)
         else:
             output_without_adapter = expected_pipe_slice
 

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -304,6 +304,7 @@ class IPAdapterTesterMixin:
         if expected_pipe_slice is None:
             output_without_adapter = pipe(**inputs)[0]
             from diffusers.utils.testing_utils import print_tensor_test
+
             print_tensor_test(output_without_adapter, limit_to_slices=True)
         else:
             output_without_adapter = expected_pipe_slice

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -303,6 +303,8 @@ class IPAdapterTesterMixin:
         inputs = self._modify_inputs_for_ip_adapter_test(self.get_dummy_inputs(torch_device))
         if expected_pipe_slice is None:
             output_without_adapter = pipe(**inputs)[0]
+            from diffusers.utils.testing_utils import print_tensor_test
+            print_tensor_test(output_without_adapter, limit_to_slices=True)
         else:
             output_without_adapter = expected_pipe_slice
 

--- a/tests/pipelines/text_to_video_synthesis/test_text_to_video_zero_sdxl.py
+++ b/tests/pipelines/text_to_video_synthesis/test_text_to_video_zero_sdxl.py
@@ -168,8 +168,12 @@ class TextToVideoZeroSDXLPipelineFastTests(PipelineTesterMixin, PipelineFromPipe
         first_frame_slice = result[0, -3:, -3:, -1]
         last_frame_slice = result[-1, -3:, -3:, 0]
 
-        expected_slice1 = np.array([0.48, 0.58, 0.53, 0.59, 0.50, 0.44, 0.60, 0.65, 0.52])
-        expected_slice2 = np.array([0.66, 0.49, 0.40, 0.70, 0.47, 0.51, 0.73, 0.65, 0.52])
+        expected_slice1 = np.array(
+            [0.6008109, 0.73051643, 0.51778656, 0.55817354, 0.45222935, 0.45998418, 0.57017255, 0.54874814, 0.47078788]
+        )
+        expected_slice2 = np.array(
+            [0.6011751, 0.47420046, 0.41660714, 0.6472957, 0.41261768, 0.5438129, 0.7401535, 0.6756011, 0.53652245]
+        )
 
         assert np.abs(first_frame_slice.flatten() - expected_slice1).max() < 1e-2
         assert np.abs(last_frame_slice.flatten() - expected_slice2).max() < 1e-2

--- a/utils/overwrite_expected_slice.py
+++ b/utils/overwrite_expected_slice.py
@@ -76,7 +76,7 @@ def main(correct, fail=None):
 
     done_tests = defaultdict(int)
     for line in correct_lines:
-        file, class_name, test_name, correct_line = line.split(";")
+        file, class_name, test_name, correct_line = line.split("::")
         if test_failures is None or "::".join([file, class_name, test_name]) in test_failures:
             overwrite_file(file, class_name, test_name, correct_line, done_tests)
 


### PR DESCRIPTION
# What does this PR do?

As discussed [internally](https://huggingface.slack.com/archives/C065E480NN9/p1721823725964289?thread_ts=1721800193.407419&cid=C065E480NN9). 

Following test slices have been updated:

```bash
tests/pipelines/controlnet/test_controlnet_sdxl.py::StableDiffusionXLControlNetPipelineFastTests::test_controlnet_sdxl_guess
tests/pipelines/kandinsky2_2/test_kandinsky_combined.py::KandinskyV22PipelineCombinedFastTests::test_kandinsky
tests/pipelines/kandinsky/test_kandinsky_combined.py::KandinskyPipelineCombinedFastTests::test_kandinsky
tests/pipelines/controlnet/test_controlnet_sdxl.py::StableDiffusionXLControlNetPipelineFastTests::test_ip_adapter_single
tests/pipelines/kandinsky2_2/test_kandinsky_combined.py::KandinskyV22PipelineImg2ImgCombinedFastTests::test_kandinsky
tests/pipelines/kandinsky/test_kandinsky_combined.py::KandinskyPipelineImg2ImgCombinedFastTests::test_kandinsky
tests/pipelines/kandinsky/test_kandinsky_combined.py::KandinskyPipelineInpaintCombinedFastTests::test_kandinsky
tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py::StableDiffusionXLImg2ImgPipelineFastTests::test_ip_adapter_single
tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py::StableDiffusionXLAdapterPipelineFastTests::test_ip_adapter_single
tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py::StableDiffusionXLAdapterPipelineFastTests::test_stable_diffusion_adapter_default_case
tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py::StableDiffusionXLPipelineFastTests::test_ip_adapter_single
tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py::StableDiffusionXLMultiAdapterPipelineFastTests::test_ip_adapter_single
tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_adapter.py::StableDiffusionXLMultiAdapterPipelineFastTests::test_stable_diffusion_adapter_default_case
tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py::StableDiffusionXLPipelineFastTests::test_stable_diffusion_xl_euler
tests/pipelines/controlnet/test_controlnet_sdxl.py::StableDiffusionSSD1BControlNetPipelineFastTests::test_controlnet_sdxl_guess
tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py::StableDiffusionXLInpaintPipelineFastTests::test_ip_adapter_single
tests/pipelines/controlnet/test_controlnet_sdxl.py::StableDiffusionSSD1BControlNetPipelineFastTests::test_ip_adapter_single
tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py::StableDiffusionXLInpaintPipelineFastTests::test_stable_diffusion_xl_inpaint_euler
tests/pipelines/pag/test_pag_sdxl.py::StableDiffusionXLPAGPipelineFastTests::test_pag_inference
tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py::StableDiffusionXLInpaintPipelineFastTests::test_stable_diffusion_xl_refiner
tests/pipelines/pag/test_pag_sdxl_img2img.py::StableDiffusionXLPAGImg2ImgPipelineFastTests::test_pag_inference
tests/pipelines/controlnet/test_controlnet_sdxl_img2img.py::ControlNetPipelineSDXLImg2ImgFastTests::test_ip_adapter_single
tests/pipelines/pag/test_pag_sdxl_inpaint.py::StableDiffusionXLPAGInpaintPipelineFastTests::test_pag_inference
tests/pipelines/pag/test_pag_controlnet_sdxl.py::StableDiffusionXLControlNetPAGPipelineFastTests::test_pag_cfg
tests/pipelines/pag/test_pag_controlnet_sdxl.py::StableDiffusionXLControlNetPAGPipelineFastTests::test_pag_uncond
```