### PR TITLE
[chore] update notes generation spaces

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,9 @@ To create the package for PyPI.
    twine upload dist/* -r pypi
 
 10. Prepare the release notes and publish them on GitHub once everything is looking hunky-dory. You can use the following
-    Space to fetch all the commits applicable for the release: https://huggingface.co/spaces/lysandre/github-release. Repo should
-    be `huggingface/diffusers`. `tag` should be the previous release tag (v0.26.1, for example), and `branch` should be
+    Space to fetch all the commits applicable for the release: https://huggingface.co/spaces/sayakpaul/auto-release-notes-diffusers.
+    It automatically fetches the correct tag and branch but also provides the option to configure them.
+    `tag` should be the previous release tag (v0.26.1, for example), and `branch` should be
     the latest release branch (v0.27.0-release, for example). It denotes all commits that have happened on branch
     v0.27.0-release after the tag v0.26.1 was created.
 


### PR DESCRIPTION
# What does this PR do?

We rely on https://huggingface.co/spaces/lysandre/github-release to fetch release notes but sometimes, it can be confusing to determine the appropriate tag and branch to obtain the release notes. 

This changed Space (https://huggingface.co/spaces/sayakpaul/auto-release-notes-diffusers) bypasses this need by automatically fetching the appropriate tag and branch so that we don't have to struggle. It also has a token secret, so, we don't have sweat that part.

<img width="1234" alt="Screenshot 2025-01-16 at 9 00 09 AM" src="https://github.com/user-attachments/assets/dab23076-3a1f-4aef-a10d-196d88b3a075" />

