### PR TITLE
Resolve stride mismatch in UNet's ResNet to support Torch DDP

### DIFF
--- a/src/diffusers/models/resnet.py
+++ b/src/diffusers/models/resnet.py
@@ -366,7 +366,7 @@ class ResnetBlock2D(nn.Module):
         hidden_states = self.conv2(hidden_states)
 
         if self.conv_shortcut is not None:
-            input_tensor = self.conv_shortcut(input_tensor)
+            input_tensor = self.conv_shortcut(input_tensor.contiguous())
 
         output_tensor = (input_tensor + hidden_states) / self.output_scale_factor
 


### PR DESCRIPTION
Fixes https://github.com/huggingface/diffusers/issues/11083

explanation:
When using Torch's distributed training, the Diffusers code will display a "stride mismatch" warning. Simply adding `.contiguous()` in the code can resolve this issue.