### PR TITLE
Fix FluxIPAdapterTesterMixin

### DIFF
--- a/src/diffusers/loaders/transformer_flux.py
+++ b/src/diffusers/loaders/transformer_flux.py
@@ -177,3 +177,5 @@ class FluxTransformer2DLoadersMixin:
 
         self.encoder_hid_proj = MultiIPAdapterImageProjection(image_projection_layers)
         self.config.encoder_hid_dim_type = "ip_image_proj"
+
+        self.to(dtype=self.dtype, device=self.device)


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/diffusers/actions/runs/12461857058/job/34782019153#step:7:1831

Adds `self.to(dtype=self.dtype, device=self.device)` to `FluxTransformer2DLoadersMixin`'s `_load_ip_adapter_weights` like in `UNet2DConditionLoadersMixin`

https://github.com/huggingface/diffusers/blob/5fcee4a4471d32d3a5959e55805303a7ec7a801e/src/diffusers/loaders/unet.py#L897

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

cc @DN6 
