### PR TITLE
Fix EMAModel test_from_pretrained

### DIFF
--- a/tests/others/test_ema.py
+++ b/tests/others/test_ema.py
@@ -67,6 +67,7 @@ class EMAModelTests(unittest.TestCase):
 
             # Load the EMA model from the saved directory
             loaded_ema_unet = EMAModel.from_pretrained(tmpdir, model_cls=UNet2DConditionModel, foreach=False)
+            loaded_ema_unet.to(torch_device)
 
         # Check that the shadow parameters of the loaded model match the original EMA model
         for original_param, loaded_param in zip(ema_unet.shadow_params, loaded_ema_unet.shadow_params):
@@ -221,6 +222,7 @@ class EMAModelTestsForeach(unittest.TestCase):
 
             # Load the EMA model from the saved directory
             loaded_ema_unet = EMAModel.from_pretrained(tmpdir, model_cls=UNet2DConditionModel, foreach=True)
+            loaded_ema_unet.to(torch_device)
 
         # Check that the shadow parameters of the loaded model match the original EMA model
         for original_param, loaded_param in zip(ema_unet.shadow_params, loaded_ema_unet.shadow_params):


### PR DESCRIPTION
# What does this PR do?

[Torch CUDA Tests (others)](https://github.com/huggingface/diffusers/actions/runs/12434081220/job/34717007693#logs) has been failing from EMAModel.

```
FAILED tests/others/test_ema.py::EMAModelTests::test_from_pretrained - RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

`ema_unet` is on the correct device as it's created from `unet` which is moved to `torch_device`

https://github.com/huggingface/diffusers/blob/a6288a5571dbc63a03dc761a4d5300fcec61a04b/tests/others/test_ema.py#L39-L41

`loaded_ema_unet` is on CPU.

This matches `torch.allclose` call with `original_param, loaded_param` and the order of the error `cuda:0 and cpu!`.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
