### PR TITLE
[IP Adapter] Fix `cache_dir` and `local_files_only` for image encoder

### DIFF
--- a/src/diffusers/loaders/ip_adapter.py
+++ b/src/diffusers/loaders/ip_adapter.py
@@ -208,6 +208,8 @@ class IPAdapterMixin:
                             pretrained_model_name_or_path_or_dict,
                             subfolder=image_encoder_subfolder,
                             low_cpu_mem_usage=low_cpu_mem_usage,
+                            cache_dir=cache_dir,
+                            local_files_only=local_files_only,
                         ).to(self.device, dtype=self.dtype)
                         self.register_modules(image_encoder=image_encoder)
                     else:


### PR DESCRIPTION
# What does this PR do?

This PR makes the loading of the `image_encoder` use the same `cache_dir` and `local_files_only` arguments from the IPA model loading which is the expected behavior. 

Fixes #9192

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yiyixuxu @jonahclarsen
