### PR TITLE
Fix Progress Bar Updates in SD 1.5 PAG Img2Img pipeline

### DIFF
--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_img2img.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_img2img.py
@@ -1063,6 +1063,9 @@ class StableDiffusionPAGImg2ImgPipeline(
                     prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
                     negative_prompt_embeds = callback_outputs.pop("negative_prompt_embeds", negative_prompt_embeds)
 
+                if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
+                    progress_bar.update()
+
         if not output_type == "latent":
             image = self.vae.decode(latents / self.vae.config.scaling_factor, return_dict=False, generator=generator)[
                 0


### PR DESCRIPTION
# What does this PR do?

`StableDiffusionPAGImg2ImgPipeline` does not properly update the progress bar during the denoising process, making progress silent when working in a terminal environment.

This PR brings this pipeline's progress bar functionality in line with other pipelines.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] ~Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.~ **Too minor for an issue, I think.**
- [x] ~Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).~ **This brings the functionality in line with documentation, the other way around is not needed in this case.**
- [x] ~Did you write any new necessary tests?~ **Correct me if I'm wrong but I believe the progress bar functionality is not exercised in any existing tests.**

## Who can review?

Anyone can review, but based on the subject matter, @yiyixuxu and @asomoza seem to be the right folks.
