### PR TITLE
fixing argument help description train_controlnet_sd3.py

### DIFF
--- a/examples/controlnet/train_controlnet_sd3.py
+++ b/examples/controlnet/train_controlnet_sd3.py
@@ -261,7 +261,7 @@ def parse_args(input_args=None):
         type=str,
         default=None,
         help="Path to pretrained controlnet model or model identifier from huggingface.co/models."
-        " If not specified controlnet weights are initialized from unet.",
+        " If not specified controlnet weights are initialized from transformer.",
     )
     parser.add_argument(
         "--num_extra_conditioning_channels",


### PR DESCRIPTION
description mistake in controlnet_model_name_or_path argument we dont have a unet in sd3.

