### PR TITLE
fix bug for torch.uint1-7 not support in torch<2.6

### DIFF
--- a/src/diffusers/quantizers/torchao/torchao_quantizer.py
+++ b/src/diffusers/quantizers/torchao/torchao_quantizer.py
@@ -33,23 +33,29 @@ if TYPE_CHECKING:
 
 if is_torch_available():
     import torch
-    import torch.nn as nn
 
-    SUPPORTED_TORCH_DTYPES_FOR_QUANTIZATION = (
-        # At the moment, only int8 is supported for integer quantization dtypes.
-        # In Torch 2.6, int1-int7 will be introduced, so this can be visited in the future
-        # to support more quantization methods, such as intx_weight_only.
-        torch.int8,
-        torch.float8_e4m3fn,
-        torch.float8_e5m2,
-        torch.uint1,
-        torch.uint2,
-        torch.uint3,
-        torch.uint4,
-        torch.uint5,
-        torch.uint6,
-        torch.uint7,
-    )
+    if version.parse(torch.__version__) >= version.parse('2.6'):
+        SUPPORTED_TORCH_DTYPES_FOR_QUANTIZATION = (
+            # At the moment, only int8 is supported for integer quantization dtypes.
+            # In Torch 2.6, int1-int7 will be introduced, so this can be visited in the future
+            # to support more quantization methods, such as intx_weight_only.
+            torch.int8,
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+            torch.uint1,
+            torch.uint2,
+            torch.uint3,
+            torch.uint4,
+            torch.uint5,
+            torch.uint6,
+            torch.uint7,
+        )
+    else:
+        SUPPORTED_TORCH_DTYPES_FOR_QUANTIZATION = (
+            torch.int8,
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        )
 
 if is_torchao_available():
     from torchao.quantization import quantize_


### PR DESCRIPTION
# What does this PR do?

fix bug for torch.uint1-7 not support in torch<2.6

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

# before this PR

When I execute the following command

```bash
python -c "from diffusers import AutoPipelineForText2Image"
```

get the following error:

```bash
Traceback (most recent call last):
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/utils/import_utils.py", line 920, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
  File "/root/miniconda3/envs/baymax/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/pipelines/auto_pipeline.py", line 21, in <module>
    from ..models.controlnets import ControlNetUnionModel
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/models/controlnets/__init__.py", line 5, in <module>
    from .controlnet import ControlNetModel, ControlNetOutput
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/models/controlnets/controlnet.py", line 22, in <module>
    from ...loaders.single_file_model import FromOriginalModelMixin
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/loaders/single_file_model.py", line 23, in <module>
    from ..quantizers import DiffusersAutoQuantizer
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/quantizers/__init__.py", line 15, in <module>
    from .auto import DiffusersAutoQuantizer
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/quantizers/auto.py", line 31, in <module>
    from .torchao import TorchAoHfQuantizer
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/quantizers/torchao/__init__.py", line 15, in <module>
    from .torchao_quantizer import TorchAoHfQuantizer
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/quantizers/torchao/torchao_quantizer.py", line 45, in <module>
    torch.uint1,
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/torch/__init__.py", line 1833, in __getattr__
    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
AttributeError: module 'torch' has no attribute 'uint1'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 1075, in _handle_fromlist
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/utils/import_utils.py", line 911, in __getattr__
    value = getattr(module, name)
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/utils/import_utils.py", line 910, in __getattr__
    module = self._get_module(self._class_to_module[name])
  File "/root/miniconda3/envs/baymax/lib/python3.10/site-packages/diffusers/utils/import_utils.py", line 922, in _get_module
    raise RuntimeError(
RuntimeError: Failed to import diffusers.pipelines.auto_pipeline because of the following error (look up to see its traceback):
module 'torch' has no attribute 'uint1'
````

The reason is that lower versions of torch do not support torch.uint1.
I added judgment on the torch version in the PR to avoid errors，and deleted redundant code.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
