### PR TITLE
Guiders support for Wan

### DIFF
--- a/src/diffusers/hooks/_helpers.py
+++ b/src/diffusers/hooks/_helpers.py
@@ -30,7 +30,7 @@ from ..models.transformers.transformer_hunyuan_video import (
 )
 from ..models.transformers.transformer_ltx import LTXVideoTransformerBlock
 from ..models.transformers.transformer_mochi import MochiTransformerBlock
-from ..models.transformers.transformer_wan import WanAttnProcessor2_0, WanPAGAttnProcessor2_0, WanTransformerBlock
+from ..models.transformers.transformer_wan import WanTransformerBlock
 
 
 @dataclass
@@ -228,14 +228,6 @@ def _skip_attention___ret___hidden_states___encoder_hidden_states(self, *args, *
 
 
 _skip_proc_output_fn_Attention_CogView4AttnProcessor = _skip_attention___ret___hidden_states___encoder_hidden_states
-
-    # Wan
-    GuidanceMetadataRegistry.register(
-        model_class=WanAttnProcessor2_0,
-        metadata=GuidanceMetadata(
-            perturbed_attention_guidance_processor_cls=WanPAGAttnProcessor2_0,
-        ),
-    )
 
 
 def _skip_block_output_fn___hidden_states_0___ret___hidden_states(self, *args, **kwargs):

--- a/src/diffusers/hooks/_helpers.py
+++ b/src/diffusers/hooks/_helpers.py
@@ -30,7 +30,7 @@ from ..models.transformers.transformer_hunyuan_video import (
 )
 from ..models.transformers.transformer_ltx import LTXVideoTransformerBlock
 from ..models.transformers.transformer_mochi import MochiTransformerBlock
-from ..models.transformers.transformer_wan import WanTransformerBlock
+from ..models.transformers.transformer_wan import WanAttnProcessor2_0, WanPAGAttnProcessor2_0, WanTransformerBlock
 
 
 @dataclass
@@ -183,6 +183,14 @@ def _register_guidance_metadata():
         model_class=CogView4AttnProcessor,
         metadata=GuidanceMetadata(
             perturbed_attention_guidance_processor_cls=CogView4PAGAttnProcessor,
+        ),
+    )
+
+    # Wan
+    GuidanceMetadataRegistry.register(
+        model_class=WanAttnProcessor2_0,
+        metadata=GuidanceMetadata(
+            perturbed_attention_guidance_processor_cls=WanPAGAttnProcessor2_0,
         ),
     )
 

--- a/src/diffusers/hooks/_helpers.py
+++ b/src/diffusers/hooks/_helpers.py
@@ -30,7 +30,7 @@ from ..models.transformers.transformer_hunyuan_video import (
 )
 from ..models.transformers.transformer_ltx import LTXVideoTransformerBlock
 from ..models.transformers.transformer_mochi import MochiTransformerBlock
-from ..models.transformers.transformer_wan import WanTransformerBlock
+from ..models.transformers.transformer_wan import WanAttnProcessor2_0, WanPAGAttnProcessor2_0, WanTransformerBlock
 
 
 @dataclass
@@ -101,6 +101,14 @@ def _register_attention_processors_metadata():
         ),
     )
 
+    # Wan
+    AttentionProcessorRegistry.register(
+        model_class=WanAttnProcessor2_0,
+        metadata=AttentionProcessorMetadata(
+            skip_processor_output_fn=_skip_proc_output_fn_Attention_WanAttnProcessor,
+        ),
+    )
+
 
 def _register_guidance_metadata():
     # CogView4
@@ -108,6 +116,14 @@ def _register_guidance_metadata():
         model_class=CogView4AttnProcessor,
         metadata=GuidanceMetadata(
             perturbed_attention_guidance_processor_cls=CogView4PAGAttnProcessor,
+        ),
+    )
+
+    # Wan
+    GuidanceMetadataRegistry.register(
+        model_class=WanAttnProcessor2_0,
+        metadata=GuidanceMetadata(
+            perturbed_attention_guidance_processor_cls=WanPAGAttnProcessor2_0,
         ),
     )
 
@@ -217,6 +233,13 @@ def _register_transformer_blocks_metadata():
 
 
 # fmt: off
+def _skip_attention___ret___hidden_states(self, *args, **kwargs):
+    hidden_states = kwargs.get("hidden_states", None)
+    if hidden_states is None and len(args) > 0:
+        hidden_states = args[0]
+    return hidden_states
+
+
 def _skip_attention___ret___hidden_states___encoder_hidden_states(self, *args, **kwargs):
     hidden_states = kwargs.get("hidden_states", None)
     encoder_hidden_states = kwargs.get("encoder_hidden_states", None)
