### PR TITLE
Raise warning and round down if Wan num_frames is not 4k + 1

### DIFF
--- a/src/diffusers/pipelines/wan/pipeline_wan.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan.py
@@ -265,12 +265,15 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         negative_prompt,
         height,
         width,
+        num_frames,
         prompt_embeds=None,
         negative_prompt_embeds=None,
         callback_on_step_end_tensor_inputs=None,
     ):
         if height % 16 != 0 or width % 16 != 0:
             raise ValueError(f"`height` and `width` have to be divisible by 16 but are {height} and {width}.")
+        if num_frames % 4 != 1:
+            raise ValueError("`num_frames` must be of the form 4 * k + 1, for k >= 0")
 
         if callback_on_step_end_tensor_inputs is not None and not all(
             k in self._callback_tensor_inputs for k in callback_on_step_end_tensor_inputs
@@ -453,6 +456,7 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             negative_prompt,
             height,
             width,
+            num_frames,
             prompt_embeds,
             negative_prompt_embeds,
             callback_on_step_end_tensor_inputs,

--- a/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
@@ -319,7 +319,6 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         image,
         height,
         width,
-        num_frames,
         prompt_embeds=None,
         negative_prompt_embeds=None,
         callback_on_step_end_tensor_inputs=None,
@@ -328,8 +327,6 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             raise ValueError("`image` has to be of type `torch.Tensor` or `PIL.Image.Image` but is" f" {type(image)}")
         if height % 16 != 0 or width % 16 != 0:
             raise ValueError(f"`height` and `width` have to be divisible by 16 but are {height} and {width}.")
-        if num_frames % 4 != 1:
-            raise ValueError("`num_frames` must be of the form 4 * k + 1, for k >= 0")
 
         if callback_on_step_end_tensor_inputs is not None and not all(
             k in self._callback_tensor_inputs for k in callback_on_step_end_tensor_inputs
@@ -557,11 +554,17 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             image,
             height,
             width,
-            num_frames,
             prompt_embeds,
             negative_prompt_embeds,
             callback_on_step_end_tensor_inputs,
         )
+
+        if num_frames % self.vae_scale_factor_temporal != 1:
+            logger.warning(
+                f"`num_frames - 1` has to be divisible by {self.vae_scale_factor_temporal}. Rounding to the nearest number."
+            )
+            num_frames = num_frames // self.vae_scale_factor_temporal * self.vae_scale_factor_temporal + 1
+        num_frames = max(num_frames, 1)
 
         self._guidance_scale = guidance_scale
         self._attention_kwargs = attention_kwargs

--- a/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
@@ -319,6 +319,7 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         image,
         height,
         width,
+        num_frames,
         prompt_embeds=None,
         negative_prompt_embeds=None,
         callback_on_step_end_tensor_inputs=None,
@@ -327,6 +328,8 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             raise ValueError("`image` has to be of type `torch.Tensor` or `PIL.Image.Image` but is" f" {type(image)}")
         if height % 16 != 0 or width % 16 != 0:
             raise ValueError(f"`height` and `width` have to be divisible by 16 but are {height} and {width}.")
+        if num_frames % 4 != 1:
+            raise ValueError("`num_frames` must be of the form 4 * k + 1, for k >= 0")
 
         if callback_on_step_end_tensor_inputs is not None and not all(
             k in self._callback_tensor_inputs for k in callback_on_step_end_tensor_inputs
@@ -554,6 +557,7 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             image,
             height,
             width,
+            num_frames,
             prompt_embeds,
             negative_prompt_embeds,
             callback_on_step_end_tensor_inputs,


### PR DESCRIPTION
Fixes #11163.

Raises a warning if the number of frames to be generated is not a multiple of 4K + 1. The reason for it being that way is because the VAE applies a 4x temporal downscaling/upscaling and the latents are created respecting that.

It is mentioned in the [docs](https://github.com/huggingface/diffusers/blob/617c208bb4cc68fe4518164fee7cbdf5aa44ff78/docs/source/en/api/pipelines/wan.md?plain=1#L408).