### PR TITLE
[Tests] add: test to check 8bit bnb quantized models work with lora loading.

### DIFF
--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -512,7 +512,7 @@ class SlowBnb8bitFluxTests(Base8bitTests):
         self.assertTrue(max_diff < 1e-3)
 
     @require_peft_version_greater("0.14.0")
-    def test_lora_loading_works(self):
+    def test_lora_loading(self):
         self.pipeline_8bit.load_lora_weights(
             hf_hub_download("ByteDance/Hyper-SD", "Hyper-FLUX.1-dev-8steps-lora.safetensors"), adapter_name="hyper-sd"
         )


### PR DESCRIPTION
# What does this PR do?

To prevent from https://github.com/huggingface/diffusers/issues/10550. Only adds this test to 8bit. 4bit has issues and I will open a follow-up in a bit.

Slightly related: https://github.com/huggingface/diffusers/issues/10550.