### PR TITLE
[do not merge] test dynamic offload string 

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -994,7 +994,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
                 accelerate.hooks.remove_hook_from_module(model, recurse=True)
         self._all_hooks = []
 
-    def enable_model_cpu_offload(self, gpu_id: Optional[int] = None, device: Union[torch.device, str] = "cuda"):
+    def enable_model_cpu_offload(self, gpu_id: Optional[int] = None, device: Union[torch.device, str] = "cuda", model_cpu_offload_seq: Optional[str] = None):
         r"""
         Offloads all models to CPU using accelerate, reducing memory usage with a low impact on performance. Compared
         to `enable_sequential_cpu_offload`, this method moves one whole model at a time to the GPU when its `forward`
@@ -1051,7 +1051,11 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
 
         self._all_hooks = []
         hook = None
-        for model_str in self.model_cpu_offload_seq.split("->"):
+        
+        if model_cpu_offload_seq is None:
+            model_cpu_offload_seq = self.model_cpu_offload_seq
+        
+        for model_str in model_cpu_offload_seq.split("->"):
             model = all_model_components.pop(model_str, None)
 
             if not isinstance(model, torch.nn.Module):

--- a/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
+++ b/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
@@ -417,6 +417,13 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
                 clip_skip=clip_skip,
                 clip_model_index=0,
             )
+            print(f" ")
+            print(f" after get_clip_prompt_embeds(1):")
+            print(f" text_encoder: {self.text_encoder.device if self.text_encoder is not None else 'None'}")
+            print(f" text_encoder_2: {self.text_encoder_2.device if self.text_encoder_2 is not None else 'None'}")
+            print(f" text_encoder_3: {self.text_encoder_3.device if self.text_encoder_3 is not None else 'None'}")
+            print(f" transformer: {self.transformer.device if self.transformer is not None else 'None'}")
+            print(f" vae: {self.vae.device if self.vae is not None else 'None'}")
             prompt_2_embed, pooled_prompt_2_embed = self._get_clip_prompt_embeds(
                 prompt=prompt_2,
                 device=device,
@@ -424,6 +431,13 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
                 clip_skip=clip_skip,
                 clip_model_index=1,
             )
+            print(f" ")
+            print(f" after get_clip_prompt_embeds(2):")
+            print(f" text_encoder: {self.text_encoder.device if self.text_encoder is not None else 'None'}")
+            print(f" text_encoder_2: {self.text_encoder_2.device if self.text_encoder_2 is not None else 'None'}")
+            print(f" text_encoder_3: {self.text_encoder_3.device if self.text_encoder_3 is not None else 'None'}")
+            print(f" transformer: {self.transformer.device if self.transformer is not None else 'None'}")
+            print(f" vae: {self.vae.device if self.vae is not None else 'None'}")
             clip_prompt_embeds = torch.cat([prompt_embed, prompt_2_embed], dim=-1)
 
             t5_prompt_embed = self._get_t5_prompt_embeds(
@@ -432,6 +446,13 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
                 max_sequence_length=max_sequence_length,
                 device=device,
             )
+            print(f" ")
+            print(f" after get_t5_prompt_embeds:")
+            print(f" text_encoder: {self.text_encoder.device if self.text_encoder is not None else 'None'}")
+            print(f" text_encoder_2: {self.text_encoder_2.device if self.text_encoder_2 is not None else 'None'}")
+            print(f" text_encoder_3: {self.text_encoder_3.device if self.text_encoder_3 is not None else 'None'}")
+            print(f" transformer: {self.transformer.device if self.transformer is not None else 'None'}")
+            print(f" vae: {self.vae.device if self.vae is not None else 'None'}")
 
             clip_prompt_embeds = torch.nn.functional.pad(
                 clip_prompt_embeds, (0, t5_prompt_embed.shape[-1] - clip_prompt_embeds.shape[-1])
@@ -899,6 +920,13 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
             generator,
             latents,
         )
+        print(f" ")
+        print(f" before denoising loop:")
+        print(f" text_encoder: {self.text_encoder.device if self.text_encoder is not None else 'None'}")
+        print(f" text_encoder_2: {self.text_encoder_2.device if self.text_encoder_2 is not None else 'None'}")
+        print(f" text_encoder_3: {self.text_encoder_3.device if self.text_encoder_3 is not None else 'None'}")
+        print(f" transformer: {self.transformer.device if self.transformer is not None else 'None'}")
+        print(f" vae: {self.vae.device if self.vae is not None else 'None'}")
 
         # 6. Denoising loop
         with self.progress_bar(total=num_inference_steps) as progress_bar:
@@ -974,6 +1002,13 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
 
                 if XLA_AVAILABLE:
                     xm.mark_step()
+        print(f" ")
+        print(f" after denoising loop:")
+        print(f" text_encoder: {self.text_encoder.device if self.text_encoder is not None else 'None'}")
+        print(f" text_encoder_2: {self.text_encoder_2.device if self.text_encoder_2 is not None else 'None'}")
+        print(f" text_encoder_3: {self.text_encoder_3.device if self.text_encoder_3 is not None else 'None'}")
+        print(f" transformer: {self.transformer.device if self.transformer is not None else 'None'}")
+        print(f" vae: {self.vae.device if self.vae is not None else 'None'}")
 
         if output_type == "latent":
             image = latents
@@ -983,6 +1018,13 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
 
             image = self.vae.decode(latents, return_dict=False)[0]
             image = self.image_processor.postprocess(image, output_type=output_type)
+        print(f" ")
+        print(f" after decode:")
+        print(f" text_encoder: {self.text_encoder.device if self.text_encoder is not None else 'None'}")
+        print(f" text_encoder_2: {self.text_encoder_2.device if self.text_encoder_2 is not None else 'None'}")
+        print(f" text_encoder_3: {self.text_encoder_3.device if self.text_encoder_3 is not None else 'None'}")
+        print(f" transformer: {self.transformer.device if self.transformer is not None else 'None'}")
+        print(f" vae: {self.vae.device if self.vae is not None else 'None'}")
 
         # Offload all models
         self.maybe_free_model_hooks()


### PR DESCRIPTION
```python
import torch
from diffusers import StableDiffusion3Pipeline
import time

repo = "stabilityai/stable-diffusion-3-medium-diffusers"
device = "cuda:3"
dtype = torch.float16

def precompute_sd3_prompt_embeds(prompt: str, offload_seq: str=None):
    pipe = StableDiffusion3Pipeline.from_pretrained(
        repo, 
        transformer=None,
        vae=None,
        scheduler=None,
        torch_dtype=dtype)
    if offload_seq is None:
        pipe = pipe.to(device)
    elif offload_seq == "default":
        pipe.enable_model_cpu_offload(device=device)
    else:
        pipe.enable_model_cpu_offload(model_cpu_offload_seq=offload_seq, device=device)

    with torch.no_grad():
        prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds = pipe.encode_prompt(
            prompt=prompt,
            prompt_2=None,
            prompt_3=None,
            max_sequence_length=512,)
    
    return prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds

def test_sd3(prompt, offload_seq=None):
    
    print(f"\nTesting with offload_seq: {offload_seq}")
    
    prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds = precompute_sd3_prompt_embeds(prompt, offload_seq)
    


# Test different offload sequences
prompt = "A cat holding a sign that says hello world"
offload_sequences = [
    None,
    "default",
    "text_encoder_2->text_encoder_3->transformer->vae",
    "text_encoder_1->text_encoder_3->transformer->vae"
]
print_message = [
    f"no offloading, device: {device}",
    f"default offloading for sd3: text_encoder->text_encoder_2->text_encoder_3->transformer->vae",
    f"text_encoder_2->text_encoder_3->transformer->vae",
    f"text_encoder->text_encoder_3->transformer->vae",
]

for seq, msg in zip(offload_sequences, print_message):
    try:
        print(f" testing: {msg}")
        test_sd3(prompt, seq)
    except Exception as e:
        print(f"\nError with sequence {seq}:")
        print(str(e))
    finally:
        torch.cuda.empty_cache()
```
output

```
 testing: no offloading, device: cuda:3

Testing with offload_seq: None
Loading pipeline components...:  17%|████████████████▎                                                                                 | 1/6 [00:00<00:01,  2.72it/s]You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  3.95it/s]
Loading pipeline components...: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:01<00:00,  3.55it/s]
 
 after get_clip_prompt_embeds(1):
 text_encoder: cuda:3
 text_encoder_2: cuda:3
 text_encoder_3: cuda:3
 transformer: None
 vae: None
 
 after get_clip_prompt_embeds(2):
 text_encoder: cuda:3
 text_encoder_2: cuda:3
 text_encoder_3: cuda:3
 transformer: None
 vae: None
 
 after get_t5_prompt_embeds:
 text_encoder: cuda:3
 text_encoder_2: cuda:3
 text_encoder_3: cuda:3
 transformer: None
 vae: None

 testing: default offloading for sd3: text_encoder->text_encoder_2->text_encoder_3->transformer->vae

Testing with offload_seq: default
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  4.09it/s]
Loading pipeline components...: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:01<00:00,  3.94it/s]
 
 after get_clip_prompt_embeds(1):
 text_encoder: cuda:3
 text_encoder_2: cpu
 text_encoder_3: cpu
 transformer: None
 vae: None
 
 after get_clip_prompt_embeds(2):
 text_encoder: cpu
 text_encoder_2: cuda:3
 text_encoder_3: cpu
 transformer: None
 vae: None
 
 after get_t5_prompt_embeds:
 text_encoder: cpu
 text_encoder_2: cpu
 text_encoder_3: cuda:3
 transformer: None
 vae: None


 testing: text_encoder_2->text_encoder_3->transformer->vae

Testing with offload_seq: text_encoder_2->text_encoder_3->transformer->vae
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  4.31it/s]
Loading pipeline components...: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:01<00:00,  4.02it/s]
 
 after get_clip_prompt_embeds(1):
 text_encoder: cuda:3
 text_encoder_2: cpu
 text_encoder_3: cpu
 transformer: None
 vae: None
 
 after get_clip_prompt_embeds(2):
 text_encoder: cuda:3
 text_encoder_2: cuda:3
 text_encoder_3: cpu
 transformer: None
 vae: None
 
 after get_t5_prompt_embeds:
 text_encoder: cuda:3
 text_encoder_2: cpu
 text_encoder_3: cuda:3
 transformer: None
 vae: None


 testing: text_encoder->text_encoder_3->transformer->vae

Testing with offload_seq: text_encoder->text_encoder_3->transformer->vae
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  4.50it/s]
Loading pipeline components...: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:01<00:00,  4.08it/s]
 
 after get_clip_prompt_embeds(1):
 text_encoder: cuda:3
 text_encoder_2: cpu
 text_encoder_3: cpu
 transformer: None
 vae: None
 
 after get_clip_prompt_embeds(2):
 text_encoder: cuda:3
 text_encoder_2: cuda:3
 text_encoder_3: cpu
 transformer: None
 vae: None
 
 after get_t5_prompt_embeds:
 text_encoder: cpu
 text_encoder_2: cuda:3
 text_encoder_3: cuda:3
 transformer: None
 vae: None

```