### PR TITLE
Fix a dtype issue when evaluating the sana transformer with a float16 autocast context

### DIFF
--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -5896,9 +5896,10 @@ class SanaLinearAttnProcessor2_0:
 
         query, key, value = query.float(), key.float(), value.float()
 
-        value = F.pad(value, (0, 0, 0, 1), mode="constant", value=1.0)
-        scores = torch.matmul(value, key)
-        hidden_states = torch.matmul(scores, query)
+        with torch.autocast(device_type=hidden_states.device.type, enabled=False):
+            value = F.pad(value, (0, 0, 0, 1), mode="constant", value=1.0)
+            scores = torch.matmul(value, key)
+            hidden_states = torch.matmul(scores, query)
 
         hidden_states = hidden_states[:, :, :-1] / (hidden_states[:, :, -1:] + 1e-15)
         hidden_states = hidden_states.flatten(1, 2).transpose(1, 2)


### PR DESCRIPTION
# What does this PR do?

the query, key and value tensors of the attention calculations are already converted to float32 format. But if an autocast context is active, intermediate values are still converted back to float16 precision. Disabling autocast in this region prevents this unwanted conversion. The result is then converted back to the original dtype afterwards.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@lawrence-cj 