### PR TITLE
`lora_bias` PEFT version check in `unet.load_attn_procs`

### DIFF
--- a/src/diffusers/loaders/unet.py
+++ b/src/diffusers/loaders/unet.py
@@ -343,6 +343,17 @@ class UNet2DConditionLoadersMixin:
                 else:
                     if is_peft_version("<", "0.9.0"):
                         lora_config_kwargs.pop("use_dora")
+
+            if "lora_bias" in lora_config_kwargs:
+                if lora_config_kwargs["lora_bias"]:
+                    if is_peft_version("<=", "0.13.2"):
+                        raise ValueError(
+                            "You need `peft` 0.14.0 at least to use `bias` in LoRAs. Please upgrade your installation of `peft`."
+                        )
+                else:
+                    if is_peft_version("<=", "0.13.2"):
+                        lora_config_kwargs.pop("lora_bias")
+
             lora_config = LoraConfig(**lora_config_kwargs)
 
             # adapter_name


### PR DESCRIPTION
# What does this PR do?

Adds PEFT version check for `lora_bias` support to `unet.load_attn_procs`. Loading LoRAs through `load_attn_procs` is scheduled to be deprecated by `0.40.0` and is replaced by `load_lora_weights`, this check is already present in `load_lora_weights`.

Fixes #10472

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yiyixuxu @sayakpaul 
