### PR TITLE
[Schedulers] Add beta sigmas / beta noise schedule

### DIFF
--- a/src/diffusers/schedulers/scheduling_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_euler_discrete.py
@@ -20,10 +20,13 @@ import numpy as np
 import torch
 
 from ..configuration_utils import ConfigMixin, register_to_config
-from ..utils import BaseOutput, logging
+from ..utils import BaseOutput, is_scipy_available, logging
 from ..utils.torch_utils import randn_tensor
 from .scheduling_utils import KarrasDiffusionSchedulers, SchedulerMixin
 
+
+if is_scipy_available():
+    import scipy.stats
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -160,6 +163,9 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             the sigmas are determined according to a sequence of noise levels {σi}.
         use_exponential_sigmas (`bool`, *optional*, defaults to `False`):
             Whether to use exponential sigmas for step sizes in the noise schedule during the sampling process.
+        use_beta_sigmas (`bool`, *optional*, defaults to `False`):
+            Whether to use beta sigmas for step sizes in the noise schedule during the sampling process. Refer to [Beta
+            Sampling is All You Need](https://huggingface.co/papers/2407.12173) for more information.
         timestep_spacing (`str`, defaults to `"linspace"`):
             The way the timesteps should be scaled. Refer to Table 2 of the [Common Diffusion Noise Schedules and
             Sample Steps are Flawed](https://huggingface.co/papers/2305.08891) for more information.
@@ -189,6 +195,7 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         interpolation_type: str = "linear",
         use_karras_sigmas: Optional[bool] = False,
         use_exponential_sigmas: Optional[bool] = False,
+        use_beta_sigmas: Optional[bool] = False,
         sigma_min: Optional[float] = None,
         sigma_max: Optional[float] = None,
         timestep_spacing: str = "linspace",
@@ -197,8 +204,12 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         rescale_betas_zero_snr: bool = False,
         final_sigmas_type: str = "zero",  # can be "zero" or "sigma_min"
     ):
-        if sum([self.config.use_exponential_sigmas, self.config.use_karras_sigmas]) > 1:
-            raise ValueError("Only one of `config.use_exponential_sigmas`, `config.use_karras_sigmas` can be used.")
+        if self.config.use_beta_sigmas and not is_scipy_available():
+            raise ImportError("Make sure to install scipy if you want to use beta sigmas.")
+        if sum([self.config.use_beta_sigmas, self.config.use_exponential_sigmas, self.config.use_karras_sigmas]) > 1:
+            raise ValueError(
+                "Only one of `config.use_beta_sigmas`, `config.use_exponential_sigmas`, `config.use_karras_sigmas` can be used."
+            )
         if trained_betas is not None:
             self.betas = torch.tensor(trained_betas, dtype=torch.float32)
         elif beta_schedule == "linear":
@@ -241,6 +252,7 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         self.is_scale_input_called = False
         self.use_karras_sigmas = use_karras_sigmas
         self.use_exponential_sigmas = use_exponential_sigmas
+        self.use_beta_sigmas = use_beta_sigmas
 
         self._step_index = None
         self._begin_index = None
@@ -340,6 +352,8 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             raise ValueError("Cannot set `timesteps` with `config.use_karras_sigmas = True`.")
         if timesteps is not None and self.config.use_exponential_sigmas:
             raise ValueError("Cannot set `timesteps` with `config.use_exponential_sigmas = True`.")
+        if timesteps is not None and self.config.use_beta_sigmas:
+            raise ValueError("Cannot set `timesteps` with `config.use_beta_sigmas = True`.")
         if (
             timesteps is not None
             and self.config.timestep_type == "continuous"
@@ -406,6 +420,10 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
 
             elif self.config.use_exponential_sigmas:
                 sigmas = self._convert_to_exponential(in_sigmas=sigmas, num_inference_steps=self.num_inference_steps)
+                timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
+
+            elif self.config.use_beta_sigmas:
+                sigmas = self._convert_to_beta(in_sigmas=sigmas, num_inference_steps=self.num_inference_steps)
                 timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
 
             if self.config.final_sigmas_type == "sigma_min":
@@ -500,6 +518,37 @@ class EulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         sigma_max = sigma_max if sigma_max is not None else in_sigmas[0].item()
 
         sigmas = torch.linspace(math.log(sigma_max), math.log(sigma_min), num_inference_steps).exp()
+        return sigmas
+
+    def _convert_to_beta(
+        self, in_sigmas: torch.Tensor, num_inference_steps: int, alpha: float = 0.6, beta: float = 0.6
+    ) -> torch.Tensor:
+        """From "Beta Sampling is All You Need" [arXiv:2407.12173] (Lee et. al, 2024)"""
+
+        # Hack to make sure that other schedulers which copy this function don't break
+        # TODO: Add this logic to the other schedulers
+        if hasattr(self.config, "sigma_min"):
+            sigma_min = self.config.sigma_min
+        else:
+            sigma_min = None
+
+        if hasattr(self.config, "sigma_max"):
+            sigma_max = self.config.sigma_max
+        else:
+            sigma_max = None
+
+        sigma_min = sigma_min if sigma_min is not None else in_sigmas[-1].item()
+        sigma_max = sigma_max if sigma_max is not None else in_sigmas[0].item()
+
+        sigmas = torch.Tensor(
+            [
+                sigma_min + (ppf * (sigma_max - sigma_min))
+                for ppf in [
+                    scipy.stats.beta.ppf(timestep, alpha, beta)
+                    for timestep in 1 - np.linspace(0, 1, num_inference_steps)
+                ]
+            ]
+        )
         return sigmas
 
     def index_for_timestep(self, timestep, schedule_timesteps=None):


### PR DESCRIPTION
# What does this PR do?

This PR adds [beta sigmas](https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/a82d5d177c065f8a6251850e233dca97f15c13ac/modules/sd_schedulers.py#L119-L127) from [Beta Sampling is All You Need](https://huggingface.co/papers/2407.12173). Added only to Euler for now, after initial review we will add it to other schedulers. Documentation will be updated for this scheduler and any others implemented in a subsequent PR after the initial review and after they've been added to other schedulers.

The implementation is quite simple, we add `use_beta_sigmas` parameter and `_convert_to_beta` function.

Beta sigmas depends on `scipy` so we add a check with `is_scipy_available()`.

The check for `self.config.use_exponential_sigmas and self.config.use_karras_sigmas` is moved to schedule instantiation and changed to use `sum([self.config.use_beta_sigmas, self.config.use_exponential_sigmas, self.config.use_karras_sigmas]) > 1`, any future noise schedules can be added to the list to ensure only one can be selected.

As a note for reviewers: `alpha` and `beta` in `_convert_to_beta` are set to the default values [used by Forge](https://github.com/lllyasviel/stable-diffusion-webui-forge/blob/a82d5d177c065f8a6251850e233dca97f15c13ac/modules/shared_options.py#L413-L414), should we make these configurable so we can set e.g. `beta_sigmas_alpha=1.0`, `beta_sigmas_beta=1.0`? I don't know how common it is to change these values. This is also relevant to future `polyexponential` sigmas, `polyexponential` produces the same as `exponential` unless the `rho` value is changed, again I don't know how common it is to change this value, if we're not going to make the values configurable we don't need to add `polyexponential`. However it would be nice to have 1:1 compatibility with the webuis.


Example usage:
```python
from diffusers import StableDiffusionXLPipeline, EulerDiscreteScheduler
import torch

pipeline: StableDiffusionXLPipeline = StableDiffusionXLPipeline.from_pretrained(
    "stabilityai/stable-diffusion-xl-base-1.0",
    variant="fp16",
    torch_dtype=torch.float16,
)
pipeline.scheduler = EulerDiscreteScheduler.from_config(
    pipeline.scheduler.config, timestep_spacing="linspace", use_beta_sigmas=True
)
```

Note that we set `timestep_spacing="linspace"` in addition to `use_beta_sigmas=True`, this is because XL's scheduler config uses `timestep_spacing="leading"` by default and the intent is to match results from the webuis where these noise schedules are currently used. We may wish to override `timestep_spacing` to `linspace` when `use_beta_sigmas=True` or add a warning.

Tested against [Forge](https://github.com/lllyasviel/stable-diffusion-webui-forge) (note that `cuda` device for generator is essential to match Forge results):
```python
generator = torch.Generator("cuda").manual_seed(49136503742430)

image = pipeline(
    prompt="enormous kirby. space background",
    num_inference_steps=20,
    guidance_scale=5.0,
    generator=generator,
).images[0]
image
```
![output](https://github.com/user-attachments/assets/e7631c2a-efc8-44a8-b261-d26d1f852d7c)

and with the same settings on Forge we get the same result:
![00001-49136503742430](https://github.com/user-attachments/assets/93782a13-6007-4a93-b5b9-1ec86619ccd1)

The output is similar yet better than exponential #9499 note the shape of Kirby's feet and the planets.

Both beta and exponential are better than the default noise schedule with XL:
![output2](https://github.com/user-attachments/assets/bc5ee5c9-6295-4779-bf85-0e7f6924f22b)

#9490 

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
cc @asomoza @yiyixuxu 