### PR TITLE
Make flow match euler discrete scheduler thread-safe.

### DIFF
--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -293,7 +293,7 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
                 ),
             )
 
-        if self.step_index is None:
+        if self._step_index not in contextvars.copy_context():
             self._init_step_index(timestep)
 
         # Upcast to avoid precision issues when computing prev_sample


### PR DESCRIPTION
# What does this PR do?

This is a partial fix just for the euler discrete scheduler that is used by default for the Stable Diffusion 3 pipeline for #3672. I am unsure how to do this as a generic fix, nor do I think it would go along with the [HF diffusers philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) if it was possible.

I've tested this with my local `fastapi` server, and it has no issues with generating images concurrently using the `StableDiffusion3Pipeline`.

Let me know if you like this change, and I can do some updates to some other schedulers to make them usable in servers that want to do concurrent generation of images.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

- Schedulers: @yiyixuxu

![](https://bukk.it/howidowebdesign.jpg)