### PR TITLE
follow-up refactor on lumina2

### DIFF
--- a/src/diffusers/models/transformers/transformer_lumina2.py
+++ b/src/diffusers/models/transformers/transformer_lumina2.py
@@ -241,8 +241,9 @@ class Lumina2RotaryPosEmbed(nn.Module):
 
     def _precompute_freqs_cis(self, axes_dim: List[int], axes_lens: List[int], theta: int) -> List[torch.Tensor]:
         freqs_cis = []
+        freqs_dtype = torch.float32 if torch.backends.mps.is_available() else torch.float64
         for i, (d, e) in enumerate(zip(axes_dim, axes_lens)):
-            emb = get_1d_rotary_pos_embed(d, e, theta=self.theta, freqs_dtype=torch.float64)
+            emb = get_1d_rotary_pos_embed(d, e, theta=self.theta, freqs_dtype=freqs_dtype)
             freqs_cis.append(emb)
         return freqs_cis
 

--- a/src/diffusers/models/transformers/transformer_lumina2.py
+++ b/src/diffusers/models/transformers/transformer_lumina2.py
@@ -460,7 +460,6 @@ class Lumina2Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         timestep: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
         encoder_attention_mask: torch.Tensor,
-        use_mask: bool = True,
         return_dict: bool = True,
     ) -> Union[torch.Tensor, Transformer2DModelOutput]:
         # 1. Condition, positional & patch embedding
@@ -488,6 +487,8 @@ class Lumina2Transformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
 
         # 3. Joint Transformer blocks
         max_seq_len = max(seq_lengths)
+        use_mask = len(set(seq_lengths)) > 1
+
         attention_mask = hidden_states.new_zeros(batch_size, max_seq_len, dtype=torch.bool)
         joint_hidden_states = hidden_states.new_zeros(batch_size, max_seq_len, self.config.hidden_size)
         for i, (encoder_seq_len, seq_len) in enumerate(zip(encoder_seq_lengths, seq_lengths)):

--- a/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
+++ b/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
@@ -517,7 +517,6 @@ class Lumina2Text2ImgPipeline(DiffusionPipeline):
         system_prompt: Optional[str] = None,
         cfg_trunc_ratio: float = 1.0,
         cfg_normalization: bool = True,
-        use_mask_in_transformer: bool = False,
         max_sequence_length: int = 256,
     ) -> Union[ImagePipelineOutput, Tuple]:
         """
@@ -589,9 +588,6 @@ class Lumina2Text2ImgPipeline(DiffusionPipeline):
                 The ratio of the timestep interval to apply normalization-based guidance scale.
             cfg_normalization (`bool`, *optional*, defaults to `True`):
                 Whether to apply normalization-based guidance scale.
-            use_mask_in_transformer (`bool`, *optional*, defaults to `True`):
-                Whether to use attention mask in `Lumina2Transformer2DModel` for the transformer blocks. Only need to
-                set `True` when you pass a list of prompts with different lengths.
             max_sequence_length (`int`, defaults to `256`):
                 Maximum sequence length to use with the `prompt`.
 
@@ -698,7 +694,6 @@ class Lumina2Text2ImgPipeline(DiffusionPipeline):
                     timestep=current_timestep,
                     encoder_hidden_states=prompt_embeds,
                     encoder_attention_mask=prompt_attention_mask,
-                    use_mask=use_mask_in_transformer,
                     return_dict=False,
                 )[0]
 
@@ -709,7 +704,6 @@ class Lumina2Text2ImgPipeline(DiffusionPipeline):
                         timestep=current_timestep,
                         encoder_hidden_states=negative_prompt_embeds,
                         encoder_attention_mask=negative_prompt_attention_mask,
-                        use_mask=use_mask_in_transformer,
                         return_dict=False,
                     )[0]
                     noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_cond - noise_pred_uncond)

--- a/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
+++ b/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
@@ -517,7 +517,7 @@ class Lumina2Text2ImgPipeline(DiffusionPipeline):
         system_prompt: Optional[str] = None,
         cfg_trunc_ratio: float = 1.0,
         cfg_normalization: bool = True,
-        use_mask_in_transformer: bool = True,
+        use_mask_in_transformer: bool = False,
         max_sequence_length: int = 256,
     ) -> Union[ImagePipelineOutput, Tuple]:
         """
