### PR TITLE
[LoRA] fix peft state dict parsing

### DIFF
--- a/src/diffusers/loaders/lora_conversion_utils.py
+++ b/src/diffusers/loaders/lora_conversion_utils.py
@@ -519,7 +519,7 @@ def _convert_kohya_flux_lora_to_diffusers(state_dict):
         remaining_keys = list(sds_sd.keys())
         te_state_dict = {}
         if remaining_keys:
-            if not all(k.startswith("lora_te1") for k in remaining_keys):
+            if not all(k.startswith("lora_te") for k in remaining_keys):
                 raise ValueError(f"Incompatible keys detected: \n\n {', '.join(remaining_keys)}")
             for key in remaining_keys:
                 if not key.endswith("lora_down.weight"):
@@ -558,6 +558,13 @@ def _convert_kohya_flux_lora_to_diffusers(state_dict):
         new_state_dict = {**ait_sd, **te_state_dict}
         return new_state_dict
 
+    # This is  weird.
+    # https://huggingface.co/sayakpaul/different-lora-from-civitai/tree/main?show_file_info=sharp_detailed_foot.safetensors
+    # has both `peft` and non-peft state dict.
+    has_peft_state_dict = any(k.startswith("transformer.") for k in state_dict)
+    if has_peft_state_dict:
+        state_dict = {k: v for k, v in state_dict.items() if k.startswith("transformer.")}
+        return state_dict
     return _convert_sd_scripts_to_ai_toolkit(state_dict)
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/diffusers/pull/9542#issuecomment-2578735516. 

https://civitai.com/models/200251?modelVersionId=1081295 has both `peft` and non `peft` state dict inside it 🤷 

<details>
<summary>Testing code:</summary>

```py
from diffusers import FluxPipeline
import torch

pipeline = FluxPipeline.from_pretrained(
    "black-forest-labs/FLUX.1-dev", torch_dtype=torch.bfloat16
).to("cuda")
pipeline.load_lora_weights(
    "sayakpaul/different-lora-from-civitai", weight_name="sharp_detailed_foot.safetensors"
)

prompt = """
UHD, 4k, ultra detailed, cinematic, a photograph of <lora:sharp detailed image (foot focus) v1.1:0.9> sharp detailed image of a female person standing on a black mat with their bare feet in front of camera, perfect image, perfect body, perfect anatomy, sharp image, detailed image, cinematic style, high quality photography, sharp detailed image style, solo, barefoot, feet, toes, black background, toenails, close-up, foot focus, muscular, veins, soles, facing camera, feet in front of camera, polished nails, closeup, feet focus, epic, beautiful lighting, inpsiring
"""

_ = pipeline(prompt, num_inference_steps=20, generator=torch.manual_seed(2810038592))
```

</summary>