### PR TITLE
Improve `FluxPipeline` checks and logging 

### DIFF
--- a/src/diffusers/models/transformers/transformer_flux.py
+++ b/src/diffusers/models/transformers/transformer_flux.py
@@ -373,7 +373,6 @@ class FluxTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         )
         encoder_hidden_states = self.context_embedder(encoder_hidden_states)
 
-        print(f"{txt_ids.shape=}, {img_ids.shape=}")
         ids = torch.cat((txt_ids, img_ids), dim=1)
         image_rotary_emb = self.pos_embed(ids)
 


### PR DESCRIPTION
# What does this PR do?

* Remove unnecessary logging of `txt_ids` and `img_ids` shapes that bloat up the console, especially when generating large quantities of images. This is done inside of `models/transformers/transformer_flux.py`.
* If the user passes their own `latent`s to the `FluxPipeline.__call__`, then there are additional checks to ensure the right shape is being used and, if not, that the expected ones are notified to the user. Otherwise, the typical message of PyTorch's tensor mismatch is uninformative at best. As such, the docstring has also been updated.

@sayakpaul