### PR TITLE
[Fix] Using sharded checkpoints with gated repositories

### DIFF
--- a/src/diffusers/utils/hub_utils.py
+++ b/src/diffusers/utils/hub_utils.py
@@ -457,7 +457,7 @@ def _get_checkpoint_shard_files(
     ignore_patterns = ["*.json", "*.md"]
     if not local_files_only:
         # `model_info` call must guarded with the above condition.
-        model_files_info = model_info(pretrained_model_name_or_path, revision=revision)
+        model_files_info = model_info(pretrained_model_name_or_path, revision=revision, token=token)
         for shard_file in original_shard_filenames:
             shard_file_present = any(shard_file in k.rfilename for k in model_files_info.siblings)
             if not shard_file_present:


### PR DESCRIPTION
# What does this PR do?

When using sharded checkpoints with gated repositories we get an error because we don't pass the token to the `model_info` function. This PR fixes this.

## Who can review?

@sayakpaul @DN6 
