### PR TITLE
fix IsADirectoryError when running the training code

### DIFF
--- a/examples/research_projects/sd3_lora_colab/sd3_dreambooth_lora_16gb.ipynb
+++ b/examples/research_projects/sd3_lora_colab/sd3_dreambooth_lora_16gb.ipynb
@@ -196,7 +196,7 @@
       },
       "outputs": [],
       "source": [
-        "!rm -rf dog/.huggingface"
+        "!rm -rf dog/.cache"
       ]
     },
     {


### PR DESCRIPTION
fix IsADirectoryError when running the training code

# What does this PR do?

Fixes the training code crashing for sd3_dreambooth_lora_16gb.ipynb
Running the current notebook will result in the following error when running the training section
```
Traceback (most recent call last):
  File "/content/diffusers/examples/research_projects/sd3_lora_colab/train_dreambooth_lora_sd3_miniature.py", line 1147, in <module>
    main(args)
  File "/content/diffusers/examples/research_projects/sd3_lora_colab/train_dreambooth_lora_sd3_miniature.py", line 848, in main
    train_dataset = DreamBoothDataset(
  File "/content/diffusers/examples/research_projects/sd3_lora_colab/train_dreambooth_lora_sd3_miniature.py", line 521, in __init__
    instance_images = [Image.open(path) for path in list(Path(instance_data_root).iterdir())]
  File "/content/diffusers/examples/research_projects/sd3_lora_colab/train_dreambooth_lora_sd3_miniature.py", line 521, in <listcomp>
    instance_images = [Image.open(path) for path in list(Path(instance_data_root).iterdir())]
  File "/usr/local/lib/python3.10/dist-packages/PIL/Image.py", line 3431, in open
    fp = builtins.open(filename, "rb")
IsADirectoryError: [Errno 21] Is a directory: '/content/diffusers/examples/research_projects/sd3_lora_colab/dog/.cache'
Traceback (most recent call last):
  File "/usr/local/bin/accelerate", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/dist-packages/accelerate/commands/accelerate_cli.py", line 48, in main
    args.func(args)
  File "/usr/local/lib/python3.10/dist-packages/accelerate/commands/launch.py", line 1168, in launch_command
    simple_launcher(args)
  File "/usr/local/lib/python3.10/dist-packages/accelerate/commands/launch.py", line 763, in simple_launcher
    raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
subprocess.CalledProcessError: Command '['/usr/bin/python3', 'train_dreambooth_lora_sd3_miniature.py', '--pretrained_model_name_or_path=stabilityai/stable-diffusion-3-medium-diffusers', '--instance_data_dir=dog', '--data_df_path=sample_embeddings.parquet', '--output_dir=trained-sd3-lora-miniature', '--mixed_precision=fp16', '--instance_prompt=a photo of sks dog', '--resolution=1024', '--train_batch_size=1', '--gradient_accumulation_steps=4', '--gradient_checkpointing', '--use_8bit_adam', '--learning_rate=1e-4', '--report_to=wandb', '--lr_scheduler=constant', '--lr_warmup_steps=0', '--max_train_steps=500', '--seed=0']' returned non-zero exit status 1.
```

It seems like this line is outdated
```
!rm -rf dog/.huggingface
```

It should be instead
```
!rm -rf dog/.cache
```

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?




## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
