### PR TITLE
[docs] Add missing AttnProcessors

### DIFF
--- a/docs/source/en/api/attnprocessor.md
+++ b/docs/source/en/api/attnprocessor.md
@@ -28,6 +28,10 @@ An attention processor is a class for applying different types of attention mech
 
 [[autodoc]] models.attention_processor.FusedAttnProcessor2_0
 
+## Allegro
+
+[[autodoc]] models.attention_processor.AllegroAttnProcessor2_0
+
 ## AuraFlow
 
 [[autodoc]] models.attention_processor.AuraFlowAttnProcessor2_0
@@ -106,6 +110,22 @@ An attention processor is a class for applying different types of attention mech
 
 [[autodoc]] models.attention_processor.LuminaAttnProcessor2_0
 
+## Mochi
+
+[[autodoc]] models.attention_processor.MochiAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.MochiVaeAttnProcessor2_0
+
+## Sana
+
+[[autodo]] models.attention_processor.SanaLinearAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.SanaMultscaleAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.PAGCFGSanaLinearAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.PAGIdentitySanaLinearAttnProcessor2_0
+
 ## Stable Audio
 
 [[autodoc]] models.attention_processor.StableAudioAttnProcessor2_0
@@ -121,3 +141,7 @@ An attention processor is a class for applying different types of attention mech
 [[autodoc]] models.attention_processor.XFormersAttnProcessor
 
 [[autodoc]] models.attention_processor.XFormersAttnAddedKVProcessor
+
+## XLAFlashAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.XLAFlashAttnProcessor2_0

--- a/docs/source/en/api/attnprocessor.md
+++ b/docs/source/en/api/attnprocessor.md
@@ -118,7 +118,7 @@ An attention processor is a class for applying different types of attention mech
 
 ## Sana
 
-[[autodo]] models.attention_processor.SanaLinearAttnProcessor2_0
+[[autodoc]] models.attention_processor.SanaLinearAttnProcessor2_0
 
 [[autodoc]] models.attention_processor.SanaMultiscaleAttnProcessor2_0
 

--- a/docs/source/en/api/attnprocessor.md
+++ b/docs/source/en/api/attnprocessor.md
@@ -102,7 +102,7 @@ An attention processor is a class for applying different types of attention mech
 
 [[autodoc]] models.attention_processor.LoRAAttnProcessor2_0
 
-[[autodoc]] models.attention_processor.LoRAXFormersAttnProcessor
+[[autodoc]] models.attention_processor.LoRAAttnAddedKVProcessor
 
 [[autodoc]] models.attention_processor.LoRAXFormersAttnKVProcessor
 

--- a/docs/source/en/api/attnprocessor.md
+++ b/docs/source/en/api/attnprocessor.md
@@ -15,40 +15,109 @@ specific language governing permissions and limitations under the License.
 An attention processor is a class for applying different types of attention mechanisms.
 
 ## AttnProcessor
+
 [[autodoc]] models.attention_processor.AttnProcessor
 
-## AttnProcessor2_0
 [[autodoc]] models.attention_processor.AttnProcessor2_0
 
-## AttnAddedKVProcessor
 [[autodoc]] models.attention_processor.AttnAddedKVProcessor
 
-## AttnAddedKVProcessor2_0
 [[autodoc]] models.attention_processor.AttnAddedKVProcessor2_0
 
-## CrossFrameAttnProcessor
-[[autodoc]] pipelines.text_to_video_synthesis.pipeline_text_to_video_zero.CrossFrameAttnProcessor
+[[autodoc]] models.attention_processor.AttnProcessorNPU
 
-## CustomDiffusionAttnProcessor
-[[autodoc]] models.attention_processor.CustomDiffusionAttnProcessor
-
-## CustomDiffusionAttnProcessor2_0
-[[autodoc]] models.attention_processor.CustomDiffusionAttnProcessor2_0
-
-## CustomDiffusionXFormersAttnProcessor
-[[autodoc]] models.attention_processor.CustomDiffusionXFormersAttnProcessor
-
-## FusedAttnProcessor2_0
 [[autodoc]] models.attention_processor.FusedAttnProcessor2_0
 
