### PR TITLE
[IP Adapter] Fix object has no attribute with image encoder

### DIFF
--- a/src/diffusers/loaders/ip_adapter.py
+++ b/src/diffusers/loaders/ip_adapter.py
@@ -222,7 +222,11 @@ class IPAdapterMixin:
 
             # create feature extractor if it has not been registered to the pipeline yet
             if hasattr(self, "feature_extractor") and getattr(self, "feature_extractor", None) is None:
-                clip_image_size = self.image_encoder.config.image_size if self.image_encoder is not None else 224
+                # FaceID IP adapters don't need the image encoder so it's not present, in this case we default to 224
+                default_clip_size = 224
+                clip_image_size = (
+                    self.image_encoder.config.image_size if self.image_encoder is not None else default_clip_size
+                )
                 feature_extractor = CLIPImageProcessor(size=clip_image_size, crop_size=clip_image_size)
                 self.register_modules(feature_extractor=feature_extractor)
 

--- a/src/diffusers/loaders/ip_adapter.py
+++ b/src/diffusers/loaders/ip_adapter.py
@@ -222,7 +222,7 @@ class IPAdapterMixin:
 
             # create feature extractor if it has not been registered to the pipeline yet
             if hasattr(self, "feature_extractor") and getattr(self, "feature_extractor", None) is None:
-                clip_image_size = self.image_encoder.config.image_size
+                clip_image_size = self.image_encoder.config.image_size if self.image_encoder is not None else 224
                 feature_extractor = CLIPImageProcessor(size=clip_image_size, crop_size=clip_image_size)
                 self.register_modules(feature_extractor=feature_extractor)
 


### PR DESCRIPTION
# What does this PR do?

IP Adapter FaceID model don't need the image encoder so it's not loaded and the image encoder its used to get the clip size for the Kolors version, this produces an error with FaceID models. This PR sets back the default 224 size for these models.

IMO it would be better to not load the `feature extractor` altogether if it's not used (not sure) but this was in the original implementation.

Fixes #9187

## Who can review?

@sayakpaul @detkov @fabiorigano 
