### PR TITLE
Fix documentation for FluxPipeline

### DIFF
--- a/docs/source/en/api/pipelines/flux.md
+++ b/docs/source/en/api/pipelines/flux.md
@@ -367,7 +367,7 @@ transformer_8bit = FluxTransformer2DModel.from_pretrained(
 
 pipeline = FluxPipeline.from_pretrained(
     "black-forest-labs/FLUX.1-dev",
-    text_encoder=text_encoder_8bit,
+    text_encoder_2=text_encoder_8bit,
     transformer=transformer_8bit,
     torch_dtype=torch.float16,
     device_map="balanced",


### PR DESCRIPTION
Found a tiny mistake in the documentation of FluxPipeline, more specifically the part showing how the Flux model can be loaded in a quantized way. In the code example the text encoder model is passed to the wrong argument in the FluxPipeline.from_pretrained function.

# What does this PR do?




## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).



## Who can review?

Anyone in the community is free to review the PR once the tests have passed. @stevhliu will be interested?

