### PR TITLE
Group offloading improvements

### DIFF
--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -83,7 +83,10 @@ class ModuleGroup:
 
         with context:
             for group_module in self.modules:
-                group_module.to(self.onload_device, non_blocking=self.non_blocking)
+                for param in group_module.parameters():
+                    param.data = param.data.to(self.onload_device, non_blocking=self.non_blocking)
+                for buffer in group_module.buffers():
+                    buffer.data = buffer.data.to(self.onload_device, non_blocking=self.non_blocking)
             if self.parameters is not None:
                 for param in self.parameters:
                     param.data = param.data.to(self.onload_device, non_blocking=self.non_blocking)
@@ -98,6 +101,12 @@ class ModuleGroup:
             for group_module in self.modules:
                 for param in group_module.parameters():
                     param.data = self.cpu_param_dict[param]
+            if self.parameters is not None:
+                for param in self.parameters:
+                    param.data = self.cpu_param_dict[param]
+            if self.buffers is not None:
+                for buffer in self.buffers:
+                    buffer.data = self.cpu_param_dict[buffer]
         else:
             for group_module in self.modules:
                 group_module.to(self.offload_device, non_blocking=self.non_blocking)
@@ -387,9 +396,7 @@ def _apply_group_offloading_block_level(
     # Create a pinned CPU parameter dict for async data transfer if streams are to be used
     cpu_param_dict = None
     if stream is not None:
-        for param in module.parameters():
-            param.data = param.data.cpu().pin_memory()
-        cpu_param_dict = {param: param.data for param in module.parameters()}
+        cpu_param_dict = _get_pinned_cpu_param_dict(module)
 
     # Create module groups for ModuleList and Sequential blocks
     modules_with_group_offloading = set()
@@ -486,9 +493,7 @@ def _apply_group_offloading_leaf_level(
     # Create a pinned CPU parameter dict for async data transfer if streams are to be used
     cpu_param_dict = None
     if stream is not None:
-        for param in module.parameters():
-            param.data = param.data.cpu().pin_memory()
-        cpu_param_dict = {param: param.data for param in module.parameters()}
+        cpu_param_dict = _get_pinned_cpu_param_dict(module)
 
     # Create module groups for leaf modules and apply group offloading hooks
     modules_with_group_offloading = set()
@@ -602,6 +607,17 @@ def _apply_lazy_group_offloading_hook(
 
     lazy_prefetch_hook = LazyPrefetchGroupOffloadingHook()
     registry.register_hook(lazy_prefetch_hook, _LAZY_PREFETCH_GROUP_OFFLOADING)
+
+
+def _get_pinned_cpu_param_dict(module: torch.nn.Module) -> Dict[torch.nn.Parameter, torch.Tensor]:
+    cpu_param_dict = {}
+    for param in module.parameters():
+        param.data = param.data.cpu().pin_memory()
+        cpu_param_dict[param] = param.data
+    for buffer in module.buffers():
+        buffer.data = buffer.data.cpu().pin_memory()
+        cpu_param_dict[buffer] = buffer.data
+    return cpu_param_dict
 
 
 def _gather_parameters_with_no_group_offloading_parent(


### PR DESCRIPTION
To understand the issue firstly, here's the output of running Wan T2V with group offloading on 1-frame:

<details>
<summary> code </summary>

```python
import torch
from diffusers import AutoencoderKLWan, WanPipeline, UniPCMultistepScheduler
from diffusers.hooks import apply_group_offloading
from diffusers.utils import export_to_video
from diffusers.utils.logging import set_verbosity_debug

set_verbosity_debug()

# Available models: Wan-AI/Wan2.1-T2V-14B, Wan-AI/Wan2.1-T2V-1.3B
model_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
scheduler = UniPCMultistepScheduler(num_train_timesteps=1000, prediction_type="flow_prediction", use_flow_sigmas=True, flow_shift=3.0)
vae = AutoencoderKLWan.from_pretrained(model_id, subfolder="vae", torch_dtype=torch.float32)
pipe = WanPipeline.from_pretrained(model_id, vae=vae, torch_dtype=torch.bfloat16)

onload_device = torch.device("cuda")
offload_device = torch.device("cpu")

pipe.text_encoder.to(onload_device)
pipe.vae.to(onload_device)
apply_group_offloading(
    pipe.transformer,
    onload_device=onload_device,
    offload_device=offload_device,
    offload_type="block_level",
    num_blocks_per_group=1,
    use_stream=True,
)

prompt = "A cat walks on the grass, realistic"
negative_prompt = negative_prompt = "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"

output = pipe(
    prompt=prompt,
    negative_prompt=negative_prompt,
    height=480,
    width=832,
    num_frames=1,
    guidance_scale=5.0,
    num_inference_steps=30,
    generator=torch.Generator().manual_seed(42),
).frames[0]
export_to_video(output, "output.mp4", fps=15)
```
</details>

<table align=center>
<tr>
  <th> block_level=1 without cuda stream </th>
  <th> block_level=1 with cuda stream </th>
  <th> leaf_level with cuda stream </th>
</tr>
<tr>
  <td align=center><video src="https://github.com/user-attachments/assets/24b27cbd-339c-4d7e-bb84-84f926c78afc"> Your browser does not support the video tag. </video></td>
  <td align=center><video src="https://github.com/user-attachments/assets/eb05f8f3-c98c-4b41-a641-594c5cd3f980"> Your browser does not support the video tag. </video></td>
  <td align=center><video src="https://github.com/user-attachments/assets/9410afd2-8138-4ea3-9602-b761c303d1bd"> Your browser does not support the video tag. </video></td>
</tr>
</table>
<sup>leaf_level without cuda stream has output same as block_level=1 without cuda stream</sup>

This does not happen always, and is happening completely randomly based on different height/width/num_frames but I could consistently reproduce with num_frames=1 on DGX. I tried going back to #10503 and running my benchmark to see if the results were poor then too (they were not at the time of merge), but they were completely fine. So, I believe problematic outputs are dependent on the amount of computation time vs data transfer time required. The computation time is dependent on the generation parameters like height/width/num_frames, while the data transfer time is dependent on model sizes -- both factors may have contributed to the quality degradation in certain cases.

Not quite sure why, but moving modules with `nn::Module::to` with the non-default stream does not seem to be actually using it. Going back to the [cuda semantics docs](https://pytorch.org/docs/stable/notes/cuda.html#cuda-streams), it only mentions about moving tensors on non-default streams. So, I've updated our implementation to just move tensors around, and the outputs now match exactly.

The second problem is black outputs due to bfloat16 overflowing in certain cases (randomly based on generatino parameters, but does not occur with every model consistently). I'm still looking into this