### PR TITLE
Group offloading with cuda stream prefetching

### DIFF
--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -98,7 +98,6 @@ class GroupOffloadingHook(ModelHook):
 
     def onload_(self, module: torch.nn.Module) -> None:
         if self.group.onload_leader == module:
-            breakpoint()
             if self.stream is not None:
                 # Wait for previous Host->Device transfer to complete
                 self.stream.synchronize()

--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import re
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import torch
 
@@ -65,10 +65,21 @@ class GroupOffloadingHook(ModelHook):
       encounter such an error.
     """
 
-    def __init__(self, group: ModuleGroup, offload_on_init: bool = True, non_blocking: bool = False) -> None:
+    def __init__(
+        self,
+        group: ModuleGroup,
+        offload_on_init: bool = True,
+        non_blocking: bool = False,
+        stream: Optional[torch.cuda.Stream] = None,
+        next_group: Optional[ModuleGroup] = None,
+        cpu_param_dict: Optional[Dict[torch.nn.Parameter, torch.Tensor]] = None,
+    ) -> None:
         self.group = group
         self.offload_on_init = offload_on_init
         self.non_blocking = non_blocking
+        self.stream = stream
+        self.next_group = next_group
+        self.cpu_param_dict = cpu_param_dict
 
     def initialize_hook(self, module: torch.nn.Module) -> torch.nn.Module:
         if self.offload_on_init:
@@ -87,16 +98,34 @@ class GroupOffloadingHook(ModelHook):
 
     def onload_(self, module: torch.nn.Module) -> None:
         if self.group.onload_leader == module:
-            for group_module in self.group.modules:
-                group_module.to(self.group.onload_device, non_blocking=self.non_blocking)
+            breakpoint()
+            if self.stream is not None:
+                # Wait for previous Host->Device transfer to complete
+                self.stream.synchronize()
+
+                if self.next_group is None:
+                    return
+
+                # Start Host->Device transfer for next group
+                with torch.cuda.stream(self.stream):
+                    for group_module in self.next_group.modules:
+                        group_module.to(self.next_group.onload_device, non_blocking=True)
+            else:
+                for group_module in self.group.modules:
+                    group_module.to(self.group.onload_device, non_blocking=self.non_blocking)
 
     def offload_(self, module: torch.nn.Module) -> None:
         if self.group.offload_leader == module:
-            for group_module in self.group.modules:
-                group_module.to(self.group.offload_device, non_blocking=self.non_blocking)
-            # TODO: do we need to sync here because of GPU->CPU transfer?
-            if self.non_blocking and self.group.offload_device.type == "cpu":
-                torch.cpu.synchronize()
+            if self.stream is not None:
+                for group_module in self.group.modules:
+                    for param in group_module.parameters():
+                        param.data = self.cpu_param_dict[param]
+            else:
+                for group_module in self.group.modules:
+                    group_module.to(self.group.offload_device, non_blocking=self.non_blocking)
+                # TODO: do we need to sync here because of GPU->CPU transfer?
+                if self.non_blocking and self.group.offload_device.type == "cpu":
+                    torch.cpu.synchronize()
 
 
 def apply_group_offloading(
@@ -107,12 +136,22 @@ def apply_group_offloading(
     onload_device: torch.device = torch.device("cuda"),
     force_offload: bool = True,
     non_blocking: bool = False,
+    cuda_stream: bool = False,
 ) -> None:
+    stream = None
+    if cuda_stream:
+        stream = torch.cuda.Stream()
     if offload_group_patterns == "diffusers_block":
         if num_blocks_per_group is None:
             raise ValueError("num_blocks_per_group must be provided when using GroupOffloadingType.DIFFUSERS_BLOCK.")
         _apply_group_offloading_diffusers_block(
-            module, num_blocks_per_group, offload_device, onload_device, force_offload, non_blocking
+            module,
+            num_blocks_per_group,
+            offload_device,
+            onload_device,
+            force_offload,
+            non_blocking,
+            stream,
         )
     else:
         _apply_group_offloading_group_patterns(
@@ -127,7 +166,14 @@ def _apply_group_offloading_diffusers_block(
     onload_device: torch.device,
     force_offload: bool,
     non_blocking: bool,
+    stream: Optional[torch.cuda.Stream] = None,
 ) -> None:
+    cpu_param_dict = None
+    if stream is not None:
+        for param in module.parameters():
+            param.data = param.data.cpu().pin_memory()
+        cpu_param_dict = {param: param.data for param in module.parameters()}
+
     # Handle device offloading/onloading for unet/transformer stack modules
     for stack_identifier in _COMMON_STACK_IDENTIFIERS:
         if not hasattr(module, stack_identifier) or not isinstance(
@@ -137,14 +183,29 @@ def _apply_group_offloading_diffusers_block(
 
         stack = getattr(module, stack_identifier)
         num_blocks = len(stack)
+        module_groups = []
 
         for i in range(0, num_blocks, num_blocks_per_group):
             blocks = stack[i : i + num_blocks_per_group]
             group = ModuleGroup(
                 blocks, offload_device, onload_device, offload_leader=blocks[-1], onload_leader=blocks[0]
             )
+            module_groups.append(group)
+
+        for i, group in enumerate(module_groups):
+            next_group = module_groups[i + 1] if i + 1 < len(module_groups) and stream is not None else None
             should_offload = force_offload or i > 0
-            _apply_group_offloading(group, should_offload, non_blocking)
+            _apply_group_offloading(group, should_offload, non_blocking, stream, next_group, cpu_param_dict)
+
+        if stream is not None:
+            # Start Host->Device transfer for the first group
+            with torch.cuda.stream(stream):
+                for group_module in module_groups[0].modules:
+                    group_module.to(onload_device, non_blocking=True)
+            if len(module_groups) > 1:
+                # Assign the first module_group as the next_group for the last module_group
+                hook_registry = HookRegistry.check_if_exists_or_initialize(module_groups[-1].onload_leader)
+                hook_registry.hooks["group_offloading"].next_group = module_groups[0]
 
     # Handle device offloading/onloading for non-stack modules
     for name, submodule in module.named_modules():
@@ -154,7 +215,6 @@ def _apply_group_offloading_diffusers_block(
             # for enabling offloading.
             continue
         layer_name = name_split[0]
-        print(layer_name)
         if layer_name in _COMMON_STACK_IDENTIFIERS:
             continue
         group = ModuleGroup(
@@ -211,8 +271,15 @@ def _apply_group_offloading_group_patterns(
         _apply_group_offloading(group, force_offload, non_blocking)
 
 
-def _apply_group_offloading(group: ModuleGroup, offload_on_init: bool, non_blocking: bool) -> None:
+def _apply_group_offloading(
+    group: ModuleGroup,
+    offload_on_init: bool,
+    non_blocking: bool,
+    stream: Optional[torch.cuda.Stream] = None,
+    next_group: Optional[ModuleGroup] = None,
+    cpu_param_dict: Optional[Dict[torch.nn.Parameter, torch.Tensor]] = None,
+) -> None:
     for module in group.modules:
-        hook = GroupOffloadingHook(group, offload_on_init, non_blocking)
+        hook = GroupOffloadingHook(group, offload_on_init, non_blocking, stream, next_group, cpu_param_dict)
         registry = HookRegistry.check_if_exists_or_initialize(module)
         registry.register_hook(hook, "group_offloading")

--- a/src/diffusers/models/transformers/transformer_ltx.py
+++ b/src/diffusers/models/transformers/transformer_ltx.py
@@ -240,6 +240,7 @@ class LTXVideoTransformerBlock(nn.Module):
         norm_hidden_states = self.norm1(hidden_states)
 
         num_ada_params = self.scale_shift_table.shape[0]
+        breakpoint()
         ada_values = self.scale_shift_table[None, None] + temb.reshape(batch_size, temb.size(1), num_ada_params, -1)
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = ada_values.unbind(dim=2)
         norm_hidden_states = norm_hidden_states * (1 + scale_msa) + shift_msa

--- a/src/diffusers/models/transformers/transformer_ltx.py
+++ b/src/diffusers/models/transformers/transformer_ltx.py
@@ -240,7 +240,6 @@ class LTXVideoTransformerBlock(nn.Module):
         norm_hidden_states = self.norm1(hidden_states)
 
         num_ada_params = self.scale_shift_table.shape[0]
-        breakpoint()
         ada_values = self.scale_shift_table[None, None] + temb.reshape(batch_size, temb.size(1), num_ada_params, -1)
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = ada_values.unbind(dim=2)
         norm_hidden_states = norm_hidden_states * (1 + scale_msa) + shift_msa


### PR DESCRIPTION
See #10503 for more details.

<details>
<summary> Code </summary>

```python
import argparse
import gc
import os
import time

# os.environ["TORCH_LOGS"] = "+recompiles_verbose,guards"
os.environ["TORCH_LOGS"] = "+recompiles_verbose"

import types
types.MethodType

import torch
import torch._dynamo
import torch._dynamo.utils
from diffusers import LTXPipeline
from diffusers.utils import export_to_video
from diffusers.hooks import apply_group_offloading

torch._dynamo.config.cache_size_limit = 4

def cleanup():
    gc.collect()
    torch.cuda.empty_cache()
    torch.cuda.reset_peak_memory_stats()


def benchmark_fn(f, *args, **kwargs):
    torch.cuda.synchronize()
    start = torch.cuda.Event(enable_timing=True)
    end = torch.cuda.Event(enable_timing=True)

    start.record()
    output = f(*args, **kwargs)
    end.record()
    torch.cuda.synchronize()
    elapsed_time = round(start.elapsed_time(end) / 1000, 3)

    return elapsed_time, output


def normal():
    pipe = LTXPipeline.from_pretrained("a-r-r-o-w/LTX-Video-diffusers", torch_dtype=torch.bfloat16)
    pipe.to("cuda")
    
    cleanup()
    print(f"Model memory: {torch.cuda.max_memory_reserved() / 1024 ** 3:.2f} GB")

    prompt = "A woman with long brown hair and light skin smiles at another woman with long blonde hair. The woman with brown hair wears a black jacket and has a small, barely noticeable mole on her right cheek. The camera angle is a close-up, focused on the woman with brown hair's face. The lighting is warm and natural, likely from the setting sun, casting a soft glow on the scene. The scene appears to be real-life footage"
    negative_prompt = "worst quality, inconsistent motion, blurry, jittery, distorted"

    t1 = time.time()
    video = pipe(
        prompt=prompt,
        negative_prompt=negative_prompt,
        width=768,
        height=512,
        num_frames=161,
        num_inference_steps=50,
    ).frames[0]
    torch.cuda.synchronize()
    t2 = time.time()
    export_to_video(video, "output.mp4", fps=24)
    
    print(f"Inference time: {t2 - t1:.2f} s")
    print(f"Inference memory: {torch.cuda.max_memory_reserved() / 1024 ** 3:.2f} GB")


def model_cpu_offload(compile: bool = False):
    pipe = LTXPipeline.from_pretrained("a-r-r-o-w/LTX-Video-diffusers", torch_dtype=torch.bfloat16)
    pipe.enable_model_cpu_offload()

    if compile:
        pipe.transformer = torch.compile(pipe.transformer, mode="max-autotune-no-cudagraphs")
    
    cleanup()
    print(f"Model memory: {torch.cuda.max_memory_reserved() / 1024 ** 3:.2f} GB")

    prompt = "A woman with long brown hair and light skin smiles at another woman with long blonde hair. The woman with brown hair wears a black jacket and has a small, barely noticeable mole on her right cheek. The camera angle is a close-up, focused on the woman with brown hair's face. The lighting is warm and natural, likely from the setting sun, casting a soft glow on the scene. The scene appears to be real-life footage"
    negative_prompt = "worst quality, inconsistent motion, blurry, jittery, distorted"

    t1 = time.time()
    video = pipe(
        prompt=prompt,
        negative_prompt=negative_prompt,
        width=768,
        height=512,
        num_frames=161,
        num_inference_steps=50,
    ).frames[0]
    torch.cuda.synchronize()
    t2 = time.time()
    export_to_video(video, "output.mp4", fps=24)
    
    print(f"Inference time: {t2 - t1:.2f} s")
    print(f"Inference memory: {torch.cuda.max_memory_reserved() / 1024 ** 3:.2f} GB")


def sequential_cpu_offload(compile: bool = False):
    pipe = LTXPipeline.from_pretrained("a-r-r-o-w/LTX-Video-diffusers", torch_dtype=torch.bfloat16)
    pipe.enable_sequential_cpu_offload()

    if compile:
        pipe.transformer = torch.compile(pipe.transformer, mode="max-autotune-no-cudagraphs")
    
    cleanup()
    print(f"Model memory: {torch.cuda.max_memory_reserved() / 1024 ** 3:.2f} GB")

    prompt = "A woman with long brown hair and light skin smiles at another woman with long blonde hair. The woman with brown hair wears a black jacket and has a small, barely noticeable mole on her right cheek. The camera angle is a close-up, focused on the woman with brown hair's face. The lighting is warm and natural, likely from the setting sun, casting a soft glow on the scene. The scene appears to be real-life footage"
    negative_prompt = "worst quality, inconsistent motion, blurry, jittery, distorted"

    t1 = time.time()
    video = pipe(
        prompt=prompt,
        negative_prompt=negative_prompt,
        width=768,
        height=512,
        num_frames=161,
        num_inference_steps=50,
    ).frames[0]
    torch.cuda.synchronize()
    t2 = time.time()
    export_to_video(video, "output.mp4", fps=24)
    
    print(f"Inference time: {t2 - t1:.2f} s")
    print(f"Inference memory: {torch.cuda.max_memory_reserved() / 1024 ** 3:.2f} GB")


def group_offloading(offload_group_patterns: str = "diffusers_block", num_blocks_per_group: int = 4, compile: bool = False):
    pipe = LTXPipeline.from_pretrained("a-r-r-o-w/LTX-Video-diffusers", torch_dtype=torch.bfloat16)
    pipe.text_encoder.to("cuda")
    pipe.vae.to("cuda")
    apply_group_offloading(
        module=pipe.transformer,
        offload_group_patterns=offload_group_patterns,
        num_blocks_per_group=num_blocks_per_group,
        offload_device=torch.device("cpu"),
        onload_device=torch.device("cuda"),
        force_offload=True,
        non_blocking=True,
        # cuda_stream=True,
    )
    if compile:
        pipe.transformer = torch.compile(pipe.transformer, mode="max-autotune-no-cudagraphs")
        # pipe.transformer = torch.compile(pipe.transformer, backend="eager")
    
    cleanup()
    print(f"Model memory: {torch.cuda.max_memory_reserved() / 1024 ** 3:.2f} GB")

    prompt = "A woman with long brown hair and light skin smiles at another woman with long blonde hair. The woman with brown hair wears a black jacket and has a small, barely noticeable mole on her right cheek. The camera angle is a close-up, focused on the woman with brown hair's face. The lighting is warm and natural, likely from the setting sun, casting a soft glow on the scene. The scene appears to be real-life footage"
    negative_prompt = "worst quality, inconsistent motion, blurry, jittery, distorted"

    t1 = time.time()
    video = pipe(
        prompt=prompt,
        negative_prompt=negative_prompt,
        width=768,
        height=512,
        num_frames=161,
        num_inference_steps=50,
    ).frames[0]
    torch.cuda.synchronize()
    t2 = time.time()
    export_to_video(video, "output.mp4", fps=24)

    compile_times = torch._dynamo.utils.compile_times()
    print(f"Compile times: {compile_times}")
    
    print(f"Inference time: {t2 - t1:.2f} s")
    print(f"Inference memory: {torch.cuda.max_memory_reserved() / 1024 ** 3:.2f} GB")


def get_args():
    parser = argparse.ArgumentParser()
    parser.add_argument("--offload_type", type=str, default="normal", choices=["normal", "model", "sequential", "group"])
    parser.add_argument("--offload_group_patterns", type=str, default="diffusers_block")
    parser.add_argument("--num_blocks_per_group", type=int, default=4)
    parser.add_argument("--compile", action="store_true")
    return parser.parse_args()


if __name__ == "__main__":
    args = get_args()

    if args.offload_type == "normal":
        normal()
    elif args.offload_type == "model":
        model_cpu_offload(args.compile)
    elif args.offload_type == "sequential":
        sequential_cpu_offload(args.compile)
    else:
        group_offloading(args.offload_group_patterns, args.num_blocks_per_group, args.compile)
```
</details>

Results for:

```
python3 test.py --offload_type group --offload_group_patterns diffusers_block --num_blocks_per_group 4
```

Without cuda stream prefetching:

```python
Model memory: 9.70 GB
Inference time: 85.36 s
Inference memory: 21.25 GB
```

With cuda streams:

```python
# 4 block groups
Model memory: 10.26 GB
Inference time: 47.71 s
Inference memory: 21.89 GB

# 1 block groups
Model memory: 9.84 GB
Inference time: 46.15 s
Inference memory: 21.04 
```

Currently not compatible with `torch.compile` and triggers several recompilations.

Reading:
- https://pytorch.org/tutorials/intermediate/pinmem_nonblock.html
- https://gist.github.com/gau-nernst/9408e13c32d3c6e7025d92cce6cba140
- https://pytorch.org/docs/main/torch.compiler_troubleshooting.html

cc @gau-nernst because the original ideas for layer prefetching come from his implementation

cc @DN6 @yiyixuxu