### PR TITLE
[BUG FIX] [Stable Audio Pipeline] Resolve torch.Tensor.new_zeros() TypeError in function prepare_latents caused by audio_vae_length

### DIFF
--- a/src/diffusers/pipelines/stable_audio/pipeline_stable_audio.py
+++ b/src/diffusers/pipelines/stable_audio/pipeline_stable_audio.py
@@ -446,7 +446,7 @@ class StableAudioPipeline(DiffusionPipeline):
                     f"`initial_audio_waveforms` must be of shape `(batch_size, num_channels, audio_length)` or `(batch_size, audio_length)` but has `{initial_audio_waveforms.ndim}` dimensions"
                 )
 
-            audio_vae_length = self.transformer.config.sample_size * self.vae.hop_length
+            audio_vae_length = int(self.transformer.config.sample_size) * self.vae.hop_length
             audio_shape = (batch_size // num_waveforms_per_prompt, audio_channels, audio_vae_length)
 
             # check num_channels


### PR DESCRIPTION
# What does this PR do?

Parameter `initial_audio_waveforms` when passed `torch.Tensor` as described [here](https://huggingface.co/docs/diffusers/main/en/api/pipelines/stable_audio#diffusers.StableAudioPipeline.__call__.initial_audio_waveforms) raises `TypeError: new_zeros(): argument 'size' failed to unpack the object at pos 3 with error "type must be tuple of ints,but got float"`

[Notebook to Reproduce the Error](https://colab.research.google.com/drive/1xrkJe7k4cfqRCye2kQScncRZmzkrBu46?usp=sharing)

In function `prepare_latents`:

```python
audio_vae_length = self.transformer.config.sample_size * self.vae.hop_length
```

`audio_vae_length` evaluates to a `float` because `self.transformer.config.sample_size` returns a `float`

```python
audio = initial_audio_waveforms.new_zeros(audio_shape)
```

`torch.Tensor.new_zeros()` accepts a single argument `size` – a `list`, `tuple`, or `torch.Size` of `integers` defining the shape of the output tensor. [Source](https://pytorch.org/docs/stable/generated/torch.Tensor.new_zeros.html)

```python
audio_shape = (batch_size // num_waveforms_per_prompt, audio_channels, audio_vae_length)
```

But `audio_shape` is of type – `(int, int, float)` because `audio_vae_length` is a `float`

Proposed Fix is to wrap `self.transformer.config.sample_size` with `int()`

[Notebook with the Applied Fix](https://colab.research.google.com/drive/12ER3D8Rcd8O9-Uqsy7x-eWiRjnGdJQ_Q?usp=sharing)

<br>

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
**Do not** work on the `main` branch. 🤦‍♂️
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?