### PR TITLE
[Schedulers] Add exponential sigmas / exponential noise schedule

### DIFF
--- a/src/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_discrete.py
@@ -158,6 +158,8 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         use_karras_sigmas (`bool`, *optional*, defaults to `False`):
             Whether to use Karras sigmas for step sizes in the noise schedule during the sampling process. If `True`,
             the sigmas are determined according to a sequence of noise levels {σi}.
+        use_exponential_sigmas (`bool`, *optional*, defaults to `False`):
+            Whether to use exponential sigmas for step sizes in the noise schedule during the sampling process.
         timestep_spacing (`str`, defaults to `"linspace"`):
             The way the timesteps should be scaled. Refer to Table 2 of the [Common Diffusion Noise Schedules and
             Sample Steps are Flawed](https://huggingface.co/papers/2305.08891) for more information.
@@ -186,6 +188,7 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         prediction_type: str = "epsilon",
         interpolation_type: str = "linear",
         use_karras_sigmas: Optional[bool] = False,
+        use_exponential_sigmas: Optional[bool] = False,
         sigma_min: Optional[float] = None,
         sigma_max: Optional[float] = None,
         timestep_spacing: str = "linspace",
@@ -235,6 +238,7 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
 
         self.is_scale_input_called = False
         self.use_karras_sigmas = use_karras_sigmas
+        self.use_exponential_sigmas = use_exponential_sigmas
 
         self._step_index = None
         self._begin_index = None
@@ -332,6 +336,8 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             raise ValueError("Can only pass one of `num_inference_steps` or `timesteps` or `sigmas`.")
         if timesteps is not None and self.config.use_karras_sigmas:
             raise ValueError("Cannot set `timesteps` with `config.use_karras_sigmas = True`.")
+        if timesteps is not None and self.config.use_exponential_sigmas:
+            raise ValueError("Cannot set `timesteps` with `config.use_exponential_sigmas = True`.")
         if (
             timesteps is not None
             and self.config.timestep_type == "continuous"
@@ -394,6 +400,10 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
 
             if self.config.use_karras_sigmas:
                 sigmas = self._convert_to_karras(in_sigmas=sigmas, num_inference_steps=self.num_inference_steps)
+                timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
+
+            if self.config.use_exponential_sigmas:
+                sigmas = self._convert_to_exponential(in_sigmas=sigmas, num_inference_steps=self.num_inference_steps)
                 timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
 
             if self.config.final_sigmas_type == "sigma_min":
@@ -466,6 +476,28 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         min_inv_rho = sigma_min ** (1 / rho)
         max_inv_rho = sigma_max ** (1 / rho)
         sigmas = (max_inv_rho + ramp * (min_inv_rho - max_inv_rho)) ** rho
+        return sigmas
+
+    # Copied from https://github.com/crowsonkb/k-diffusion/blob/686dbad0f39640ea25c8a8c6a6e56bb40eacefa2/k_diffusion/sampling.py#L26
+    def _convert_to_exponential(self, in_sigmas: torch.Tensor, num_inference_steps: int) -> torch.Tensor:
+        """Constructs an exponential noise schedule."""
+
+        # Hack to make sure that other schedulers which copy this function don't break
+        # TODO: Add this logic to the other schedulers
+        if hasattr(self.config, "sigma_min"):
+            sigma_min = self.config.sigma_min
+        else:
+            sigma_min = None
+
+        if hasattr(self.config, "sigma_max"):
+            sigma_max = self.config.sigma_max
+        else:
+            sigma_max = None
+
+        sigma_min = sigma_min if sigma_min is not None else in_sigmas[-1].item()
+        sigma_max = sigma_max if sigma_max is not None else in_sigmas[0].item()
+
+        sigmas = torch.linspace(math.log(sigma_max), math.log(sigma_min), num_inference_steps).exp()
         return sigmas
 
     def index_for_timestep(self, timestep, schedule_timesteps=None):

--- a/src/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_discrete.py
@@ -339,7 +339,9 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         if timesteps is not None and self.config.use_exponential_sigmas:
             raise ValueError("Cannot set `timesteps` with `config.use_exponential_sigmas = True`.")
         if self.config.use_exponential_sigmas and self.config.use_karras_sigmas:
-           raise ValueErrror("Cannot set both `config.use_exponential_sigmas = True` and config.use_karras_sigmas = True`") 
+            raise ValueError(
+                "Cannot set both `config.use_exponential_sigmas = True` and config.use_karras_sigmas = True`"
+            )
         if (
             timesteps is not None
             and self.config.timestep_type == "continuous"

--- a/src/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_discrete.py
@@ -338,6 +338,8 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             raise ValueError("Cannot set `timesteps` with `config.use_karras_sigmas = True`.")
         if timesteps is not None and self.config.use_exponential_sigmas:
             raise ValueError("Cannot set `timesteps` with `config.use_exponential_sigmas = True`.")
+        if self.config.use_exponential_sigmas and self.config.use_karras_sigmas:
+           raise ValueErrror("Cannot set both `config.use_exponential_sigmas = True` and config.use_karras_sigmas = True`") 
         if (
             timesteps is not None
             and self.config.timestep_type == "continuous"
@@ -402,7 +404,7 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
                 sigmas = self._convert_to_karras(in_sigmas=sigmas, num_inference_steps=self.num_inference_steps)
                 timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
 
-            if self.config.use_exponential_sigmas:
+            elif self.config.use_exponential_sigmas:
                 sigmas = self._convert_to_exponential(in_sigmas=sigmas, num_inference_steps=self.num_inference_steps)
                 timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
 


### PR DESCRIPTION
# What does this PR do?

This PR adds [exponential sigmas](https://github.com/crowsonkb/k-diffusion/blob/686dbad0f39640ea25c8a8c6a6e56bb40eacefa2/k_diffusion/sampling.py#L26-L29). Added only to Euler for now, after initial review we will add it to other schedulers, and add the other schedulers in the linked issue in subsequent PRs.

The implementation is quite simple, we add `use_exponential_sigmas` parameter and `_convert_to_exponential` function.

Example usage:
```python
from diffusers import StableDiffusionXLPipeline, EulerDiscreteScheduler
import torch

pipeline: StableDiffusionXLPipeline = StableDiffusionXLPipeline.from_pretrained(
    "stabilityai/stable-diffusion-xl-base-1.0",
    variant="fp16",
    torch_dtype=torch.float16,
)
pipeline.scheduler = EulerDiscreteScheduler.from_config(
    pipeline.scheduler.config, timestep_spacing="linspace", use_exponential_sigmas=True
)
```

Note that we set `timestep_spacing="linspace"` in addition to `use_exponential_sigmas=True`, this is because XL's scheduler config uses `timestep_spacing="leading"` by default and the intent is to match results from the webuis where these noise schedules are currently used. We may wish to override `timestep_spacing` to `linspace` when `use_exponential_sigmas=True` or add a warning.

Tested against [Forge](https://github.com/lllyasviel/stable-diffusion-webui-forge) (note that `cuda` device for generator is essential to match Forge results):
```python
generator = torch.Generator("cuda").manual_seed(49136503742430)

image = pipeline(
    prompt="enormous kirby. space background",
    num_inference_steps=20,
    guidance_scale=5.0,
    generator=generator,
).images[0]
image
```
![output](https://github.com/user-attachments/assets/1136735a-dddc-4049-bfd9-bb868582e53f)

and with the same settings on Forge we get the same result:
![00002-49136503742430](https://github.com/user-attachments/assets/b8f19dab-cf76-4e5c-ac62-8eef46e1f1dd)

For reference with the default XL scheduler in Diffusers we get:
![output2](https://github.com/user-attachments/assets/59844dff-246c-40fa-bf3c-4305600546bc)


#9490 

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
cc @asomoza @yiyixuxu 