### PR TITLE
Add methods for conversion between noise and denoised predictions to UniPC

### DIFF
--- a/src/diffusers/schedulers/scheduling_unipc_multistep.py
+++ b/src/diffusers/schedulers/scheduling_unipc_multistep.py
@@ -527,6 +527,67 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
         )
         return sigmas
 
+    def convert_noise_to_x0(self, model_output: torch.Tensor, sample: torch.Tensor, timestep: int) -> torch.Tensor:
+        """
+        Convert to original sample x0 from noise prediction.
+
+        Args:
+            model_output (`torch.Tensor`): The model output.
+            sample (`torch.Tensor`): A current instance of a sample created by the diffusion process.
+            timestep (`int`): The current discrete timestep in the diffusion chain.
+
+        Returns:
+            `torch.Tensor`: The predicted original sample (x0).
+        """
+        if self.step_index is None:
+            self._init_step_index(timestep)
+        sigma = self.sigmas[self.step_index]
+        alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma)
+
+        if self.config.prediction_type == "epsilon":
+            return (sample - sigma_t * model_output) / alpha_t
+        elif self.config.prediction_type == "sample":
+            return model_output
+        elif self.config.prediction_type == "v_prediction":
+            return alpha_t * sample - sigma_t * model_output
+        else:
+            raise ValueError(
+                f"prediction_type given as {self.config.prediction_type} must be one of `epsilon`, `sample`, or"
+                " `v_prediction`."
+            )
+
+    def convert_x0_to_noise(self, pred_x0: torch.Tensor, sample: torch.Tensor, timestep: int) -> torch.Tensor:
+        """
+        Convert to noise prediction from original sample x0.
+
+        Args:
+            pred_x0 (`torch.Tensor`): The predicted original sample (x0).
+            sample (`torch.Tensor`): A current instance of a sample created by the diffusion process.
+            timestep (`int`): The current discrete timestep in the diffusion chain.
+
+        Returns:
+            `torch.Tensor`: The converted noise prediction.
+        """
+        if self.step_index is None:
+            self._init_step_index(timestep)
+        sigma = self.sigmas[self.step_index]
+        alpha_t, sigma_t = self._sigma_to_alpha_sigma_t(sigma)
+
+        if self.config.prediction_type == "epsilon":
+            x0_pred = (sample - alpha_t * pred_x0) / sigma_t
+        elif self.config.prediction_type == "sample":
+            x0_pred = pred_x0
+        elif self.config.prediction_type == "v_prediction":
+            x0_pred = alpha_t * pred_x0 + sigma_t * sample
+        else:
+            raise ValueError(
+                f"prediction_type given as {self.config.prediction_type} must be one of `epsilon`, `sample`, or"
+                " `v_prediction`."
+            )
+        if self.config.thresholding:
+            x0_pred = self._threshold_sample(x0_pred)
+        return x0_pred
+
     def convert_model_output(
         self,
         model_output: torch.Tensor,

--- a/tests/schedulers/test_scheduler_unipc.py
+++ b/tests/schedulers/test_scheduler_unipc.py
@@ -284,6 +284,43 @@ class UniPCMultistepSchedulerTest(SchedulerCommonTest):
         assert abs(result_sum.item() - 315.5757) < 1e-2, f" expected result sum 315.5757, but get {result_sum}"
         assert abs(result_mean.item() - 0.4109) < 1e-3, f" expected result mean 0.4109, but get {result_mean}"
 
+    def test_convert_model_output(self):
+        for prediction_type in ["epsilon", "sample"]:
+            scheduler_class = self.scheduler_classes[0]
+            scheduler_config = self.get_scheduler_config(prediction_type=prediction_type)
+            scheduler = scheduler_class(**scheduler_config)
+
+            num_inference_steps = 10
+            model = self.dummy_model()
+            sample = self.dummy_sample_deter
+            scheduler.set_timesteps(num_inference_steps)
+
+            for i, t in enumerate(scheduler.timesteps):
+                residual = model(sample, t)
+                pred_x0 = scheduler.convert_noise_to_x0(residual, sample, timestep=t)
+                pred_noise = scheduler.convert_x0_to_noise(pred_x0, sample, timestep=t)
+                assert (
+                    abs(torch.mean(torch.abs(pred_noise)).item() - torch.mean(torch.abs(residual)).item()) < 1e-4
+                ), prediction_type
+                sample = scheduler.step(residual, t, sample).prev_sample
+
+        scheduler_class = self.scheduler_classes[0]
+        prediction_type = "v_prediction"
+        scheduler_config = self.get_scheduler_config(prediction_type=prediction_type)
+        scheduler = scheduler_class(**scheduler_config)
+        num_inference_steps = 10
+        model = self.dummy_model()
+        sample = self.dummy_sample_deter
+        scheduler.set_timesteps(num_inference_steps)
+        for i, t in enumerate(scheduler.timesteps):
+            residual = model(sample, t)
+            pred_x0 = scheduler.convert_noise_to_x0(residual, sample, timestep=t)
+            pred_noise = scheduler.convert_x0_to_noise(pred_x0, sample, timestep=t)
+            sample = scheduler.step(residual, t, sample).prev_sample
+        assert (
+            abs(torch.mean(torch.abs(pred_noise)).item() - torch.mean(torch.abs(residual)).item()) < 2e-2
+        ), prediction_type
+
 
 class UniPCMultistepScheduler1DTest(UniPCMultistepSchedulerTest):
     @property


### PR DESCRIPTION
# What does this PR do?

This PR adds `convert_noise_to_x0` and `convert_x0_to_noise` methods to UniPC scheduler for converting to original sample x0 from noise prediction and converting to noise prediction from original sample x0 respectively.

A test, `test_convert_model_output` is added, which performs a full loop, converting model output with `convert_noise_to_x0`, then back to noised prediction with `convert_x0_to_noise` and compares that result to model output. In the `v_prediction` case comparison is done at the end of the loop because the required tolerance seems to change per step.

`convert_noise_to_x0` and `convert_x0_to_noise` are added as separate methods than the existing `convert_model_output` for a few reasons:
1. `convert_model_output` has deprecated `timestep` in favor of internal `step_index`, however, conversion methods could be used before `step` is called when `step_index` isn't set. Conversion methods accept `timestep` and call `_init_step_index(timestep)` when `self.step_index is None`.
2. Using `convert_model_output` for the conversion resulted in numerical inaccuracies, I noticed a potential discrepancy in `convert_model_output` compared to the working `convert_x0_to_noise`, 
```python
# convert_model_output
if self.predict_x0:
    if self.config.prediction_type == "epsilon":
        x0_pred = (sample - sigma_t * model_output) / alpha_t
    elif self.config.prediction_type == "sample":
        x0_pred = model_output
...
else:
    if self.config.prediction_type == "epsilon":
        return model_output
    elif self.config.prediction_type == "sample":
        epsilon = (sample - alpha_t * model_output) / sigma_t
        return epsilon
```
```python
# convert_x0_to_noise
if self.config.prediction_type == "epsilon":
    x0_pred = (sample - alpha_t * pred_x0) / sigma_t
elif self.config.prediction_type == "sample":
    x0_pred = pred_x0
```
`convert_model_output` with `prediction_type == "epsilon"` returns `model_output` when it should possibly be returning `(sample - alpha_t * model_output) / sigma_t` like in `convert_x0_to_noise`. `predict_x0=False` path appears to be untested/unusued, so I'm not sure whether there's a mistake in `convert_model_output` or whether it's just specific to the scheduler's needs.

I'd like to get more eyes on this to decide whether `convert_model_output` needs fixing or whether to stick with separate methods. Input on the currently deprecated usage of timestep would also be useful.

Also as this is being implemented for guidance methods like APG, I have tested `convert_noise_to_x0` and `convert_x0_to_noise` in a pipeline with APG, the image result is as expected.

#9629

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yiyixuxu