### PR TITLE
[tests] make 2 tests device-agnostic  

### DIFF
--- a/tests/models/autoencoders/test_models_vae.py
+++ b/tests/models/autoencoders/test_models_vae.py
@@ -1032,9 +1032,9 @@ class ConsistencyDecoderVAEIntegrationTests(unittest.TestCase):
             "https://huggingface.co/datasets/hf-internal-testing/diffusers-images/resolve/main"
             "/img2img/sketch-mountains-input.jpg"
         ).resize((256, 256))
-        image = torch.from_numpy(np.array(image).transpose(2, 0, 1).astype(np.float32) / 127.5 - 1)[
-            None, :, :, :
-        ].to(torch_device)
+        image = torch.from_numpy(np.array(image).transpose(2, 0, 1).astype(np.float32) / 127.5 - 1)[None, :, :, :].to(
+            torch_device
+        )
 
         latent = vae.encode(image).latent_dist.mean
 

--- a/tests/models/autoencoders/test_models_vae.py
+++ b/tests/models/autoencoders/test_models_vae.py
@@ -1034,7 +1034,7 @@ class ConsistencyDecoderVAEIntegrationTests(unittest.TestCase):
         ).resize((256, 256))
         image = torch.from_numpy(np.array(image).transpose(2, 0, 1).astype(np.float32) / 127.5 - 1)[
             None, :, :, :
-        ].cuda()
+        ].to(torch_device)
 
         latent = vae.encode(image).latent_dist.mean
 
@@ -1075,7 +1075,7 @@ class ConsistencyDecoderVAEIntegrationTests(unittest.TestCase):
         image = (
             torch.from_numpy(np.array(image).transpose(2, 0, 1).astype(np.float32) / 127.5 - 1)[None, :, :, :]
             .half()
-            .cuda()
+            .to(torch_device)
         )
 
         latent = vae.encode(image).latent_dist.mean


### PR DESCRIPTION
## What does this PR do?
Hi, this PR makes 2 tests work on XPU. 
```bash
pytest -rA tests/models/autoencoders/test_models_vae.py::ConsistencyDecoderVAEIntegrationTests::test_encode_decode
pytest -rA tests/models/autoencoders/test_models_vae.py::ConsistencyDecoderVAEIntegrationTests::test_encode_decode_f16
```
Below are the results:
```bash
================================================ short test summary info =================================================
PASSED tests/models/autoencoders/test_models_vae.py::ConsistencyDecoderVAEIntegrationTests::test_encode_decode_f16
============================================= 1 passed, 2 warnings in 3.76s ==============================================
```
```bash
================================================ short test summary info =================================================
PASSED tests/models/autoencoders/test_models_vae.py::ConsistencyDecoderVAEIntegrationTests::test_encode_decode
============================================= 1 passed, 2 warnings in 3.77s ==============================================
```

 @yiyixuxu and @asomoza


