### PR TITLE
Add Lumina T2I Auto Pipe Mapping

### DIFF
--- a/src/diffusers/pipelines/auto_pipeline.py
+++ b/src/diffusers/pipelines/auto_pipeline.py
@@ -49,6 +49,7 @@ from .kandinsky2_2 import (
 )
 from .kandinsky3 import Kandinsky3Img2ImgPipeline, Kandinsky3Pipeline
 from .latent_consistency_models import LatentConsistencyModelImg2ImgPipeline, LatentConsistencyModelPipeline
+from .lumina import LuminaText2ImgPipeline
 from .pag import (
     HunyuanDiTPAGPipeline,
     PixArtSigmaPAGPipeline,
@@ -106,6 +107,7 @@ AUTO_TEXT2IMAGE_PIPELINES_MAPPING = OrderedDict(
         ("pixart-sigma-pag", PixArtSigmaPAGPipeline),
         ("auraflow", AuraFlowPipeline),
         ("flux", FluxPipeline),
+        ("lumina", LuminaText2ImgPipeline),
     ]
 )
 


### PR DESCRIPTION
Doesn't appear to be an I2I pipe despite using a known VAE?

![00004](https://github.com/user-attachments/assets/b77ee9d2-90b6-4012-bb2b-1dc12b850df9)
`quickdif 'bright dslr portrait photograph of a kitten in a flower garden' -m 'Alpha-VLLM/Lumina-Next-SFT-diffusers' --dtype bf16`