### PR TITLE
Fix AutoPipeline `from_pipe` where source pipeline is missing target pipeline's optional components

### DIFF
--- a/src/diffusers/pipelines/auto_pipeline.py
+++ b/src/diffusers/pipelines/auto_pipeline.py
@@ -529,10 +529,7 @@ class AutoPipelineForText2Image(ConfigMixin):
         }
 
         missing_modules = (
-            set(expected_modules)
-            - set(pipeline._optional_components)
-            - set(text_2_image_cls._optional_components)
-            - set(text_2_image_kwargs.keys())
+            set(expected_modules) - set(text_2_image_cls._optional_components) - set(text_2_image_kwargs.keys())
         )
 
         if len(missing_modules) > 0:
@@ -844,10 +841,7 @@ class AutoPipelineForImage2Image(ConfigMixin):
         }
 
         missing_modules = (
-            set(expected_modules)
-            - set(pipeline._optional_components)
-            - set(image_2_image_cls._optional_components)
-            - set(image_2_image_kwargs.keys())
+            set(expected_modules) - set(image_2_image_cls._optional_components) - set(image_2_image_kwargs.keys())
         )
 
         if len(missing_modules) > 0:
@@ -1152,10 +1146,7 @@ class AutoPipelineForInpainting(ConfigMixin):
         }
 
         missing_modules = (
-            set(expected_modules)
-            - set(pipeline._optional_components)
-            - set(inpainting_cls._optional_components)
-            - set(inpainting_kwargs.keys())
+            set(expected_modules) - set(inpainting_cls._optional_components) - set(inpainting_kwargs.keys())
         )
 
         if len(missing_modules) > 0:

--- a/src/diffusers/pipelines/auto_pipeline.py
+++ b/src/diffusers/pipelines/auto_pipeline.py
@@ -528,7 +528,12 @@ class AutoPipelineForText2Image(ConfigMixin):
             if k not in text_2_image_kwargs
         }
 
-        missing_modules = set(expected_modules) - set(pipeline._optional_components) - set(text_2_image_kwargs.keys())
+        missing_modules = (
+            set(expected_modules)
+            - set(pipeline._optional_components)
+            - set(text_2_image_cls._optional_components)
+            - set(text_2_image_kwargs.keys())
+        )
 
         if len(missing_modules) > 0:
             raise ValueError(
@@ -838,7 +843,12 @@ class AutoPipelineForImage2Image(ConfigMixin):
             if k not in image_2_image_kwargs
         }
 
-        missing_modules = set(expected_modules) - set(pipeline._optional_components) - set(image_2_image_kwargs.keys())
+        missing_modules = (
+            set(expected_modules)
+            - set(pipeline._optional_components)
+            - set(image_2_image_cls._optional_components)
+            - set(image_2_image_kwargs.keys())
+        )
 
         if len(missing_modules) > 0:
             raise ValueError(
@@ -1141,7 +1151,12 @@ class AutoPipelineForInpainting(ConfigMixin):
             if k not in inpainting_kwargs
         }
 
-        missing_modules = set(expected_modules) - set(pipeline._optional_components) - set(inpainting_kwargs.keys())
+        missing_modules = (
+            set(expected_modules)
+            - set(pipeline._optional_components)
+            - set(inpainting_cls._optional_components)
+            - set(inpainting_kwargs.keys())
+        )
 
         if len(missing_modules) > 0:
             raise ValueError(


### PR DESCRIPTION
# What does this PR do?

Flux IPAdapter introduced optional components `feature_extractor` and `image_encoder` to FluxPipeline, the changes have not yet been replicated to Img2Img/Inpaint pipelines, when checking for missing modules in `from_pipe` we consider the target pipeline's `expected_modules` and the source pipeline's `_optional_components`, we should also consider the target pipeline's optional components.

```python
from diffusers import FluxPipeline, AutoPipelineForInpainting, AutoPipelineForText2Image
import torch

pipe = FluxPipeline.from_pretrained(
  "black-forest-labs/FLUX.1-schnell", torch_dtype=torch.bfloat16
)
pipe = AutoPipelineForInpainting.from_pipe(pipe)
pipe = AutoPipelineForText2Image.from_pipe(pipe)
```

```python
File Untitled-8:8
      7 pipe = AutoPipelineForInpainting.from_pipe(pipe)
----> 8 pipe = AutoPipelineForText2Image.from_pipe(pipe)

File diffusers/src/diffusers/pipelines/auto_pipeline.py:534, in AutoPipelineForText2Image.from_pipe(cls, pipeline, **kwargs)
    531 missing_modules = set(expected_modules) - set(pipeline._optional_components) - set(text_2_image_kwargs.keys())
    533 if len(missing_modules) > 0:
--> 534     raise ValueError(
    535         f"Pipeline {text_2_image_cls} expected {expected_modules}, but only {set(list(passed_class_obj.keys()) + list(original_class_obj.keys()))} were passed"
    536     )
    538 model = text_2_image_cls(**text_2_image_kwargs)
    539 model.register_to_config(_name_or_path=pretrained_model_name_or_path)

ValueError: Pipeline <class 'diffusers.pipelines.flux.pipeline_flux.FluxPipeline'> expected {'tokenizer_2', 'tokenizer', 'text_encoder', 'image_encoder', 'vae', 'scheduler', 'transformer', 'feature_extractor', 'text_encoder_2'}, but only {'tokenizer_2', 'tokenizer', 'text_encoder', 'vae', 'scheduler', 'transformer', 'text_encoder_2'} were passed
```

Fixes #10399


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yiyixuxu @vladmandic 