### PR TITLE
fix one uncaught deprecation warning for accessing vae_latent_channels in VaeImagePreprocessor

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -569,7 +569,7 @@ class VaeImageProcessor(ConfigMixin):
 
             channel = image.shape[1]
             # don't need any preprocess if the image is latents
-            if channel == self.vae_latent_channels:
+            if channel == self.config.vae_latent_channels:
                 return image
 
             height, width = self.get_default_height_width(image, height, width)


### PR DESCRIPTION
# What does this PR do?

Fixes a deprecation warning in the `VaeImagePreprocessor`.
`vae_latent_channels` was directly accessed where it should be access from `self.config`.