### PR TITLE
Add `beta`, `exponential` and `karras` sigmas to `FlowMatchEulerDiscreteScheduler`

### DIFF
--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -20,9 +20,12 @@ import numpy as np
 import torch
 
 from ..configuration_utils import ConfigMixin, register_to_config
-from ..utils import BaseOutput, logging
+from ..utils import BaseOutput, is_scipy_available, logging
 from .scheduling_utils import SchedulerMixin
 
+
+if is_scipy_available():
+    import scipy.stats
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -72,7 +75,16 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         base_image_seq_len: Optional[int] = 256,
         max_image_seq_len: Optional[int] = 4096,
         invert_sigmas: bool = False,
+        use_karras_sigmas: Optional[bool] = False,
+        use_exponential_sigmas: Optional[bool] = False,
+        use_beta_sigmas: Optional[bool] = False,
     ):
+        if self.config.use_beta_sigmas and not is_scipy_available():
+            raise ImportError("Make sure to install scipy if you want to use beta sigmas.")
+        if sum([self.config.use_beta_sigmas, self.config.use_exponential_sigmas, self.config.use_karras_sigmas]) > 1:
+            raise ValueError(
+                "Only one of `config.use_beta_sigmas`, `config.use_exponential_sigmas`, `config.use_karras_sigmas` can be used."
+            )
         timesteps = np.linspace(1, num_train_timesteps, num_train_timesteps, dtype=np.float32)[::-1].copy()
         timesteps = torch.from_numpy(timesteps).to(dtype=torch.float32)
 
