### PR TITLE
Use `torch` in `get_2d_rotary_pos_embed`

### DIFF
--- a/examples/community/pipeline_hunyuandit_differential_img2img.py
+++ b/examples/community/pipeline_hunyuandit_differential_img2img.py
@@ -1009,6 +1009,7 @@ class HunyuanDiTDifferentialImg2ImgPipeline(DiffusionPipeline):
             grid_crops_coords,
             (grid_height, grid_width),
             device=device,
+            output_type="pt",
         )
 
         style = torch.tensor([0], device=device)

--- a/examples/community/pipeline_hunyuandit_differential_img2img.py
+++ b/examples/community/pipeline_hunyuandit_differential_img2img.py
@@ -1008,6 +1008,7 @@ class HunyuanDiTDifferentialImg2ImgPipeline(DiffusionPipeline):
             self.transformer.inner_dim // self.transformer.num_heads,
             grid_crops_coords,
             (grid_height, grid_width),
+            device=device,
         )
 
         style = torch.tensor([0], device=device)

--- a/src/diffusers/pipelines/controlnet_hunyuandit/pipeline_hunyuandit_controlnet.py
+++ b/src/diffusers/pipelines/controlnet_hunyuandit/pipeline_hunyuandit_controlnet.py
@@ -925,7 +925,10 @@ class HunyuanDiTControlNetPipeline(DiffusionPipeline):
         base_size = 512 // 8 // self.transformer.config.patch_size
         grid_crops_coords = get_resize_crop_region_for_grid((grid_height, grid_width), base_size)
         image_rotary_emb = get_2d_rotary_pos_embed(
-            self.transformer.inner_dim // self.transformer.num_heads, grid_crops_coords, (grid_height, grid_width)
+            self.transformer.inner_dim // self.transformer.num_heads,
+            grid_crops_coords,
+            (grid_height, grid_width),
+            device=device,
         )
 
         style = torch.tensor([0], device=device)

--- a/src/diffusers/pipelines/controlnet_hunyuandit/pipeline_hunyuandit_controlnet.py
+++ b/src/diffusers/pipelines/controlnet_hunyuandit/pipeline_hunyuandit_controlnet.py
@@ -929,6 +929,7 @@ class HunyuanDiTControlNetPipeline(DiffusionPipeline):
             grid_crops_coords,
             (grid_height, grid_width),
             device=device,
+            output_type="pt",
         )
 
         style = torch.tensor([0], device=device)

--- a/src/diffusers/pipelines/hunyuandit/pipeline_hunyuandit.py
+++ b/src/diffusers/pipelines/hunyuandit/pipeline_hunyuandit.py
@@ -802,6 +802,7 @@ class HunyuanDiTPipeline(DiffusionPipeline):
             grid_crops_coords,
             (grid_height, grid_width),
             device=device,
+            output_type="pt",
         )
 
         style = torch.tensor([0], device=device)

--- a/src/diffusers/pipelines/hunyuandit/pipeline_hunyuandit.py
+++ b/src/diffusers/pipelines/hunyuandit/pipeline_hunyuandit.py
@@ -798,7 +798,10 @@ class HunyuanDiTPipeline(DiffusionPipeline):
         base_size = 512 // 8 // self.transformer.config.patch_size
         grid_crops_coords = get_resize_crop_region_for_grid((grid_height, grid_width), base_size)
         image_rotary_emb = get_2d_rotary_pos_embed(
-            self.transformer.inner_dim // self.transformer.num_heads, grid_crops_coords, (grid_height, grid_width)
+            self.transformer.inner_dim // self.transformer.num_heads,
+            grid_crops_coords,
+            (grid_height, grid_width),
+            device=device,
         )
 
         style = torch.tensor([0], device=device)

--- a/src/diffusers/pipelines/pag/pipeline_pag_hunyuandit.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_hunyuandit.py
@@ -818,7 +818,10 @@ class HunyuanDiTPAGPipeline(DiffusionPipeline, PAGMixin):
         base_size = 512 // 8 // self.transformer.config.patch_size
         grid_crops_coords = get_resize_crop_region_for_grid((grid_height, grid_width), base_size)
         image_rotary_emb = get_2d_rotary_pos_embed(
-            self.transformer.inner_dim // self.transformer.num_heads, grid_crops_coords, (grid_height, grid_width)
+            self.transformer.inner_dim // self.transformer.num_heads,
+            grid_crops_coords,
+            (grid_height, grid_width),
+            device=device,
         )
 
         style = torch.tensor([0], device=device)

--- a/src/diffusers/pipelines/pag/pipeline_pag_hunyuandit.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_hunyuandit.py
@@ -822,6 +822,7 @@ class HunyuanDiTPAGPipeline(DiffusionPipeline, PAGMixin):
             grid_crops_coords,
             (grid_height, grid_width),
             device=device,
+            output_type="pt",
         )
 
         style = torch.tensor([0], device=device)


### PR DESCRIPTION
# What does this PR do?

Refactors `get_2d_rotary_pos_embed` to use `torch` instead of `numpy`, and adds `device` argument so that tensors can be created on e.g. `cuda`.

Usage of `get_2d_rotary_pos_embed` in HunyuanDiT pipelines is updated to pass `device`.

`torch` and `numpy` versions match numerically.

<details>
  <summary>Reproduction</summary>

  ```python
from diffusers.models.embeddings import get_2d_rotary_pos_embed
import torch


def get_resize_crop_region_for_grid(src, tgt_size):
    th = tw = tgt_size
    h, w = src

    r = h / w

    # resize
    if r > 1:
        resize_height = th
        resize_width = int(round(th / h * w))
    else:
        resize_width = tw
        resize_height = int(round(tw / w * h))

    crop_top = int(round((th - resize_height) / 2.0))
    crop_left = int(round((tw - resize_width) / 2.0))

    return (crop_top, crop_left), (crop_top + resize_height, crop_left + resize_width)


height, width = 1024, 1024
height = int((height // 16) * 16)
width = int((width // 16) * 16)
num_attention_heads = 16
attention_head_dim = 88
patch_size = 2
inner_dim = num_attention_heads * attention_head_dim
grid_height = height // 8 // patch_size
grid_width = width // 8 // patch_size
base_size = 512 // 8 // patch_size
grid_crops_coords = get_resize_crop_region_for_grid(
    (grid_height, grid_width), base_size
)
image_rotary_emb_np = get_2d_rotary_pos_embed(
    inner_dim // num_attention_heads,
    grid_crops_coords,
    (grid_height, grid_width),
    output_type="np",
)

image_rotary_emb = get_2d_rotary_pos_embed(
    inner_dim // num_attention_heads,
    grid_crops_coords,
    (grid_height, grid_width),
    output_type="pt",
)

torch.testing.assert_close(image_rotary_emb[0], image_rotary_emb_np[0])
torch.testing.assert_close(image_rotary_emb[1], image_rotary_emb_np[1])
```

</details>

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul @yiyixuxu