### PR TITLE
map BACKEND_RESET_MAX_MEMORY_ALLOCATED to reset_peak_memory_stats on XPU

### DIFF
--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -1161,7 +1161,7 @@ if is_torch_available():
     }
     BACKEND_RESET_MAX_MEMORY_ALLOCATED = {
         "cuda": torch.cuda.reset_max_memory_allocated,
-        "xpu": None,
+        "xpu": getattr(torch.xpu, "reset_peak_memory_stats", None),
         "cpu": None,
         "mps": None,
         "default": None,


### PR DESCRIPTION
**why do this**
In CUDA implementation,  `reset_max_memory_allocated` is directly routed to `reset_peak_memory_stats` implicitly, as in code https://github.com/pytorch/pytorch/blob/main/torch/cuda/memory.py#L471. So, for pytorch xpu, we didn't implement `reset_max_memory_allocated` and suggest users to directly use `reset_peak_memory_stats` explicitly. 
