### PR TITLE
Make CogVideoX RoPE implementation consistent

### DIFF
--- a/src/diffusers/pipelines/cogvideo/pipeline_cogvideox.py
+++ b/src/diffusers/pipelines/cogvideo/pipeline_cogvideox.py
@@ -446,19 +446,34 @@ class CogVideoXPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin):
         p = self.transformer.config.patch_size
         p_t = self.transformer.config.patch_size_t or 1
 
-        base_size_width = self.transformer.config.sample_width // p
-        base_size_height = self.transformer.config.sample_height // p
-        base_num_frames = (num_frames + p_t - 1) // p_t
+        if p_t is None:
+            # CogVideoX 1.0
+            base_size_width = self.transformer.config.sample_width // p
+            base_size_height = self.transformer.config.sample_height // p
 
-        grid_crops_coords = get_resize_crop_region_for_grid(
-            (grid_height, grid_width), base_size_width, base_size_height
-        )
-        freqs_cos, freqs_sin = get_3d_rotary_pos_embed(
-            embed_dim=self.transformer.config.attention_head_dim,
-            crops_coords=grid_crops_coords,
-            grid_size=(grid_height, grid_width),
-            temporal_size=base_num_frames,
-        )
+            grid_crops_coords = get_resize_crop_region_for_grid(
+                (grid_height, grid_width), base_size_width, base_size_height
+            )
+            freqs_cos, freqs_sin = get_3d_rotary_pos_embed(
+                embed_dim=self.transformer.config.attention_head_dim,
+                crops_coords=grid_crops_coords,
+                grid_size=(grid_height, grid_width),
+                temporal_size=num_frames,
+            )
+        else:
+            # CogVideoX 1.5
+            base_size_width = self.transformer.config.sample_width // p
+            base_size_height = self.transformer.config.sample_height // p
+            base_num_frames = (num_frames + p_t - 1) // p_t
+
+            freqs_cos, freqs_sin = get_3d_rotary_pos_embed(
+                embed_dim=self.transformer.config.attention_head_dim,
+                crops_coords=None,
+                grid_size=(grid_height, grid_width),
+                temporal_size=base_num_frames,
+                grid_type="slice",
+                max_size=(base_size_height, base_size_width),
+            )
 
         freqs_cos = freqs_cos.to(device=device)
         freqs_sin = freqs_sin.to(device=device)

--- a/src/diffusers/pipelines/cogvideo/pipeline_cogvideox.py
+++ b/src/diffusers/pipelines/cogvideo/pipeline_cogvideox.py
@@ -444,13 +444,13 @@ class CogVideoXPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin):
         grid_width = width // (self.vae_scale_factor_spatial * self.transformer.config.patch_size)
 
         p = self.transformer.config.patch_size
-        p_t = self.transformer.config.patch_size_t or 1
+        p_t = self.transformer.config.patch_size_t
+
+        base_size_width = self.transformer.config.sample_width // p
+        base_size_height = self.transformer.config.sample_height // p
 
         if p_t is None:
             # CogVideoX 1.0
-            base_size_width = self.transformer.config.sample_width // p
-            base_size_height = self.transformer.config.sample_height // p
-
             grid_crops_coords = get_resize_crop_region_for_grid(
                 (grid_height, grid_width), base_size_width, base_size_height
             )
@@ -462,8 +462,6 @@ class CogVideoXPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin):
             )
         else:
             # CogVideoX 1.5
-            base_size_width = self.transformer.config.sample_width // p
-            base_size_height = self.transformer.config.sample_height // p
             base_num_frames = (num_frames + p_t - 1) // p_t
 
             freqs_cos, freqs_sin = get_3d_rotary_pos_embed(

--- a/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_fun_control.py
+++ b/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_fun_control.py
@@ -490,13 +490,13 @@ class CogVideoXFunControlPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin):
         grid_width = width // (self.vae_scale_factor_spatial * self.transformer.config.patch_size)
 
         p = self.transformer.config.patch_size
-        p_t = self.transformer.config.patch_size_t or 1
+        p_t = self.transformer.config.patch_size_t
+
+        base_size_width = self.transformer.config.sample_width // p
+        base_size_height = self.transformer.config.sample_height // p
 
         if p_t is None:
             # CogVideoX 1.0
-            base_size_width = self.transformer.config.sample_width // p
-            base_size_height = self.transformer.config.sample_height // p
-
             grid_crops_coords = get_resize_crop_region_for_grid(
                 (grid_height, grid_width), base_size_width, base_size_height
             )
@@ -508,8 +508,6 @@ class CogVideoXFunControlPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin):
             )
         else:
             # CogVideoX 1.5
