### PR TITLE
Add support of Xlabs Controlnets

### DIFF
--- a/src/diffusers/models/controlnet_flux.py
+++ b/src/diffusers/models/controlnet_flux.py
@@ -22,12 +22,15 @@ from ..configuration_utils import ConfigMixin, register_to_config
 from ..loaders import PeftAdapterMixin
 from ..models.attention_processor import AttentionProcessor
 from ..models.modeling_utils import ModelMixin
-from ..utils import USE_PEFT_BACKEND, is_torch_version, logging, scale_lora_layers, unscale_lora_layers
-from .controlnet import BaseOutput, zero_module, ControlNetConditioningEmbedding
-from .embeddings import CombinedTimestepGuidanceTextProjEmbeddings, CombinedTimestepTextProjEmbeddings, FluxPosEmbed
+from ..utils import (USE_PEFT_BACKEND, is_torch_version, logging,
+                     scale_lora_layers, unscale_lora_layers)
+from .controlnet import (BaseOutput, ControlNetConditioningEmbedding,
+                         zero_module)
+from .embeddings import (CombinedTimestepGuidanceTextProjEmbeddings,
+                         CombinedTimestepTextProjEmbeddings, FluxPosEmbed)
 from .modeling_outputs import Transformer2DModelOutput
-from .transformers.transformer_flux import FluxSingleTransformerBlock, FluxTransformerBlock
-
+from .transformers.transformer_flux import (FluxSingleTransformerBlock,
+                                            FluxTransformerBlock)
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 

--- a/src/diffusers/models/transformers/transformer_flux.py
+++ b/src/diffusers/models/transformers/transformer_flux.py
@@ -508,6 +508,7 @@ class FluxTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrig
             if controlnet_block_samples is not None:
                 interval_control = len(self.transformer_blocks) / len(controlnet_block_samples)
                 interval_control = int(np.ceil(interval_control))
+                # For Xlabs ControlNet.
                 if len(controlnet_block_samples) == 2:
                     hidden_states = hidden_states + controlnet_block_samples[index_block % 2]
                 else:

--- a/src/diffusers/models/transformers/transformer_flux.py
+++ b/src/diffusers/models/transformers/transformer_flux.py
@@ -508,7 +508,10 @@ class FluxTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrig
             if controlnet_block_samples is not None:
                 interval_control = len(self.transformer_blocks) / len(controlnet_block_samples)
                 interval_control = int(np.ceil(interval_control))
