### PR TITLE
Hunyuan Video adjustments

### DIFF
--- a/src/diffusers/pipelines/hunyuan_video/pipeline_hunyuan_skyreels_image2video.py
+++ b/src/diffusers/pipelines/hunyuan_video/pipeline_hunyuan_skyreels_image2video.py
@@ -139,11 +139,14 @@ def retrieve_timesteps(
     elif sigmas is not None:
         accept_sigmas = "sigmas" in set(inspect.signature(scheduler.set_timesteps).parameters.keys())
         if not accept_sigmas:
-            raise ValueError(
+            print(
                 f"The current scheduler class {scheduler.__class__}'s `set_timesteps` does not support custom"
-                f" sigmas schedules. Please check whether you are using the correct scheduler."
+                f" sigmas schedules. Please check whether you are using the correct scheduler. The pipeline"
+                f" will continue without setting sigma values"
             )
-        scheduler.set_timesteps(sigmas=sigmas, device=device, **kwargs)
+            scheduler.set_timesteps(num_inference_steps, device=device)
+        else:
+            scheduler.set_timesteps(sigmas=sigmas, device=device, **kwargs)
         timesteps = scheduler.timesteps
         num_inference_steps = len(timesteps)
     else:

--- a/src/diffusers/pipelines/hunyuan_video/pipeline_hunyuan_video.py
+++ b/src/diffusers/pipelines/hunyuan_video/pipeline_hunyuan_video.py
@@ -128,11 +128,14 @@ def retrieve_timesteps(
     elif sigmas is not None:
         accept_sigmas = "sigmas" in set(inspect.signature(scheduler.set_timesteps).parameters.keys())
         if not accept_sigmas:
-            raise ValueError(
+            print(
                 f"The current scheduler class {scheduler.__class__}'s `set_timesteps` does not support custom"
-                f" sigmas schedules. Please check whether you are using the correct scheduler."
+                f" sigmas schedules. Please check whether you are using the correct scheduler. The pipeline"
+                f" will continue without setting sigma values"
             )
-        scheduler.set_timesteps(sigmas=sigmas, device=device, **kwargs)
+            scheduler.set_timesteps(num_inference_steps, device=device)
+        else:
+            scheduler.set_timesteps(sigmas=sigmas, device=device, **kwargs)
         timesteps = scheduler.timesteps
         num_inference_steps = len(timesteps)
     else:

--- a/src/diffusers/pipelines/hunyuan_video/pipeline_hunyuan_video_image2video.py
+++ b/src/diffusers/pipelines/hunyuan_video/pipeline_hunyuan_video_image2video.py
@@ -141,11 +141,14 @@ def retrieve_timesteps(
     elif sigmas is not None:
         accept_sigmas = "sigmas" in set(inspect.signature(scheduler.set_timesteps).parameters.keys())
         if not accept_sigmas:
-            raise ValueError(
+            print(
                 f"The current scheduler class {scheduler.__class__}'s `set_timesteps` does not support custom"
-                f" sigmas schedules. Please check whether you are using the correct scheduler."
+                f" sigmas schedules. Please check whether you are using the correct scheduler. The pipeline"
+                f" will continue without setting sigma values"
             )
-        scheduler.set_timesteps(sigmas=sigmas, device=device, **kwargs)
+            scheduler.set_timesteps(num_inference_steps, device=device)
+        else:
+            scheduler.set_timesteps(sigmas=sigmas, device=device, **kwargs)
         timesteps = scheduler.timesteps
         num_inference_steps = len(timesteps)
     else:


### PR DESCRIPTION
# What does this PR do?

Two things

The STG Hunyuan Video community pipeline had a typo where the forward methods were being replaced within the denoising loop. This also caused callback_on_step_end to return with the last index in the stg index list since the variable used to iterate over the forward methods was also `i`. This only seemed to appear in the HunyuanVideo stg pipeline but I may have missed something.

`UniPCMultistepScheduler(prediction_type="flow_prediction", use_flow_sigmas=True, flow_shift=shift)` works for HunyuanVideo but errors out with the current behavior. This changes that to instead just warn the user (there may be a cleaner way of doing this)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@yiyixuxu @asomoza 
