### PR TITLE
[LoRA] support Kohya Flux LoRAs that have text encoders as well

### DIFF
--- a/tests/lora/test_lora_layers_flux.py
+++ b/tests/lora/test_lora_layers_flux.py
@@ -167,7 +167,7 @@ class FluxLoRATests(unittest.TestCase, PeftLoraLoaderMixinTests):
 @slow
 @require_torch_gpu
 @require_peft_backend
-# @unittest.skip("We cannot run inference on this model with the current CI hardware")
+@unittest.skip("We cannot run inference on this model with the current CI hardware")
 # TODO (DN6, sayakpaul): move these tests to a beefier GPU
 class FluxLoRAIntegrationTests(unittest.TestCase):
     """internal note: The integration slices were obtained on audace."""

--- a/tests/lora/test_lora_layers_flux.py
+++ b/tests/lora/test_lora_layers_flux.py
@@ -246,7 +246,7 @@ class FluxLoRAIntegrationTests(unittest.TestCase):
 
         out_slice = out[0, -3:, -3:, -1].flatten()
         print_tensor_test(out_slice)
-        expected_slice = np.array([0.6367, 0.6367, 0.6328, 0.6367, 0.6328, 0.6289, 0.6367, 0.6328, 0.6484])
+        expected_slice = np.array([0.4023, 0.4043, 0.4023, 0.3965, 0.3984, 0.3984, 0.3906, 0.3906, 0.4219])
 
         assert np.allclose(out_slice, expected_slice, atol=1e-4, rtol=1e-4)
 

--- a/tests/lora/test_lora_layers_flux.py
+++ b/tests/lora/test_lora_layers_flux.py
@@ -27,7 +27,6 @@ from diffusers import FlowMatchEulerDiscreteScheduler, FluxPipeline, FluxTransfo
 from diffusers.utils.testing_utils import (
     floats_tensor,
     is_peft_available,
-    print_tensor_test,
     require_peft_backend,
     require_torch_gpu,
     slow,
@@ -245,7 +244,6 @@ class FluxLoRAIntegrationTests(unittest.TestCase):
         ).images
 
         out_slice = out[0, -3:, -3:, -1].flatten()
-        print_tensor_test(out_slice)
         expected_slice = np.array([0.4023, 0.4043, 0.4023, 0.3965, 0.3984, 0.3984, 0.3906, 0.3906, 0.4219])
 
         assert np.allclose(out_slice, expected_slice, atol=1e-4, rtol=1e-4)


### PR DESCRIPTION
# What does this PR do?

https://huggingface.co/cocktailpeanut has a bunch of very nice Flux LoRAs that were trained using Kohya but has text encoder components too. This PR adds support for fully loading those LoRAs. 

Test code (has a slow test in this PR too):

```python
from diffusers import FluxPipeline
import torch 

pipeline = FluxPipeline.from_pretrained(
    "black-forest-labs/FLUX.1-dev", torch_dtype=torch.bfloat16
).to("cuda")

pipeline.load_lora_weights("cocktailpeanut/optimus", weight_name="optimus.safetensors")
  
prompts = [
    "optimus is cleaning the house with broomstick",
    "optimus is a DJ performing at a hip nightclub",
    "optimus is competing in a bboy break dancing competition",
    "optimus is playing tennis in a tennis court"
]
images = pipeline(
    prompts, 
    num_inference_steps=50,
    guidance_scale=3.5,
    max_sequence_length=512,
    generator=torch.manual_seed(0)
).images
for i, image in enumerate(images):
    image.save(f"{i}.png")
```

Favorite sample:
![image](https://github.com/user-attachments/assets/dbc43c42-badc-4691-af15-4958da838fdf)

<sup>optimus is a DJ performing at a hip nightclub</sup>