### PR TITLE
FluxPosEmbed: Remove Squeeze No-op

### DIFF
--- a/src/diffusers/models/embeddings.py
+++ b/src/diffusers/models/embeddings.py
@@ -690,7 +690,7 @@ class FluxPosEmbed(nn.Module):
         n_axes = ids.shape[-1]
         cos_out = []
         sin_out = []
-        pos = ids.squeeze().float()
+        pos = ids.float()
         is_mps = ids.device.type == "mps"
         freqs_dtype = torch.float32 if is_mps else torch.float64
         for i in range(n_axes):


### PR DESCRIPTION
# What does this PR do?
The [Squeeze operation](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/embeddings.py#L693) performed in FluxPosEmbed is a no op after the [change ](https://github.com/huggingface/diffusers/commit/c2916175186e2b6d9c2d09b13a753cc47f5d9e19#diff-68d4ddab9d9846465f7d3b0a8583b256f7293df93e60a04eaeaced3b85de15aaL367) to make txt_ids and img_ids into 2D tensors was committed. Can we remove the Squeeze op used this case? This class is currently only used in transformer_flux.py and controlnet_flux.py and both models accept 2D txt and img ids.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sayakpaul @yiyixuxu @DN6



