### PR TITLE
Fix LatteTransformer3DModel dtype mismatch with enable_temporal_attentions

### DIFF
--- a/src/diffusers/models/transformers/latte_transformer_3d.py
+++ b/src/diffusers/models/transformers/latte_transformer_3d.py
@@ -273,7 +273,7 @@ class LatteTransformer3DModel(ModelMixin, ConfigMixin, CacheMixin):
                 hidden_states = hidden_states.reshape(-1, hidden_states.shape[-2], hidden_states.shape[-1])
 
                 if i == 0 and num_frame > 1:
-                    hidden_states = hidden_states + self.temp_pos_embed
+                    hidden_states = hidden_states + self.temp_pos_embed.to(hidden_states.dtype)
 
                 if torch.is_grad_enabled() and self.gradient_checkpointing:
                     hidden_states = self._gradient_checkpointing_func(


### PR DESCRIPTION
# What does this PR do?

`temp_pos_embed` is in `float32`, `hidden_states` is in the appropriate dtype before `hidden_states = hidden_states + self.temp_pos_embed` then it becomes `float32`. `temp_pos_embed` is cast to `hidden_states.dtype` instead.

Fixes #11137


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
