### PR TITLE
update get_parameter_dtype

### DIFF
--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -98,7 +98,7 @@ def get_parameter_dtype(parameter: torch.nn.Module) -> torch.dtype:
         try:
             return next(parameter.buffers()).dtype
         except StopIteration:
-            # Forch.nn.DataParallel compatibility in PyTorch 1.5
+            # For torch.nn.DataParallel compatibility in PyTorch 1.5
 
             def find_tensor_attributes(module: torch.nn.Module) -> List[Tuple[str, Tensor]]:
                 tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -93,24 +93,20 @@ def get_parameter_device(parameter: torch.nn.Module) -> torch.device:
 
 def get_parameter_dtype(parameter: torch.nn.Module) -> torch.dtype:
     try:
-        params = tuple(parameter.parameters())
-        if len(params) > 0:
-            return params[0].dtype
-
-        buffers = tuple(parameter.buffers())
-        if len(buffers) > 0:
-            return buffers[0].dtype
-
+        return next(parameter.parameters()).dtype
     except StopIteration:
-        # For torch.nn.DataParallel compatibility in PyTorch 1.5
+        try:
+            return next(parameter.buffers()).dtype
+        except StopIteration:
+            # Forch.nn.DataParallel compatibility in PyTorch 1.5
 
-        def find_tensor_attributes(module: torch.nn.Module) -> List[Tuple[str, Tensor]]:
-            tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]
-            return tuples
+            def find_tensor_attributes(module: torch.nn.Module) -> List[Tuple[str, Tensor]]:
+                tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]
+                return tuples
 
-        gen = parameter._named_members(get_members_fn=find_tensor_attributes)
-        first_tuple = next(gen)
-        return first_tuple[1].dtype
+            gen = parameter._named_members(get_members_fn=find_tensor_attributes)
+            first_tuple = next(gen)
+            return first_tuple[1].dtype
 
 
 class ModelMixin(torch.nn.Module, PushToHubMixin):


### PR DESCRIPTION
small optimization on `dtype` method for our `ModelMixin `
see context in this PR https://github.com/huggingface/diffusers/issues/9520#event-14388046203 


main: `Getting unet.dtype took 0.004666426 seconds`
PR branch: `Getting unet.dtype took 0.000084107 seconds`
```python
from diffusers import UNetMotionModel, UNet2DConditionModel, MotionAdapter
import torch

dtype = torch.float32

adapter = MotionAdapter.from_pretrained("guoyww/animatediff-motion-adapter-v1-5-2", torch_dtype=dtype)
# load SD 1.5 based finetuned model
model_id = "SG161222/Realistic_Vision_V5.1_noVAE"
unet = UNet2DConditionModel.from_pretrained(model_id, subfolder="unet", torch_dtype=dtype)

# wrap model with motion adapter
unet = UNetMotionModel.from_unet2d(unet, adapter)
unet.to("cuda")

import time
from contextlib import contextmanager

@contextmanager
def timer(name):
    start_time = time.perf_counter()
    yield
    end_time = time.perf_counter()
    print(f"{name} took {end_time - start_time:.9f} seconds")

with timer("Getting unet.dtype"):
    print(unet.dtype)
```