### PR TITLE
Correct pipeline_output.py to the type Mochi

### DIFF
--- a/src/diffusers/pipelines/mochi/pipeline_output.py
+++ b/src/diffusers/pipelines/mochi/pipeline_output.py
@@ -8,7 +8,7 @@ from diffusers.utils import BaseOutput
 @dataclass
 class MochiPipelineOutput(BaseOutput):
     r"""
-    Output class for CogVideo pipelines.
+    Output class for Mochi pipelines.
 
     Args:
         frames (`torch.Tensor`, `np.ndarray`, or List[List[PIL.Image.Image]]):


### PR DESCRIPTION
# What does this PR do?

The autodocs are incorrect as a result of this oversight in the header

Mochi is the correct pipeline type


![image](https://github.com/user-attachments/assets/659a71d5-1fc8-4541-b1f1-a542c38282a9)



## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
originally 
Co-authored-by: Dhruv Nair 
Co-authored-by: yiyixuxu 

@yiyixuxu 
@stevhliu @sayakpaul
