### PR TITLE
Fix failing CogVideoX LoRA fuse test

### DIFF
--- a/src/diffusers/models/embeddings.py
+++ b/src/diffusers/models/embeddings.py
@@ -748,10 +748,10 @@ class CogVideoXPatchEmbed(nn.Module):
                 pos_embedding = self._get_positional_embeddings(
                     height, width, pre_time_compression_frames, device=embeds.device
                 )
-                pos_embedding = pos_embedding.to(dtype=embeds.dtype)
             else:
                 pos_embedding = self.pos_embedding
 
+            pos_embedding = pos_embedding.to(dtype=embeds.dtype)
             embeds = embeds + pos_embedding
 
         return embeds


### PR DESCRIPTION
Context: https://huggingface.slack.com/archives/C065E480NN9/p1734937335392109?thread_ts=1734935953.846629&cid=C065E480NN9

Fixes test: https://github.com/huggingface/diffusers/actions/runs/12461857058/job/34781970659#step:6:6623

This went uncaught in #10270 because it only happens when `.to()` is not called on a pipeline, or `torch_dtype` is not specified while loading transformer component. The failing lora test does neither, so the alternative branch of code was never tested.

`pos_embedding` is `torch.int64`, which casts `embeds` to `torch.int64` as well unless casted correctly in both branches