### PR TITLE
Revert RePaint scheduler 'fix'

### DIFF
--- a/src/diffusers/schedulers/scheduling_repaint.py
+++ b/src/diffusers/schedulers/scheduling_repaint.py
@@ -319,7 +319,11 @@ class RePaintScheduler(SchedulerMixin, ConfigMixin):
         prev_unknown_part = alpha_prod_t_prev**0.5 * pred_original_sample + pred_sample_direction + variance
 
         # 8. Algorithm 1 Line 5 https://arxiv.org/pdf/2201.09865.pdf
-        prev_known_part = (alpha_prod_t_prev**0.5) * original_image + (1 - alpha_prod_t_prev) * noise
+        # The computation reported in Algorithm 1 Line 5 is incorrect. Line 5 refers to formula (8a) of the same paper,
+        # which tells to sample from a Gaussian distribution with mean "(alpha_prod_t_prev**0.5) * original_image"
+        # and variance "(1 - alpha_prod_t_prev)". This means that the standard Gaussian distribution "noise" should be
+        # scaled by the square root of the variance (as it is done here), however Algorithm 1 Line 5 tells to scale by the variance.
+        prev_known_part = (alpha_prod_t_prev**0.5) * original_image + ((1 - alpha_prod_t_prev) ** 0.5) * noise
 
         # 9. Algorithm 1 Line 8 https://arxiv.org/pdf/2201.09865.pdf
         pred_prev_sample = mask * prev_known_part + (1.0 - mask) * prev_unknown_part


### PR DESCRIPTION
# What does this PR do?

Reverts 'fix' introduced by pull request #10185; the PR adjusted the code accordingly to Algorithm 1 Line 5 of the RePaint paper ([https://arxiv.org/pdf/2201.09865.pdf](https://arxiv.org/pdf/2201.09865.pdf)), however that line is reported incorrectly in the paper itself.

Algorithm 1 Line 5 refers to formula 8a of the same paper

$$x_{t-1}^{\text{known}} \sim \mathcal{N}(\sqrt{\bar{\alpha}} x_0, (1 - \bar{\alpha}) \mathbf{I})$$

which tells to sample from a Gaussian distribution $\mathcal{N}(\mu, \sigma^2)$ with $\mu = \sqrt{\bar{\alpha}} x_0$ and $\sigma^2 = (1 - \bar{\alpha})$. In order to obtain this result, the standard Gaussian distribution $\epsilon \sim \mathcal{N}(\mathbf{0}, \mathbf{I})$ should be stretched by a factor $\sigma$ and translated by a factor $\mu$ (source: [Wikipedia](https://en.wikipedia.org/wiki/Normal_distribution#General_normal_distribution)). The correct operation should therefore be

$$x_{t-1}^{\text{known}} = \sqrt{\bar{\alpha}} x_0 + \sqrt{(1 - \bar{\alpha})} \epsilon$$

as it was indeed calculated before the change; Algorithm 1 Line 5 wrongly reports a stretching factor of $\sigma^2$. This PR restores the previous (correct) computation and adds some comments on the subject.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes degraded performance using RePaint. Below are examples obtained using the example code in the [documentation](https://huggingface.co/docs/diffusers/main/en/api/pipelines/repaint).

### Diffusers v0.31.0 (before the 'fix')
![inference_0-31-0](https://github.com/user-attachments/assets/fc8b6cea-da0d-4215-a8fe-511912febda5)

### Diffusers v0.32.1 (after the 'fix')
![inference_0-32-1](https://github.com/user-attachments/assets/adaf2df4-dd6f-4f0a-93c3-f50ee6c3b267)


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- Schedulers: @yiyixuxu
