### PR TITLE
Add support for LoRA weight files exported from SAT 

### DIFF
--- a/examples/cogvideo/load_cogvideox_lora.py
+++ b/examples/cogvideo/load_cogvideox_lora.py
@@ -1,0 +1,107 @@
+# Copyright 2024 The HuggingFace Team.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import math 
+import random 
+import time
+from diffusers.utils import export_to_video
+from diffusers.image_processor import VaeImageProcessor
+from datetime import datetime, timedelta
+from diffusers import CogVideoXPipeline, CogVideoXDDIMScheduler, CogVideoXDPMScheduler
+import os
+import torch
+import argparse
+
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--pretrained_model_name_or_path",
+        type=str,
+        default=None,
+        required=True,
+        help="Path to pretrained model or model identifier from huggingface.co/models.",
+    )
+    parser.add_argument(
+        "--lora_weights_path",
+        type=str,
+        default=None,
+        required=True,
+        help="Path to lora weights.",
+    )
+    parser.add_argument(
+        "--lora_r",
+        type=int,
+        default=128,
+        help="""LoRA weights have a rank parameter, with the default for 2B trans set at 128 and 5B trans set at 256. 
+        This part is used to calculate the value for lora_scale, which is by default divided by the alpha value, 
+        used for stable learning and to prevent underflow. In the SAT training framework,
+        alpha is set to 1 by default. The higher the rank, the better the expressive capability,
+        but it requires more memory and training time. Increasing this number blindly isn't always better.
+        The formula for lora_scale is: lora_r / alpha.
+        """,
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="output",
+        help="The output directory where the model predictions and checkpoints will be written.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = get_args()
+    pipe = CogVideoXPipeline.from_pretrained(args.pretrained_model_name_or_path, torch_dtype=torch.bfloat16).to(device)
+    pipe.load_lora_weights(args.lora_weights_path,  weight_name="pytorch_lora_weights.safetensors", adapter_name="test_1")
+    pipe.fuse_lora(lora_scale=1/128)
+
+
+    pipe.scheduler = CogVideoXDPMScheduler.from_config(pipe.scheduler.config, timestep_spacing="trailing")
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    prompt="""In the heart of a bustling city, a young woman with long, flowing brown hair and a radiant smile stands out. She's donned in a cozy white beanie adorned with playful animal ears, adding a touch of whimsy to her appearance. Her eyes sparkle with joy as she looks directly into the camera, her expression inviting and warm. The background is a blur of activity, with indistinct figures moving about, suggesting a lively public space. The lighting is soft and diffused, casting a gentle glow on her face and highlighting her features. The overall mood is cheerful and vibrant, capturing a moment of happiness in the midst of urban life.
+    """
+    latents = pipe(
+        prompt=prompt,
+        num_videos_per_prompt=1,
+        num_inference_steps=50,
+        num_frames=49,
+        use_dynamic_cfg=True,
+        output_type="pt",
+        guidance_scale=3.0,
+        generator=torch.Generator(device="cpu").manual_seed(42),
+    ).frames
+    batch_size = latents.shape[0]
+    batch_video_frames = []
+    for batch_idx in range(batch_size):
+        pt_image = latents[batch_idx]
+        pt_image = torch.stack([pt_image[i] for i in range(pt_image.shape[0])])
+
+        image_np = VaeImageProcessor.pt_to_numpy(pt_image)
+        image_pil = VaeImageProcessor.numpy_to_pil(image_np)
+        batch_video_frames.append(image_pil)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    video_path = f"{args.output_dir}/{timestamp}.mp4"
+    os.makedirs(os.path.dirname(video_path), exist_ok=True)
+    tensor = batch_video_frames[0]
+    fps=math.ceil((len(batch_video_frames[0]) - 1) / 6)
+
+    export_to_video(tensor, video_path, fps=fps)

--- a/examples/cogvideo/load_cogvideox_lora.py
+++ b/examples/cogvideo/load_cogvideox_lora.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     args = get_args()
     pipe = CogVideoXPipeline.from_pretrained(args.pretrained_model_name_or_path, torch_dtype=torch.bfloat16).to(device)
     pipe.load_lora_weights(args.lora_weights_path,  weight_name="pytorch_lora_weights.safetensors", adapter_name="test_1")
-    pipe.fuse_lora(lora_scale=1/128)
+    pipe.fuse_lora(lora_scale=1/args.lora_r)
 
 
     pipe.scheduler = CogVideoXDPMScheduler.from_config(pipe.scheduler.config, timestep_spacing="trailing")

--- a/examples/cogvideo/train_cogvideox_lora.py
+++ b/examples/cogvideo/train_cogvideox_lora.py
@@ -1015,7 +1015,7 @@ def main(args):
             r=args.rank,
             lora_alpha=args.lora_alpha,
             init_lora_weights=True,
-            target_modules=["q_proj", "k_proj", "v_proj", "out_proj"],
+            target_modules=["q", "k", "v", "o"],
         )
         text_encoder.add_adapter(text_lora_config)
 
@@ -1284,7 +1284,7 @@ def main(args):
         if args.train_text_encoder:
             text_encoder.train()
             # set top parameter requires_grad = True for gradient checkpointing works
-            accelerator.unwrap_model(text_encoder).text_model.embeddings.requires_grad_(True)
+            accelerator.unwrap_model(text_encoder).shared.requires_grad_(True)
 
         for step, batch in enumerate(train_dataloader):
             models_to_accumulate = [transformer]

--- a/src/diffusers/loaders/lora_pipeline.py
+++ b/src/diffusers/loaders/lora_pipeline.py
@@ -2473,7 +2473,14 @@ class CogVideoXLoraLoaderMixin(LoraBaseMixin):
                 if "lora_B" in key:
                     rank[key] = val.shape[1]
 
-            lora_config_kwargs = get_peft_kwargs(rank, network_alpha_dict=None, peft_state_dict=state_dict)
+            # alpha_dict length should be 1, as we only have defult alpha for transformer
+            lora_config_kwargs = get_peft_kwargs(
+                rank,
+                network_alpha_dict={
+                    "transformer": 1.0
+                    },
+                peft_state_dict=state_dict
+            )
             if "use_dora" in lora_config_kwargs:
                 if lora_config_kwargs["use_dora"] and is_peft_version("<", "0.9.0"):
                     raise ValueError(


### PR DESCRIPTION

## Description
This PR introduces functionality to load and infer using LoRA weight files exported from SAT. The weights can be exported using the script `tools/export_sat_lora_weight.py` located in the CogVideoX repository, and then loaded for inference with `load_cogvideox_lora.py`.

- **Export**: LoRA weight files can be exported from SATD using `export_sat_lora_weight.py`.
- **Inference**: After loading the weights via `load_cogvideox_lora.py`, you can proceed with inference.

### Additional info on LoRA weights:
- LoRA weights have a rank parameter, with 2B trans default at 128, and 5B trans default at 256.
- The `lora_scale` is calculated as `lora_r / alpha`, where alpha is typically 1 in SAT training for stability and preventing underflow.
- Higher rank offers better expressiveness but requires more memory and longer training times.