### PR TITLE
Dreambooth lora flux bug 3dtensor to 2dtensor

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux.py
@@ -1007,8 +1007,7 @@ def encode_prompt(
         text_input_ids=text_input_ids_list[1] if text_input_ids_list else None,
     )
 
-    text_ids = torch.zeros(batch_size, prompt_embeds.shape[1], 3).to(device=device, dtype=dtype)
-    text_ids = text_ids.repeat(num_images_per_prompt, 1, 1)
+    text_ids = torch.zeros(prompt_embeds.shape[1], 3).to(device=device, dtype=dtype)
 
     return prompt_embeds, pooled_prompt_embeds, text_ids
 


### PR DESCRIPTION
# What does this PR do?
currently doing
```py   
text_ids = torch.zeros(batch_size, prompt_embeds.shape[1], 3).to(device=device, dtype=dtype)
```

results in warning:
```Bash
09/03/2024 10:45:35 - INFO - __main__ - ***** Running training *****
09/03/2024 10:45:35 - INFO - __main__ -   Num examples = 26
09/03/2024 10:45:35 - INFO - __main__ -   Num batches each epoch = 26
09/03/2024 10:45:35 - INFO - __main__ -   Num Epochs = 154
09/03/2024 10:45:35 - INFO - __main__ -   Instantaneous batch size per device = 1
09/03/2024 10:45:35 - INFO - __main__ -   Total train batch size (w. parallel, distributed & accumulation) = 2
09/03/2024 10:45:35 - INFO - __main__ -   Gradient Accumulation steps = 2
09/03/2024 10:45:35 - INFO - __main__ -   Total optimization steps = 2000
Steps:   0%|                                                                                                                                                                            | 0/2000 [00:00<?, ?it/s]
Passing `txt_ids` 3d torch.Tensor is deprecated.Please remove the batch dimension and pass it as a 2d torch Tensor
Steps:   0%|                                                                                                                                                       | 0/2000 [00:01<?, ?it/s, loss=0.522, lr=5e-5]
Passing `txt_ids` 3d torch.Tensor is deprecated.Please remove the batch dimension and pass it as a 2d torch Tensor
```
removed batch_size and the next line that reassigns txt_ids from :
https://github.com/huggingface/diffusers/blob/8ecf499d8bda3721ce89f5cb8c804afec4966b6a/examples/dreambooth/train_dreambooth_lora_flux.py#L994

to
```py
text_ids = torch.zeros(prompt_embeds.shape[1], 3).to(device=device, dtype=dtype) 
```