### PR TITLE
Add missing `isinstance` for arg checks in GGUFParameter

### DIFF
--- a/src/diffusers/quantizers/gguf/utils.py
+++ b/src/diffusers/quantizers/gguf/utils.py
@@ -418,7 +418,7 @@ class GGUFParameter(torch.nn.Parameter):
         # so that we preserve quant_type information
         quant_type = None
         for arg in args:
-            if isinstance(arg, list) and (arg[0], GGUFParameter):
+            if isinstance(arg, list) and isinstance(arg[0], GGUFParameter):
                 quant_type = arg[0].quant_type
                 break
             if isinstance(arg, GGUFParameter):


### PR DESCRIPTION
# What does this PR do?

Adds a missing isinstance check as part of getting torch.compile working with GGUFParameter (#10795)

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [X] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@DN6
