### PR TITLE
Inplace sums, remove call to `F.pad`  and better memory count

### DIFF
--- a/src/diffusers/models/autoencoders/autoencoder_kl_cogvideox.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_cogvideox.py
@@ -41,9 +41,7 @@ class CogVideoXSafeConv3d(nn.Conv3d):
     """
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        memory_count = (
-            (input.shape[0] * input.shape[1] * input.shape[2] * input.shape[3] * input.shape[4]) * 2 / 1024**3
-        )
+        memory_count = torch.prod(torch.tensor(input.shape)) * 2 / 1024**3
 
         # Set to 2GB, suitable for CuDNN
         if memory_count > 2:

--- a/src/diffusers/models/autoencoders/autoencoder_kl_cogvideox.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_cogvideox.py
@@ -303,7 +303,7 @@ class CogVideoXResnetBlock3D(nn.Module):
         hidden_states, new_conv_cache["conv1"] = self.conv1(hidden_states, conv_cache=conv_cache.get("conv1"))
 
         if temb is not None:
-            hidden_states = hidden_states + self.temb_proj(self.nonlinearity(temb))[:, :, None, None, None]
+            hidden_states.add_(self.temb_proj(self.nonlinearity(temb))[:, :, None, None, None])
 
         if zq is not None:
             hidden_states, new_conv_cache["norm2"] = self.norm2(hidden_states, zq, conv_cache=conv_cache.get("norm2"))
@@ -322,7 +322,7 @@ class CogVideoXResnetBlock3D(nn.Module):
             else:
                 inputs = self.conv_shortcut(inputs)
 
-        hidden_states = hidden_states + inputs
+        hidden_states.add_(inputs)
         return hidden_states, new_conv_cache
 
 

--- a/src/diffusers/models/autoencoders/autoencoder_kl_cogvideox.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_cogvideox.py
@@ -103,6 +103,7 @@ class CogVideoXCausalConv3d(nn.Module):
         self.width_pad = width_pad
         self.time_pad = time_pad
         self.time_causal_padding = (width_pad, width_pad, height_pad, height_pad, time_pad, 0)
+        self.const_padding_conv3d =  (0, self.width_pad, self.height_pad) 
 
         self.temporal_dim = 2
         self.time_kernel_size = time_kernel_size
@@ -115,6 +116,8 @@ class CogVideoXCausalConv3d(nn.Module):
             kernel_size=kernel_size,
             stride=stride,
             dilation=dilation,
+            padding = 0 if self.pad_mode == 'replicate' else self.const_padding_conv3d,
+            padding_mode = 'zeros',
         )
 
     def fake_context_parallel_forward(
@@ -135,9 +138,7 @@ class CogVideoXCausalConv3d(nn.Module):
         if self.pad_mode == "replicate":
             conv_cache = None
         else:
-            padding_2d = (self.width_pad, self.width_pad, self.height_pad, self.height_pad)
             conv_cache = inputs[:, :, -self.time_kernel_size + 1 :].clone()
-            inputs = F.pad(inputs, padding_2d, mode="constant", value=0)
 
         output = self.conv(inputs)
         return output, conv_cache


### PR DESCRIPTION
- perform in-place sums of `hidden_states` ie doing `a.add_(b)` instead of `a=a+b` to reduce temp memory allocation
- remove call to asymmetric padding in `F.pad` of non-`replicate` pad mode, and instead let padding be done by `Conv3d` for more efficient execution;
- computation of `memory_count` doesn't extend dimensions to allow `torch.compile` to do a better optimisation (?)