### PR TITLE
Fix StableDiffusionXLPAGInpaintPipeline

### DIFF
--- a/src/diffusers/pipelines/auto_pipeline.py
+++ b/src/diffusers/pipelines/auto_pipeline.py
@@ -953,7 +953,7 @@ class AutoPipelineForInpainting(ConfigMixin):
         if "enable_pag" in kwargs:
             enable_pag = kwargs.pop("enable_pag")
             if enable_pag:
-                orig_class_name = config["_class_name"].replace("Pipeline", "PAGPipeline")
+                orig_class_name = config["_class_name"].replace("InpaintPipeline", "PAGInpaintPipeline")
 
         inpainting_cls = _get_task_class(AUTO_INPAINT_PIPELINES_MAPPING, orig_class_name)
 

--- a/src/diffusers/pipelines/auto_pipeline.py
+++ b/src/diffusers/pipelines/auto_pipeline.py
@@ -953,7 +953,11 @@ class AutoPipelineForInpainting(ConfigMixin):
         if "enable_pag" in kwargs:
             enable_pag = kwargs.pop("enable_pag")
             if enable_pag:
-                orig_class_name = config["_class_name"].replace("InpaintPipeline", "Pipeline").replace("Pipeline", "PAGInpaintPipeline")
+                orig_class_name = (
+                    config["_class_name"]
+                    .replace("InpaintPipeline", "Pipeline")
+                    .replace("Pipeline", "PAGInpaintPipeline")
+                )
 
         inpainting_cls = _get_task_class(AUTO_INPAINT_PIPELINES_MAPPING, orig_class_name)
 

--- a/src/diffusers/pipelines/auto_pipeline.py
+++ b/src/diffusers/pipelines/auto_pipeline.py
@@ -953,7 +953,7 @@ class AutoPipelineForInpainting(ConfigMixin):
         if "enable_pag" in kwargs:
             enable_pag = kwargs.pop("enable_pag")
             if enable_pag:
-                orig_class_name = config["_class_name"].replace("InpaintPipeline", "PAGInpaintPipeline")
+                orig_class_name = config["_class_name"].replace("InpaintPipeline", "Pipeline").replace("Pipeline", "PAGInpaintPipeline")
 
         inpainting_cls = _get_task_class(AUTO_INPAINT_PIPELINES_MAPPING, orig_class_name)
 

--- a/src/diffusers/pipelines/auto_pipeline.py
+++ b/src/diffusers/pipelines/auto_pipeline.py
@@ -953,11 +953,8 @@ class AutoPipelineForInpainting(ConfigMixin):
         if "enable_pag" in kwargs:
             enable_pag = kwargs.pop("enable_pag")
             if enable_pag:
-                orig_class_name = (
-                    config["_class_name"]
-                    .replace("InpaintPipeline", "Pipeline")
-                    .replace("Pipeline", "PAGInpaintPipeline")
-                )
+                to_replace = "InpaintPipeline" if "Inpaint" in config["_class_name"] else "Pipeline"
+                orig_class_name = config["_class_name"].replace(to_replace, "PAG" + to_replace)
 
         inpainting_cls = _get_task_class(AUTO_INPAINT_PIPELINES_MAPPING, orig_class_name)
 

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
@@ -1471,6 +1471,14 @@ class StableDiffusionXLPAGInpaintPipeline(
             generator,
             self.do_classifier_free_guidance,
         )
