### PR TITLE
store activation cls instead of function

### DIFF
--- a/src/diffusers/models/activations.py
+++ b/src/diffusers/models/activations.py
@@ -24,12 +24,12 @@ from ..utils.import_utils import is_torch_npu_available, is_torch_version
 if is_torch_npu_available():
     import torch_npu
 
-ACTIVATION_FUNCTIONS = {
-    "swish": nn.SiLU(),
-    "silu": nn.SiLU(),
-    "mish": nn.Mish(),
-    "gelu": nn.GELU(),
-    "relu": nn.ReLU(),
+ACT2CLS = {
+    "swish": nn.SiLU,
+    "silu": nn.SiLU,
+    "mish": nn.Mish,
+    "gelu": nn.GELU,
+    "relu": nn.ReLU,
 }
 
 
@@ -44,11 +44,10 @@ def get_activation(act_fn: str) -> nn.Module:
     """
 
     act_fn = act_fn.lower()
-    if act_fn in ACTIVATION_FUNCTIONS:
-        return ACTIVATION_FUNCTIONS[act_fn]
+    if act_fn in ACT2CLS:
+        return ACT2CLS[act_fn]()
     else:
-        raise ValueError(f"Unsupported activation function: {act_fn}")
-
+        raise ValueError(f"activation function {act_fn} not found in ACT2FN mapping {list(ACT2CLS.keys())}")
 
 class FP32SiLU(nn.Module):
     r"""

--- a/src/diffusers/models/activations.py
+++ b/src/diffusers/models/activations.py
@@ -49,6 +49,7 @@ def get_activation(act_fn: str) -> nn.Module:
     else:
         raise ValueError(f"activation function {act_fn} not found in ACT2FN mapping {list(ACT2CLS.keys())}")
 
+
 class FP32SiLU(nn.Module):
     r"""
     SiLU activation function with input upcasted to torch.float32.


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/diffusers/pull/10822. The activations function were stored in a dict, so if we load a models with hooks that contains activation function then we load a new model without hooks, the new model still ends up with hooks on the activation layers. This is because the same activation were used. To fix the issue, we just need to make sure to instantiate from the class. 
