### PR TITLE
Revert `save_model` in ModelMixin save_pretrained and use safe_serialization=False in test

### DIFF
--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -714,10 +714,7 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
             if safe_serialization:
                 # At some point we will need to deal better with save_function (used for TPU and other distributed
                 # joyfulness), but for now this enough.
-                try:
-                    safetensors.torch.save_file(shard, filepath, metadata={"format": "pt"})
-                except RuntimeError:
-                    safetensors.torch.save_model(model_to_save, filepath, metadata={"format": "pt"})
+                safetensors.torch.save_file(shard, filepath, metadata={"format": "pt"})
             else:
                 torch.save(shard, filepath)
 

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -2293,7 +2293,7 @@ class PipelineTesterMixin:
         specified_key = next(iter(components.keys()))
 
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
-            pipe.save_pretrained(tmpdirname)
+            pipe.save_pretrained(tmpdirname, safe_serialization=False)
             torch_dtype_dict = {specified_key: torch.bfloat16, "default": torch.float16}
             loaded_pipe = self.pipeline_class.from_pretrained(tmpdirname, torch_dtype=torch_dtype_dict)
 


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/diffusers/pull/10301/files/8f713111acff4361605df037f576cf6a97a09567#diff-6a3b9a08c1d37dbc341131632415fea800af242a84fb31f1bcd40d725e2eeeeb


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

