### PR TITLE
debug `EMAModel.from_pretrained()`

### DIFF
--- a/src/diffusers/training_utils.py
+++ b/src/diffusers/training_utils.py
@@ -379,7 +379,7 @@ class EMAModel:
 
     @classmethod
     def from_pretrained(cls, path, model_cls, foreach=False) -> "EMAModel":
-        _, ema_kwargs = model_cls.load_config(path, return_unused_kwargs=True)
+        _, ema_kwargs = model_cls.from_config(path, return_unused_kwargs=True)
         model = model_cls.from_pretrained(path)
 
         ema_model = cls(model.parameters(), model_cls=model_cls, model_config=model.config, foreach=foreach)


### PR DESCRIPTION
# What does this PR do?

`model_cls.load_config()` is modified to **`model_cls.from_config()`**.

When setting `return_unused_kwargs=True`, for `model_cls.load_config()`, the returned unused kwargs are referred to as **unused input args**, instead of unused args for `model_cls` initialization. So the returned `ema_kwargs` are always empty (`{}`).

**`model_cls.from_config()`** will return the real **unused args for model initialization**, which are the expected `ema_kwargs`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

General functionalities: @sayakpaul @yiyixuxu @DN6
