### PR TITLE
[Examples] Computing FID in unconditional image generation

### DIFF
--- a/examples/unconditional_image_generation/README.md
+++ b/examples/unconditional_image_generation/README.md
@@ -76,6 +76,7 @@ A full training run takes 2 hours on 4xV100 GPUs.
 
 <img src="https://user-images.githubusercontent.com/26864830/180248200-928953b4-db38-48db-b0c6-8b740fe6786f.png" width="700" />
 
+To obtain a quantitative evaluation of generated images, you can compute FID by passing `--compute_fid`.
 ### Training with multiple GPUs
 
 `accelerate` allows for seamless multi-GPU training. Follow the instructions [here](https://huggingface.co/docs/accelerate/basic_tutorials/launch)

--- a/examples/unconditional_image_generation/requirements.txt
+++ b/examples/unconditional_image_generation/requirements.txt
@@ -1,3 +1,5 @@
 accelerate>=0.16.0
 torchvision
 datasets
+torchmetrics
+torch-fidelity


### PR DESCRIPTION
Hi,

First, thank you for providing great examples. Since sometimes there's a need for quantitative assessment of image generation, I believe it would be great to include FID computation in one of the examples, particularly for unconditional image generation. It's quite straightforward: simply by passing the ```--compute_fid``` argument, now it's possible to log the FID score in the tracker.