### PR TITLE
DDUF - Load transformers components manually

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ _deps = [
     "filelock",
     "flax>=0.4.1",
     "hf-doc-builder>=0.3.0",
-    "huggingface-hub>=0.23.2",
+    "huggingface-hub>=0.27.0",
     "requests-mock==1.10.0",
     "importlib_metadata",
     "invisible-watermark>=0.2.0",

--- a/src/diffusers/dependency_versions_table.py
+++ b/src/diffusers/dependency_versions_table.py
@@ -9,7 +9,7 @@ deps = {
     "filelock": "filelock",
     "flax": "flax>=0.4.1",
     "hf-doc-builder": "hf-doc-builder>=0.3.0",
-    "huggingface-hub": "huggingface-hub>=0.23.2",
+    "huggingface-hub": "huggingface-hub>=0.27.0",
     "requests-mock": "requests-mock==1.10.0",
     "importlib_metadata": "importlib_metadata",
     "invisible-watermark": "invisible-watermark>=0.2.0",

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -822,7 +822,6 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
 
         dduf_entries = None
         if dduf_file:
-
             dduf_file_path = os.path.join(cached_folder, dduf_file)
             dduf_entries = read_dduf_file(dduf_file_path)
             # The reader contains already all the files needed, no need to check it again

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -836,7 +836,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         # We retrieve the information by matching whether variant model checkpoints exist in the subfolders.
         # Example: `diffusion_pytorch_model.safetensors` -> `diffusion_pytorch_model.fp16.safetensors`
         # with variant being `"fp16"`.
-        # TODO: adapt logic for DDUF files (at the moment, scans the local directory which doesn't make sense)
+        # TODO: adapt logic for DDUF files (at the moment, scans the local directory which doesn't make sense in DDUF context)
         model_variants = _identify_model_variants(folder=cached_folder, variant=variant, config=config_dict)
         if len(model_variants) == 0 and variant is not None:
             error_message = f"You are trying to load the model files of the `variant={variant}`, but no such modeling files are available."

--- a/src/diffusers/pipelines/transformers_loading_utils.py
+++ b/src/diffusers/pipelines/transformers_loading_utils.py
@@ -1,0 +1,94 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import os
+import tempfile
+from typing import TYPE_CHECKING, Dict
+
+from huggingface_hub import DDUFEntry
+
+from ..utils import is_safetensors_available, is_transformers_available
+
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedModel, PreTrainedTokenizer
+
+if is_transformers_available():
+    from transformers import PretrainedConfig, PreTrainedModel, PreTrainedTokenizer
+
+if is_safetensors_available():
+    import safetensors.torch
+
+
+def load_tokenizer_from_dduf(
+    cls: "PreTrainedTokenizer", name: str, dduf_entries: Dict[str, DDUFEntry]
+) -> "PreTrainedTokenizer":
+    """
+    Load a tokenizer from a DDUF archive.
+
+    In practice, `transformers` do not provide a way to load a tokenizer from a DDUF archive. This function is a workaround
+    by extracting the tokenizer files from the DDUF archive and loading the tokenizer from the extracted files. There is an
+    extra cost of extracting the files, but of limited impact as the tokenizer files are usually small-ish.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        for entry_name, entry in dduf_entries.items():
+            if entry_name.startswith(name + "/"):
+                tmp_entry_path = os.path.join(tmp_dir, *entry_name.split("/"))
+                with open(tmp_entry_path, "wb") as f:
+                    with entry.as_mmap() as mm:
+                        f.write(mm)
+        return cls.from_pretrained(tmp_dir, **kwargs)
+
+
+def load_transformers_model_from_dduf(
+    cls: "PreTrainedModel", name: str, dduf_entries: Dict[str, DDUFEntry], **kwargs
+) -> "PreTrainedModel":
+    """
+    Load a transformers model from a DDUF archive.
+
+    In practice, `transformers` do not provide a way to load a model from a DDUF archive. This function is a workaround
+    by instantiating a model from the config file and loading the weights from the DDUF archive directly.
+    """
+    config_file = dduf_entries.get(f"{name}/config.json")
+    if config_file is None:
+        raise EnvironmentError(
+            f"Could not find a config.json file for component {name} in DDUF file (contains {dduf_entries.keys()})."
+        )
+    config = PretrainedConfig(**json.loads(config_file.read_text()))
+
+    model = cls(config)
+    weight_files = [
+        entry
+        for entry_name, entry in dduf_entries.items()
+        if entry_name.startswith(f"{name}/") and entry_name.endswith(".safetensors")
+    ]
+
+    if not weight_files:
+        raise EnvironmentError(
+            f"Could not find any weight file for component {name} in DDUF file (contains {dduf_entries.keys()})."
+        )
+    if not is_safetensors_available():
+        raise EnvironmentError(
+            "Safetensors is not available, cannot load model from DDUF. Please `pip install safetensors`."
+        )
+
+    # TODO: use kwargs (torch_dtype, device_map, max_memory, offload_folder, offload_state_dict, use_safetensors, low_cpu_mem_usage)
+    # TODO: is there something else we should take care of?
+    for entry in weight_files:
+        with entry.as_mmap() as mm:
+            state_dict = safetensors.torch.load(mm)
+            model.load_state_dict(state_dict)
+
+    return model


### PR DESCRIPTION
This PR adds a workaround to load `transformers` components without passing DDUF entries to `transformers`.

As mentioned with @LysandreJik on [slack](https://huggingface.slack.com/archives/C0821RXC9T5/p1733412799640689?thread_ts=1733372897.316429&cid=C0821RXC9T5) (private), modifying `transformers` internals to load from a DDUF archive (https://github.com/huggingface/transformers/pull/35093) is going to be hard to scale. Also it makes `transformers` internals heavily depends on `diffusers`'s DDUF format which we don't even know yet if it will be adopted by the community ( :crossed_fingers: ). On slack we briefly discussed a way to update `transformers` in such a way that loading from a folder or a zip directory works the same but even that is a hazardous non-trivial change. After further discussions, we ended up suggesting a solution balancing between loading speed and maintainability:
- for `tokenizers` components, we will unzip the archive to a temporary directory and load from there => it's not the most optimized way I/O-wise but given tokenizers are small-ish in general, it shouldn't impact users so badly
- for `transformers` models, we will 1. load the config 2. instantiate an empty model from the config 3. load the weights manually from `diffusers`

This way we keep the heavy load in `diffusers` and are therefore able to do it in an optimized way (i.e. directly from the DDUF file).  

This PR introduces the required changes for this to work. I did not handle all the low-level kwargs (torch_dtype, device_map, max_memory, offload_folder, offload_state_dict, use_safetensors, low_cpu_mem_usage) since it's not my area of expertise but I believe it shouldn't  cause problem.

I also took the opportunity to set `huggingface_hub 0.27.x` as the lowest required dependency to benefit from the dduf helpers directly. Release is not out yet but will be before we merge the "big dduf PR" in diffusers.

**What I suggest now is:**
- merge this PR "as is" in the DDUF branch
- work from their to handle the loading kwargs
- close https://github.com/huggingface/transformers/pull/35093 without merging 

