### PR TITLE
Fix train_text_to_image.py --help

### DIFF
--- a/examples/text_to_image/train_text_to_image.py
+++ b/examples/text_to_image/train_text_to_image.py
@@ -365,8 +365,8 @@ def parse_args():
         "--dream_training",
         action="store_true",
         help=(
-            "Use the DREAM training method, which makes training more efficient and accurate at the ",
-            "expense of doing an extra forward pass. See: https://arxiv.org/abs/2312.00210",
+            "Use the DREAM training method, which makes training more efficient and accurate at the "
+            "expense of doing an extra forward pass. See: https://arxiv.org/abs/2312.00210"
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
Running `python train_text_to_image.py -h`  to see the command help fails with the following error:
```
  File "/home/jovyan/scene-text-translation/scene_text_translation/training/patches_generation/text_to_image.py", line 1156, in <module>
    main()
  File "/home/jovyan/scene-text-translation/scene_text_translation/training/patches_generation/text_to_image.py", line 523, in main
    args = parse_args()
  File "/home/jovyan/scene-text-translation/scene_text_translation/training/patches_generation/text_to_image.py", line 506, in parse_args
    args = parser.parse_args()
  File "/opt/conda/lib/python3.10/argparse.py", line 1833, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/opt/conda/lib/python3.10/argparse.py", line 1866, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/opt/conda/lib/python3.10/argparse.py", line 2079, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/opt/conda/lib/python3.10/argparse.py", line 2019, in consume_optional
    take_action(action, args, option_string)
  File "/opt/conda/lib/python3.10/argparse.py", line 1943, in take_action
    action(self, namespace, argument_values, option_string)
  File "/opt/conda/lib/python3.10/argparse.py", line 1106, in __call__
    parser.print_help()
  File "/opt/conda/lib/python3.10/argparse.py", line 2567, in print_help
    self._print_message(self.format_help(), file)
  File "/opt/conda/lib/python3.10/argparse.py", line 2551, in format_help
    return formatter.format_help()
  File "/opt/conda/lib/python3.10/argparse.py", line 283, in format_help
    help = self._root_section.format_help()
  File "/opt/conda/lib/python3.10/argparse.py", line 214, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/opt/conda/lib/python3.10/argparse.py", line 214, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/opt/conda/lib/python3.10/argparse.py", line 214, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/opt/conda/lib/python3.10/argparse.py", line 214, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/opt/conda/lib/python3.10/argparse.py", line 539, in _format_action
    if action.help and action.help.strip():
AttributeError: 'tuple' object has no attribute 'strip'
```

This is because the `dream_training` argument's help is a tuple while it should be a string. This PR simply fixes this. 

CC @sayakpaul 
