### PR TITLE
Tensor-parallel like FeedForward to lower memory requirements

### DIFF
--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -1215,9 +1215,19 @@ class FeedForward(nn.Module):
         bias: bool = True,
     ):
         super().__init__()
+
         if inner_dim is None:
             inner_dim = int(dim * mult)
         dim_out = dim_out if dim_out is not None else dim
+
+        self._dim = dim
+        self._dim_out = dim_out
+        self._mult = mult
+        self._dropout = dropout
+        self._activation_fn = activation_fn
+        self._final_dropout = final_dropout
+        self._inner_dim = inner_dim
+        self._bias = bias
 
         if activation_fn == "gelu":
             act_fn = GELU(dim, inner_dim, bias=bias)

--- a/src/diffusers/models/memory_utils.py
+++ b/src/diffusers/models/memory_utils.py
@@ -1,0 +1,178 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import torch
+
+from ..utils import logging
+from .activations import GEGLU, GELU, ApproximateGELU, LinearActivation, SwiGLU
+from .attention import FeedForward
+
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+
+class _MemoryOptimizedFeedForward(torch.nn.Module):
+    r"""
+    See [`~models.attention.FeedForward`] parameter documentation. This class is a copy of the FeedForward class. The
+    only difference is that this module is optimized for memory.
+
+    This method achieves memory savings by applying the ideas of tensor-parallelism sequentially. Input projection
+    layers are split column-wise and output projection layers are split row-wise. This allows for the computation of
+    the feedforward pass to occur without ever materializing the full intermediate tensor. Typically, the intermediate
+    tensor takes 4x-8x more memory than the input tensor. This method reduces that with a small performance tradeoff.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        dim_out: Optional[int] = None,
+        mult: int = 4,
+        dropout: float = 0.0,
+        activation_fn: str = "geglu",
+        final_dropout: bool = False,
+        inner_dim: Optional[int] = None,
+        bias: bool = True,
+        num_splits: int = 4,
+    ) -> None:
+        super().__init__()
+
+        if inner_dim is None:
+            inner_dim = int(dim * mult)
+
+        dim_out = dim_out if dim_out is not None else dim
+
+        dim_split = inner_dim // num_splits
+        if inner_dim % dim_split != 0:
+            raise ValueError(f"inner_dim must be divisible by {mult=}, or {num_splits=} if provided.")
+
+        self._dim = dim
+        self._dim_out = dim_out
+        self._mult = mult
+        self._dropout = dropout
+        self._activation_fn = activation_fn
+        self._final_dropout = final_dropout
+        self._inner_dim = inner_dim
+        self._bias = bias
+        self._num_splits = num_splits
+
+        def get_activation_fn(dim_: int, inner_dim_: int):
+            if activation_fn == "gelu":
+                act_fn = GELU(dim_, inner_dim_, bias=bias)
+            if activation_fn == "gelu-approximate":
+                act_fn = GELU(dim_, inner_dim_, approximate="tanh", bias=bias)
+            elif activation_fn == "geglu":
+                act_fn = GEGLU(dim_, inner_dim_, bias=bias)
+            elif activation_fn == "geglu-approximate":
+                act_fn = ApproximateGELU(dim_, inner_dim_, bias=bias)
+            elif activation_fn == "swiglu":
+                act_fn = SwiGLU(dim_, inner_dim_, bias=bias)
+            elif activation_fn == "linear-silu":
+                act_fn = LinearActivation(dim_, inner_dim_, bias=bias, activation="silu")
+            return act_fn
+
+        # Split column-wise
+        self.proj_in = torch.nn.ModuleList([get_activation_fn(dim, dim_split) for _ in range(inner_dim // dim_split)])
+
+        self.dropout = torch.nn.Dropout(dropout)
+
+        # Split row-wise
+        self.proj_out = torch.nn.ModuleList(
+            [torch.nn.Linear(dim_split, dim_out, bias=False) for _ in range(inner_dim // dim_split)]
+        )
+
+        self.bias = None
+        if bias:
+            self.bias = torch.nn.Parameter(torch.zeros(dim_out))
+
+        self.final_dropout = None
+        if final_dropout:
+            self.final_dropout = torch.nn.Dropout(dropout)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        # Output tensor for "all_reduce" operation
+        output = hidden_states.new_zeros(hidden_states.shape)
+
+        # Apply feedforward pass sequentially since this is intended for memory optimization on a single GPU
+        for proj_in, proj_out in zip(self.proj_in, self.proj_out):
+            out = proj_in(hidden_states)
+            out = self.dropout(out)
+            out = proj_out(out)
+            # Perform "all_reduce"
+            output += out
+
+        if self.bias is not None:
+            output += self.bias
+        if self.final_dropout is not None:
+            output = self.final_dropout(output)
+
+        return output
+
+
+def apply_memory_optimized_feedforward(module: torch.nn.Module, num_splits: Optional[int] = None) -> torch.nn.Module:
+    module_dict = dict(module.named_modules())
+
+    for name, submodule in module_dict.items():
+        if not isinstance(submodule, FeedForward):
+            continue
+
+        logger.debug(f"Applying memory optimized feedforward to layer '{name}'")
+        state_dict = submodule.state_dict()
+        num_splits = submodule._mult if num_splits is None else num_splits
+
+        # remap net.0.proj.weight
+        net_0_proj = state_dict.pop("net.0.proj.weight")
+        net_0_proj = net_0_proj.chunk(num_splits, dim=0)
+        for i in range(num_splits):
+            state_dict[f"proj_in.{i}.proj.weight"] = net_0_proj[i]
+
+        # remap net.0.proj.bias
+        if "net.0.proj.bias" in state_dict:
+            net_0_proj_bias = state_dict.pop("net.0.proj.bias")
+            net_0_proj_bias = net_0_proj_bias.chunk(num_splits, dim=0)
+            for i in range(num_splits):
+                state_dict[f"proj_in.{i}.proj.bias"] = net_0_proj_bias[i]
+
+        # remap net.2.weight
+        net_2_weight = state_dict.pop("net.2.weight")
+        net_2_weight = net_2_weight.chunk(num_splits, dim=1)
+        for i in range(num_splits):
+            state_dict[f"proj_out.{i}.weight"] = net_2_weight[i]
+
+        # remap net.2.bias
+        if "net.2.bias" in state_dict:
+            net_2_bias = state_dict.pop("net.2.bias")
+            state_dict["bias"] = net_2_bias
+
+        with torch.device("meta"):
+            new_ff = _MemoryOptimizedFeedForward(
+                dim=submodule._dim,
+                dim_out=submodule._dim_out,
+                mult=submodule._mult,
+                dropout=submodule._dropout,
+                activation_fn=submodule._activation_fn,
+                final_dropout=submodule._final_dropout,
+                inner_dim=submodule._inner_dim,
+                bias=submodule._bias,
+                num_splits=num_splits,
+            )
+
+        new_ff.load_state_dict(state_dict, strict=True, assign=True)
+
+        parent_module_name, _, submodule_name = name.rpartition(".")
+        parent_module = module_dict[parent_module_name]
+        setattr(parent_module, submodule_name, new_ff)
+
+    return module


### PR DESCRIPTION
In tensor parallelism, we split the internal layers of modules either column-wise or row-wise across multiple GPUs, perform individual forward passes for each split, and then all_reduce with a sum to gather outputs. We can do the same thing sequentially on a single GPU. Doing so:
- does not reduce memory usage from model weights ❌ 
- does reduce memory usage from intermediate activations ✅ (goal of this PR)

Typically there is a 4x-8x expansion in the intermediate hidden dimension of the FFs. This results in a 4x-8x larger intermediate tensor being created compared to input tensor. Given that we hav large models like HunyuanVideo now, the sequence length can be very large (> 2**14 for decent frames/resolution), so FFs end up allocating much additional memory -- this is much more worse for training without gradient checkpointing (or partial gradient checkpointing #10611) because all intermediate tensors need to be stored. We can, however, get rid of allocating a large intermediate tensor.

There are some gotchas. Applying this directly on an arbitrary model will most likely not show any memory savings. In order for this to have any effect, we first need to optimize the memory usage of a model to the point where `FeedForward` hidden dim expansion actually starts to affect the peak memory required. There are many ways reach the tipping point where FFs end up causing the peaks (sometimes multiple of below mentioned techniques need to be combined to reach that point):
- Quantization or FP8 Layerwise-upcasting
- Memory-optimized attention
- Chunked feed-forward (we will be deprecating the way we do it currently soon)
- Split-Inference (reference is FreeNoise [here](https://github.com/huggingface/diffusers/blob/a647682224fed7d65ac4d2a75ed9f2db8e5253e7/src/diffusers/pipelines/free_noise_utils.py#L37))
- CPU/Sequential offloading of internal/leaf modules - Group offloading (see #10503)
- ... other things I'm forgetting

With the latest group offloading support upcoming, we know that VRAM usage can be reduced significantly without any penalty to throughput, given adequate CPU RAM. This reduces the memory peaks from model weights. The main cause of the spiky points on memory trace is now due either:
- Default SDPA backend - can be somewhat flattened with flash attention backend or using flash-attn library directly with custom attention processor
- FeedForward - this was also a huge problem when we added FreeNoise, but split-inference helped improve things back then

We can reduce these memory peaks by making use of ideas from tensor and sequence-parellism and applying them sequentially for single-GPU case. This PR implements the tensor-parallel equivalent of FFs. Will do a follow-up for sequence-parallism based optimization in the near future after some more important things are taken care of.

Onto the benchmark numbers!

<details>
<summary> Benchmark </summary>

```python
import gc

import torch

from diffusers.models.attention import FeedForward
from diffusers.models.memory_utils import apply_memory_optimized_feedforward
from diffusers.utils.logging import set_verbosity_debug

# set_verbosity_debug()


class DummyModel(torch.nn.Module):
    def __init__(self, dim: int, dim_out: int, mult: int, activation_fn: str, num_layers: int = 5):
        super().__init__()
        
        self.blocks = torch.nn.ModuleList([
            FeedForward(dim=dim, dim_out=dim_out, mult=mult, activation_fn=activation_fn)
            for _ in range(num_layers)
        ])
    
    def forward(self, x):
        for block in self.blocks:
            x = block(x)
        return x


def benchmark_fn(f, *args, **kwargs):
    torch.cuda.synchronize()
    start = torch.cuda.Event(enable_timing=True)
    end = torch.cuda.Event(enable_timing=True)

    start.record()
    output = f(*args, **kwargs)
    end.record()
    torch.cuda.synchronize()
    elapsed_time = round(start.elapsed_time(end) / 1000, 3)

    return elapsed_time, output


def reset_memory():
    gc.collect()
    torch.cuda.empty_cache()
    torch.cuda.reset_peak_memory_stats()
    torch.cuda.synchronize()


ACTIVATION_FUNCTIONS = ["gelu", "gelu-approximate", "geglu", "geglu-approximate", "swiglu", "linear-silu"]

batch_size = 2
sequence_length = 8192
dim = 4096
mult = 4
num_layers = 5

@torch.no_grad()
def main(act_fn, device="cuda"):
    model = DummyModel(dim=dim, dim_out=dim, mult=mult, activation_fn=act_fn, num_layers=num_layers)
    model.to(device)

    input = torch.randn(batch_size, sequence_length, dim, device=device)
    
    # Benchmark normal FF
    model(input)  # warmup
    reset_memory()
    elapsed_time, output1 = benchmark_fn(model, input)
    max_memory_allocated = torch.cuda.max_memory_allocated() / 1024 ** 3
    print(f"Normal FF: {elapsed_time=:.2f}s, {max_memory_allocated=:.2f}GB")

    # Benchmark memory optimized FF
    model(input)  # warmup
    reset_memory()
    model = apply_memory_optimized_feedforward(model)
    elapsed_time, output2 = benchmark_fn(model, input)
    max_memory_allocated = torch.cuda.max_memory_allocated() / 1024 ** 3
    print(f"Memory optimized FF: {elapsed_time=:.2f}s, {max_memory_allocated=:.2f}GB")

    diff = output1 - output2
    absmax = diff.abs().max()
    absmean = diff.abs().mean()
    print(f"Output comparison: {absmax=:.5f}, {absmean=:.5f}")


if __name__ == "__main__":
    for act_fn in ACTIVATION_FUNCTIONS:
        # for device in ["cuda", "cpu"]:
        for device in ["cuda"]:
            print(f"Activation function: {act_fn}, device={device}")
            main(act_fn, device=device)
            print()
```

</details>

Benchmarks results:

```
Activation function: gelu, device=cuda
Normal FF: elapsed_time=1.29s, max_memory_allocated=5.01GB
Memory optimized FF: elapsed_time=1.40s, max_memory_allocated=4.26GB
Output comparison: absmax=0.00000, absmean=0.00000

Activation function: gelu-approximate, device=cuda
Normal FF: elapsed_time=1.29s, max_memory_allocated=5.01GB
Memory optimized FF: elapsed_time=1.28s, max_memory_allocated=4.26GB
Output comparison: absmax=0.00000, absmean=0.00000

Activation function: geglu, device=cuda
Normal FF: elapsed_time=1.92s, max_memory_allocated=8.26GB
Memory optimized FF: elapsed_time=1.92s, max_memory_allocated=6.01GB
Output comparison: absmax=0.00015, absmean=0.00003

Activation function: geglu-approximate, device=cuda
Normal FF: elapsed_time=1.30s, max_memory_allocated=6.01GB
Memory optimized FF: elapsed_time=1.70s, max_memory_allocated=4.51GB
Output comparison: absmax=0.00000, absmean=0.00000

Activation function: swiglu, device=cuda
Normal FF: elapsed_time=1.92s, max_memory_allocated=8.26GB
Memory optimized FF: elapsed_time=1.92s, max_memory_allocated=6.01GB
Output comparison: absmax=0.00014, absmean=0.00003

Activation function: linear-silu, device=cuda
Normal FF: elapsed_time=1.29s, max_memory_allocated=5.01GB
Memory optimized FF: elapsed_time=1.29s, max_memory_allocated=4.26GB
Output comparison: absmax=0.00000, absmean=0.00000
```

To make it easier to parse, table:

| Activation Function       |Type                  | Elapsed Time | Max Memory Allocated |
|---------------------------|----------------------|--------------|----------------------|
| gelu                      |Normal FF             | 1.29s        | 5.01GB               |
|                           |Memory Optimized FF   | 1.40s        | 4.26GB               |
| gelu-approximate          |Normal FF             | 1.29s        | 5.01GB               |
|                           |Memory Optimized FF   | 1.28s        | 4.26GB               |
| geglu                     |Normal FF             | 1.92s        | 8.26GB               |
|                           |Memory Optimized FF   | 1.92s        | 6.01GB               |
| geglu-approximate         |Normal FF             | 1.30s        | 6.01GB               |
|                           |Memory Optimized FF   | 1.70s        | 4.51GB               |
| swiglu                    |Normal FF             | 1.92s        | 8.26GB               |
|                           |Memory Optimized FF   | 1.92s        | 6.01GB               |
| linear-silu               |Normal FF             | 1.29s        | 5.01GB               |
|                           |Memory Optimized FF   | 1.29s        | 4.26GB               |

<details>
<summary> minimal reproducer with memory trace </summary>

```python
import gc
import torch
from diffusers.models.attention import FeedForward


class MemoryOptimizedFeedForward(torch.nn.Module):
    def __init__(self, dim, dim_out, mult, activation_fn, num_splits=4):
        super().__init__()
        self.dim = dim
        self.dim_out = dim_out
        self.mult = mult
        self.activation_fn = activation_fn
        self.num_splits = num_splits
        self.inner_dim = dim * mult

        self.proj = torch.nn.ModuleList([
            torch.nn.Linear(dim, self.inner_dim // num_splits) for _ in range(num_splits)
        ])
        self.act_fn = torch.nn.GELU()
        self.out = torch.nn.ModuleList([
            torch.nn.Linear(self.inner_dim // num_splits, dim_out, bias=False) for _ in range(num_splits)
        ])
        self.bias = torch.nn.Parameter(torch.zeros(dim_out))
    
    def forward(self, x):
        outputs = x.new_zeros(x.shape)
        for i in range(self.num_splits):
            out = self.proj[i](x)
            out = self.act_fn(out)
            out = self.out[i](out)
            outputs += out
        outputs += self.bias
        return outputs


def reset_memory():
    gc.collect()
    torch.cuda.empty_cache()
    torch.cuda.reset_peak_memory_stats()
    torch.cuda.synchronize()


def run_forward(model, *args):
    output = model(*args)
    return output

torch.cuda.memory._record_memory_history()

dim = 4096
mult = 4
ff_normal = FeedForward(dim=dim, mult=mult, dim_out=dim, activation_fn="gelu")
ff_split = MemoryOptimizedFeedForward(dim=dim, dim_out=dim, mult=mult, activation_fn="gelu", num_splits=mult)

for i, layer in enumerate(ff_split.proj):
    layer.weight.data.copy_(ff_normal.net[0].proj.weight.data.chunk(ff_split.num_splits, dim=0)[i])
    layer.bias.data.copy_(ff_normal.net[0].proj.bias.data.chunk(ff_split.num_splits, dim=0)[i])

for i, layer in enumerate(ff_split.out):
    layer.weight.data.copy_(ff_normal.net[2].weight.data.chunk(ff_split.num_splits, dim=1)[i])

ff_split.bias.data.copy_(ff_normal.net[2].bias.data)

device = "cuda"
ff_normal.to(device)
ff_split.to(device)

batch_size = 2
sequence_length = 8192
input = torch.randn((batch_size, sequence_length, dim), device=device)

with torch.no_grad():
    reset_memory()
    output1 = run_forward(ff_normal, input)
    print(f"Max memory reserved: {torch.cuda.max_memory_reserved() / 1024 ** 3:.3f} GB")
    
    reset_memory()
    output2 = run_forward(ff_split, input)
    print(f"Max memory reserved: {torch.cuda.max_memory_reserved() / 1024 ** 3:.3f} GB")

    diff = output1 - output2
    print(diff.abs().max(), diff.abs().mean())

torch.cuda.memory._dump_snapshot("ff.pickle")
```
</details>

Results:

```
Max memory reserved: 3.271 GB
Max memory reserved: 2.271 GB
tensor(6.7353e-06, device='cuda:0') tensor(3.3257e-07, device='cuda:0')
```

@DN6 @yiyixuxu Would like a first-pass review before making further changes to gather feedback on what should be changed. Can add docs and think about how to expose a single API for applying memory optimizations so that we don't confuse users

cc @bghira (As an admirer and power-user of SimpleTuner, I think some of the latest optimizations will help benefit training as well [group offloading with cuda stream prefetching + this]. Would love to see how low we can go for training the biggest available models with negligible impact to speed)