### PR TITLE
fix `EMAModel.use_ema_warmup`

### DIFF
--- a/src/diffusers/training_utils.py
+++ b/src/diffusers/training_utils.py
@@ -341,9 +341,6 @@ class EMAModel:
             )
             parameters = parameters.parameters()
 
-            # set use_ema_warmup to True if a torch.nn.Module is passed for backwards compatibility
-            use_ema_warmup = True
-
         if kwargs.get("max_value", None) is not None:
             deprecation_message = "The `max_value` argument is deprecated. Please use `decay` instead."
             deprecate("max_value", "1.0.0", deprecation_message, standard_warn=False)
@@ -414,7 +411,7 @@ class EMAModel:
         if self.use_ema_warmup:
             cur_decay_value = 1 - (1 + step / self.inv_gamma) ** -self.power
         else:
-            cur_decay_value = (1 + step) / (10 + step)
+            cur_decay_value = self.decay
 
         cur_decay_value = min(cur_decay_value, self.decay)
         # make sure decay is not smaller than min_decay


### PR DESCRIPTION
# What does this PR do?

I do not understand for a long time why `use_ema_warmup` is forced to be `True` in `EMAModel.__init__()`. It is really inconvenient for really proferming fixed-decay EMA.

And it is also unreasonable to still use warmup by `cur_decay_value = (1 + step) / (10 + step)` when `use_ema_warmup=False`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

General functionalities: @sayakpaul @yiyixuxu @DN6
