### PR TITLE
fix singlestep dpm tests

### DIFF
--- a/src/diffusers/schedulers/scheduling_dpmsolver_singlestep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_singlestep.py
@@ -330,6 +330,7 @@ class DPMSolverSinglestepScheduler(SchedulerMixin, ConfigMixin):
             # Clipping the minimum of all lambda(t) for numerical stability.
             # This is critical for cosine (squaredcos_cap_v2) noise schedule.
             clipped_idx = torch.searchsorted(torch.flip(self.lambda_t, [0]), self.config.lambda_min_clipped)
+            clipped_idx = clipped_idx.item()
             timesteps = (
                 np.linspace(0, self.config.num_train_timesteps - 1 - clipped_idx, num_inference_steps + 1)
                 .round()[::-1][:-1]


### PR DESCRIPTION
fix the failing singlestep scheduler tests

thanks to @gfaires  to help identify this is only an issue with newer numpy version https://github.com/huggingface/diffusers/issues/9359



it comes down to this, this creates a numpy array in earlier versions (as expected), however it creates a pytorcn tensor in newer version - this is just really blizzard and I couln;t find relevant information about it 

```python
import numpy as np
import torch
# Print NumPy version
print(f"NumPy version: {np.__version__}")

ts = np.linspace(0, torch.tensor(999), 51)
print(type(ts))
```