+## AuraFlow
+
+[[autodoc]] models.attention_processor.AuraFlowAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.FusedAuraFlowAttnProcessor2_0
+
+## CogVideoX
+
+[[autodoc]] models.attention_processor.CogVideoXAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.FusedCogVideoXAttnProcessor2_0
+
+## CrossFrameAttnProcessor
+
+[[autodoc]] pipelines.text_to_video_synthesis.pipeline_text_to_video_zero.CrossFrameAttnProcessor
+
+## Custom Diffusion
+
+[[autodoc]] models.attention_processor.CustomDiffusionAttnProcessor
+
+[[autodoc]] models.attention_processor.CustomDiffusionAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.CustomDiffusionXFormersAttnProcessor
+
+## Flux
+
+[[autodoc]] models.attention_processor.FluxAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.FusedFluxAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.FluxSingleAttnProcessor2_0
+
+## Hunyuan
+
+[[autodoc]] models.attention_processor.HunyuanAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.FusedHunyuanAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.PAGHunyuanAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.PAGCFGHunyuanAttnProcessor2_0
+
+## IdentitySelfAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.PAGIdentitySelfAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.PAGCFGIdentitySelfAttnProcessor2_0
+
+## IP-Adapter
+
+[[autodoc]] models.attention_processor.IPAdapterAttnProcessor
+
+[[autodoc]] models.attention_processor.IPAdapterAttnProcessor2_0
+
+## JointAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.JointAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.PAGJointAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.PAGCFGJointAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.FusedJointAttnProcessor2_0
+
+## LoRA
+
+[[autodoc]] models.attention_processor.LoRAAttnProcessor
+
+[[autodoc]] models.attention_processor.LoRAAttnProcessor2_0
+
+[[autodoc]] models.attention_processor.LoRAXFormersAttnProcessor
+
+[[autodoc]] models.attention_processor.LoRAXFormersAttnKVProcessor
+
+## Lumina-T2X
+
+[[autodoc]] models.attention_processor.LuminaAttnProcessor2_0
+
+## Stable Audio
+
+[[autodoc]] models.attention_processor.StableAudioAttnProcessor2_0
+
 ## SlicedAttnProcessor
+
 [[autodoc]] models.attention_processor.SlicedAttnProcessor
 
-## SlicedAttnAddedKVProcessor
 [[autodoc]] models.attention_processor.SlicedAttnAddedKVProcessor
 
 ## XFormersAttnProcessor
+
 [[autodoc]] models.attention_processor.XFormersAttnProcessor
 
-## AttnProcessorNPU
-[[autodoc]] models.attention_processor.AttnProcessorNPU
+[[autodoc]] models.attention_processor.XFormersAttnAddedKVProcessor

--- a/docs/source/en/api/attnprocessor.md
+++ b/docs/source/en/api/attnprocessor.md
@@ -104,7 +104,7 @@ An attention processor is a class for applying different types of attention mech
 
 [[autodoc]] models.attention_processor.LoRAAttnAddedKVProcessor
 
-[[autodoc]] models.attention_processor.LoRAXFormersAttnKVProcessor
+[[autodoc]] models.attention_processor.LoRAXFormersAttnProcessor
 
 ## Lumina-T2X
 

--- a/docs/source/en/api/attnprocessor.md
+++ b/docs/source/en/api/attnprocessor.md
@@ -120,7 +120,7 @@ An attention processor is a class for applying different types of attention mech
 
 [[autodo]] models.attention_processor.SanaLinearAttnProcessor2_0
 
-[[autodoc]] models.attention_processor.SanaMultscaleAttnProcessor2_0
+[[autodoc]] models.attention_processor.SanaMultiscaleAttnProcessor2_0
 
 [[autodoc]] models.attention_processor.PAGCFGSanaLinearAttnProcessor2_0
 

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -5426,6 +5426,7 @@ class LoRAAttnProcessor:
     r"""
     Processor for implementing attention with LoRA.
     """
+
     def __init__(self):
         pass
 
@@ -5434,6 +5435,7 @@ class LoRAAttnProcessor2_0:
     r"""
     Processor for implementing attention with LoRA (enabled by default if you're using PyTorch 2.0).
     """
+
     def __init__(self):
         pass
 
@@ -5442,6 +5444,7 @@ class LoRAXFormersAttnProcessor:
     r"""
     Processor for implementing attention with LoRA using xFormers.
     """
+
     def __init__(self):
         pass
 
@@ -5450,6 +5453,7 @@ class LoRAAttnAddedKVProcessor:
     r"""
     Processor for implementing attention with LoRA with extra learnable key and value matrices for the text encoder.
     """
+
     def __init__(self):
         pass
 

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -5423,21 +5423,33 @@ class SanaMultiscaleAttnProcessor2_0:
 
 
 class LoRAAttnProcessor:
+    r"""
+    Processor for implementing attention with LoRA.
+    """
     def __init__(self):
         pass
 
 
 class LoRAAttnProcessor2_0:
+    r"""
+    Processor for implementing attention with LoRA (enabled by default if you're using PyTorch 2.0).
+    """
     def __init__(self):
         pass
 
 
 class LoRAXFormersAttnProcessor:
+    r"""
+    Processor for implementing attention with LoRA using xFormers.
+    """
     def __init__(self):
         pass
 
 
 class LoRAAttnAddedKVProcessor:
+    r"""
+    Processor for implementing attention with LoRA with extra learnable key and value matrices for the text encoder.
+    """
     def __init__(self):
         pass
 


### PR DESCRIPTION
Adds missing `AttnProcessor` classes to the API docs.