### PR TITLE
fix autopipeline for kolors img2img

### DIFF
--- a/src/diffusers/pipelines/auto_pipeline.py
+++ b/src/diffusers/pipelines/auto_pipeline.py
@@ -163,12 +163,12 @@ _AUTO_INPAINT_DECODER_PIPELINES_MAPPING = OrderedDict(
 )
 
 if is_sentencepiece_available():
-    from .kolors import KolorsPipeline
+    from .kolors import KolorsImg2ImgPipeline, KolorsPipeline
     from .pag import KolorsPAGPipeline
 
     AUTO_TEXT2IMAGE_PIPELINES_MAPPING["kolors"] = KolorsPipeline
     AUTO_TEXT2IMAGE_PIPELINES_MAPPING["kolors-pag"] = KolorsPAGPipeline
-    AUTO_IMAGE2IMAGE_PIPELINES_MAPPING["kolors"] = KolorsPipeline
+    AUTO_IMAGE2IMAGE_PIPELINES_MAPPING["kolors"] = KolorsImg2ImgPipeline
 
 SUPPORTED_TASKS_MAPPINGS = [
     AUTO_TEXT2IMAGE_PIPELINES_MAPPING,


### PR DESCRIPTION
I made a mistake in https://github.com/huggingface/diffusers/pull/9065/files#
fixing it! 


sanity check 
```python
from diffusers import AutoPipelineForText2Image, AutoPipelineForImage2Image
import torch

repo = "Kwai-Kolors/Kolors-diffusers"

pipe_txt2img = AutoPipelineForText2Image.from_pretrained(repo, variant="fp16", torch_dtype=torch.float16).to("cuda")
assert pipe_txt2img.__class__.__name__ == "KolorsPipeline"

pipe_txt2img_pag = AutoPipelineForText2Image.from_pretrained(repo, torch_dtype=torch.float16, variant="fp16", enable_pag=True).to("cuda")
assert pipe_txt2img_pag.__class__.__name__ == "KolorsPAGPipeline"

pipe_img2img = AutoPipelineForImage2Image.from_pretrained(repo, variant="fp16", torch_dtype=torch.float16).to("cuda")
assert pipe_img2img.__class__.__name__ == "KolorsImg2ImgPipeline"
```