@@ -185,22 +197,32 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             device (`str` or `torch.device`, *optional*):
                 The device to which the timesteps should be moved to. If `None`, the timesteps are not moved.
         """
-
         if self.config.use_dynamic_shifting and mu is None:
             raise ValueError(" you have a pass a value for `mu` when `use_dynamic_shifting` is set to be `True`")
 
         if sigmas is None:
-            self.num_inference_steps = num_inference_steps
             timesteps = np.linspace(
                 self._sigma_to_t(self.sigma_max), self._sigma_to_t(self.sigma_min), num_inference_steps
             )
 
             sigmas = timesteps / self.config.num_train_timesteps
+        else:
+            num_inference_steps = len(sigmas)
+        self.num_inference_steps = num_inference_steps
 
         if self.config.use_dynamic_shifting:
             sigmas = self.time_shift(mu, 1.0, sigmas)
         else:
             sigmas = self.config.shift * sigmas / (1 + (self.config.shift - 1) * sigmas)
+
+        if self.config.use_karras_sigmas:
+            sigmas = self._convert_to_karras(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
+
+        elif self.config.use_exponential_sigmas:
+            sigmas = self._convert_to_exponential(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
+
+        elif self.config.use_beta_sigmas:
+            sigmas = self._convert_to_beta(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
 
         sigmas = torch.from_numpy(sigmas).to(dtype=torch.float32, device=device)
         timesteps = sigmas * self.config.num_train_timesteps
@@ -313,6 +335,86 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             return (prev_sample,)
 
         return FlowMatchEulerDiscreteSchedulerOutput(prev_sample=prev_sample)
+
+    # Copied from diffusers.schedulers.scheduling_euler_discrete.EulerDiscreteScheduler._convert_to_karras
+    def _convert_to_karras(self, in_sigmas: torch.Tensor, num_inference_steps) -> torch.Tensor:
+        """Constructs the noise schedule of Karras et al. (2022)."""
+
+        # Hack to make sure that other schedulers which copy this function don't break
+        # TODO: Add this logic to the other schedulers
+        if hasattr(self.config, "sigma_min"):
+            sigma_min = self.config.sigma_min
+        else:
+            sigma_min = None
+
+        if hasattr(self.config, "sigma_max"):
+            sigma_max = self.config.sigma_max
+        else:
+            sigma_max = None
+
+        sigma_min = sigma_min if sigma_min is not None else in_sigmas[-1].item()
+        sigma_max = sigma_max if sigma_max is not None else in_sigmas[0].item()
+
+        rho = 7.0  # 7.0 is the value used in the paper
+        ramp = np.linspace(0, 1, num_inference_steps)
+        min_inv_rho = sigma_min ** (1 / rho)
+        max_inv_rho = sigma_max ** (1 / rho)
+        sigmas = (max_inv_rho + ramp * (min_inv_rho - max_inv_rho)) ** rho
+        return sigmas
+
+    # Copied from diffusers.schedulers.scheduling_euler_discrete.EulerDiscreteScheduler._convert_to_exponential
+    def _convert_to_exponential(self, in_sigmas: torch.Tensor, num_inference_steps: int) -> torch.Tensor:
+        """Constructs an exponential noise schedule."""
+
+        # Hack to make sure that other schedulers which copy this function don't break
+        # TODO: Add this logic to the other schedulers
+        if hasattr(self.config, "sigma_min"):
+            sigma_min = self.config.sigma_min
+        else:
+            sigma_min = None
+
+        if hasattr(self.config, "sigma_max"):
+            sigma_max = self.config.sigma_max
+        else:
+            sigma_max = None
+
+        sigma_min = sigma_min if sigma_min is not None else in_sigmas[-1].item()
+        sigma_max = sigma_max if sigma_max is not None else in_sigmas[0].item()
+
+        sigmas = np.exp(np.linspace(math.log(sigma_max), math.log(sigma_min), num_inference_steps))
+        return sigmas
+
+    # Copied from diffusers.schedulers.scheduling_euler_discrete.EulerDiscreteScheduler._convert_to_beta
+    def _convert_to_beta(
+        self, in_sigmas: torch.Tensor, num_inference_steps: int, alpha: float = 0.6, beta: float = 0.6
+    ) -> torch.Tensor:
+        """From "Beta Sampling is All You Need" [arXiv:2407.12173] (Lee et. al, 2024)"""
+
+        # Hack to make sure that other schedulers which copy this function don't break
+        # TODO: Add this logic to the other schedulers
+        if hasattr(self.config, "sigma_min"):
+            sigma_min = self.config.sigma_min
+        else:
+            sigma_min = None
+
+        if hasattr(self.config, "sigma_max"):
+            sigma_max = self.config.sigma_max
+        else:
+            sigma_max = None
+
+        sigma_min = sigma_min if sigma_min is not None else in_sigmas[-1].item()
+        sigma_max = sigma_max if sigma_max is not None else in_sigmas[0].item()
+
+        sigmas = np.array(
+            [
+                sigma_min + (ppf * (sigma_max - sigma_min))
+                for ppf in [
+                    scipy.stats.beta.ppf(timestep, alpha, beta)
+                    for timestep in 1 - np.linspace(0, 1, num_inference_steps)
+                ]
+            ]
+        )
+        return sigmas
 
     def __len__(self):
         return self.config.num_train_timesteps


### PR DESCRIPTION
# What does this PR do?

Add `beta`, `exponential` and `karras` sigmas to `FlowMatchEulerDiscreteScheduler`.

```python
from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
import numpy as np


def calculate_shift(
    image_seq_len,
    base_seq_len: int = 256,
    max_seq_len: int = 4096,
    base_shift: float = 0.5,
    max_shift: float = 1.16,
):
    m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
    b = base_shift - m * base_seq_len
    mu = image_seq_len * m + b
    return mu

image_seq_len = 4096
mu = calculate_shift(image_seq_len)
num_inference_steps = 8
sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)

flow_match = FlowMatchEulerDiscreteScheduler.from_pretrained("black-forest-labs/FLUX.1-dev", subfolder="scheduler", use_beta_sigmas=True)
flow_match.set_timesteps(sigmas=sigmas, mu=mu)
print(f"flow_match beta (sigmas) {flow_match.sigmas} {flow_match.sigmas.shape[0]}")
print(f"flow_match beta (sigmas) {flow_match.timesteps} {flow_match.timesteps.shape[0]}")

flow_match.set_timesteps(num_inference_steps, mu=mu)
print(f"flow_match beta ({num_inference_steps}) {flow_match.sigmas} {flow_match.sigmas.shape[0]}")
print(f"flow_match beta ({num_inference_steps}) {flow_match.timesteps} {flow_match.timesteps.shape[0]}")

flow_match = FlowMatchEulerDiscreteScheduler.from_pretrained("black-forest-labs/FLUX.1-dev", subfolder="scheduler", use_exponential_sigmas=True)
flow_match.set_timesteps(sigmas=sigmas, mu=mu)
print(f"flow_match exponential (sigmas) {flow_match.sigmas} {flow_match.sigmas.shape[0]}")
print(f"flow_match exponential (sigmas) {flow_match.timesteps} {flow_match.timesteps.shape[0]}")

flow_match.set_timesteps(num_inference_steps, mu=mu)
print(f"flow_match exponential ({num_inference_steps}) {flow_match.sigmas} {flow_match.sigmas.shape[0]}")
print(f"flow_match exponential ({num_inference_steps}) {flow_match.timesteps} {flow_match.timesteps.shape[0]}")

flow_match = FlowMatchEulerDiscreteScheduler.from_pretrained("black-forest-labs/FLUX.1-dev", subfolder="scheduler", use_beta_sigmas=True)
flow_match.set_timesteps(sigmas=sigmas, mu=mu)
print(f"flow_match karras (sigmas) {flow_match.sigmas} {flow_match.sigmas.shape[0]}")
print(f"flow_match karras (sigmas) {flow_match.timesteps} {flow_match.timesteps.shape[0]}")

flow_match.set_timesteps(num_inference_steps, mu=mu)
print(f"flow_match karras ({num_inference_steps}) {flow_match.sigmas} {flow_match.sigmas.shape[0]}")
print(f"flow_match karras ({num_inference_steps}) {flow_match.timesteps} {flow_match.timesteps.shape[0]}")
```
```python
flow_match beta (sigmas) tensor([1.0000, 0.9511, 0.8510, 0.7242, 0.5888, 0.4620, 0.3619, 0.3130, 0.0000]) 9
flow_match beta (sigmas) tensor([1000.0000,  951.1288,  851.0334,  724.2367,  588.8108,  462.0141,
         361.9187,  313.0475]) 8
flow_match beta (8) tensor([1.0000, 0.9291, 0.7838, 0.5998, 0.4033, 0.2193, 0.0741, 0.0032, 0.0000]) 9
flow_match beta (8) tensor([1000.0000,  929.0844,  783.8388,  599.8478,  403.3352,  219.3442,
          74.0985,    3.1830]) 8
flow_match exponential (sigmas) tensor([1.0000, 0.8471, 0.7176, 0.6079, 0.5150, 0.4362, 0.3695, 0.3130, 0.0000]) 9
flow_match exponential (sigmas) tensor([1000.0000,  847.1188,  717.6103,  607.9012,  514.9645,  436.2361,
         369.5438,  313.0475]) 8
flow_match exponential (8) tensor([1.0000, 0.4398, 0.1934, 0.0851, 0.0374, 0.0165, 0.0072, 0.0032, 0.0000]) 9
flow_match exponential (8) tensor([1000.0000,  439.8065,  193.4298,   85.0717,   37.4151,   16.4554,
           7.2372,    3.1830]) 8
flow_match karras (sigmas) tensor([1.0000, 0.9511, 0.8510, 0.7242, 0.5888, 0.4620, 0.3619, 0.3130, 0.0000]) 9
flow_match karras (sigmas) tensor([1000.0000,  951.1288,  851.0334,  724.2367,  588.8108,  462.0141,
         361.9187,  313.0475]) 8
flow_match karras (8) tensor([1.0000, 0.9291, 0.7838, 0.5998, 0.4033, 0.2193, 0.0741, 0.0032, 0.0000]) 9
flow_match karras (8) tensor([1000.0000,  929.0844,  783.8388,  599.8478,  403.3352,  219.3442,
          74.0985,    3.1830]) 8
```

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

cc @yiyixuxu @asomoza 