### PR TITLE
Fix the missing parentheses when calling is_torchao_available in quantization_config.py.

### DIFF
--- a/src/diffusers/quantizers/quantization_config.py
+++ b/src/diffusers/quantizers/quantization_config.py
@@ -47,7 +47,7 @@ class QuantizationMethod(str, Enum):
     TORCHAO = "torchao"
 
 
-if is_torchao_available:
+if is_torchao_available():
     from torchao.quantization.quant_primitives import MappingType
 
     class TorchAoJSONEncoder(json.JSONEncoder):


### PR DESCRIPTION
Missing parentheses when calling ```is_torchao_available()``` will result in an import error in systems without ```torchao```.