### PR TITLE
[Sana][bug fix]change clean_caption from True to False.

### DIFF
--- a/src/diffusers/pipelines/sana/pipeline_sana.py
+++ b/src/diffusers/pipelines/sana/pipeline_sana.py
@@ -619,7 +619,7 @@ class SanaPipeline(DiffusionPipeline, SanaLoraLoaderMixin):
         negative_prompt_attention_mask: Optional[torch.Tensor] = None,
         output_type: Optional[str] = "pil",
         return_dict: bool = True,
-        clean_caption: bool = True,
+        clean_caption: bool = False,
         use_resolution_binning: bool = True,
         attention_kwargs: Optional[Dict[str, Any]] = None,
         callback_on_step_end: Optional[Callable[[int, int, Dict], None]] = None,


### PR DESCRIPTION
# What does this PR do?

Due to SanaPipeline's support of multiple languages, changing the default clean_caption from True to False is better for better performance.

Cc: @yiyixuxu 