### PR TITLE
[fix] sync ControlNet-SD3 attention parameters of dual_attention_layer and qk_norm with SD3

### DIFF
--- a/src/diffusers/models/controlnets/controlnet_sd3.py
+++ b/src/diffusers/models/controlnets/controlnet_sd3.py
@@ -56,6 +56,10 @@ class SD3ControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginal
         out_channels: int = 16,
         pos_embed_max_size: int = 96,
         extra_conditioning_channels: int = 0,
+        dual_attention_layers: Tuple[
+            int, ...
+        ] = (),  # () for sd3.0; (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12) for sd3.5
+        qk_norm: Optional[str] = None,
     ):
         super().__init__()
         default_out_channels = in_channels
@@ -84,6 +88,8 @@ class SD3ControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginal
                     num_attention_heads=num_attention_heads,
                     attention_head_dim=self.config.attention_head_dim,
                     context_pre_only=False,
+                    qk_norm=qk_norm,
+                    use_dual_attention=True if i in dual_attention_layers else False,
                 )
                 for i in range(num_layers)
             ]
@@ -243,7 +249,7 @@ class SD3ControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginal
 
     @classmethod
     def from_transformer(
-        cls, transformer, num_layers=12, num_extra_conditioning_channels=1, load_weights_from_transformer=True
+        cls, transformer, num_layers=12, num_extra_conditioning_channels=0, load_weights_from_transformer=True
     ):
         config = transformer.config
         config["num_layers"] = num_layers or config.num_layers


### PR DESCRIPTION
When initializing ControlNet-SD3 with the from_transformer method, the dual_attention_layers and qk_norm parameters were not defined in the __init__ method, resulting in the following error:
```
[rank1]:   File "train_controlnet_sd3.py", line 989, in main
[rank1]:     controlnet = SD3ControlNetModel.from_transformer(transformer)
[rank1]:   File "/home/23124047r/anaconda3/envs/py38/lib/python3.8/site-packages/diffusers/models/controlnet_sd3.py", line 251, in from_transformer
[rank1]:     controlnet = cls(**config)
[rank1]:   File "/home/23124047r/anaconda3/envs/py38/lib/python3.8/site-packages/diffusers/configuration_utils.py", line 665, in inner_init
[rank1]:     init(self, *args, **init_kwargs)
[rank1]: TypeError: __init__() got an unexpected keyword argument 'dual_attention_layers'
```
To resolve this, the missing keyword arguments were added to ensure compatibility with the from_transformer method.

And pos_embed_input for conditioning images needs to be the same as it in original transformers, for the images shape are the same.


