### PR TITLE
AutoModel instead of AutoModelForCausalLM

### DIFF
--- a/docs/source/en/api/pipelines/sana.md
+++ b/docs/source/en/api/pipelines/sana.md
@@ -59,10 +59,10 @@ Refer to the [Quantization](../../quantization/overview) overview to learn more 
 ```py
 import torch
 from diffusers import BitsAndBytesConfig as DiffusersBitsAndBytesConfig, SanaTransformer2DModel, SanaPipeline
-from transformers import BitsAndBytesConfig as BitsAndBytesConfig, AutoModelForCausalLM
+from transformers import BitsAndBytesConfig as BitsAndBytesConfig, AutoModel
 
 quant_config = BitsAndBytesConfig(load_in_8bit=True)
-text_encoder_8bit = AutoModelForCausalLM.from_pretrained(
+text_encoder_8bit = AutoModel.from_pretrained(
     "Efficient-Large-Model/Sana_1600M_1024px_diffusers",
     subfolder="text_encoder",
     quantization_config=quant_config,


### PR DESCRIPTION
# What does this PR do?

`AutoModel` instead of `AutoModelForCausalLM` in the `SanaPipeline` quantization example at https://huggingface.co/docs/diffusers/main/en/api/pipelines/sana#quantization

Fixes #10489

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
@sayakpaul @lawrence-cj @stevhliu