-            base_size_width = self.transformer.config.sample_width // p
-            base_size_height = self.transformer.config.sample_height // p
             base_num_frames = (num_frames + p_t - 1) // p_t
 
             freqs_cos, freqs_sin = get_3d_rotary_pos_embed(

--- a/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_fun_control.py
+++ b/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_fun_control.py
@@ -492,19 +492,34 @@ class CogVideoXFunControlPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin):
         p = self.transformer.config.patch_size
         p_t = self.transformer.config.patch_size_t or 1
 
-        base_size_width = self.transformer.config.sample_width // p
-        base_size_height = self.transformer.config.sample_height // p
-        base_num_frames = (num_frames + p_t - 1) // p_t
+        if p_t is None:
+            # CogVideoX 1.0
+            base_size_width = self.transformer.config.sample_width // p
+            base_size_height = self.transformer.config.sample_height // p
 
-        grid_crops_coords = get_resize_crop_region_for_grid(
-            (grid_height, grid_width), base_size_width, base_size_height
-        )
-        freqs_cos, freqs_sin = get_3d_rotary_pos_embed(
-            embed_dim=self.transformer.config.attention_head_dim,
-            crops_coords=grid_crops_coords,
-            grid_size=(grid_height, grid_width),
-            temporal_size=base_num_frames,
-        )
+            grid_crops_coords = get_resize_crop_region_for_grid(
+                (grid_height, grid_width), base_size_width, base_size_height
+            )
+            freqs_cos, freqs_sin = get_3d_rotary_pos_embed(
+                embed_dim=self.transformer.config.attention_head_dim,
+                crops_coords=grid_crops_coords,
+                grid_size=(grid_height, grid_width),
+                temporal_size=num_frames,
+            )
+        else:
+            # CogVideoX 1.5
+            base_size_width = self.transformer.config.sample_width // p
+            base_size_height = self.transformer.config.sample_height // p
+            base_num_frames = (num_frames + p_t - 1) // p_t
+
+            freqs_cos, freqs_sin = get_3d_rotary_pos_embed(
+                embed_dim=self.transformer.config.attention_head_dim,
+                crops_coords=None,
+                grid_size=(grid_height, grid_width),
+                temporal_size=base_num_frames,
+                grid_type="slice",
+                max_size=(base_size_height, base_size_width),
+            )
 
         freqs_cos = freqs_cos.to(device=device)
         freqs_sin = freqs_sin.to(device=device)

--- a/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_image2video.py
+++ b/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_image2video.py
@@ -540,13 +540,13 @@ class CogVideoXImageToVideoPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin)
         grid_width = width // (self.vae_scale_factor_spatial * self.transformer.config.patch_size)
 
         p = self.transformer.config.patch_size
-        p_t = self.transformer.config.patch_size_t or 1
+        p_t = self.transformer.config.patch_size_t
+
+        base_size_width = self.transformer.config.sample_width // p
+        base_size_height = self.transformer.config.sample_height // p
 
         if p_t is None:
             # CogVideoX 1.0
-            base_size_width = self.transformer.config.sample_width // p
-            base_size_height = self.transformer.config.sample_height // p
-
             grid_crops_coords = get_resize_crop_region_for_grid(
                 (grid_height, grid_width), base_size_width, base_size_height
             )
@@ -558,8 +558,6 @@ class CogVideoXImageToVideoPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin)
             )
         else:
             # CogVideoX 1.5
-            base_size_width = self.transformer.config.sample_width // p
-            base_size_height = self.transformer.config.sample_height // p
             base_num_frames = (num_frames + p_t - 1) // p_t
 
             freqs_cos, freqs_sin = get_3d_rotary_pos_embed(

--- a/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_image2video.py
+++ b/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_image2video.py
@@ -528,6 +528,7 @@ class CogVideoXImageToVideoPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin)
             self.transformer.unfuse_qkv_projections()
             self.fusing_transformer = False
 
+    # Copied from diffusers.pipelines.cogvideo.pipeline_cogvideox.CogVideoXPipeline._prepare_rotary_positional_embeddings
     def _prepare_rotary_positional_embeddings(
         self,
         height: int,
@@ -539,10 +540,10 @@ class CogVideoXImageToVideoPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin)
         grid_width = width // (self.vae_scale_factor_spatial * self.transformer.config.patch_size)
 
         p = self.transformer.config.patch_size
-        p_t = self.transformer.config.patch_size_t
+        p_t = self.transformer.config.patch_size_t or 1
 
         if p_t is None:
-            # CogVideoX 1.0 I2V
+            # CogVideoX 1.0
             base_size_width = self.transformer.config.sample_width // p
             base_size_height = self.transformer.config.sample_height // p
 
@@ -556,7 +557,7 @@ class CogVideoXImageToVideoPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin)
                 temporal_size=num_frames,
             )
         else:
