### PR TITLE
Add `Self` type hint to `ModelMixin`'s `from_pretrained`

### DIFF
--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -31,6 +31,7 @@ import torch.utils.checkpoint
 from huggingface_hub import DDUFEntry, create_repo, split_torch_state_dict_into_shards
 from huggingface_hub.utils import validate_hf_hub_args
 from torch import Tensor, nn
+from typing_extensions import Self
 
 from .. import __version__
 from ..hooks import apply_layerwise_casting
@@ -605,7 +606,7 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
 
     @classmethod
     @validate_hf_hub_args
-    def from_pretrained(cls, pretrained_model_name_or_path: Optional[Union[str, os.PathLike]], **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path: Optional[Union[str, os.PathLike]], **kwargs) -> Self:
         r"""
         Instantiate a pretrained PyTorch model from a pretrained model configuration.
 


### PR DESCRIPTION
# What does this PR do?

Follow up to #10714 for `ModelMixin`'s `from_pretrained`

```python
from diffusers import AutoencoderKL

model = AutoencoderKL.from_pretrained("")
```

```
(variable) model: Any
```

With the change

```
(variable) model: AutoencoderKL
```


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yiyixuxu 
