### PR TITLE
add onnxruntime-migraphx as part of check for onnxruntime in import_utils.py

### DIFF
--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -149,6 +149,7 @@ if _onnx_available:
         "onnxruntime-openvino",
         "ort_nightly_directml",
         "onnxruntime-rocm",
+        "onnxruntime-migraphx",
         "onnxruntime-training",
     )
     _onnxruntime_version = None


### PR DESCRIPTION
# What does this PR do?

The onnxruntime check would fail if only onnxruntime-migraphx was installed. Added to the list of candidates.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Core library:
- General functionalities: @sayakpaul @yiyixuxu @DN6

