### PR TITLE
[LoRA] restrict certain keys to be checked for peft config update.

### DIFF
--- a/src/diffusers/loaders/peft.py
+++ b/src/diffusers/loaders/peft.py
@@ -53,6 +53,7 @@ _SET_ADAPTER_SCALE_FN_MAPPING = {
     "LTXVideoTransformer3DModel": lambda model_cls, weights: weights,
     "SanaTransformer2DModel": lambda model_cls, weights: weights,
 }
+_NO_CONFIG_UPDATE_KEYS = ["to_k", "to_q", "to_v"]
 
 
 def _maybe_adjust_config(config):
@@ -67,6 +68,8 @@ def _maybe_adjust_config(config):
     original_r = config["r"]
 
     for key in list(rank_pattern.keys()):
+        if any(prefix in key for prefix in _NO_CONFIG_UPDATE_KEYS):
+            continue
         key_rank = rank_pattern[key]
 
         # try to detect ambiguity


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/diffusers/issues/10804

Code:

```py
import torch
from diffusers import FluxPipeline

pipe = FluxPipeline.from_pretrained(
    "black-forest-labs/FLUX.1-dev", torch_dtype=torch.bfloat16
).to("cuda")

pipe.load_lora_weights(
    "sayakpaul/different-lora-from-civitai", 
    weight_name="wow_details.safetensors", 
    adapter_name="wow_details"
)

prompt = "a tiny astronaut hatching from an egg on the moon"
out = pipe(
    prompt=prompt,
    guidance_scale=3.5,
    height=1024,
    width=1024,
    num_inference_steps=25,
).images[0]
out.save("image.png")
```