### PR TITLE
[fix] Correct progress bar initialization in train_instruct_pix2pix.py

### DIFF
--- a/examples/instruct_pix2pix/train_instruct_pix2pix.py
+++ b/examples/instruct_pix2pix/train_instruct_pix2pix.py
@@ -842,7 +842,7 @@ def main():
             resume_step = resume_global_step % (num_update_steps_per_epoch * args.gradient_accumulation_steps)
 
     # Only show the progress bar once on each machine.
-    progress_bar = tqdm(range(global_step, args.max_train_steps), disable=not accelerator.is_local_main_process)
+    progress_bar = tqdm(range(0, args.max_train_steps), disable=not accelerator.is_local_main_process)
     progress_bar.set_description("Steps")
 
     for epoch in range(first_epoch, args.num_train_epochs):


### PR DESCRIPTION
This PR ensures the progress bar starts from 0 when resuming from a checkpoint, fixing an issue where it previously started at global_step and caused wrong progress tracking.