@@ -228,6 +251,7 @@ def _skip_attention___ret___hidden_states___encoder_hidden_states(self, *args, *
 
 
 _skip_proc_output_fn_Attention_CogView4AttnProcessor = _skip_attention___ret___hidden_states___encoder_hidden_states
+_skip_proc_output_fn_Attention_WanAttnProcessor = _skip_attention___ret___hidden_states
 
 
 def _skip_block_output_fn___hidden_states_0___ret___hidden_states(self, *args, **kwargs):

--- a/src/diffusers/models/transformers/transformer_wan.py
+++ b/src/diffusers/models/transformers/transformer_wan.py
@@ -537,7 +537,7 @@ class WanPAGAttnProcessor2_0:
                 query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
             )
         else:
-            # Perturbed attention applied only when self-attention
+            # Perturbed attention applied only to self-attention path
             hidden_states = value
 
         hidden_states = hidden_states.transpose(1, 2).flatten(2, 3)

--- a/src/diffusers/models/transformers/transformer_wan.py
+++ b/src/diffusers/models/transformers/transformer_wan.py
@@ -467,3 +467,85 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
             return (output,)
 
         return Transformer2DModelOutput(sample=output)
+
+
+### ===== Custom attention processors for guidance methods ===== ###
+
+
+class WanPAGAttnProcessor2_0:
+    def __init__(self):
+        if not hasattr(F, "scaled_dot_product_attention"):
+            raise ImportError("WanAttnProcessor2_0 requires PyTorch 2.0. To use it, please upgrade PyTorch to 2.0.")
+
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        rotary_emb: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        is_encoder_hidden_states_provided = encoder_hidden_states is not None
+        encoder_hidden_states_img = None
+        if attn.add_k_proj is not None:
+            encoder_hidden_states_img = encoder_hidden_states[:, :257]
+            encoder_hidden_states = encoder_hidden_states[:, 257:]
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+
+        query = attn.to_q(hidden_states)
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
+        query = query.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+        key = key.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+        value = value.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+
+        if rotary_emb is not None:
+
+            def apply_rotary_emb(hidden_states: torch.Tensor, freqs: torch.Tensor):
+                x_rotated = torch.view_as_complex(hidden_states.to(torch.float64).unflatten(3, (-1, 2)))
+                x_out = torch.view_as_real(x_rotated * freqs).flatten(3, 4)
+                return x_out.type_as(hidden_states)
+
+            query = apply_rotary_emb(query, rotary_emb)
+            key = apply_rotary_emb(key, rotary_emb)
+
+        # I2V task
+        hidden_states_img = None
+        if encoder_hidden_states_img is not None:
+            key_img = attn.add_k_proj(encoder_hidden_states_img)
+            key_img = attn.norm_added_k(key_img)
+            value_img = attn.add_v_proj(encoder_hidden_states_img)
+
+            key_img = key_img.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+            value_img = value_img.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+
+            hidden_states_img = F.scaled_dot_product_attention(
+                query, key_img, value_img, attn_mask=None, dropout_p=0.0, is_causal=False
+            )
+            hidden_states_img = hidden_states_img.transpose(1, 2).flatten(2, 3)
+            hidden_states_img = hidden_states_img.type_as(query)
+
+        if is_encoder_hidden_states_provided:
+            hidden_states = F.scaled_dot_product_attention(
+                query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+            )
+        else:
+            # Perturbed attention applied only when self-attention
+            hidden_states = value
+
+        hidden_states = hidden_states.transpose(1, 2).flatten(2, 3)
+        hidden_states = hidden_states.type_as(query)
+
+        if hidden_states_img is not None:
+            hidden_states = hidden_states + hidden_states_img
+
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+        return hidden_states

--- a/src/diffusers/pipelines/cogview4/pipeline_cogview4.py
+++ b/src/diffusers/pipelines/cogview4/pipeline_cogview4.py
@@ -617,7 +617,7 @@ class CogView4Pipeline(DiffusionPipeline, CogView4LoraLoaderMixin):
         num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
 
         conds = [prompt_embeds, negative_prompt_embeds, original_size, target_size, crops_coords_top_left]
-        prompt_embeds, negative_prompt_embeds, original_size, target_size, crops_coords_top_left = [[v] for v in conds]
+        prompt_embeds, negative_prompt_embeds, original_size, target_size, crops_coords_top_left = [[c] for c in conds]
 
         with self.progress_bar(total=num_inference_steps) as progress_bar, self.transformer._cache_context() as cc:
             for i, t in enumerate(timesteps):


