### PR TITLE
Use `t` instead of `timestep` in `_apply_perturbed_attention_guidance`

### DIFF
--- a/src/diffusers/pipelines/pag/pipeline_pag_sana.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sana.py
@@ -840,7 +840,7 @@ class SanaPAGPipeline(DiffusionPipeline, PAGMixin):
                 # perform guidance
                 if self.do_perturbed_attention_guidance:
                     noise_pred = self._apply_perturbed_attention_guidance(
-                        noise_pred, self.do_classifier_free_guidance, guidance_scale, timestep
+                        noise_pred, self.do_classifier_free_guidance, guidance_scale, t
                     )
                 elif self.do_classifier_free_guidance:
                     noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)


### PR DESCRIPTION
# What does this PR do?

To match usages of `_apply_perturbed_attention_guidance` we pass `t` instead of `timestep` (which is expanded).

```
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yiyixuxu @vladmandic 