### PR TITLE
change the default Sana pre-trained model for LoRA to BF16 version

### DIFF
--- a/examples/dreambooth/README_sana.md
+++ b/examples/dreambooth/README_sana.md
@@ -73,7 +73,7 @@ This will also allow us to push the trained LoRA parameters to the Hugging Face 
 Now, we can launch training using:
 
 ```bash
-export MODEL_NAME="Efficient-Large-Model/Sana_1600M_1024px_diffusers"
+export MODEL_NAME="Efficient-Large-Model/Sana_1600M_1024px_BF16_diffusers"
 export INSTANCE_DIR="dog"
 export OUTPUT_DIR="trained-sana-lora"
 


### PR DESCRIPTION
# What does this PR do?
change the default pre-train model for LoRA training of Sana to the BF16 version for better performance

Cc: @sayakpaul 

-->
