### PR TITLE
Faster set_adapters

### DIFF
--- a/src/diffusers/utils/peft_utils.py
+++ b/src/diffusers/utils/peft_utils.py
@@ -253,29 +253,20 @@ def set_weights_and_activate_adapters(model, adapter_names, weights):
         parts = module_name.split(".")
         # e.g. key = "down_blocks.1.attentions.0"
         key = f"{parts[0]}.{parts[1]}.attentions.{parts[3]}"
-        block_weight = weight_for_adapter.get(key, 1.0)
+        return weight_for_adapter.get(key, 1.0)
 
-        return block_weight
-
-    # iterate over each adapter, make it active and set the corresponding scaling weight
-    for adapter_name, weight in zip(adapter_names, weights):
-        for module_name, module in model.named_modules():
-            if isinstance(module, BaseTunerLayer):
-                # For backward compatbility with previous PEFT versions
-                if hasattr(module, "set_adapter"):
-                    module.set_adapter(adapter_name)
-                else:
-                    module.active_adapter = adapter_name
-                module.set_scale(adapter_name, get_module_weight(weight, module_name))
-
-    # set multiple active adapters
-    for module in model.modules():
+    # Iterate over modules once
+    for module_name, module in model.named_modules():
         if isinstance(module, BaseTunerLayer):
-            # For backward compatbility with previous PEFT versions
+            # For backward compatibility with previous PEFT versions, set multiple active adapters
             if hasattr(module, "set_adapter"):
                 module.set_adapter(adapter_names)
             else:
                 module.active_adapter = adapter_names
+
+            # Set the scaling weight for each adapter for this module
+            for adapter_name, weight in zip(adapter_names, weights):
+                module.set_scale(adapter_name, get_module_weight(weight, module_name))
 
 
 def check_peft_version(min_version: str) -> None:

--- a/src/diffusers/utils/peft_utils.py
+++ b/src/diffusers/utils/peft_utils.py
@@ -253,9 +253,10 @@ def set_weights_and_activate_adapters(model, adapter_names, weights):
         parts = module_name.split(".")
         # e.g. key = "down_blocks.1.attentions.0"
         key = f"{parts[0]}.{parts[1]}.attentions.{parts[3]}"
-        return weight_for_adapter.get(key, 1.0)
+        block_weight = weight_for_adapter.get(key, 1.0)
+        
+        return block_weight
 
-    # Iterate over modules once
     for module_name, module in model.named_modules():
         if isinstance(module, BaseTunerLayer):
             # For backward compatibility with previous PEFT versions, set multiple active adapters

--- a/src/diffusers/utils/peft_utils.py
+++ b/src/diffusers/utils/peft_utils.py
@@ -254,7 +254,7 @@ def set_weights_and_activate_adapters(model, adapter_names, weights):
         # e.g. key = "down_blocks.1.attentions.0"
         key = f"{parts[0]}.{parts[1]}.attentions.{parts[3]}"
         block_weight = weight_for_adapter.get(key, 1.0)
-        
+
         return block_weight
 
     for module_name, module in model.named_modules():


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

The previous code iterated through `model.named_modules()` **for each adapter**, which can be very costly when the number of adapters reaches hundreds.

I've slightly changed the logic to iterate over `model.named_modules()` **only once**, setting the adapters for each submodule within that pass.

I haven't run extensive qualitative tests yet, but in my local experiment (Flux with 150+ adapters 😅) this change is significantly faster.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- PEFT: @sayakpaul @BenjaminBossan

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