-            # CogVideoX 1.5 I2V
+            # CogVideoX 1.5
             base_size_width = self.transformer.config.sample_width // p
             base_size_height = self.transformer.config.sample_height // p
             base_num_frames = (num_frames + p_t - 1) // p_t

--- a/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_video2video.py
+++ b/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_video2video.py
@@ -520,13 +520,13 @@ class CogVideoXVideoToVideoPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin)
         grid_width = width // (self.vae_scale_factor_spatial * self.transformer.config.patch_size)
 
         p = self.transformer.config.patch_size
-        p_t = self.transformer.config.patch_size_t or 1
+        p_t = self.transformer.config.patch_size_t
+
+        base_size_width = self.transformer.config.sample_width // p
+        base_size_height = self.transformer.config.sample_height // p
 
         if p_t is None:
             # CogVideoX 1.0
-            base_size_width = self.transformer.config.sample_width // p
-            base_size_height = self.transformer.config.sample_height // p
-
             grid_crops_coords = get_resize_crop_region_for_grid(
                 (grid_height, grid_width), base_size_width, base_size_height
             )
@@ -538,8 +538,6 @@ class CogVideoXVideoToVideoPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin)
             )
         else:
             # CogVideoX 1.5
-            base_size_width = self.transformer.config.sample_width // p
-            base_size_height = self.transformer.config.sample_height // p
             base_num_frames = (num_frames + p_t - 1) // p_t
 
             freqs_cos, freqs_sin = get_3d_rotary_pos_embed(

--- a/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_video2video.py
+++ b/src/diffusers/pipelines/cogvideo/pipeline_cogvideox_video2video.py
@@ -522,19 +522,34 @@ class CogVideoXVideoToVideoPipeline(DiffusionPipeline, CogVideoXLoraLoaderMixin)
         p = self.transformer.config.patch_size
         p_t = self.transformer.config.patch_size_t or 1
 
-        base_size_width = self.transformer.config.sample_width // p
-        base_size_height = self.transformer.config.sample_height // p
-        base_num_frames = (num_frames + p_t - 1) // p_t
+        if p_t is None:
+            # CogVideoX 1.0
+            base_size_width = self.transformer.config.sample_width // p
+            base_size_height = self.transformer.config.sample_height // p
 
-        grid_crops_coords = get_resize_crop_region_for_grid(
-            (grid_height, grid_width), base_size_width, base_size_height
-        )
-        freqs_cos, freqs_sin = get_3d_rotary_pos_embed(
-            embed_dim=self.transformer.config.attention_head_dim,
-            crops_coords=grid_crops_coords,
-            grid_size=(grid_height, grid_width),
-            temporal_size=base_num_frames,
-        )
+            grid_crops_coords = get_resize_crop_region_for_grid(
+                (grid_height, grid_width), base_size_width, base_size_height
+            )
+            freqs_cos, freqs_sin = get_3d_rotary_pos_embed(
+                embed_dim=self.transformer.config.attention_head_dim,
+                crops_coords=grid_crops_coords,
+                grid_size=(grid_height, grid_width),
+                temporal_size=num_frames,
+            )
+        else:
+            # CogVideoX 1.5
+            base_size_width = self.transformer.config.sample_width // p
+            base_size_height = self.transformer.config.sample_height // p
+            base_num_frames = (num_frames + p_t - 1) // p_t
+
+            freqs_cos, freqs_sin = get_3d_rotary_pos_embed(
+                embed_dim=self.transformer.config.attention_head_dim,
+                crops_coords=None,
+                grid_size=(grid_height, grid_width),
+                temporal_size=base_num_frames,
+                grid_type="slice",
+                max_size=(base_size_height, base_size_width),
+            )
 
         freqs_cos = freqs_cos.to(device=device)
         freqs_sin = freqs_sin.to(device=device)


### PR DESCRIPTION
# What does this PR do?

CogVideoX 1.5 models use a slightly different RoPE implementation compared to 1.0. When we merged the CogVideoX 1.5 PR, this was the status of RoPE implementations:
- 1.0 T2V and I2V used 1.0 RoPE implementation
- 1.5 I2V used 1.5 RoPE implementation
- 1.5 T2V used 1.0 RoPE implementation (inconsistent)

All models still worked as expected and there weren't any bugs. This PR just makes sure that 1.5 T2V uses 1.5 RoPE implementation (the reason why it still worked before is because linspace and slice implementation are equivalent at the 1360x768 resolution, which is the only resolution 1.5 T2V supports, but differ otherwise). The 1.5 T2V needs to use sliced implementation though to keep things consistent with the original code base (even though the outputs match with 1.0 implementation).

The config for 1.5 T2V on the official checkpoints has been correctly updated (https://huggingface.co/THUDM/CogVideoX1.5-5B/commit/6b80d8556f820bf58e4e9719ec71450aff55c246), but unless we also make these changes, it will become incompatible. So requesting a speedy merge @DN6 