### PR TITLE
[tests] no hard-coded cuda 

### DIFF
--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -312,7 +312,7 @@ class BnB8bitBasicTests(Base8bitTests):
         _ = self.model_fp16.float()
 
         # Check that this does not throw an error
-        _ = self.model_fp16.cuda()
+        _ = self.model_fp16.to(torch_device)
 
 
 class Bnb8bitDeviceTests(Base8bitTests):


### PR DESCRIPTION
## What does this PR do?
As the title suggest, this PR enables the case to run on XPU. test tesult is shown as below:

```bash
PASSED tests/quantization/bnb/test_mixed_int8.py::BnB8bitBasicTests::test_device_and_dtype_assignment
```

cc @hlky 
