### PR TITLE
Add Noise Schedule/Schedule Type to Schedulers Overview documentation

### DIFF
--- a/docs/source/en/api/schedulers/overview.md
+++ b/docs/source/en/api/schedulers/overview.md
@@ -45,6 +45,13 @@ Many schedulers are implemented from the [k-diffusion](https://github.com/crowso
 | N/A                 | [`DEISMultistepScheduler`]          |                                                                                                               |
 | N/A                 | [`UniPCMultistepScheduler`]         |                                                                                                               |
 
+## Noise Schedules/Schedule Type
+| A1111/k-diffusion   | 🤗 Diffusers                           |
+|---------------------|----------------------------------------|
+| Karras              | init with `use_karras_sigmas=True`     |
+| sgm_uniform         | init with `timestep_spacing="trailing"`|
+| simple              | init with `timestep_spacing="trailing"`|
+
 All schedulers are built from the base [`SchedulerMixin`] class which implements low level utilities shared by all schedulers.
 
 ## SchedulerMixin

--- a/docs/source/en/api/schedulers/overview.md
+++ b/docs/source/en/api/schedulers/overview.md
@@ -45,7 +45,7 @@ Many schedulers are implemented from the [k-diffusion](https://github.com/crowso
 | N/A                 | [`DEISMultistepScheduler`]          |                                                                                                               |
 | N/A                 | [`UniPCMultistepScheduler`]         |                                                                                                               |
 
-## Noise Schedules/Schedule Type
+## Noise schedules and schedule types
 | A1111/k-diffusion   | 🤗 Diffusers                           |
 |---------------------|----------------------------------------|
 | Karras              | init with `use_karras_sigmas=True`     |


### PR DESCRIPTION
# What does this PR do?

As discussed in https://github.com/huggingface/diffusers/issues/9416#issuecomment-2368647232 this PR adds documentation for Noise Schedule/Schedule Type to Schedulers Overview documentation, specifically regarding the equivalent of `sgm_uniform` and `simple` Schedule types as they are known in the webuis. This section can be updated when other schedule types are supported as in #9499.

Also see https://github.com/huggingface/diffusers/issues/9416#issuecomment-2363793200 and #9490 for the reproduction/comparison.



Fixes #9416 


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

cc @yiyixuxu @stevhliu