-                hidden_states = hidden_states + controlnet_block_samples[index_block // interval_control]
+                if len(controlnet_block_samples) == 2:
+                    hidden_states = hidden_states + controlnet_block_samples[index_block % 2]
+                else:
+                    hidden_states = hidden_states + controlnet_block_samples[index_block // interval_control]
 
         hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
 

--- a/src/diffusers/models/transformers/transformer_flux.py
+++ b/src/diffusers/models/transformers/transformer_flux.py
@@ -402,6 +402,7 @@ class FluxTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrig
         controlnet_block_samples=None,
         controlnet_single_block_samples=None,
         return_dict: bool = True,
+        controlnet_blocks_repeat: bool = False,
     ) -> Union[torch.FloatTensor, Transformer2DModelOutput]:
         """
         The [`FluxTransformer2DModel`] forward method.
@@ -509,8 +510,8 @@ class FluxTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrig
                 interval_control = len(self.transformer_blocks) / len(controlnet_block_samples)
                 interval_control = int(np.ceil(interval_control))
                 # For Xlabs ControlNet.
-                if len(controlnet_block_samples) == 2:
-                    hidden_states = hidden_states + controlnet_block_samples[index_block % 2]
+                if controlnet_blocks_repeat:
+                    hidden_states = hidden_states + controlnet_block_samples[index_block % len(controlnet_block_samples)]
                 else:
                     hidden_states = hidden_states + controlnet_block_samples[index_block // interval_control]
 

--- a/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
@@ -740,7 +740,7 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
 
         # 3. Prepare control image
         num_channels_latents = self.transformer.config.in_channels // 4
-        if isinstance(self.controlnet, FluxControlNetModel):
+        if isinstance(self.controlnet, FluxControlNetModel) and not self.controlnet.is_xlabs_controlnet:
             control_image = self.prepare_image(
                 image=control_image,
                 width=width,
@@ -772,6 +772,17 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
                     raise ValueError(" For `FluxControlNet`, `control_mode` should be an `int` or `None`")
                 control_mode = torch.tensor(control_mode).to(device, dtype=torch.long)
                 control_mode = control_mode.view(-1, 1).expand(control_image.shape[0], 1)
+
+        elif isinstance(self.controlnet, FluxControlNetModel) and self.controlnet.is_xlabs_controlnet:
+            control_image = self.prepare_image(
+                image=control_image,
+                width=width,
+                height=height,
+                batch_size=batch_size * num_images_per_prompt,
+                num_images_per_prompt=num_images_per_prompt,
+                device=device,
+                dtype=self.vae.dtype,
+            )
 
         elif isinstance(self.controlnet, FluxMultiControlNetModel):
             control_images = []

--- a/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
@@ -752,7 +752,7 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
             )
             height, width = control_image.shape[-2:]
 
-            if not self.controlnet.is_xlabs_controlnet:
+            if self.controlnet.input_hint_block is None:
                 # vae encode
                 control_image = self.vae.encode(control_image).latent_dist.sample()
                 control_image = (control_image - self.vae.config.shift_factor) * self.vae.config.scaling_factor

--- a/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
@@ -739,6 +739,7 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
         )
 
         # 3. Prepare control image
+        controlnet_blocks_repeat = False
         num_channels_latents = self.transformer.config.in_channels // 4
         if isinstance(self.controlnet, FluxControlNetModel):
             control_image = self.prepare_image(
@@ -766,6 +767,8 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
                     height_control_image,
                     width_control_image,
                 )
+            else:
+                controlnet_blocks_repeat = True
 
             # Here we ensure that `control_mode` has the same length as the control_image.
             if control_mode is not None:
@@ -926,6 +929,7 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
                     img_ids=latent_image_ids,
                     joint_attention_kwargs=self.joint_attention_kwargs,
                     return_dict=False,
+                    controlnet_blocks_repeat=controlnet_blocks_repeat,
                 )[0]
 
                 # compute the previous noisy sample x_t -> x_t-1

--- a/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
@@ -740,7 +740,7 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
 
         # 3. Prepare control image
         num_channels_latents = self.transformer.config.in_channels // 4
-        if isinstance(self.controlnet, FluxControlNetModel) and not self.controlnet.is_xlabs_controlnet:
+        if isinstance(self.controlnet, FluxControlNetModel):
             control_image = self.prepare_image(
                 image=control_image,
                 width=width,
@@ -752,19 +752,20 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
             )
             height, width = control_image.shape[-2:]
 
-            # vae encode
-            control_image = self.vae.encode(control_image).latent_dist.sample()
-            control_image = (control_image - self.vae.config.shift_factor) * self.vae.config.scaling_factor
+            if not self.controlnet.is_xlabs_controlnet:
+                # vae encode
+                control_image = self.vae.encode(control_image).latent_dist.sample()
+                control_image = (control_image - self.vae.config.shift_factor) * self.vae.config.scaling_factor
 
-            # pack
-            height_control_image, width_control_image = control_image.shape[2:]
-            control_image = self._pack_latents(
-                control_image,
-                batch_size * num_images_per_prompt,
-                num_channels_latents,
-                height_control_image,
-                width_control_image,
-            )
+                # pack
+                height_control_image, width_control_image = control_image.shape[2:]
+                control_image = self._pack_latents(
+                    control_image,
+                    batch_size * num_images_per_prompt,
+                    num_channels_latents,
+                    height_control_image,
+                    width_control_image,
+                )
 
             # Here we ensure that `control_mode` has the same length as the control_image.
             if control_mode is not None:
@@ -772,17 +773,6 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
                     raise ValueError(" For `FluxControlNet`, `control_mode` should be an `int` or `None`")
                 control_mode = torch.tensor(control_mode).to(device, dtype=torch.long)
                 control_mode = control_mode.view(-1, 1).expand(control_image.shape[0], 1)
-
-        elif isinstance(self.controlnet, FluxControlNetModel) and self.controlnet.is_xlabs_controlnet:
-            control_image = self.prepare_image(
-                image=control_image,
-                width=width,
-                height=height,
-                batch_size=batch_size * num_images_per_prompt,
-                num_images_per_prompt=num_images_per_prompt,
-                device=device,
-                dtype=self.vae.dtype,
-            )
 
         elif isinstance(self.controlnet, FluxMultiControlNetModel):
             control_images = []


### PR DESCRIPTION
# What does this PR do?

Hi! 
This PR brings support of Xlabs Controlnets, so it can be used with Diffusers.
We converted checkpoints to the Diffusers format and it can be downloaded here:
- https://huggingface.co/XLabs-AI/flux-controlnet-depth-diffusers
- https://huggingface.co/XLabs-AI/flux-controlnet-canny-diffusers
- https://huggingface.co/XLabs-AI/flux-controlnet-hed-diffusers

The request: https://github.com/huggingface/diffusers/issues/9378
## Who can review?

Anyone in the community is free to review the PR once the tests have passed. 
@sayakpaul

## How to use
Here is the example of code to launch Canny Controlnet.
```
import torch
from diffusers.utils import load_image
from diffusers import FluxControlNetModel
from diffusers.pipelines import FluxControlNetPipeline
from PIL import Image
import numpy as np

generator = torch.Generator(device="cuda").manual_seed(87544357)

controlnet = FluxControlNetModel.from_pretrained(
  "Xlabs-AI/flux-controlnet-canny-diffusers",
  torch_dtype=torch.bfloat16,
  use_safetensors=True,
)
pipe = FluxControlNetPipeline.from_pretrained(
  "black-forest-labs/FLUX.1-dev",
  controlnet=controlnet,
  torch_dtype=torch.bfloat16
)
pipe.to("cuda")

control_image = load_image("https://huggingface.co/Xlabs-AI/flux-controlnet-canny-diffusers/resolve/main/canny_example.png")
prompt = "handsome girl with rainbow hair, anime"

image = pipe(
    prompt,
    control_image=control_image,
    controlnet_conditioning_scale=0.7,
    num_inference_steps=25,
    guidance_scale=3.5,
    height=1024,
    width=768,
    generator=generator,
    num_images_per_prompt=1,
).images[0]

image.save("output_test_controlnet.png")
```
## Examples

![Group 1](https://github.com/user-attachments/assets/91e3f2fa-9491-4442-8cb1-429a57563b86)
"photo of village in the winter"

![Group 2](https://github.com/user-attachments/assets/35307466-e8ae-48ab-85cf-8c6646c3c630)
"it programmer sitting in the office"

![Group 3](https://github.com/user-attachments/assets/f36a1b17-5374-473b-a84a-4fa1578ca0c7)
"couple of man and woman in the water, dancing"

![Group 4](https://github.com/user-attachments/assets/c49bef51-e5ba-4f7e-b1de-efdeb5afb353)
"photo of woman in the beach"

![Group 5](https://github.com/user-attachments/assets/3f9f7f56-65e4-4525-ae90-957c13465145)
"futuristic bulding in the spain"

![Group 6](https://github.com/user-attachments/assets/0c8bd557-8520-40e8-b630-1ebce8d435b5)
"2d art, girl in the magic city, sparkles, fantasy"

