### PR TITLE
fix: for checking mandatory and optional pipeline components

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -998,7 +998,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             for module in missing_modules:
                 init_kwargs[module] = passed_class_obj.get(module, None)
         elif len(missing_modules) > 0:
-            passed_modules = set(list(init_kwargs.keys()) + list(passed_class_obj.keys())) - optional_kwargs
+            passed_modules = set(list(init_kwargs.keys()) + list(passed_class_obj.keys())) - set(optional_kwargs)
             raise ValueError(
                 f"Pipeline {pipeline_class} expected {expected_modules}, but only {passed_modules} were passed."
             )


### PR DESCRIPTION
# What does this PR do?

This PR correct the verification of mandatory and optional pipeline components. Currently, if a mandatory component is not informed, an exception is generated due to an operation on incompatible types. The adjustment matches the type of the list of optional components so that the operation is executed correctly and the correct treatment is given to the user.

## Expected:
```
Pipeline <class 'diffusers.pipelines.controlnet.pipeline_controlnet_sd_xl.StableDiffusionXLControlNetPipeline'> expected ['controlnet', 'feature_extractor', 'image_encoder', 'scheduler', 'text_encoder', 'text_encoder_2', 'tokenizer', 'tokenizer_2', 'unet', 'vae'], but only {'tokenizer_2', 'scheduler', 'tokenizer', 'text_encoder', 'vae', 'text_encoder_2', 'unet'} were passed.
  File "/mnt/f/projetos/diffusers/src/diffusers/pipelines/pipeline_utils.py", line 1002, in from_pretrained
    raise ValueError(
  File "/mnt/f/Projetos/diffusers/venv/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "/mnt/f/Projetos/diffusers/lang_code_data/test_verification_components.py", line 4, in <module>
    pipe = StableDiffusionXLControlNetPipeline.from_pretrained("SG161222/RealVisXL_V4.0",
  File "/home/master/miniconda3/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/master/miniconda3/lib/python3.10/runpy.py", line 196, in _run_module_as_main (Current frame)
    return _run_code(code, main_globals, None,
ValueError: Pipeline <class 'diffusers.pipelines.controlnet.pipeline_controlnet_sd_xl.StableDiffusionXLControlNetPipeline'> expected ['controlnet', 'feature_extractor', 'image_encoder', 'scheduler', 'text_encoder', 'text_encoder_2', 'tokenizer', 'tokenizer_2', 'unet', 'vae'], but only {'tokenizer_2', 'scheduler', 'tokenizer', 'text_encoder', 'vae', 'text_encoder_2', 'unet'} were passed.
```

## Current error:
```
Exception has occurred: TypeError       (note: full exception trace is shown but execution is paused at: _run_module_as_main)
unsupported operand type(s) for -: 'set' and 'list'
  File "/mnt/f/projetos/diffusers/src/diffusers/pipelines/pipeline_utils.py", line 1001, in from_pretrained
    passed_modules = set(list(init_kwargs.keys()) + list(passed_class_obj.keys())) - optional_kwargs
  File "/mnt/f/Projetos/diffusers/venv/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "/mnt/f/Projetos/diffusers/lang_code_data/test_verification_components.py", line 4, in <module>
    pipe = StableDiffusionXLControlNetPipeline.from_pretrained("SG161222/RealVisXL_V4.0",
  File "/home/master/miniconda3/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/master/miniconda3/lib/python3.10/runpy.py", line 196, in _run_module_as_main (Current frame)
    return _run_code(code, main_globals, None,
TypeError: unsupported operand type(s) for -: 'set' and 'list'
```

## Error simulation:
```py
import torch
from diffusers import StableDiffusionXLControlNetPipeline

pipe = StableDiffusionXLControlNetPipeline.from_pretrained("SG161222/RealVisXL_V4.0", 
                                                            torch_dtype=torch.float16,                                                            
                                                            use_safetensors=True,
                                                            variant="fp16")
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@asomoza @yiyixuxu 
