### PR TITLE
[refactor] apply qk norm in attention processors

### DIFF
--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -1785,6 +1785,11 @@ class AttnProcessor2_0:
         key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
         value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
 
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
         # the output of sdp = (batch, num_heads, seq_len, head_dim)
         # TODO: add support for attn.scale when we move to Torch 2.1
         hidden_states = F.scaled_dot_product_attention(
@@ -2313,6 +2318,11 @@ class FusedAttnProcessor2_0:
         query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
         key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
         value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
 
         # the output of sdp = (batch, num_heads, seq_len, head_dim)
         # TODO: add support for attn.scale when we move to Torch 2.1

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -192,7 +192,8 @@ class Attention(nn.Module):
             self.norm_q = RMSNorm(dim_head, eps=eps)
             self.norm_k = RMSNorm(dim_head, eps=eps)
         else:
-            raise ValueError(f"unknown qk_norm: {qk_norm}. Should be None or 'layer_norm'")
+            allowed_qk_norms = set("layer_norm", "fp32_layer_norm", "layer_norm_across_heads", "rms_norm")
+            raise ValueError(f"Unexpected value for {qk_norm=}. It must be one of {allowed_qk_norms}")
 
         if cross_attention_norm is None:
             self.norm_cross = None
@@ -660,6 +661,13 @@ class Attention(nn.Module):
             assert False
 
         return encoder_hidden_states
+
+    def maybe_apply_qk_norm(self, query: torch.Tensor, key: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.norm_q is not None:
+            query = self.norm_q(query)
+        if self.norm_k is not None:
+            key = self.norm_k(key)
+        return query, key
 
     @torch.no_grad()
     def fuse_projections(self, fuse=True):
@@ -1218,11 +1226,8 @@ class AuraFlowAttnProcessor2_0:
         key = key.view(batch_size, -1, attn.heads, head_dim)
         value = value.view(batch_size, -1, attn.heads, head_dim)
 
-        # Apply QK norm.
-        if attn.norm_q is not None:
-            query = attn.norm_q(query)
-        if attn.norm_k is not None:
-            key = attn.norm_k(key)
+        # Apply QK-norm if needed
+        query, key = attn.maybe_apply_qk_norm(query, key)
 
         # Concatenate the projections.
         if encoder_hidden_states is not None:
@@ -1323,10 +1328,8 @@ class FluxSingleAttnProcessor2_0:
         key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
         value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
 
-        if attn.norm_q is not None:
-            query = attn.norm_q(query)
-        if attn.norm_k is not None:
-            key = attn.norm_k(key)
+        # Apply QK-norm if needed
+        query, key = attn.maybe_apply_qk_norm(query, key)
 
         # Apply RoPE if needed
         if image_rotary_emb is not None:
@@ -1387,10 +1390,8 @@ class FluxAttnProcessor2_0:
         key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
         value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
 
-        if attn.norm_q is not None:
-            query = attn.norm_q(query)
-        if attn.norm_k is not None:
-            key = attn.norm_k(key)
+        # Apply QK-norm if needed
+        query, key = attn.maybe_apply_qk_norm(query, key)
 
         # `context` projections.
         encoder_hidden_states_query_proj = attn.add_q_proj(encoder_hidden_states)
@@ -1785,6 +1786,9 @@ class AttnProcessor2_0:
         key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
         value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
 
+        # Apply QK-norm if needed
+        query, key = attn.maybe_apply_qk_norm(query, key)
+
         # the output of sdp = (batch, num_heads, seq_len, head_dim)
         # TODO: add support for attn.scale when we move to Torch 2.1
         hidden_states = F.scaled_dot_product_attention(
@@ -1889,10 +1893,8 @@ class StableAudioAttnProcessor2_0:
             key = torch.repeat_interleave(key, heads_per_kv_head, dim=1)
             value = torch.repeat_interleave(value, heads_per_kv_head, dim=1)
 
-        if attn.norm_q is not None:
-            query = attn.norm_q(query)
-        if attn.norm_k is not None:
-            key = attn.norm_k(key)
+        # Apply QK-norm if needed
+        query, key = attn.maybe_apply_qk_norm(query, key)
 
         # Apply RoPE if needed
         if rotary_emb is not None:
@@ -2003,10 +2005,8 @@ class HunyuanAttnProcessor2_0:
         key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
         value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
 
-        if attn.norm_q is not None:
-            query = attn.norm_q(query)
-        if attn.norm_k is not None:
-            key = attn.norm_k(key)
+        # Apply QK-norm if needed
+        query, key = attn.maybe_apply_qk_norm(query, key)
 
         # Apply RoPE if needed
         if image_rotary_emb is not None:
@@ -2106,10 +2106,8 @@ class FusedHunyuanAttnProcessor2_0:
         key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
         value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
 
-        if attn.norm_q is not None:
-            query = attn.norm_q(query)
-        if attn.norm_k is not None:
-            key = attn.norm_k(key)
+        # Apply QK-norm if needed
+        query, key = attn.maybe_apply_qk_norm(query, key)
 
         # Apply RoPE if needed
         if image_rotary_emb is not None:
@@ -2185,11 +2183,8 @@ class LuminaAttnProcessor2_0:
         # Get key-value heads
         kv_heads = inner_dim // head_dim
 
-        # Apply Query-Key Norm if needed
-        if attn.norm_q is not None:
-            query = attn.norm_q(query)
-        if attn.norm_k is not None:
-            key = attn.norm_k(key)
+        # Apply QK-norm if needed
+        query, key = attn.maybe_apply_qk_norm(query, key)
 
         query = query.view(batch_size, -1, attn.heads, head_dim)
 
@@ -2313,6 +2308,9 @@ class FusedAttnProcessor2_0:
         query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
         key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
         value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        # Apply QK-norm if needed
+        query, key = attn.maybe_apply_qk_norm(query, key)
 
         # the output of sdp = (batch, num_heads, seq_len, head_dim)
         # TODO: add support for attn.scale when we move to Torch 2.1


### PR DESCRIPTION
# What does this PR do?

- Applies QK-norm in some of the attention processors that currently support it, and newly in the default AttentionProcessor2_0 and FusedAttentionProcessor2_0 (for you know what :eyes:).
- I think we should also refactor some of the attention processors and determine if we need these many.
- We should also probably re-order these in alphabetical order to make it easier to read, and group the normal and fused variants together.

Happy to take it up in this PR if we're okay with it.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul @yiyixuxu 