### PR TITLE
fixed a dtype bfloat16 bug in torch_utils.py

### DIFF
--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -98,11 +98,8 @@ def fourier_filter(x_in: "torch.Tensor", threshold: int, scale: int) -> "torch.T
     """
     x = x_in
     B, C, H, W = x.shape
-
-    # Non-power of 2 images must be float32
-    if (W & (W - 1)) != 0 or (H & (H - 1)) != 0:
-        x = x.to(dtype=torch.float32)
-
+    x = x.to(dtype=torch.float32)
+    
     # FFT
     x_freq = fftn(x, dim=(-2, -1))
     x_freq = fftshift(x_freq, dim=(-2, -1))

--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -98,7 +98,12 @@ def fourier_filter(x_in: "torch.Tensor", threshold: int, scale: int) -> "torch.T
     """
     x = x_in
     B, C, H, W = x.shape
-    x = x.to(dtype=torch.float32)
+    # Non-power of 2 images must be float32
+    if (W & (W - 1)) != 0 or (H & (H - 1)) != 0:
+        x = x.to(dtype=torch.float32)
+    # fftn does not support bfloat16
+    elif x.dtype == torch.bfloat16:
+        x = x.to(dtype=torch.float32)
     
     # FFT
     x_freq = fftn(x, dim=(-2, -1))

--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -98,13 +98,14 @@ def fourier_filter(x_in: "torch.Tensor", threshold: int, scale: int) -> "torch.T
     """
     x = x_in
     B, C, H, W = x.shape
+
     # Non-power of 2 images must be float32
     if (W & (W - 1)) != 0 or (H & (H - 1)) != 0:
         x = x.to(dtype=torch.float32)
     # fftn does not support bfloat16
     elif x.dtype == torch.bfloat16:
         x = x.to(dtype=torch.float32)
-    
+
     # FFT
     x_freq = fftn(x, dim=(-2, -1))
     x_freq = fftshift(x_freq, dim=(-2, -1))


### PR DESCRIPTION
when generating 1024*1024 image with bfloat16 dtype, there is an exception:
  File "/opt/conda/lib/python3.10/site-packages/diffusers/utils/torch_utils.py", line 107, in fourier_filter
    x_freq = fftn(x, dim=(-2, -1))
RuntimeError: Unsupported dtype BFloat16

# What does this PR do?
fix a bug.

@hlky 