+        if self.do_perturbed_attention_guidance:
+            if self.do_classifier_free_guidance:
+                mask, _ = mask.chunk(2)
+                masked_image_latents, _ = masked_image_latents.chunk(2)
+            mask = self._prepare_perturbed_attention_guidance(mask, mask, self.do_classifier_free_guidance)
+            masked_image_latents = self._prepare_perturbed_attention_guidance(
+                masked_image_latents, masked_image_latents, self.do_classifier_free_guidance
+            )
 
         # 8. Check that sizes of mask, masked image and latents match
         if num_channels_unet == 9:

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
@@ -1668,10 +1668,10 @@ class StableDiffusionXLPAGInpaintPipeline(
 
                 if num_channels_unet == 4:
                     init_latents_proper = image_latents
-                    if self.do_classifier_free_guidance:
-                        init_mask, _ = mask.chunk(2)
+                    if self.do_perturbed_attention_guidance:
+                        init_mask, *_ = mask.chunk(3) if self.do_classifier_free_guidance else mask.chunk(2)
                     else:
-                        init_mask = mask
+                        init_mask, *_ = mask.chunk(2) if self.do_classifier_free_guidance else mask
 
                     if i < len(timesteps) - 1:
                         noise_timestep = timesteps[i + 1]

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
@@ -837,7 +837,7 @@ class StableDiffusionXLPAGInpaintPipeline(
 
         return image_latents
 
-    # Modified from diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl_inpaint.StableDiffusionXLInpaintPipeline.prepare_mask_latents
+    # Copied from diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl_inpaint.StableDiffusionXLInpaintPipeline.prepare_mask_latents
     def prepare_mask_latents(
         self, mask, masked_image, batch_size, height, width, dtype, device, generator, do_classifier_free_guidance
     ):
@@ -859,10 +859,7 @@ class StableDiffusionXLPAGInpaintPipeline(
                 )
             mask = mask.repeat(batch_size // mask.shape[0], 1, 1, 1)
 
-        if self.do_perturbed_attention_guidance:
-            mask = torch.cat([mask] * 3) if do_classifier_free_guidance else torch.cat([mask] * 2)
-        else:
-            mask = torch.cat([mask] * 2) if do_classifier_free_guidance else mask
+        mask = torch.cat([mask] * 2) if do_classifier_free_guidance else mask
 
         if masked_image is not None and masked_image.shape[1] == 4:
             masked_image_latents = masked_image
@@ -885,16 +882,9 @@ class StableDiffusionXLPAGInpaintPipeline(
                     batch_size // masked_image_latents.shape[0], 1, 1, 1
                 )
 
-            if self.do_perturbed_attention_guidance:
-                masked_image_latents = (
-                    torch.cat([masked_image_latents] * 3)
-                    if do_classifier_free_guidance
-                    else torch.cat([masked_image_latents] * 2)
-                )
-            else:
-                masked_image_latents = (
-                    torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
-                )
+            masked_image_latents = (
+                torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
+            )
 
             # aligning device to prevent device errors when concating it with the latent model input
             masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
@@ -837,7 +837,7 @@ class StableDiffusionXLPAGInpaintPipeline(
 
         return image_latents
 
-    # Copied from diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl_inpaint.StableDiffusionXLInpaintPipeline.prepare_mask_latents
+    # Modified from diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl_inpaint.StableDiffusionXLInpaintPipeline.prepare_mask_latents
     def prepare_mask_latents(
         self, mask, masked_image, batch_size, height, width, dtype, device, generator, do_classifier_free_guidance
     ):
@@ -859,7 +859,10 @@ class StableDiffusionXLPAGInpaintPipeline(
                 )
             mask = mask.repeat(batch_size // mask.shape[0], 1, 1, 1)
 
-        mask = torch.cat([mask] * 2) if do_classifier_free_guidance else mask
+        if self.do_perturbed_attention_guidance:
+            mask = torch.cat([mask] * 3) if do_classifier_free_guidance else torch.cat([mask] * 2)
+        else:
+            mask = torch.cat([mask] * 2) if do_classifier_free_guidance else mask
 
         if masked_image is not None and masked_image.shape[1] == 4:
             masked_image_latents = masked_image
@@ -882,9 +885,15 @@ class StableDiffusionXLPAGInpaintPipeline(
                     batch_size // masked_image_latents.shape[0], 1, 1, 1
                 )
 
-            masked_image_latents = (
-                torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
-            )
+            if self.do_perturbed_attention_guidance:
+                masked_image_latents = (
+                    torch.cat([masked_image_latents] * 3) if do_classifier_free_guidance
+                    else torch.cat([masked_image_latents] * 2)
+                )
+            else:
+                masked_image_latents = (
+                    torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
+                )
 
             # aligning device to prevent device errors when concating it with the latent model input
             masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
@@ -887,7 +887,8 @@ class StableDiffusionXLPAGInpaintPipeline(
 
             if self.do_perturbed_attention_guidance:
                 masked_image_latents = (
-                    torch.cat([masked_image_latents] * 3) if do_classifier_free_guidance
+                    torch.cat([masked_image_latents] * 3)
+                    if do_classifier_free_guidance
                     else torch.cat([masked_image_latents] * 2)
                 )
             else:


### PR DESCRIPTION
# What does this PR do?

Fixed the issue preventing model and inference with `StableDiffusionXLInpaintPipeline` class in UNet where `in_channels=9`.

**1. When loading models of the `StableDiffusionXLInpaintPipeline` class like `diffusers/stable-diffusion-xl-1.0-inpainting-0.1`, the load fails if `enable_pag=True`.**

error:
```bash
File /hdd/repo/diffusers/src/diffusers/pipelines/auto_pipeline.py:958, in AutoPipelineForInpainting.from_pretrained(cls, pretrained_model_or_path, **kwargs)
    954     if enable_pag:
    955         orig_class_name = config["_class_name"].replace("InpaintPipeline",
    956                                                         "PAG3InpaintPipeline")
--> 958 inpainting_cls = _get_task_class(AUTO_INPAINT_PIPELINES_MAPPING, orig_class_name)
    960 kwargs = {**load_config_kwargs, **kwargs}
    961 return inpainting_cls.from_pretrained(pretrained_model_or_path, **kwargs)
...
    198 if throw_error_if_not_exist:
--> 199     raise ValueError(
    200         f"AutoPipeline can't find a pipeline linked to {pipeline_class_name} for {model_name}")

ValueError: AutoPipeline can't find a pipeline linked to StableDiffusionXLPAG3InpaintPipeline for None
```

Fixed to find the correct class `StableDiffusionXLPAGInpaintPipeline`.


**2. When calling `__call__` with a model where `in_channels=9` in the UNet, `latent_model_input` is not created correctly**

error:
```bash
File /hdd/repo/diffusers/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py:1623, in StableDiffusionXLPAGInpaintPipeline.__call__(self, prompt, prompt_2, image, mask_image, masked_image_latents, height, width, padding_mask_crop, strength, num_inference_steps, timesteps, sigmas, denoising_start, denoising_end, guidance_scale, negative_prompt, negative_prompt_2, num_images_per_prompt, eta, generator, latents, prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds, ip_adapter_image, ip_adapter_image_embeds, output_type, return_dict, cross_attention_kwargs, guidance_rescale, original_size, crops_coords_top_left, target_size, negative_original_size, negative_crops_coords_top_left, negative_target_size, aesthetic_score, negative_aesthetic_score, clip_skip, callback_on_step_end, callback_on_step_end_tensor_inputs, pag_scale, pag_adaptive_scale)
   1620 latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
   1622 if num_channels_unet == 9:
-> 1623     latent_model_input = torch.cat([latent_model_input, mask, masked_image_latents], dim=1)
   1625 # predict the noise residual
   1626 added_cond_kwargs = {"text_embeds": add_text_embeds, "time_ids": add_time_ids}

RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 3 but got size 2 for tensor number 1 in the list.
```

The batch size of `mask` and `masked_image_latents` differs from that of `latent_model_input`. This has been fixed.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul @yiyixuxu @DN6 
