### PR TITLE
[CI] Match remaining assertions from big runner

### DIFF
--- a/tests/lora/test_lora_layers_sd3.py
+++ b/tests/lora/test_lora_layers_sd3.py
@@ -36,8 +36,6 @@ from diffusers.utils.testing_utils import (
     require_peft_backend,
     require_torch_gpu,
     torch_device,
-    print_tensor_test
-    
 )
 
 
@@ -179,8 +177,7 @@ class SD3LoraIntegrationTests(unittest.TestCase):
 
         image = pipe(**inputs).images[0]
         image_slice = image[0, -3:, -3:]
-        print_tensor_test(image_slice)
-        expected_slice = np.array([0.5396, 0.5776, 0.7432, 0.5151, 0.5586, 0.7383, 0.5537, 0.5933, 0.7153])
+        expected_slice = np.array([0.5649, 0.5405, 0.5488, 0.5688, 0.5449, 0.5513, 0.5337, 0.5107, 0.5059])
 
         max_diff = numpy_cosine_similarity_distance(expected_slice.flatten(), image_slice.flatten())
 

--- a/tests/lora/test_lora_layers_sd3.py
+++ b/tests/lora/test_lora_layers_sd3.py
@@ -36,6 +36,8 @@ from diffusers.utils.testing_utils import (
     require_peft_backend,
     require_torch_gpu,
     torch_device,
+    print_tensor_test
+    
 )
 
 
@@ -177,6 +179,7 @@ class SD3LoraIntegrationTests(unittest.TestCase):
 
         image = pipe(**inputs).images[0]
         image_slice = image[0, -3:, -3:]
+        print_tensor_test(image_slice)
         expected_slice = np.array([0.5396, 0.5776, 0.7432, 0.5151, 0.5586, 0.7383, 0.5537, 0.5933, 0.7153])
 
         max_diff = numpy_cosine_similarity_distance(expected_slice.flatten(), image_slice.flatten())

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -372,9 +372,7 @@ class SlowBnb8bitTests(Base8bitTests):
             output_type="np",
         ).images
         out_slice = output[0, -3:, -3:, -1].flatten()
-        from diffusers.utils.testing_utils import print_tensor_test
-        print_tensor_test(out_slice)
-        expected_slice = np.array([0.0376, 0.0359, 0.0015, 0.0449, 0.0479, 0.0098, 0.0083, 0.0295, 0.0295])
+        expected_slice = np.array([0.0674, 0.0623, 0.0364, 0.0632, 0.0671, 0.0430, 0.0317, 0.0493, 0.0583])
 
         max_diff = numpy_cosine_similarity_distance(expected_slice, out_slice)
         self.assertTrue(max_diff < 1e-2)

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -372,6 +372,8 @@ class SlowBnb8bitTests(Base8bitTests):
             output_type="np",
         ).images
         out_slice = output[0, -3:, -3:, -1].flatten()
+        from diffusers.utils.testing_utils import print_tensor_test
+        print_tensor_test(out_slice)
         expected_slice = np.array([0.0376, 0.0359, 0.0015, 0.0449, 0.0479, 0.0098, 0.0083, 0.0295, 0.0295])
 
         max_diff = numpy_cosine_similarity_distance(expected_slice, out_slice)


### PR DESCRIPTION
# What does this PR do?

Some tests were left to be updated in the previous PRs. This PR updates the assertion slices. 

Note the slice in one of the quantization tests is being changed to match what we're getting in our CI runner. If we follow the environment as mentioned [here](https://github.com/huggingface/diffusers/tree/main/tests/quantization/bnb), it will pass. 