### PR TITLE
Fix for multi-GPU WAN inference

### DIFF
--- a/src/diffusers/models/transformers/transformer_wan.py
+++ b/src/diffusers/models/transformers/transformer_wan.py
@@ -441,6 +441,14 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
 
         # 5. Output norm, projection & unpatchify
         shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
+
+        # Move the shift and scale tensors to the same device as hidden_states.
+        # When using multi-GPU inference via accelerate these will be on the
+        # first device rather than the last device, which hidden_states ends up
+        # on.
+        shift = shift.to(hidden_states.device)
+        scale = scale.to(hidden_states.device)
+
         hidden_states = (self.norm_out(hidden_states.float()) * (1 + scale) + shift).type_as(hidden_states)
         hidden_states = self.proj_out(hidden_states)
 


### PR DESCRIPTION
When running on multiple GPUs, currently WAN will crash because the `shift` and `scale` parameters are GPU 0 while the `hidden_states` from the main blocks end up on the last GPU.

## `transformer_wan.py`
```py
       # shift and scale use parameters assigned to GPU 0
       shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
       hidden_states = (self.norm_out(hidden_states.float()) * (1 + scale) + shift).type_as(hidden_states)`
```

The fix is pretty simple -- ensure shift and scale are on the correct GPU by doing a `.to` to being them to the same device as `hidden_states`.

You can verify the bug by attempting to do inference with multiple GPUs and accelerate:

```py
model_id = "Wan-AI/Wan2.1-I2V-14B-720P-Diffusers"
transformer = WanTransformer3DModel.from_pretrained(model_id,
    torch_dtype=torch.bfloat16,
    subfolder="transformer",
    device_map="balanced",
    max_memory={0: "14GB", 1: "16GB", 2: "16GB", 3: "16GB", 4: "16GB"})
pipe = WanImageToVideoPipeline.from_pretrained(model_id,
    transformer=transformer,
    torch_dtype=torch.bfloat16)
```

This is the correct configuration to run WAN 14b on 5x 3090s in bfloat16.


## Who can review?
@yiyixuxu @DN6 
