### PR TITLE
[tests] Fix broken cuda, nightly and lora tests on main for CogVideoX

### DIFF
--- a/src/diffusers/models/embeddings.py
+++ b/src/diffusers/models/embeddings.py
@@ -692,7 +692,7 @@ class CogVideoXPatchEmbed(nn.Module):
             output_type="pt",
         )
         pos_embedding = pos_embedding.flatten(0, 1)
-        joint_pos_embedding = torch.zeros(
+        joint_pos_embedding = pos_embedding.new_zeros(
             1, self.max_text_seq_length + num_patches, self.embed_dim, requires_grad=False
         )
         joint_pos_embedding.data[:, self.max_text_seq_length :].copy_(pos_embedding)


### PR DESCRIPTION
The following tests seem to be failing for CogVideoX.

- https://github.com/huggingface/diffusers/actions/runs/12363852812/job/34505996753#step:6:8181
- https://github.com/huggingface/diffusers/actions/runs/12363852812/job/34505997403#step:6:4272
- https://github.com/huggingface/diffusers/actions/runs/12376965810/job/34545486823#step:7:7971

After bisecting between Dec. 1st to today, I found that it starts to break in #10156. The test failures are understandable because the scale of changes is large, and we only run Fast CPU tests on PRs. The fix in this PR is how the original implementation should've been