@@ -590,7 +590,8 @@ class Lumina2Text2ImgPipeline(DiffusionPipeline):
             cfg_normalization (`bool`, *optional*, defaults to `True`):
                 Whether to apply normalization-based guidance scale.
             use_mask_in_transformer (`bool`, *optional*, defaults to `True`):
-                Whether to use attention mask in `Lumina2Transformer2DModel`. Set `False` for performance gain.
+                Whether to use attention mask in `Lumina2Transformer2DModel` for the transformer blocks. Only need to
+                set `True` when you pass a list of prompts with different lengths.
             max_sequence_length (`int`, defaults to `256`):
                 Maximum sequence length to use with the `prompt`.
 
@@ -697,7 +698,7 @@ class Lumina2Text2ImgPipeline(DiffusionPipeline):
                     timestep=current_timestep,
                     encoder_hidden_states=prompt_embeds,
                     encoder_attention_mask=prompt_attention_mask,
-                    use_mask_in_transformer=use_mask_in_transformer,
+                    use_mask=use_mask_in_transformer,
                     return_dict=False,
                 )[0]
 
@@ -708,7 +709,7 @@ class Lumina2Text2ImgPipeline(DiffusionPipeline):
                         timestep=current_timestep,
                         encoder_hidden_states=negative_prompt_embeds,
                         encoder_attention_mask=negative_prompt_attention_mask,
-                        use_mask_in_transformer=use_mask_in_transformer,
+                        use_mask=use_mask_in_transformer,
                         return_dict=False,
                     )[0]
                     noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_cond - noise_pred_uncond)

--- a/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
+++ b/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
@@ -696,7 +696,7 @@ class Lumina2Text2ImgPipeline(DiffusionPipeline):
                     hidden_states=latents,
                     timestep=current_timestep,
                     encoder_hidden_states=prompt_embeds,
-                    attention_mask=prompt_attention_mask,
+                    encoder_attention_mask=prompt_attention_mask,
                     use_mask_in_transformer=use_mask_in_transformer,
                     return_dict=False,
                 )[0]
@@ -707,7 +707,7 @@ class Lumina2Text2ImgPipeline(DiffusionPipeline):
                         hidden_states=latents,
                         timestep=current_timestep,
                         encoder_hidden_states=negative_prompt_embeds,
-                        attention_mask=negative_prompt_attention_mask,
+                        encoder_attention_mask=negative_prompt_attention_mask,
                         use_mask_in_transformer=use_mask_in_transformer,
                         return_dict=False,
                     )[0]

--- a/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
+++ b/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
@@ -24,8 +24,6 @@ from ...models import AutoencoderKL
 from ...models.transformers.transformer_lumina2 import Lumina2Transformer2DModel
 from ...schedulers import FlowMatchEulerDiscreteScheduler
 from ...utils import (
-    is_bs4_available,
-    is_ftfy_available,
     is_torch_xla_available,
     logging,
     replace_example_docstring,
@@ -43,12 +41,6 @@ else:
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
-
-if is_bs4_available():
-    pass
-
-if is_ftfy_available():
-    pass
 
 EXAMPLE_DOC_STRING = """
     Examples:

--- a/tests/models/transformers/test_models_transformer_lumina2.py
+++ b/tests/models/transformers/test_models_transformer_lumina2.py
@@ -51,7 +51,7 @@ class Lumina2Transformer2DModelTransformerTests(ModelTesterMixin, unittest.TestC
             "hidden_states": hidden_states,
             "encoder_hidden_states": encoder_hidden_states,
             "timestep": timestep,
-            "attention_mask": attention_mask,
+            "encoder_attention_mask": attention_mask,
         }
 
     @property


### PR DESCRIPTION
This PR:
1. refactor and simplify ROPE: removed all the logic related to different image sizes (we do not need to support this for inference)
2. for now, I switched the default for `use_mask_in_transformer` to be `False` because:
   * for single prompt (most common use case), the outputs are identical and we are getting a performance gain with `use_mask_in_transformer=False` (see details https://github.com/huggingface/diffusers/pull/10776#discussion_r1953806298)
   * for list of prompts, mask should be used (see context  https://github.com/huggingface/diffusers/pull/10642#issuecomment-2654861362) - I think maybe we can remove this argument from pipeline, and automatically set to use mask when a list of prompts are passed (and otherwise set to be False)
