### PR TITLE
Fix `use_lu_lambdas` and `use_karras_sigmas` with `beta_schedule=squaredcos_cap_v2` in `DPMSolverMultistepScheduler`

### DIFF
--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -399,12 +399,12 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
         if self.config.use_karras_sigmas:
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_karras(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
-            timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas]).round()
+            timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
         elif self.config.use_lu_lambdas:
             lambdas = np.flip(log_sigmas.copy())
             lambdas = self._convert_to_lu(in_lambdas=lambdas, num_inference_steps=num_inference_steps)
             sigmas = np.exp(lambdas)
-            timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas]).round()
+            timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
         elif self.config.use_exponential_sigmas:
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_exponential(in_sigmas=sigmas, num_inference_steps=num_inference_steps)

--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -400,11 +400,15 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_karras(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
+            if self.config.beta_schedule in {"linear", "scaled_linear"}:
+                timesteps = timesteps.round()
         elif self.config.use_lu_lambdas:
             lambdas = np.flip(log_sigmas.copy())
             lambdas = self._convert_to_lu(in_lambdas=lambdas, num_inference_steps=num_inference_steps)
             sigmas = np.exp(lambdas)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
+            if self.config.beta_schedule in {"linear", "scaled_linear"}:
+                timesteps = timesteps.round()
         elif self.config.use_exponential_sigmas:
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_exponential(in_sigmas=sigmas, num_inference_steps=num_inference_steps)

--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -400,7 +400,7 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_karras(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
-            if self.config.beta_schedule ! = "squaredcos_cap_v2":
+            if self.config.beta_schedule != "squaredcos_cap_v2":
                 timesteps = timesteps.round()
         elif self.config.use_lu_lambdas:
             lambdas = np.flip(log_sigmas.copy())

--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -407,7 +407,7 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
             lambdas = self._convert_to_lu(in_lambdas=lambdas, num_inference_steps=num_inference_steps)
             sigmas = np.exp(lambdas)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
-            if self.config.beta_schedule in {"linear", "scaled_linear"}:
+            if self.config.beta_schedule != "squaredcos_cap_v2":
                 timesteps = timesteps.round()
         elif self.config.use_exponential_sigmas:
             sigmas = np.flip(sigmas).copy()

--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -400,7 +400,7 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_karras(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
-            if self.config.beta_schedule in {"linear", "scaled_linear"}:
+            if self.config.beta_schedule ! = "squaredcos_cap_v2":
                 timesteps = timesteps.round()
         elif self.config.use_lu_lambdas:
             lambdas = np.flip(log_sigmas.copy())


### PR DESCRIPTION
# What does this PR do?

`.round()` was applied with `use_lu_lambdas` and `use_karras_sigmas`, this seems to give incorrect `_step_index` from `index_for_timestep` as multiple timesteps are the same.

<details><summary>Reproduction</summary>
<p>

```python
from diffusers import DPMSolverMultistepScheduler
import torch


def dummy_model():
    def model(sample, t, *args):
        # if t is a tensor, match the number of dimensions of sample
        if isinstance(t, torch.Tensor):
            num_dims = len(sample.shape)
            # pad t with 1s to match num_dims
            t = t.reshape(-1, *(1,) * (num_dims - 1)).to(
                sample.device, dtype=sample.dtype
            )

        return sample * t / (t + 1)

    return model


def dummy_sample_deter():
    batch_size = 4
    num_channels = 3
    height = 8
    width = 8

    num_elems = batch_size * num_channels * height * width
    sample = torch.arange(num_elems)
    sample = sample.reshape(num_channels, height, width, batch_size)
    sample = sample / num_elems
    sample = sample.permute(3, 0, 1, 2)

    return sample


scheduler = DPMSolverMultistepScheduler(
    **{
        "num_train_timesteps": 1000,
        "beta_start": 0.00085,
        "beta_end": 0.012,
        "beta_schedule": "squaredcos_cap_v2",
        "solver_order": 2,
        "prediction_type": "epsilon",
        "dynamic_thresholding_ratio": 0.995,
        "sample_max_value": 1.0,
        "algorithm_type": "dpmsolver++",
        "solver_type": "midpoint",
        "lower_order_final": True,
        "use_karras_sigmas": True,
        # "use_lu_lambdas": True,
        "flow_shift": 1.0,
        "final_sigmas_type": "zero",
        "timestep_spacing": "linspace",
        "steps_offset": 0,
    }
)
scheduler.set_timesteps(20)
scheduler.timesteps, scheduler.sigmas, scheduler.timesteps.shape, scheduler.sigmas.shape

model = dummy_model()
sample = dummy_sample_deter()

generator = torch.manual_seed(0)

for i, t in enumerate(scheduler.timesteps):
    print(scheduler._step_index)
    residual = model(sample, t)
    sample = scheduler.step(residual, t, sample, generator=generator).prev_sample
```

</p>
</details> 


<details><summary>`use_karras_sigmas`</summary>
<p>

```python
(tensor([999, 998, 998, 998, 998, 998, 998, 998, 998, 997, 996, 994, 989, 978,
         949, 867, 623, 221,  33,   0]),
 tensor([2.0291e+04, 1.4548e+04, 1.0258e+04, 7.1015e+03, 4.8171e+03, 3.1939e+03,
         2.0641e+03, 1.2957e+03, 7.8684e+02, 4.5987e+02, 2.5703e+02, 1.3628e+02,
         6.7820e+01, 3.1240e+01, 1.3064e+01, 4.8251e+00, 1.5101e+00, 3.7478e-01,
         6.5665e-02, 6.4271e-03, 0.0000e+00]),
 torch.Size([20]),
 torch.Size([21]))
```

</p>
</details> 


<details><summary>`use_lu_lambdas`</summary>
<p>

```python
(tensor([999, 998, 998, 998, 998, 997, 995, 991, 981, 961, 916, 820, 639, 393,
         195,  86,  35,  12,   3,   0]),
 tensor([2.0291e+04, 9.2309e+03, 4.1993e+03, 1.9103e+03, 8.6904e+02, 3.9534e+02,
         1.7985e+02, 8.1815e+01, 3.7219e+01, 1.6932e+01, 7.7024e+00, 3.5040e+00,
         1.5940e+00, 7.2514e-01, 3.2988e-01, 1.5007e-01, 6.8268e-02, 3.1056e-02,
         1.4128e-02, 6.4271e-03, 0.0000e+00]),
 torch.Size([20]),
 torch.Size([21]))
```

</p>
</details> 


Fixes #10738

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yiyixuxu @vladmandic 