### PR DESCRIPTION
This PR shows the changes required to make existing pipelines compatible with guiders.

Example results with Wan 1.3B:

<table align=center>
<tr>
  <th align=center colspan=5>Guidance methods</th>
</tr>
<tr>
  <th align=center>APG</th>
  <th align=center>CFG</th>
  <th align=center>CFG-Zero*</th>
  <th align=center>PAG</th>
  <th align=center>SLG</th>
</tr>
<tr>
  <td align=center><video src="https://github.com/user-attachments/assets/4526740f-f34a-4af6-bfcc-fa04732b1a8b"> Your browser does not support the video tag. </video></td>
  <td align=center><video src="https://github.com/user-attachments/assets/cb888ea3-a634-4f68-954e-dc5697990d74"> Your browser does not support the video tag. </video></td>
  <td align=center><video src="https://github.com/user-attachments/assets/a3f5e219-a318-438e-a4cb-cb117c8350c0"> Your browser does not support the video tag. </video></td>
  <td align=center><video src="https://github.com/user-attachments/assets/997b95e7-c0c6-4283-8a21-614e7ea32a5e"> Your browser does not support the video tag. </video></td>
  <td align=center><video src="https://github.com/user-attachments/assets/e0d9697d-ef9c-439e-b7fb-e63a94435ef1"> Your browser does not support the video tag. </video></td>
</tr>
</table>
<sup><i>A frog doing his taxes while he sits on a swing!</i></sup>

<details>
<summary> code </summary>

```python
import argparse
from pathlib import Path

import torch
from diffusers import AutoencoderKLWan, WanPipeline
from diffusers.hooks import apply_first_block_cache, FirstBlockCacheConfig
from diffusers.guiders import AdaptiveProjectedGuidance
from diffusers.guiders import ClassifierFreeGuidance
from diffusers.guiders import ClassifierFreeZeroStarGuidance
from diffusers.guiders import PerturbedAttentionGuidance
from diffusers.guiders import SkipLayerGuidance
from diffusers.hooks import LayerSkipConfig
from diffusers.utils import export_to_video


def main(args):
    output_dir = Path(args.output_dir)
    output_dir.mkdir(parents=True, exist_ok=True)
    
    model_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
    vae = AutoencoderKLWan.from_pretrained(model_id, subfolder="vae", torch_dtype=torch.float32)
    pipe = WanPipeline.from_pretrained(model_id, vae=vae, torch_dtype=torch.bfloat16)
    pipe.to("cuda")

    if args.cache_threshold is not None:
        pipe.transformer.enable_cache(FirstBlockCacheConfig(threshold=args.cache_threshold))

    cfg = ClassifierFreeGuidance(guidance_scale=5.0)

    slg = SkipLayerGuidance(
        guidance_scale=4.0,
        skip_layer_guidance_scale=2.0,
        skip_layer_guidance_start=0.01,
        skip_layer_guidance_stop=0.2,
        skip_layer_config=LayerSkipConfig(indices=[11, 16]),
    )

    cfgz = ClassifierFreeZeroStarGuidance(
        guidance_scale=5.0,
        zero_init_steps=1,
    )

    apg = AdaptiveProjectedGuidance(
        guidance_scale=12.0,
        adaptive_projected_guidance_momentum=0.2,
        adaptive_projected_guidance_rescale=15.0,
        eta=1.0,
        guidance_rescale=0.0,
        use_original_formulation=False,
    )

    pag = PerturbedAttentionGuidance(
        pag_applied_layers="blocks.11",
        guidance_scale=4.0,
        pag_scale=1.5,
    )

    prompt = "A frog doing his taxes while he sits on a swing!"
    negative_prompt = "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"

    cfg_methods = [cfg, slg, cfgz, apg, pag]

    for guidance in cfg_methods:
        video = pipe(prompt=prompt, negative_prompt=negative_prompt, guidance=guidance, generator=torch.Generator().manual_seed(42)).frames[0]
        if args.cache_threshold is not None:
            output_path = output_dir / f"{guidance.__class__.__name__}_cache_threshold_{args.cache_threshold:.3f}.mp4"
        else:
            output_path = output_dir / f"{guidance.__class__.__name__}.mp4"
        export_to_video(video, output_path, fps=16)


def get_args():
    parser = argparse.ArgumentParser()
    parser.add_argument("--output_dir", type=str, default="basic_comparison_wan")
    parser.add_argument("--cache_threshold", type=float, default=None)
    return parser.parse_args()


if __name__ == "__main__":
    args = get_args()
    main(args)
```
</details>