### PR TITLE
Use `ignore_cleanup_errors=True` in `TemporaryDirectory` for Windows compatibility

### DIFF
--- a/examples/advanced_diffusion_training/test_dreambooth_lora_flux_advanced.py
+++ b/examples/advanced_diffusion_training/test_dreambooth_lora_flux_advanced.py
@@ -16,9 +16,10 @@
 import logging
 import os
 import sys
-import tempfile
 
 import safetensors
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -39,7 +40,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
     script_path = "examples/advanced_diffusion_training/train_dreambooth_lora_flux_advanced.py"
 
     def test_dreambooth_lora_flux(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -71,7 +72,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_text_encoder_flux(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -104,7 +105,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_expected_prefix)
 
     def test_dreambooth_lora_pivotal_tuning_flux_clip(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -146,7 +147,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_pivotal_tuning_flux_clip_t5(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -189,7 +190,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_latent_caching(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -222,7 +223,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_flux_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -245,7 +246,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_flux_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/advanced_diffusion_training/test_dreambooth_lora_flux_advanced.py
+++ b/examples/advanced_diffusion_training/test_dreambooth_lora_flux_advanced.py
@@ -39,7 +39,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
     script_path = "examples/advanced_diffusion_training/train_dreambooth_lora_flux_advanced.py"
 
     def test_dreambooth_lora_flux(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -71,7 +71,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_text_encoder_flux(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -104,7 +104,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_expected_prefix)
 
     def test_dreambooth_lora_pivotal_tuning_flux_clip(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -146,7 +146,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_pivotal_tuning_flux_clip_t5(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -189,7 +189,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_latent_caching(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -222,7 +222,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_flux_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -245,7 +245,7 @@ class DreamBoothLoRAFluxAdvanced(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_flux_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/community/sde_drag.py
+++ b/examples/community/sde_drag.py
@@ -1,5 +1,4 @@
 import math
-import tempfile
 from typing import List, Optional
 
 import numpy as np
@@ -21,6 +20,7 @@ from diffusers.models.attention_processor import (
     SlicedAttnAddedKVProcessor,
 )
 from diffusers.optimization import get_scheduler
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 class SdeDragPipeline(DiffusionPipeline):
@@ -320,7 +320,7 @@ class SdeDragPipeline(DiffusionPipeline):
             lr_scheduler.step()
             optimizer.zero_grad()
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as save_lora_dir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as save_lora_dir:
             StableDiffusionLoraLoaderMixin.save_lora_weights(
                 save_directory=save_lora_dir,
                 unet_lora_layers=unet_lora_layers,

--- a/examples/community/sde_drag.py
+++ b/examples/community/sde_drag.py
@@ -320,7 +320,7 @@ class SdeDragPipeline(DiffusionPipeline):
             lr_scheduler.step()
             optimizer.zero_grad()
 
-        with tempfile.TemporaryDirectory() as save_lora_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as save_lora_dir:
             StableDiffusionLoraLoaderMixin.save_lora_weights(
                 save_directory=save_lora_dir,
                 unet_lora_layers=unet_lora_layers,

--- a/examples/consistency_distillation/test_lcm_lora.py
+++ b/examples/consistency_distillation/test_lcm_lora.py
@@ -16,9 +16,10 @@
 import logging
 import os
 import sys
-import tempfile
 
 import safetensors
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -34,7 +35,7 @@ logger.addHandler(stream_handler)
 
 class TextToImageLCM(ExamplesTestsAccelerate):
     def test_text_to_image_lcm_lora_sdxl(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/consistency_distillation/train_lcm_distill_lora_sdxl.py
                 --pretrained_teacher_model hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -61,7 +62,7 @@ class TextToImageLCM(ExamplesTestsAccelerate):
             self.assertTrue(is_lora)
 
     def test_text_to_image_lcm_lora_sdxl_checkpointing(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/consistency_distillation/train_lcm_distill_lora_sdxl.py
                 --pretrained_teacher_model hf-internal-testing/tiny-stable-diffusion-xl-pipe

--- a/examples/consistency_distillation/test_lcm_lora.py
+++ b/examples/consistency_distillation/test_lcm_lora.py
@@ -34,7 +34,7 @@ logger.addHandler(stream_handler)
 
 class TextToImageLCM(ExamplesTestsAccelerate):
     def test_text_to_image_lcm_lora_sdxl(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/consistency_distillation/train_lcm_distill_lora_sdxl.py
                 --pretrained_teacher_model hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -61,7 +61,7 @@ class TextToImageLCM(ExamplesTestsAccelerate):
             self.assertTrue(is_lora)
 
     def test_text_to_image_lcm_lora_sdxl_checkpointing(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/consistency_distillation/train_lcm_distill_lora_sdxl.py
                 --pretrained_teacher_model hf-internal-testing/tiny-stable-diffusion-xl-pipe

--- a/examples/controlnet/test_controlnet.py
+++ b/examples/controlnet/test_controlnet.py
@@ -32,7 +32,7 @@ logger.addHandler(stream_handler)
 
 class ControlNet(ExamplesTestsAccelerate):
     def test_controlnet_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -55,7 +55,7 @@ class ControlNet(ExamplesTestsAccelerate):
             )
 
     def test_controlnet_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -98,7 +98,7 @@ class ControlNet(ExamplesTestsAccelerate):
 
 class ControlNetSDXL(ExamplesTestsAccelerate):
     def test_controlnet_sdxl(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet_sdxl.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -119,7 +119,7 @@ class ControlNetSDXL(ExamplesTestsAccelerate):
 
 class ControlNetSD3(ExamplesTestsAccelerate):
     def test_controlnet_sd3(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet_sd3.py
             --pretrained_model_name_or_path=DavyMorgan/tiny-sd3-pipe
@@ -140,7 +140,7 @@ class ControlNetSD3(ExamplesTestsAccelerate):
 
 class ControlNetSD35(ExamplesTestsAccelerate):
     def test_controlnet_sd3(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet_sd3.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-sd35-pipe
@@ -161,7 +161,7 @@ class ControlNetSD35(ExamplesTestsAccelerate):
 
 class ControlNetflux(ExamplesTestsAccelerate):
     def test_controlnet_flux(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet_flux.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-flux-pipe

--- a/examples/controlnet/test_controlnet.py
+++ b/examples/controlnet/test_controlnet.py
@@ -16,7 +16,8 @@
 import logging
 import os
 import sys
-import tempfile
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -32,7 +33,7 @@ logger.addHandler(stream_handler)
 
 class ControlNet(ExamplesTestsAccelerate):
     def test_controlnet_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -55,7 +56,7 @@ class ControlNet(ExamplesTestsAccelerate):
             )
 
     def test_controlnet_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -98,7 +99,7 @@ class ControlNet(ExamplesTestsAccelerate):
 
 class ControlNetSDXL(ExamplesTestsAccelerate):
     def test_controlnet_sdxl(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet_sdxl.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -119,7 +120,7 @@ class ControlNetSDXL(ExamplesTestsAccelerate):
 
 class ControlNetSD3(ExamplesTestsAccelerate):
     def test_controlnet_sd3(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet_sd3.py
             --pretrained_model_name_or_path=DavyMorgan/tiny-sd3-pipe
@@ -140,7 +141,7 @@ class ControlNetSD3(ExamplesTestsAccelerate):
 
 class ControlNetSD35(ExamplesTestsAccelerate):
     def test_controlnet_sd3(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet_sd3.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-sd35-pipe
@@ -161,7 +162,7 @@ class ControlNetSD35(ExamplesTestsAccelerate):
 
 class ControlNetflux(ExamplesTestsAccelerate):
     def test_controlnet_flux(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/controlnet/train_controlnet_flux.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-flux-pipe

--- a/examples/custom_diffusion/test_custom_diffusion.py
+++ b/examples/custom_diffusion/test_custom_diffusion.py
@@ -16,7 +16,8 @@
 import logging
 import os
 import sys
-import tempfile
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -32,7 +33,7 @@ logger.addHandler(stream_handler)
 
 class CustomDiffusion(ExamplesTestsAccelerate):
     def test_custom_diffusion(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/custom_diffusion/train_custom_diffusion.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -57,7 +58,7 @@ class CustomDiffusion(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "<new1>.bin")))
 
     def test_custom_diffusion_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/custom_diffusion/train_custom_diffusion.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -79,7 +80,7 @@ class CustomDiffusion(ExamplesTestsAccelerate):
             self.assertEqual({x for x in os.listdir(tmpdir) if "checkpoint" in x}, {"checkpoint-4", "checkpoint-6"})
 
     def test_custom_diffusion_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/custom_diffusion/train_custom_diffusion.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe

--- a/examples/custom_diffusion/test_custom_diffusion.py
+++ b/examples/custom_diffusion/test_custom_diffusion.py
@@ -32,7 +32,7 @@ logger.addHandler(stream_handler)
 
 class CustomDiffusion(ExamplesTestsAccelerate):
     def test_custom_diffusion(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/custom_diffusion/train_custom_diffusion.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -57,7 +57,7 @@ class CustomDiffusion(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "<new1>.bin")))
 
     def test_custom_diffusion_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/custom_diffusion/train_custom_diffusion.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -79,7 +79,7 @@ class CustomDiffusion(ExamplesTestsAccelerate):
             self.assertEqual({x for x in os.listdir(tmpdir) if "checkpoint" in x}, {"checkpoint-4", "checkpoint-6"})
 
     def test_custom_diffusion_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/custom_diffusion/train_custom_diffusion.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe

--- a/examples/dreambooth/test_dreambooth.py
+++ b/examples/dreambooth/test_dreambooth.py
@@ -35,7 +35,7 @@ logger.addHandler(stream_handler)
 
 class DreamBooth(ExamplesTestsAccelerate):
     def test_dreambooth(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -58,7 +58,7 @@ class DreamBooth(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "scheduler", "scheduler_config.json")))
 
     def test_dreambooth_if(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-if-pipe
@@ -87,7 +87,7 @@ class DreamBooth(ExamplesTestsAccelerate):
         instance_prompt = "photo"
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -163,7 +163,7 @@ class DreamBooth(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isdir(os.path.join(tmpdir, "checkpoint-6")))
 
     def test_dreambooth_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/dreambooth/train_dreambooth.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -186,7 +186,7 @@ class DreamBooth(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/dreambooth/train_dreambooth.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe

--- a/examples/dreambooth/test_dreambooth.py
+++ b/examples/dreambooth/test_dreambooth.py
@@ -17,9 +17,9 @@ import logging
 import os
 import shutil
 import sys
-import tempfile
 
 from diffusers import DiffusionPipeline, UNet2DConditionModel
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -35,7 +35,7 @@ logger.addHandler(stream_handler)
 
 class DreamBooth(ExamplesTestsAccelerate):
     def test_dreambooth(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -58,7 +58,7 @@ class DreamBooth(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "scheduler", "scheduler_config.json")))
 
     def test_dreambooth_if(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-if-pipe
@@ -87,7 +87,7 @@ class DreamBooth(ExamplesTestsAccelerate):
         instance_prompt = "photo"
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -163,7 +163,7 @@ class DreamBooth(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isdir(os.path.join(tmpdir, "checkpoint-6")))
 
     def test_dreambooth_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/dreambooth/train_dreambooth.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -186,7 +186,7 @@ class DreamBooth(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/dreambooth/train_dreambooth.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe

--- a/examples/dreambooth/test_dreambooth_flux.py
+++ b/examples/dreambooth/test_dreambooth_flux.py
@@ -17,9 +17,9 @@ import logging
 import os
 import shutil
 import sys
-import tempfile
 
 from diffusers import DiffusionPipeline, FluxTransformer2DModel
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -40,7 +40,7 @@ class DreamBoothFlux(ExamplesTestsAccelerate):
     script_path = "examples/dreambooth/train_dreambooth_flux.py"
 
     def test_dreambooth(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -63,7 +63,7 @@ class DreamBoothFlux(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "scheduler", "scheduler_config.json")))
 
     def test_dreambooth_checkpointing(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -139,7 +139,7 @@ class DreamBoothFlux(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isdir(os.path.join(tmpdir, "checkpoint-6")))
 
     def test_dreambooth_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -162,7 +162,7 @@ class DreamBoothFlux(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/dreambooth/test_dreambooth_flux.py
+++ b/examples/dreambooth/test_dreambooth_flux.py
@@ -40,7 +40,7 @@ class DreamBoothFlux(ExamplesTestsAccelerate):
     script_path = "examples/dreambooth/train_dreambooth_flux.py"
 
     def test_dreambooth(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -63,7 +63,7 @@ class DreamBoothFlux(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "scheduler", "scheduler_config.json")))
 
     def test_dreambooth_checkpointing(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -139,7 +139,7 @@ class DreamBoothFlux(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isdir(os.path.join(tmpdir, "checkpoint-6")))
 
     def test_dreambooth_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -162,7 +162,7 @@ class DreamBoothFlux(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/dreambooth/test_dreambooth_lora.py
+++ b/examples/dreambooth/test_dreambooth_lora.py
@@ -36,7 +36,7 @@ logger.addHandler(stream_handler)
 
 class DreamBoothLoRA(ExamplesTestsAccelerate):
     def test_dreambooth_lora(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -68,7 +68,7 @@ class DreamBoothLoRA(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_unet)
 
     def test_dreambooth_lora_with_text_encoder(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -102,7 +102,7 @@ class DreamBoothLoRA(ExamplesTestsAccelerate):
             self.assertTrue(is_correct_naming)
 
     def test_dreambooth_lora_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/dreambooth/train_dreambooth_lora.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -125,7 +125,7 @@ class DreamBoothLoRA(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/dreambooth/train_dreambooth_lora.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -163,7 +163,7 @@ class DreamBoothLoRA(ExamplesTestsAccelerate):
             self.assertEqual({x for x in os.listdir(tmpdir) if "checkpoint" in x}, {"checkpoint-6", "checkpoint-8"})
 
     def test_dreambooth_lora_if_model(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-if-pipe
@@ -200,7 +200,7 @@ class DreamBoothLoRA(ExamplesTestsAccelerate):
 
 class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
     def test_dreambooth_lora_sdxl(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -232,7 +232,7 @@ class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_unet)
 
     def test_dreambooth_lora_sdxl_with_text_encoder(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -268,7 +268,7 @@ class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_unet)
 
     def test_dreambooth_lora_sdxl_custom_captions(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -289,7 +289,7 @@ class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
             run_command(self._launch_args + test_args)
 
     def test_dreambooth_lora_sdxl_text_encoder_custom_captions(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -313,7 +313,7 @@ class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
     def test_dreambooth_lora_sdxl_checkpointing_checkpoints_total_limit(self):
         pipeline_path = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path {pipeline_path}
@@ -345,7 +345,7 @@ class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
     def test_dreambooth_lora_sdxl_text_encoder_checkpointing_checkpoints_total_limit(self):
         pipeline_path = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path {pipeline_path}

--- a/examples/dreambooth/test_dreambooth_lora.py
+++ b/examples/dreambooth/test_dreambooth_lora.py
@@ -16,9 +16,10 @@
 import logging
 import os
 import sys
-import tempfile
 
 import safetensors
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -36,7 +37,7 @@ logger.addHandler(stream_handler)
 
 class DreamBoothLoRA(ExamplesTestsAccelerate):
     def test_dreambooth_lora(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -68,7 +69,7 @@ class DreamBoothLoRA(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_unet)
 
     def test_dreambooth_lora_with_text_encoder(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -102,7 +103,7 @@ class DreamBoothLoRA(ExamplesTestsAccelerate):
             self.assertTrue(is_correct_naming)
 
     def test_dreambooth_lora_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/dreambooth/train_dreambooth_lora.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -125,7 +126,7 @@ class DreamBoothLoRA(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/dreambooth/train_dreambooth_lora.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -163,7 +164,7 @@ class DreamBoothLoRA(ExamplesTestsAccelerate):
             self.assertEqual({x for x in os.listdir(tmpdir) if "checkpoint" in x}, {"checkpoint-6", "checkpoint-8"})
 
     def test_dreambooth_lora_if_model(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-if-pipe
@@ -200,7 +201,7 @@ class DreamBoothLoRA(ExamplesTestsAccelerate):
 
 class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
     def test_dreambooth_lora_sdxl(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -232,7 +233,7 @@ class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_unet)
 
     def test_dreambooth_lora_sdxl_with_text_encoder(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -268,7 +269,7 @@ class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_unet)
 
     def test_dreambooth_lora_sdxl_custom_captions(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -289,7 +290,7 @@ class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
             run_command(self._launch_args + test_args)
 
     def test_dreambooth_lora_sdxl_text_encoder_custom_captions(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -313,7 +314,7 @@ class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
     def test_dreambooth_lora_sdxl_checkpointing_checkpoints_total_limit(self):
         pipeline_path = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path {pipeline_path}
@@ -345,7 +346,7 @@ class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
     def test_dreambooth_lora_sdxl_text_encoder_checkpointing_checkpoints_total_limit(self):
         pipeline_path = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path {pipeline_path}

--- a/examples/dreambooth/test_dreambooth_lora_edm.py
+++ b/examples/dreambooth/test_dreambooth_lora_edm.py
@@ -16,9 +16,10 @@
 import logging
 import os
 import sys
-import tempfile
 
 import safetensors
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -34,7 +35,7 @@ logger.addHandler(stream_handler)
 
 class DreamBoothLoRASDXLWithEDM(ExamplesTestsAccelerate):
     def test_dreambooth_lora_sdxl_with_edm(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -67,7 +68,7 @@ class DreamBoothLoRASDXLWithEDM(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_unet)
 
     def test_dreambooth_lora_playground(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-playground-v2-5-pipe

--- a/examples/dreambooth/test_dreambooth_lora_edm.py
+++ b/examples/dreambooth/test_dreambooth_lora_edm.py
@@ -34,7 +34,7 @@ logger.addHandler(stream_handler)
 
 class DreamBoothLoRASDXLWithEDM(ExamplesTestsAccelerate):
     def test_dreambooth_lora_sdxl_with_edm(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -67,7 +67,7 @@ class DreamBoothLoRASDXLWithEDM(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_unet)
 
     def test_dreambooth_lora_playground(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/dreambooth/train_dreambooth_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-playground-v2-5-pipe

--- a/examples/dreambooth/test_dreambooth_lora_flux.py
+++ b/examples/dreambooth/test_dreambooth_lora_flux.py
@@ -16,9 +16,10 @@
 import logging
 import os
 import sys
-import tempfile
 
 import safetensors
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -40,7 +41,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
     transformer_layer_type = "single_transformer_blocks.0.attn.to_k"
 
     def test_dreambooth_lora_flux(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -72,7 +73,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_text_encoder_flux(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -105,7 +106,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_expected_prefix)
 
     def test_dreambooth_lora_latent_caching(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -138,7 +139,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_layers(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -175,7 +176,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_flux_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -198,7 +199,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_flux_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/dreambooth/test_dreambooth_lora_flux.py
+++ b/examples/dreambooth/test_dreambooth_lora_flux.py
@@ -40,7 +40,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
     transformer_layer_type = "single_transformer_blocks.0.attn.to_k"
 
     def test_dreambooth_lora_flux(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -72,7 +72,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_text_encoder_flux(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -105,7 +105,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_expected_prefix)
 
     def test_dreambooth_lora_latent_caching(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -138,7 +138,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_layers(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -175,7 +175,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_flux_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -198,7 +198,7 @@ class DreamBoothLoRAFlux(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_flux_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/dreambooth/test_dreambooth_lora_lumina2.py
+++ b/examples/dreambooth/test_dreambooth_lora_lumina2.py
@@ -39,7 +39,7 @@ class DreamBoothLoRAlumina2(ExamplesTestsAccelerate):
     transformer_layer_type = "layers.0.attn.to_k"
 
     def test_dreambooth_lora_lumina2(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -72,7 +72,7 @@ class DreamBoothLoRAlumina2(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_latent_caching(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -106,7 +106,7 @@ class DreamBoothLoRAlumina2(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_layers(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -142,7 +142,7 @@ class DreamBoothLoRAlumina2(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_lumina2_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -166,7 +166,7 @@ class DreamBoothLoRAlumina2(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_lumina2_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/dreambooth/test_dreambooth_lora_lumina2.py
+++ b/examples/dreambooth/test_dreambooth_lora_lumina2.py
@@ -16,9 +16,10 @@
 import logging
 import os
 import sys
-import tempfile
 
 import safetensors
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -39,7 +40,7 @@ class DreamBoothLoRAlumina2(ExamplesTestsAccelerate):
     transformer_layer_type = "layers.0.attn.to_k"
 
     def test_dreambooth_lora_lumina2(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -72,7 +73,7 @@ class DreamBoothLoRAlumina2(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_latent_caching(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -106,7 +107,7 @@ class DreamBoothLoRAlumina2(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_layers(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -142,7 +143,7 @@ class DreamBoothLoRAlumina2(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_lumina2_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -166,7 +167,7 @@ class DreamBoothLoRAlumina2(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_lumina2_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/dreambooth/test_dreambooth_lora_sana.py
+++ b/examples/dreambooth/test_dreambooth_lora_sana.py
@@ -39,7 +39,7 @@ class DreamBoothLoRASANA(ExamplesTestsAccelerate):
     transformer_layer_type = "transformer_blocks.0.attn1.to_k"
 
     def test_dreambooth_lora_sana(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -72,7 +72,7 @@ class DreamBoothLoRASANA(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_latent_caching(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -106,7 +106,7 @@ class DreamBoothLoRASANA(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_layers(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -142,7 +142,7 @@ class DreamBoothLoRASANA(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_sana_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -166,7 +166,7 @@ class DreamBoothLoRASANA(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_sana_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/dreambooth/test_dreambooth_lora_sana.py
+++ b/examples/dreambooth/test_dreambooth_lora_sana.py
@@ -16,9 +16,10 @@
 import logging
 import os
 import sys
-import tempfile
 
 import safetensors
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -39,7 +40,7 @@ class DreamBoothLoRASANA(ExamplesTestsAccelerate):
     transformer_layer_type = "transformer_blocks.0.attn1.to_k"
 
     def test_dreambooth_lora_sana(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -72,7 +73,7 @@ class DreamBoothLoRASANA(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_latent_caching(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -106,7 +107,7 @@ class DreamBoothLoRASANA(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_layers(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -142,7 +143,7 @@ class DreamBoothLoRASANA(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_sana_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -166,7 +167,7 @@ class DreamBoothLoRASANA(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_sana_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/dreambooth/test_dreambooth_lora_sd3.py
+++ b/examples/dreambooth/test_dreambooth_lora_sd3.py
@@ -42,7 +42,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
     layer_type = "attn.to_k"
 
     def test_dreambooth_lora_sd3(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -74,7 +74,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_text_encoder_sd3(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -107,7 +107,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_expected_prefix)
 
     def test_dreambooth_lora_latent_caching(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -140,7 +140,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_block(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -176,7 +176,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_layer(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -208,7 +208,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_sd3_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -231,7 +231,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_sd3_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/dreambooth/test_dreambooth_lora_sd3.py
+++ b/examples/dreambooth/test_dreambooth_lora_sd3.py
@@ -16,9 +16,10 @@
 import logging
 import os
 import sys
-import tempfile
 
 import safetensors
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -42,7 +43,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
     layer_type = "attn.to_k"
 
     def test_dreambooth_lora_sd3(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -74,7 +75,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_text_encoder_sd3(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -107,7 +108,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_expected_prefix)
 
     def test_dreambooth_lora_latent_caching(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -140,7 +141,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_block(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -176,7 +177,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_layer(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -208,7 +209,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             self.assertTrue(starts_with_transformer)
 
     def test_dreambooth_lora_sd3_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -231,7 +232,7 @@ class DreamBoothLoRASD3(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_lora_sd3_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/dreambooth/test_dreambooth_sd3.py
+++ b/examples/dreambooth/test_dreambooth_sd3.py
@@ -40,7 +40,7 @@ class DreamBoothSD3(ExamplesTestsAccelerate):
     script_path = "examples/dreambooth/train_dreambooth_sd3.py"
 
     def test_dreambooth(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -63,7 +63,7 @@ class DreamBoothSD3(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "scheduler", "scheduler_config.json")))
 
     def test_dreambooth_checkpointing(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -139,7 +139,7 @@ class DreamBoothSD3(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isdir(os.path.join(tmpdir, "checkpoint-6")))
 
     def test_dreambooth_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -162,7 +162,7 @@ class DreamBoothSD3(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/dreambooth/test_dreambooth_sd3.py
+++ b/examples/dreambooth/test_dreambooth_sd3.py
@@ -17,9 +17,9 @@ import logging
 import os
 import shutil
 import sys
-import tempfile
 
 from diffusers import DiffusionPipeline, SD3Transformer2DModel
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -40,7 +40,7 @@ class DreamBoothSD3(ExamplesTestsAccelerate):
     script_path = "examples/dreambooth/train_dreambooth_sd3.py"
 
     def test_dreambooth(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
@@ -63,7 +63,7 @@ class DreamBoothSD3(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "scheduler", "scheduler_config.json")))
 
     def test_dreambooth_checkpointing(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -139,7 +139,7 @@ class DreamBoothSD3(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isdir(os.path.join(tmpdir, "checkpoint-6")))
 
     def test_dreambooth_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}
@@ -162,7 +162,7 @@ class DreamBoothSD3(ExamplesTestsAccelerate):
             )
 
     def test_dreambooth_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             {self.script_path}
             --pretrained_model_name_or_path={self.pretrained_model_name_or_path}

--- a/examples/instruct_pix2pix/test_instruct_pix2pix.py
+++ b/examples/instruct_pix2pix/test_instruct_pix2pix.py
@@ -32,7 +32,7 @@ logger.addHandler(stream_handler)
 
 class InstructPix2Pix(ExamplesTestsAccelerate):
     def test_instruct_pix2pix_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/instruct_pix2pix/train_instruct_pix2pix.py
                 --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -55,7 +55,7 @@ class InstructPix2Pix(ExamplesTestsAccelerate):
             )
 
     def test_instruct_pix2pix_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/instruct_pix2pix/train_instruct_pix2pix.py
                 --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe

--- a/examples/instruct_pix2pix/test_instruct_pix2pix.py
+++ b/examples/instruct_pix2pix/test_instruct_pix2pix.py
@@ -16,7 +16,8 @@
 import logging
 import os
 import sys
-import tempfile
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -32,7 +33,7 @@ logger.addHandler(stream_handler)
 
 class InstructPix2Pix(ExamplesTestsAccelerate):
     def test_instruct_pix2pix_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/instruct_pix2pix/train_instruct_pix2pix.py
                 --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe
@@ -55,7 +56,7 @@ class InstructPix2Pix(ExamplesTestsAccelerate):
             )
 
     def test_instruct_pix2pix_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/instruct_pix2pix/train_instruct_pix2pix.py
                 --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-pipe

--- a/examples/t2i_adapter/test_t2i_adapter.py
+++ b/examples/t2i_adapter/test_t2i_adapter.py
@@ -32,7 +32,7 @@ logger.addHandler(stream_handler)
 
 class T2IAdapter(ExamplesTestsAccelerate):
     def test_t2i_adapter_sdxl(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/t2i_adapter/train_t2i_adapter_sdxl.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-xl-pipe

--- a/examples/t2i_adapter/test_t2i_adapter.py
+++ b/examples/t2i_adapter/test_t2i_adapter.py
@@ -16,7 +16,8 @@
 import logging
 import os
 import sys
-import tempfile
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -32,7 +33,7 @@ logger.addHandler(stream_handler)
 
 class T2IAdapter(ExamplesTestsAccelerate):
     def test_t2i_adapter_sdxl(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
             examples/t2i_adapter/train_t2i_adapter_sdxl.py
             --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-xl-pipe

--- a/examples/text_to_image/test_text_to_image.py
+++ b/examples/text_to_image/test_text_to_image.py
@@ -36,7 +36,7 @@ logger.addHandler(stream_handler)
 
 class TextToImage(ExamplesTestsAccelerate):
     def test_text_to_image(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/text_to_image/train_text_to_image.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -63,7 +63,7 @@ class TextToImage(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -145,7 +145,7 @@ class TextToImage(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -229,7 +229,7 @@ class TextToImage(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 6, checkpointing_steps == 2, checkpoints_total_limit == 2
             # Should create checkpoints at steps 2, 4, 6
@@ -268,7 +268,7 @@ class TextToImage(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -341,7 +341,7 @@ class TextToImage(ExamplesTestsAccelerate):
 
 class TextToImageSDXL(ExamplesTestsAccelerate):
     def test_text_to_image_sdxl(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/text_to_image/train_text_to_image_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe

--- a/examples/text_to_image/test_text_to_image.py
+++ b/examples/text_to_image/test_text_to_image.py
@@ -18,9 +18,9 @@ import logging
 import os
 import shutil
 import sys
-import tempfile
 
 from diffusers import DiffusionPipeline, UNet2DConditionModel  # noqa: E402
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -36,7 +36,7 @@ logger.addHandler(stream_handler)
 
 class TextToImage(ExamplesTestsAccelerate):
     def test_text_to_image(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/text_to_image/train_text_to_image.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -63,7 +63,7 @@ class TextToImage(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -145,7 +145,7 @@ class TextToImage(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -229,7 +229,7 @@ class TextToImage(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 6, checkpointing_steps == 2, checkpoints_total_limit == 2
             # Should create checkpoints at steps 2, 4, 6
@@ -268,7 +268,7 @@ class TextToImage(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -341,7 +341,7 @@ class TextToImage(ExamplesTestsAccelerate):
 
 class TextToImageSDXL(ExamplesTestsAccelerate):
     def test_text_to_image_sdxl(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/text_to_image/train_text_to_image_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe

--- a/examples/text_to_image/test_text_to_image_lora.py
+++ b/examples/text_to_image/test_text_to_image_lora.py
@@ -40,7 +40,7 @@ class TextToImageLoRA(ExamplesTestsAccelerate):
         prompt = "a prompt"
         pipeline_path = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 6, checkpointing_steps == 2, checkpoints_total_limit == 2
             # Should create checkpoints at steps 2, 4, 6
@@ -77,7 +77,7 @@ class TextToImageLoRA(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 6, checkpointing_steps == 2, checkpoints_total_limit == 2
             # Should create checkpoints at steps 2, 4, 6
@@ -120,7 +120,7 @@ class TextToImageLoRA(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -201,7 +201,7 @@ class TextToImageLoRA(ExamplesTestsAccelerate):
 
 class TextToImageLoRASDXL(ExamplesTestsAccelerate):
     def test_text_to_image_lora_sdxl(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/text_to_image/train_text_to_image_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -227,7 +227,7 @@ class TextToImageLoRASDXL(ExamplesTestsAccelerate):
             self.assertTrue(is_lora)
 
     def test_text_to_image_lora_sdxl_with_text_encoder(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/text_to_image/train_text_to_image_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -265,7 +265,7 @@ class TextToImageLoRASDXL(ExamplesTestsAccelerate):
         prompt = "a prompt"
         pipeline_path = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 6, checkpointing_steps == 2, checkpoints_total_limit == 2
             # Should create checkpoints at steps 2, 4, 6

--- a/examples/text_to_image/test_text_to_image_lora.py
+++ b/examples/text_to_image/test_text_to_image_lora.py
@@ -17,11 +17,11 @@
 import logging
 import os
 import sys
-import tempfile
 
 import safetensors
 
 from diffusers import DiffusionPipeline  # noqa: E402
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -40,7 +40,7 @@ class TextToImageLoRA(ExamplesTestsAccelerate):
         prompt = "a prompt"
         pipeline_path = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 6, checkpointing_steps == 2, checkpoints_total_limit == 2
             # Should create checkpoints at steps 2, 4, 6
@@ -77,7 +77,7 @@ class TextToImageLoRA(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 6, checkpointing_steps == 2, checkpoints_total_limit == 2
             # Should create checkpoints at steps 2, 4, 6
@@ -120,7 +120,7 @@ class TextToImageLoRA(ExamplesTestsAccelerate):
         pretrained_model_name_or_path = "hf-internal-testing/tiny-stable-diffusion-pipe"
         prompt = "a prompt"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
             # Should create checkpoints at steps 2, 4
@@ -201,7 +201,7 @@ class TextToImageLoRA(ExamplesTestsAccelerate):
 
 class TextToImageLoRASDXL(ExamplesTestsAccelerate):
     def test_text_to_image_lora_sdxl(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/text_to_image/train_text_to_image_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -227,7 +227,7 @@ class TextToImageLoRASDXL(ExamplesTestsAccelerate):
             self.assertTrue(is_lora)
 
     def test_text_to_image_lora_sdxl_with_text_encoder(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/text_to_image/train_text_to_image_lora_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
@@ -265,7 +265,7 @@ class TextToImageLoRASDXL(ExamplesTestsAccelerate):
         prompt = "a prompt"
         pipeline_path = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Run training script with checkpointing
             # max_train_steps == 6, checkpointing_steps == 2, checkpoints_total_limit == 2
             # Should create checkpoints at steps 2, 4, 6

--- a/examples/textual_inversion/test_textual_inversion.py
+++ b/examples/textual_inversion/test_textual_inversion.py
@@ -16,7 +16,8 @@
 import logging
 import os
 import sys
-import tempfile
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -32,7 +33,7 @@ logger.addHandler(stream_handler)
 
 class TextualInversion(ExamplesTestsAccelerate):
     def test_textual_inversion(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -58,7 +59,7 @@ class TextualInversion(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "learned_embeds.safetensors")))
 
     def test_textual_inversion_checkpointing(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -90,7 +91,7 @@ class TextualInversion(ExamplesTestsAccelerate):
             )
 
     def test_textual_inversion_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe

--- a/examples/textual_inversion/test_textual_inversion.py
+++ b/examples/textual_inversion/test_textual_inversion.py
@@ -32,7 +32,7 @@ logger.addHandler(stream_handler)
 
 class TextualInversion(ExamplesTestsAccelerate):
     def test_textual_inversion(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -58,7 +58,7 @@ class TextualInversion(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "learned_embeds.safetensors")))
 
     def test_textual_inversion_checkpointing(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe
@@ -90,7 +90,7 @@ class TextualInversion(ExamplesTestsAccelerate):
             )
 
     def test_textual_inversion_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-pipe

--- a/examples/textual_inversion/test_textual_inversion_sdxl.py
+++ b/examples/textual_inversion/test_textual_inversion_sdxl.py
@@ -32,7 +32,7 @@ logger.addHandler(stream_handler)
 
 class TextualInversionSdxl(ExamplesTestsAccelerate):
     def test_textual_inversion_sdxl(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-sdxl-pipe
@@ -58,7 +58,7 @@ class TextualInversionSdxl(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "learned_embeds.safetensors")))
 
     def test_textual_inversion_sdxl_checkpointing(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-sdxl-pipe
@@ -90,7 +90,7 @@ class TextualInversionSdxl(ExamplesTestsAccelerate):
             )
 
     def test_textual_inversion_sdxl_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-sdxl-pipe

--- a/examples/textual_inversion/test_textual_inversion_sdxl.py
+++ b/examples/textual_inversion/test_textual_inversion_sdxl.py
@@ -16,7 +16,8 @@
 import logging
 import os
 import sys
-import tempfile
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -32,7 +33,7 @@ logger.addHandler(stream_handler)
 
 class TextualInversionSdxl(ExamplesTestsAccelerate):
     def test_textual_inversion_sdxl(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-sdxl-pipe
@@ -58,7 +59,7 @@ class TextualInversionSdxl(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "learned_embeds.safetensors")))
 
     def test_textual_inversion_sdxl_checkpointing(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-sdxl-pipe
@@ -90,7 +91,7 @@ class TextualInversionSdxl(ExamplesTestsAccelerate):
             )
 
     def test_textual_inversion_sdxl_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/textual_inversion/textual_inversion_sdxl.py
                 --pretrained_model_name_or_path hf-internal-testing/tiny-sdxl-pipe

--- a/examples/unconditional_image_generation/test_unconditional.py
+++ b/examples/unconditional_image_generation/test_unconditional.py
@@ -32,7 +32,7 @@ logger.addHandler(stream_handler)
 
 class Unconditional(ExamplesTestsAccelerate):
     def test_train_unconditional(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/unconditional_image_generation/train_unconditional.py
                 --dataset_name hf-internal-testing/dummy_image_class_data
@@ -53,7 +53,7 @@ class Unconditional(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "scheduler", "scheduler_config.json")))
 
     def test_unconditional_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             initial_run_args = f"""
                 examples/unconditional_image_generation/train_unconditional.py
                 --dataset_name hf-internal-testing/dummy_image_class_data
@@ -80,7 +80,7 @@ class Unconditional(ExamplesTestsAccelerate):
             )
 
     def test_unconditional_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             initial_run_args = f"""
                 examples/unconditional_image_generation/train_unconditional.py
                 --dataset_name hf-internal-testing/dummy_image_class_data

--- a/examples/unconditional_image_generation/test_unconditional.py
+++ b/examples/unconditional_image_generation/test_unconditional.py
@@ -16,7 +16,8 @@
 import logging
 import os
 import sys
-import tempfile
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 sys.path.append("..")
@@ -32,7 +33,7 @@ logger.addHandler(stream_handler)
 
 class Unconditional(ExamplesTestsAccelerate):
     def test_train_unconditional(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             test_args = f"""
                 examples/unconditional_image_generation/train_unconditional.py
                 --dataset_name hf-internal-testing/dummy_image_class_data
@@ -53,7 +54,7 @@ class Unconditional(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "scheduler", "scheduler_config.json")))
 
     def test_unconditional_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             initial_run_args = f"""
                 examples/unconditional_image_generation/train_unconditional.py
                 --dataset_name hf-internal-testing/dummy_image_class_data
@@ -80,7 +81,7 @@ class Unconditional(ExamplesTestsAccelerate):
             )
 
     def test_unconditional_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             initial_run_args = f"""
                 examples/unconditional_image_generation/train_unconditional.py
                 --dataset_name hf-internal-testing/dummy_image_class_data

--- a/examples/vqgan/test_vqgan.py
+++ b/examples/vqgan/test_vqgan.py
@@ -88,7 +88,7 @@ class TextToImage(ExamplesTestsAccelerate):
         return vqmodel_config_path, discriminator_config_path
 
     def test_vqmodel(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             vqmodel_config_path, discriminator_config_path = self.get_vq_and_discriminator_configs(tmpdir)
             test_args = f"""
                 examples/vqgan/train_vqgan.py
@@ -115,7 +115,7 @@ class TextToImage(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "vqmodel", "diffusion_pytorch_model.safetensors")))
 
     def test_vqmodel_checkpointing(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             vqmodel_config_path, discriminator_config_path = self.get_vq_and_discriminator_configs(tmpdir)
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
@@ -199,7 +199,7 @@ class TextToImage(ExamplesTestsAccelerate):
             )
 
     def test_vqmodel_checkpointing_use_ema(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             vqmodel_config_path, discriminator_config_path = self.get_vq_and_discriminator_configs(tmpdir)
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
@@ -283,7 +283,7 @@ class TextToImage(ExamplesTestsAccelerate):
             )
 
     def test_vqmodel_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             vqmodel_config_path, discriminator_config_path = self.get_vq_and_discriminator_configs(tmpdir)
             # Run training script with checkpointing
             # max_train_steps == 6, checkpointing_steps == 2, checkpoints_total_limit == 2
@@ -321,7 +321,7 @@ class TextToImage(ExamplesTestsAccelerate):
             self.assertEqual({x for x in os.listdir(tmpdir) if "checkpoint" in x}, {"checkpoint-4", "checkpoint-6"})
 
     def test_vqmodel_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             vqmodel_config_path, discriminator_config_path = self.get_vq_and_discriminator_configs(tmpdir)
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2

--- a/examples/vqgan/test_vqgan.py
+++ b/examples/vqgan/test_vqgan.py
@@ -19,12 +19,11 @@ import logging
 import os
 import shutil
 import sys
-import tempfile
 
 import torch
 
 from diffusers import VQModel
-from diffusers.utils.testing_utils import require_timm
+from diffusers.utils.testing_utils import TemporaryDirectory, require_timm
 
 
 sys.path.append("..")
@@ -88,7 +87,7 @@ class TextToImage(ExamplesTestsAccelerate):
         return vqmodel_config_path, discriminator_config_path
 
     def test_vqmodel(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             vqmodel_config_path, discriminator_config_path = self.get_vq_and_discriminator_configs(tmpdir)
             test_args = f"""
                 examples/vqgan/train_vqgan.py
@@ -115,7 +114,7 @@ class TextToImage(ExamplesTestsAccelerate):
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "vqmodel", "diffusion_pytorch_model.safetensors")))
 
     def test_vqmodel_checkpointing(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             vqmodel_config_path, discriminator_config_path = self.get_vq_and_discriminator_configs(tmpdir)
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
@@ -199,7 +198,7 @@ class TextToImage(ExamplesTestsAccelerate):
             )
 
     def test_vqmodel_checkpointing_use_ema(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             vqmodel_config_path, discriminator_config_path = self.get_vq_and_discriminator_configs(tmpdir)
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2
@@ -283,7 +282,7 @@ class TextToImage(ExamplesTestsAccelerate):
             )
 
     def test_vqmodel_checkpointing_checkpoints_total_limit(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             vqmodel_config_path, discriminator_config_path = self.get_vq_and_discriminator_configs(tmpdir)
             # Run training script with checkpointing
             # max_train_steps == 6, checkpointing_steps == 2, checkpoints_total_limit == 2
@@ -321,7 +320,7 @@ class TextToImage(ExamplesTestsAccelerate):
             self.assertEqual({x for x in os.listdir(tmpdir) if "checkpoint" in x}, {"checkpoint-4", "checkpoint-6"})
 
     def test_vqmodel_checkpointing_checkpoints_total_limit_removes_multiple_checkpoints(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             vqmodel_config_path, discriminator_config_path = self.get_vq_and_discriminator_configs(tmpdir)
             # Run training script with checkpointing
             # max_train_steps == 4, checkpointing_steps == 2

--- a/src/diffusers/pipelines/transformers_loading_utils.py
+++ b/src/diffusers/pipelines/transformers_loading_utils.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 import contextlib
 import os
-import tempfile
 from typing import TYPE_CHECKING, Dict
 
 from huggingface_hub import DDUFEntry
 from tqdm import tqdm
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 from ..utils import is_safetensors_available, is_transformers_available, is_transformers_version
 
@@ -44,7 +45,7 @@ def _load_tokenizer_from_dduf(
     files. There is an extra cost of extracting the files, but of limited impact as the tokenizer files are usually
     small-ish.
     """
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
+    with TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
         for entry_name, entry in dduf_entries.items():
             if entry_name.startswith(name + "/"):
                 tmp_entry_path = os.path.join(tmp_dir, *entry_name.split("/"))
@@ -91,7 +92,7 @@ def _load_transformers_model_from_dduf(
             "You can install it with: `pip install --upgrade transformers`"
         )
 
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
+    with TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
         from transformers import AutoConfig, GenerationConfig
 
         tmp_config_file = os.path.join(tmp_dir, "config.json")

--- a/src/diffusers/pipelines/transformers_loading_utils.py
+++ b/src/diffusers/pipelines/transformers_loading_utils.py
@@ -44,7 +44,7 @@ def _load_tokenizer_from_dduf(
     files. There is an extra cost of extracting the files, but of limited impact as the tokenizer files are usually
     small-ish.
     """
-    with tempfile.TemporaryDirectory() as tmp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
         for entry_name, entry in dduf_entries.items():
             if entry_name.startswith(name + "/"):
                 tmp_entry_path = os.path.join(tmp_dir, *entry_name.split("/"))
@@ -91,7 +91,7 @@ def _load_transformers_model_from_dduf(
             "You can install it with: `pip install --upgrade transformers`"
         )
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
         from transformers import AutoConfig, GenerationConfig
 
         tmp_config_file = os.path.join(tmp_dir, "config.json")

--- a/src/diffusers/utils/hub_utils.py
+++ b/src/diffusers/utils/hub_utils.py
@@ -542,7 +542,7 @@ class PushToHubMixin:
         if "Scheduler" not in self.__class__.__name__:
             save_kwargs.update({"variant": variant})
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             self.save_pretrained(tmpdir, **save_kwargs)
 
             # Update model card if needed:

--- a/src/diffusers/utils/hub_utils.py
+++ b/src/diffusers/utils/hub_utils.py
@@ -18,7 +18,6 @@ import json
 import os
 import re
 import sys
-import tempfile
 import warnings
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -45,6 +44,8 @@ from huggingface_hub.utils import (
 )
 from packaging import version
 from requests import HTTPError
+
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 from .. import __version__
 from .constants import (
@@ -542,7 +543,7 @@ class PushToHubMixin:
         if "Scheduler" not in self.__class__.__name__:
             save_kwargs.update({"variant": variant})
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             self.save_pretrained(tmpdir, **save_kwargs)
 
             # Update model card if needed:

--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -1388,15 +1388,13 @@ GenericAlias = List[int]
 
 
 class TemporaryDirectory:
-    """Create and return a temporary directory.  This has the same
-    behavior as mkdtemp but can be used as a context manager.  For
-    example:
+    """Create and return a temporary directory. This has the same
+    behavior as mkdtemp but can be used as a context manager. For example:
 
         with TemporaryDirectory() as tmpdir:
             ...
 
-    Upon exiting the context, the directory and everything contained
-    in it are removed.
+    Upon exiting the context, the directory and everything contained in it are removed.
     """
 
     def __init__(self, suffix=None, prefix=None, dir=None, ignore_cleanup_errors=False):

--- a/tests/lora/test_deprecated_utilities.py
+++ b/tests/lora/test_deprecated_utilities.py
@@ -29,7 +29,7 @@ class UtilityMethodDeprecationTests(unittest.TestCase):
         assert "Using the `_fetch_state_dict()` method from" in warning_message
 
     def test_best_guess_weight_name_cls_method_raises_warning(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             state_dict = torch.nn.Linear(3, 3).state_dict()
             torch.save(state_dict, os.path.join(tmpdir, "pytorch_lora_weights.bin"))
 

--- a/tests/lora/test_deprecated_utilities.py
+++ b/tests/lora/test_deprecated_utilities.py
@@ -1,10 +1,10 @@
 import os
-import tempfile
 import unittest
 
 import torch
 
 from diffusers.loaders.lora_base import LoraBaseMixin
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 class UtilityMethodDeprecationTests(unittest.TestCase):
@@ -29,7 +29,7 @@ class UtilityMethodDeprecationTests(unittest.TestCase):
         assert "Using the `_fetch_state_dict()` method from" in warning_message
 
     def test_best_guess_weight_name_cls_method_raises_warning(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             state_dict = torch.nn.Linear(3, 3).state_dict()
             torch.save(state_dict, os.path.join(tmpdir, "pytorch_lora_weights.bin"))
 

--- a/tests/lora/test_lora_layers_cogview4.py
+++ b/tests/lora/test_lora_layers_cogview4.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import sys
-import tempfile
 import unittest
 
 import numpy as np
@@ -21,7 +20,13 @@ import torch
 from transformers import AutoTokenizer, GlmModel
 
 from diffusers import AutoencoderKL, CogView4Pipeline, CogView4Transformer2DModel, FlowMatchEulerDiscreteScheduler
-from diffusers.utils.testing_utils import floats_tensor, require_peft_backend, skip_mps, torch_device
+from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
+    floats_tensor,
+    require_peft_backend,
+    skip_mps,
+    torch_device,
+)
 
 
 sys.path.append(".")
@@ -128,7 +133,7 @@ class CogView4LoRATests(unittest.TestCase, PeftLoraLoaderMixinTests):
 
             images_lora = pipe(**inputs, generator=torch.manual_seed(0))[0]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 pipe.save_pretrained(tmpdirname)
 
                 pipe_from_pretrained = self.pipeline_class.from_pretrained(tmpdirname)

--- a/tests/lora/test_lora_layers_cogview4.py
+++ b/tests/lora/test_lora_layers_cogview4.py
@@ -128,7 +128,7 @@ class CogView4LoRATests(unittest.TestCase, PeftLoraLoaderMixinTests):
 
             images_lora = pipe(**inputs, generator=torch.manual_seed(0))[0]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 pipe.save_pretrained(tmpdirname)
 
                 pipe_from_pretrained = self.pipeline_class.from_pretrained(tmpdirname)

--- a/tests/lora/test_lora_layers_flux.py
+++ b/tests/lora/test_lora_layers_flux.py
@@ -130,7 +130,7 @@ class FluxLoRATests(unittest.TestCase, PeftLoraLoaderMixinTests):
 
         images_lora = pipe(**inputs, generator=torch.manual_seed(0)).images
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             denoiser_state_dict = get_peft_model_state_dict(pipe.transformer)
             self.pipeline_class.save_lora_weights(tmpdirname, transformer_lora_layers=denoiser_state_dict)
 
@@ -186,7 +186,7 @@ class FluxLoRATests(unittest.TestCase, PeftLoraLoaderMixinTests):
             "LoRA should lead to different results.",
         )
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             denoiser_state_dict = get_peft_model_state_dict(pipe.transformer)
             self.pipeline_class.save_lora_weights(tmpdirname, transformer_lora_layers=denoiser_state_dict)
 
@@ -235,7 +235,7 @@ class FluxLoRATests(unittest.TestCase, PeftLoraLoaderMixinTests):
             "LoRA should lead to different results.",
         )
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             denoiser_state_dict = get_peft_model_state_dict(pipe.transformer)
             self.pipeline_class.save_lora_weights(tmpdirname, transformer_lora_layers=denoiser_state_dict)
 

--- a/tests/lora/test_lora_layers_flux.py
+++ b/tests/lora/test_lora_layers_flux.py
@@ -16,7 +16,6 @@ import copy
 import gc
 import os
 import sys
-import tempfile
 import unittest
 
 import numpy as np
@@ -31,6 +30,7 @@ from diffusers import FlowMatchEulerDiscreteScheduler, FluxControlPipeline, Flux
 from diffusers.utils import load_image, logging
 from diffusers.utils.testing_utils import (
     CaptureLogger,
+    TemporaryDirectory,
     floats_tensor,
     is_peft_available,
     nightly,
@@ -130,7 +130,7 @@ class FluxLoRATests(unittest.TestCase, PeftLoraLoaderMixinTests):
 
         images_lora = pipe(**inputs, generator=torch.manual_seed(0)).images
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             denoiser_state_dict = get_peft_model_state_dict(pipe.transformer)
             self.pipeline_class.save_lora_weights(tmpdirname, transformer_lora_layers=denoiser_state_dict)
 
@@ -186,7 +186,7 @@ class FluxLoRATests(unittest.TestCase, PeftLoraLoaderMixinTests):
             "LoRA should lead to different results.",
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             denoiser_state_dict = get_peft_model_state_dict(pipe.transformer)
             self.pipeline_class.save_lora_weights(tmpdirname, transformer_lora_layers=denoiser_state_dict)
 
@@ -235,7 +235,7 @@ class FluxLoRATests(unittest.TestCase, PeftLoraLoaderMixinTests):
             "LoRA should lead to different results.",
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             denoiser_state_dict = get_peft_model_state_dict(pipe.transformer)
             self.pipeline_class.save_lora_weights(tmpdirname, transformer_lora_layers=denoiser_state_dict)
 

--- a/tests/lora/utils.py
+++ b/tests/lora/utils.py
@@ -400,7 +400,7 @@ class PeftLoraLoaderMixinTests:
 
             images_lora = pipe(**inputs, generator=torch.manual_seed(0))[0]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
                 lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
                 self.pipeline_class.save_lora_weights(
@@ -608,7 +608,7 @@ class PeftLoraLoaderMixinTests:
 
             images_lora = pipe(**inputs, generator=torch.manual_seed(0))[0]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 modules_to_save = self._get_modules_to_save(pipe)
                 lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
 
@@ -720,7 +720,7 @@ class PeftLoraLoaderMixinTests:
 
             images_lora = pipe(**inputs, generator=torch.manual_seed(0))[0]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 pipe.save_pretrained(tmpdirname)
 
                 pipe_from_pretrained = self.pipeline_class.from_pretrained(tmpdirname)
@@ -778,7 +778,7 @@ class PeftLoraLoaderMixinTests:
 
             images_lora = pipe(**inputs, generator=torch.manual_seed(0))[0]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
                 lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
                 self.pipeline_class.save_lora_weights(
@@ -1838,7 +1838,7 @@ class PeftLoraLoaderMixinTests:
         denoiser.add_adapter(denoiser_lora_config)
         self.assertTrue(check_if_lora_correctly_set(denoiser), "Lora not correctly set in denoiser.")
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
             lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
             self.pipeline_class.save_lora_weights(
@@ -1875,7 +1875,7 @@ class PeftLoraLoaderMixinTests:
         denoiser.add_adapter(denoiser_lora_config)
         self.assertTrue(check_if_lora_correctly_set(denoiser), "Lora not correctly set in denoiser.")
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
             lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
             self.pipeline_class.save_lora_weights(
@@ -2047,7 +2047,7 @@ class PeftLoraLoaderMixinTests:
                 "Lora + scale should match the output of `set_adapters()`.",
             )
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
                 lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
                 self.pipeline_class.save_lora_weights(
@@ -2310,7 +2310,7 @@ class PeftLoraLoaderMixinTests:
         pipe(**inputs, generator=torch.manual_seed(0))[0]
 
         # 2. Test forward with load_lora_weights
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
             lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
             self.pipeline_class.save_lora_weights(

--- a/tests/lora/utils.py
+++ b/tests/lora/utils.py
@@ -15,7 +15,6 @@
 import inspect
 import os
 import re
-import tempfile
 import unittest
 from itertools import product
 
@@ -33,6 +32,7 @@ from diffusers.utils import logging
 from diffusers.utils.import_utils import is_peft_available
 from diffusers.utils.testing_utils import (
     CaptureLogger,
+    TemporaryDirectory,
     floats_tensor,
     is_torch_version,
     require_peft_backend,
@@ -400,7 +400,7 @@ class PeftLoraLoaderMixinTests:
 
             images_lora = pipe(**inputs, generator=torch.manual_seed(0))[0]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
                 lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
                 self.pipeline_class.save_lora_weights(
@@ -608,7 +608,7 @@ class PeftLoraLoaderMixinTests:
 
             images_lora = pipe(**inputs, generator=torch.manual_seed(0))[0]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 modules_to_save = self._get_modules_to_save(pipe)
                 lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
 
@@ -720,7 +720,7 @@ class PeftLoraLoaderMixinTests:
 
             images_lora = pipe(**inputs, generator=torch.manual_seed(0))[0]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 pipe.save_pretrained(tmpdirname)
 
                 pipe_from_pretrained = self.pipeline_class.from_pretrained(tmpdirname)
@@ -778,7 +778,7 @@ class PeftLoraLoaderMixinTests:
 
             images_lora = pipe(**inputs, generator=torch.manual_seed(0))[0]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
                 lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
                 self.pipeline_class.save_lora_weights(
@@ -1838,7 +1838,7 @@ class PeftLoraLoaderMixinTests:
         denoiser.add_adapter(denoiser_lora_config)
         self.assertTrue(check_if_lora_correctly_set(denoiser), "Lora not correctly set in denoiser.")
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
             lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
             self.pipeline_class.save_lora_weights(
@@ -1875,7 +1875,7 @@ class PeftLoraLoaderMixinTests:
         denoiser.add_adapter(denoiser_lora_config)
         self.assertTrue(check_if_lora_correctly_set(denoiser), "Lora not correctly set in denoiser.")
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
             lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
             self.pipeline_class.save_lora_weights(
@@ -2047,7 +2047,7 @@ class PeftLoraLoaderMixinTests:
                 "Lora + scale should match the output of `set_adapters()`.",
             )
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
                 lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
                 self.pipeline_class.save_lora_weights(
@@ -2310,7 +2310,7 @@ class PeftLoraLoaderMixinTests:
         pipe(**inputs, generator=torch.manual_seed(0))[0]
 
         # 2. Test forward with load_lora_weights
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             modules_to_save = self._get_modules_to_save(pipe, has_denoiser=True)
             lora_state_dicts = self._get_lora_state_dicts(modules_to_save)
             self.pipeline_class.save_lora_weights(

--- a/tests/models/test_attention_processor.py
+++ b/tests/models/test_attention_processor.py
@@ -114,7 +114,7 @@ class DeprecatedAttentionBlockTests(unittest.TestCase):
             output_type="np",
         ).images
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # save the converted model
             pipe.save_pretrained(tmpdir)
 

--- a/tests/models/test_attention_processor.py
+++ b/tests/models/test_attention_processor.py
@@ -1,4 +1,3 @@
-import tempfile
 import unittest
 
 import numpy as np
@@ -7,7 +6,7 @@ import torch
 
 from diffusers import DiffusionPipeline
 from diffusers.models.attention_processor import Attention, AttnAddedKVProcessor
-from diffusers.utils.testing_utils import torch_device
+from diffusers.utils.testing_utils import TemporaryDirectory, torch_device
 
 
 class AttnAddedKVProcessorTests(unittest.TestCase):
@@ -114,7 +113,7 @@ class DeprecatedAttentionBlockTests(unittest.TestCase):
             output_type="np",
         ).images
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # save the converted model
             pipe.save_pretrained(tmpdir)
 

--- a/tests/models/test_modeling_common.py
+++ b/tests/models/test_modeling_common.py
@@ -112,7 +112,7 @@ def _test_from_save_pretrained_dynamo(in_queue, out_queue, timeout):
         model.to(torch_device)
         model = torch.compile(model)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_pretrained(tmpdirname, safe_serialization=False)
             new_model = model_class.from_pretrained(tmpdirname)
             new_model.to(torch_device)
@@ -230,7 +230,7 @@ class ModelUtilsTest(unittest.TestCase):
 
         with self.assertWarns(FutureWarning) as warning:
             if use_local:
-                with tempfile.TemporaryDirectory() as tmpdirname:
+                with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                     tmpdirname = snapshot_download(repo_id=repo_id)
                     _ = load_model(tmpdirname)
             else:
@@ -288,7 +288,7 @@ class ModelUtilsTest(unittest.TestCase):
     def test_one_request_upon_cached(self):
         use_safetensors = False
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             with requests_mock.mock(real_http=True) as m:
                 UNet2DConditionModel.from_pretrained(
                     "hf-internal-testing/tiny-stable-diffusion-torch",
@@ -317,7 +317,9 @@ class ModelUtilsTest(unittest.TestCase):
             ), "We should call only `model_info` to check for commit hash and  knowing if shard index is present."
 
     def test_weight_overwrite(self):
-        with tempfile.TemporaryDirectory() as tmpdirname, self.assertRaises(ValueError) as error_context:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname, self.assertRaises(
+            ValueError
+        ) as error_context:
             UNet2DConditionModel.from_pretrained(
                 "hf-internal-testing/tiny-stable-diffusion-torch",
                 subfolder="unet",
@@ -328,7 +330,7 @@ class ModelUtilsTest(unittest.TestCase):
         # make sure that error message states what keys are missing
         assert "Cannot load" in str(error_context.exception)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model = UNet2DConditionModel.from_pretrained(
                 "hf-internal-testing/tiny-stable-diffusion-torch",
                 subfolder="unet",
@@ -448,7 +450,7 @@ class ModelTesterMixin:
         model.to(torch_device)
         model.eval()
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_pretrained(tmpdirname, safe_serialization=False)
             new_model = self.model_class.from_pretrained(tmpdirname)
             if hasattr(new_model, "set_default_attn_processor"):
@@ -685,7 +687,7 @@ class ModelTesterMixin:
         model.to(torch_device)
         model.eval()
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_pretrained(tmpdirname, variant="fp16", safe_serialization=False)
             new_model = self.model_class.from_pretrained(tmpdirname, variant="fp16")
             if hasattr(new_model, "set_default_attn_processor"):
@@ -740,7 +742,7 @@ class ModelTesterMixin:
         for dtype in [torch.float32, torch.float16, torch.bfloat16]:
             if torch_device == "mps" and dtype == torch.bfloat16:
                 continue
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 model.to(dtype)
                 model.save_pretrained(tmpdirname, safe_serialization=False)
                 new_model = self.model_class.from_pretrained(tmpdirname, low_cpu_mem_usage=True, torch_dtype=dtype)
@@ -817,7 +819,7 @@ class ModelTesterMixin:
 
         # test if the model can be loaded from the config
         # and has all the expected shape
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_pretrained(tmpdirname, safe_serialization=False)
             new_model = self.model_class.from_pretrained(tmpdirname)
             new_model.to(torch_device)
@@ -1088,7 +1090,7 @@ class ModelTesterMixin:
 
         self.assertFalse(torch.allclose(output_no_lora, outputs_with_lora, atol=1e-4, rtol=1e-4))
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             model.save_lora_adapter(tmpdir)
             self.assertTrue(os.path.isfile(os.path.join(tmpdir, "pytorch_lora_weights.safetensors")))
 
@@ -1135,7 +1137,7 @@ class ModelTesterMixin:
         model.add_adapter(denoiser_lora_config)
         self.assertTrue(check_if_lora_correctly_set(model), "LoRA layers not set correctly")
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             wrong_name = "foo"
             with self.assertRaises(ValueError) as err_context:
                 model.save_lora_adapter(tmpdir, adapter_name=wrong_name)
@@ -1157,7 +1159,7 @@ class ModelTesterMixin:
         model_size = compute_module_sizes(model)[""]
         # We test several splits of sizes to make sure it works.
         max_gpu_sizes = [int(p * model_size) for p in self.model_split_percents[1:]]
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             model.cpu().save_pretrained(tmp_dir)
 
             for max_size in max_gpu_sizes:
@@ -1189,7 +1191,7 @@ class ModelTesterMixin:
         # Force disk offload by setting very small CPU memory
         max_memory = {0: max_size, "cpu": int(0.1 * max_size)}
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             model.cpu().save_pretrained(tmp_dir, safe_serialization=False)
             with self.assertRaises(ValueError):
                 # This errors out because it's missing an offload folder
@@ -1218,7 +1220,7 @@ class ModelTesterMixin:
         base_output = model(**inputs_dict)
 
         model_size = compute_module_sizes(model)[""]
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             model.cpu().save_pretrained(tmp_dir)
 
             max_size = int(self.model_split_percents[0] * model_size)
@@ -1248,7 +1250,7 @@ class ModelTesterMixin:
         model_size = compute_module_sizes(model)[""]
         # We test several splits of sizes to make sure it works.
         max_gpu_sizes = [int(p * model_size) for p in self.model_split_percents[1:]]
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             model.cpu().save_pretrained(tmp_dir)
 
             for max_size in max_gpu_sizes:
@@ -1276,7 +1278,7 @@ class ModelTesterMixin:
 
         model_size = compute_module_persistent_sizes(model)[""]
         max_shard_size = int((model_size * 0.75) / (2**10))  # Convert to KB as these test models are small.
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             model.cpu().save_pretrained(tmp_dir, max_shard_size=f"{max_shard_size}KB")
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, SAFE_WEIGHTS_INDEX_NAME)))
 
@@ -1309,7 +1311,7 @@ class ModelTesterMixin:
         model_size = compute_module_persistent_sizes(model)[""]
         max_shard_size = int((model_size * 0.75) / (2**10))  # Convert to KB as these test models are small.
         variant = "fp16"
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             # It doesn't matter if the actual model is in fp16 or not. Just adding the variant and
             # testing if loading works with the variant when the checkpoint is sharded should be
             # enough.
@@ -1348,7 +1350,7 @@ class ModelTesterMixin:
 
         model_size = compute_module_persistent_sizes(model)[""]
         max_shard_size = int((model_size * 0.75) / (2**10))  # Convert to KB as these test models are small.
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             model.cpu().save_pretrained(tmp_dir, max_shard_size=f"{max_shard_size}KB")
             self.assertTrue(os.path.exists(os.path.join(tmp_dir, SAFE_WEIGHTS_INDEX_NAME)))
 
@@ -1378,7 +1380,7 @@ class ModelTesterMixin:
             model_size = compute_module_persistent_sizes(model)[""]
             max_shard_size = int((model_size * 0.75) / (2**10))  # Convert to KB as these test models are small.
             variant = "fp16"
-            with tempfile.TemporaryDirectory() as tmp_dir:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
                 model.cpu().save_pretrained(
                     tmp_dir, variant=variant, max_shard_size=f"{max_shard_size}KB", safe_serialization=use_safe
                 )
@@ -1605,7 +1607,7 @@ class ModelPushToHubTester(unittest.TestCase):
         delete_repo(token=TOKEN, repo_id=self.repo_id)
 
         # Push to hub via save_pretrained
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             model.save_pretrained(tmp_dir, repo_id=self.repo_id, push_to_hub=True, token=TOKEN)
 
         new_model = UNet2DConditionModel.from_pretrained(f"{USER}/{self.repo_id}")
@@ -1636,7 +1638,7 @@ class ModelPushToHubTester(unittest.TestCase):
         delete_repo(token=TOKEN, repo_id=self.org_repo_id)
 
         # Push to hub via save_pretrained
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             model.save_pretrained(tmp_dir, push_to_hub=True, token=TOKEN, repo_id=self.org_repo_id)
 
         new_model = UNet2DConditionModel.from_pretrained(self.org_repo_id)
@@ -1780,7 +1782,7 @@ class TestLoraHotSwappingForModel(unittest.TestCase):
         assert not (output0_before == 0).all()
         assert not (output1_before == 0).all()
 
-        with tempfile.TemporaryDirectory() as tmp_dirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dirname:
             # save the adapter checkpoints
             unet.save_lora_adapter(os.path.join(tmp_dirname, "0"), safe_serialization=True, adapter_name="adapter0")
             unet.save_lora_adapter(os.path.join(tmp_dirname, "1"), safe_serialization=True, adapter_name="adapter1")

--- a/tests/models/unets/test_models_unet_2d_condition.py
+++ b/tests/models/unets/test_models_unet_2d_condition.py
@@ -748,7 +748,7 @@ class UNet2DConditionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.Test
         with torch.no_grad():
             sample = model(**inputs_dict).sample
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_attn_procs(tmpdirname, safe_serialization=False)
             self.assertTrue(os.path.isfile(os.path.join(tmpdirname, "pytorch_custom_diffusion_weights.bin")))
             torch.manual_seed(0)
@@ -1098,7 +1098,7 @@ class UNet2DConditionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.Test
         with torch.no_grad():
             lora_sample_1 = model(**inputs_dict).sample
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_attn_procs(tmpdirname)
             model.unload_lora()
 
@@ -1132,7 +1132,7 @@ class UNet2DConditionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.Test
 
         assert check_if_lora_correctly_set(model), "Lora not correctly set in UNet."
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             with self.assertWarns(FutureWarning) as warning:
                 model.save_attn_procs(tmpdirname)
 

--- a/tests/models/unets/test_models_unet_2d_condition.py
+++ b/tests/models/unets/test_models_unet_2d_condition.py
@@ -16,7 +16,6 @@
 import copy
 import gc
 import os
-import tempfile
 import unittest
 from collections import OrderedDict
 
@@ -35,6 +34,7 @@ from diffusers.models.embeddings import ImageProjection, IPAdapterFaceIDImagePro
 from diffusers.utils import logging
 from diffusers.utils.import_utils import is_xformers_available
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     backend_max_memory_allocated,
     backend_reset_max_memory_allocated,
@@ -748,7 +748,7 @@ class UNet2DConditionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.Test
         with torch.no_grad():
             sample = model(**inputs_dict).sample
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_attn_procs(tmpdirname, safe_serialization=False)
             self.assertTrue(os.path.isfile(os.path.join(tmpdirname, "pytorch_custom_diffusion_weights.bin")))
             torch.manual_seed(0)
@@ -1098,7 +1098,7 @@ class UNet2DConditionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.Test
         with torch.no_grad():
             lora_sample_1 = model(**inputs_dict).sample
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_attn_procs(tmpdirname)
             model.unload_lora()
 
@@ -1132,7 +1132,7 @@ class UNet2DConditionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.Test
 
         assert check_if_lora_correctly_set(model), "Lora not correctly set in UNet."
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             with self.assertWarns(FutureWarning) as warning:
                 model.save_attn_procs(tmpdirname)
 

--- a/tests/models/unets/test_models_unet_motion.py
+++ b/tests/models/unets/test_models_unet_motion.py
@@ -127,7 +127,7 @@ class UNetMotionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.TestCase)
         model = self.model_class(**init_dict)
         model.to(torch_device)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_motion_modules(tmpdirname)
             self.assertTrue(os.path.isfile(os.path.join(tmpdirname, "diffusion_pytorch_model.safetensors")))
 
@@ -211,7 +211,7 @@ class UNetMotionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.TestCase)
         model.to(torch_device)
         model.eval()
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_pretrained(tmpdirname, safe_serialization=False)
             torch.manual_seed(0)
             new_model = self.model_class.from_pretrained(tmpdirname)
@@ -238,7 +238,7 @@ class UNetMotionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.TestCase)
         model.to(torch_device)
         model.eval()
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_pretrained(tmpdirname, variant="fp16", safe_serialization=False)
 
             torch.manual_seed(0)

--- a/tests/models/unets/test_models_unet_motion.py
+++ b/tests/models/unets/test_models_unet_motion.py
@@ -15,7 +15,6 @@
 
 import copy
 import os
-import tempfile
 import unittest
 
 import numpy as np
@@ -25,6 +24,7 @@ from diffusers import MotionAdapter, UNet2DConditionModel, UNetMotionModel
 from diffusers.utils import logging
 from diffusers.utils.import_utils import is_xformers_available
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     enable_full_determinism,
     floats_tensor,
     torch_device,
@@ -127,7 +127,7 @@ class UNetMotionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.TestCase)
         model = self.model_class(**init_dict)
         model.to(torch_device)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_motion_modules(tmpdirname)
             self.assertTrue(os.path.isfile(os.path.join(tmpdirname, "diffusion_pytorch_model.safetensors")))
 
@@ -211,7 +211,7 @@ class UNetMotionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.TestCase)
         model.to(torch_device)
         model.eval()
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_pretrained(tmpdirname, safe_serialization=False)
             torch.manual_seed(0)
             new_model = self.model_class.from_pretrained(tmpdirname)
@@ -238,7 +238,7 @@ class UNetMotionModelTests(ModelTesterMixin, UNetTesterMixin, unittest.TestCase)
         model.to(torch_device)
         model.eval()
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model.save_pretrained(tmpdirname, variant="fp16", safe_serialization=False)
 
             torch.manual_seed(0)

--- a/tests/others/test_config.py
+++ b/tests/others/test_config.py
@@ -152,7 +152,7 @@ class ConfigTester(unittest.TestCase):
         assert config["d"] == "for diffusion"
         assert config["e"] == [1, 3]
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             obj.save_config(tmpdirname)
             new_obj = SampleObject.from_config(SampleObject.load_config(tmpdirname))
             new_config = new_obj.config
@@ -276,7 +276,7 @@ class ConfigTester(unittest.TestCase):
         # make sure that default config has all keys in `_use_default_values`
         assert set(config_dict.keys()) == set(config.config._use_default_values)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             config.save_config(tmpdirname)
 
             # now loading it with SampleObject2 should put f into `_use_default_values`

--- a/tests/others/test_config.py
+++ b/tests/others/test_config.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import json
-import tempfile
 import unittest
 from pathlib import Path
 
@@ -28,7 +27,7 @@ from diffusers import (
     logging,
 )
 from diffusers.configuration_utils import ConfigMixin, register_to_config
-from diffusers.utils.testing_utils import CaptureLogger
+from diffusers.utils.testing_utils import CaptureLogger, TemporaryDirectory
 
 
 class SampleObject(ConfigMixin):
@@ -152,7 +151,7 @@ class ConfigTester(unittest.TestCase):
         assert config["d"] == "for diffusion"
         assert config["e"] == [1, 3]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             obj.save_config(tmpdirname)
             new_obj = SampleObject.from_config(SampleObject.load_config(tmpdirname))
             new_config = new_obj.config
@@ -276,7 +275,7 @@ class ConfigTester(unittest.TestCase):
         # make sure that default config has all keys in `_use_default_values`
         assert set(config_dict.keys()) == set(config.config._use_default_values)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             config.save_config(tmpdirname)
 
             # now loading it with SampleObject2 should put f into `_use_default_values`

--- a/tests/others/test_ema.py
+++ b/tests/others/test_ema.py
@@ -62,7 +62,7 @@ class EMAModelTests(unittest.TestCase):
     def test_from_pretrained(self):
         # Save the model parameters to a temporary directory
         unet, ema_unet = self.get_models()
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             ema_unet.save_pretrained(tmpdir)
 
             # Load the EMA model from the saved directory
@@ -167,7 +167,7 @@ class EMAModelTests(unittest.TestCase):
         unet, ema_unet = self.get_models()
         noisy_latents, timesteps, encoder_hidden_states = self.get_dummy_inputs()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             ema_unet.save_pretrained(tmpdir)
             loaded_unet = UNet2DConditionModel.from_pretrained(tmpdir, model_cls=UNet2DConditionModel)
             loaded_unet = loaded_unet.to(unet.device)
@@ -217,7 +217,7 @@ class EMAModelTestsForeach(unittest.TestCase):
     def test_from_pretrained(self):
         # Save the model parameters to a temporary directory
         unet, ema_unet = self.get_models()
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             ema_unet.save_pretrained(tmpdir)
 
             # Load the EMA model from the saved directory
@@ -322,7 +322,7 @@ class EMAModelTestsForeach(unittest.TestCase):
         unet, ema_unet = self.get_models()
         noisy_latents, timesteps, encoder_hidden_states = self.get_dummy_inputs()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             ema_unet.save_pretrained(tmpdir)
             loaded_unet = UNet2DConditionModel.from_pretrained(tmpdir, model_cls=UNet2DConditionModel)
             loaded_unet = loaded_unet.to(unet.device)

--- a/tests/others/test_ema.py
+++ b/tests/others/test_ema.py
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tempfile
 import unittest
 
 import torch
 
 from diffusers import UNet2DConditionModel
 from diffusers.training_utils import EMAModel
-from diffusers.utils.testing_utils import enable_full_determinism, skip_mps, torch_device
+from diffusers.utils.testing_utils import TemporaryDirectory, enable_full_determinism, skip_mps, torch_device
 
 
 enable_full_determinism()
@@ -62,7 +61,7 @@ class EMAModelTests(unittest.TestCase):
     def test_from_pretrained(self):
         # Save the model parameters to a temporary directory
         unet, ema_unet = self.get_models()
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             ema_unet.save_pretrained(tmpdir)
 
             # Load the EMA model from the saved directory
@@ -167,7 +166,7 @@ class EMAModelTests(unittest.TestCase):
         unet, ema_unet = self.get_models()
         noisy_latents, timesteps, encoder_hidden_states = self.get_dummy_inputs()
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             ema_unet.save_pretrained(tmpdir)
             loaded_unet = UNet2DConditionModel.from_pretrained(tmpdir, model_cls=UNet2DConditionModel)
             loaded_unet = loaded_unet.to(unet.device)
@@ -217,7 +216,7 @@ class EMAModelTestsForeach(unittest.TestCase):
     def test_from_pretrained(self):
         # Save the model parameters to a temporary directory
         unet, ema_unet = self.get_models()
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             ema_unet.save_pretrained(tmpdir)
 
             # Load the EMA model from the saved directory
@@ -322,7 +321,7 @@ class EMAModelTestsForeach(unittest.TestCase):
         unet, ema_unet = self.get_models()
         noisy_latents, timesteps, encoder_hidden_states = self.get_dummy_inputs()
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             ema_unet.save_pretrained(tmpdir)
             loaded_unet = UNet2DConditionModel.from_pretrained(tmpdir, model_cls=UNet2DConditionModel)
             loaded_unet = loaded_unet.to(unet.device)

--- a/tests/pipelines/allegro/test_allegro.py
+++ b/tests/pipelines/allegro/test_allegro.py
@@ -15,7 +15,6 @@
 import gc
 import inspect
 import os
-import tempfile
 import unittest
 
 import numpy as np
@@ -24,6 +23,7 @@ from transformers import AutoTokenizer, T5Config, T5EncoderModel
 
 from diffusers import AllegroPipeline, AllegroTransformer3DModel, AutoencoderKLAllegro, DDIMScheduler
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     enable_full_determinism,
     numpy_cosine_similarity_distance,
     require_hf_hub_version_greater,
@@ -320,7 +320,7 @@ class AllegroPipelineFastTests(PipelineTesterMixin, PyramidAttentionBroadcastTes
 
         pipeline_out = pipe(**inputs)[0].cpu()
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             dduf_filename = os.path.join(tmpdir, f"{pipe.__class__.__name__.lower()}.dduf")
             pipe.save_pretrained(tmpdir, safe_serialization=True)
             export_folder_as_dduf(dduf_filename, folder_path=tmpdir)

--- a/tests/pipelines/allegro/test_allegro.py
+++ b/tests/pipelines/allegro/test_allegro.py
@@ -320,7 +320,7 @@ class AllegroPipelineFastTests(PipelineTesterMixin, PyramidAttentionBroadcastTes
 
         pipeline_out = pipe(**inputs)[0].cpu()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             dduf_filename = os.path.join(tmpdir, f"{pipe.__class__.__name__.lower()}.dduf")
             pipe.save_pretrained(tmpdir, safe_serialization=True)
             export_folder_as_dduf(dduf_filename, folder_path=tmpdir)

--- a/tests/pipelines/controlnet/test_controlnet.py
+++ b/tests/pipelines/controlnet/test_controlnet.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import gc
-import tempfile
 import traceback
 import unittest
 
@@ -34,6 +33,7 @@ from diffusers import (
 from diffusers.pipelines.controlnet.pipeline_controlnet import MultiControlNetModel
 from diffusers.utils.import_utils import is_xformers_available
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     backend_max_memory_allocated,
     backend_reset_max_memory_allocated,
@@ -486,7 +486,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         pipe = self.pipeline_class(**components)
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             try:
                 # save_pretrained is not implemented for Multi-ControlNet
                 pipe.save_pretrained(tmpdir)
@@ -714,7 +714,7 @@ class StableDiffusionMultiControlNetOneModelPipelineFastTests(
         pipe = self.pipeline_class(**components)
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             try:
                 # save_pretrained is not implemented for Multi-ControlNet
                 pipe.save_pretrained(tmpdir)

--- a/tests/pipelines/controlnet/test_controlnet.py
+++ b/tests/pipelines/controlnet/test_controlnet.py
@@ -486,7 +486,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         pipe = self.pipeline_class(**components)
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             try:
                 # save_pretrained is not implemented for Multi-ControlNet
                 pipe.save_pretrained(tmpdir)
@@ -714,7 +714,7 @@ class StableDiffusionMultiControlNetOneModelPipelineFastTests(
         pipe = self.pipeline_class(**components)
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             try:
                 # save_pretrained is not implemented for Multi-ControlNet
                 pipe.save_pretrained(tmpdir)

--- a/tests/pipelines/controlnet/test_controlnet_img2img.py
+++ b/tests/pipelines/controlnet/test_controlnet_img2img.py
@@ -391,7 +391,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         pipe = self.pipeline_class(**components)
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             try:
                 # save_pretrained is not implemented for Multi-ControlNet
                 pipe.save_pretrained(tmpdir)

--- a/tests/pipelines/controlnet/test_controlnet_img2img.py
+++ b/tests/pipelines/controlnet/test_controlnet_img2img.py
@@ -17,7 +17,6 @@
 
 import gc
 import random
-import tempfile
 import unittest
 
 import numpy as np
@@ -36,6 +35,7 @@ from diffusers.pipelines.controlnet.pipeline_controlnet import MultiControlNetMo
 from diffusers.utils import load_image
 from diffusers.utils.import_utils import is_xformers_available
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     enable_full_determinism,
     floats_tensor,
     load_numpy,
@@ -391,7 +391,7 @@ class StableDiffusionMultiControlNetPipelineFastTests(
         pipe = self.pipeline_class(**components)
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             try:
                 # save_pretrained is not implemented for Multi-ControlNet
                 pipe.save_pretrained(tmpdir)

--- a/tests/pipelines/controlnet/test_controlnet_inpaint.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint.py
@@ -443,7 +443,7 @@ class MultiControlNetInpaintPipelineFastTests(
         pipe = self.pipeline_class(**components)
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             try:
                 # save_pretrained is not implemented for Multi-ControlNet
                 pipe.save_pretrained(tmpdir)

--- a/tests/pipelines/controlnet/test_controlnet_inpaint.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint.py
@@ -17,7 +17,6 @@
 
 import gc
 import random
-import tempfile
 import unittest
 
 import numpy as np
@@ -36,6 +35,7 @@ from diffusers.pipelines.controlnet.pipeline_controlnet import MultiControlNetMo
 from diffusers.utils import load_image
 from diffusers.utils.import_utils import is_xformers_available
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     enable_full_determinism,
     floats_tensor,
     load_numpy,
@@ -443,7 +443,7 @@ class MultiControlNetInpaintPipelineFastTests(
         pipe = self.pipeline_class(**components)
         pipe.to(torch_device)
         pipe.set_progress_bar_config(disable=None)
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             try:
                 # save_pretrained is not implemented for Multi-ControlNet
                 pipe.save_pretrained(tmpdir)

--- a/tests/pipelines/deepfloyd_if/__init__.py
+++ b/tests/pipelines/deepfloyd_if/__init__.py
@@ -203,7 +203,7 @@ class IFPipelineTesterMixin:
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)
@@ -257,7 +257,7 @@ class IFPipelineTesterMixin:
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/deepfloyd_if/__init__.py
+++ b/tests/pipelines/deepfloyd_if/__init__.py
@@ -7,7 +7,7 @@ from transformers import AutoTokenizer, T5EncoderModel
 from diffusers import DDPMScheduler, UNet2DConditionModel
 from diffusers.models.attention_processor import AttnAddedKVProcessor
 from diffusers.pipelines.deepfloyd_if import IFWatermarker
-from diffusers.utils.testing_utils import torch_device
+from diffusers.utils.testing_utils import TemporaryDirectory, torch_device
 
 from ..test_pipelines_common import to_np
 
@@ -203,7 +203,7 @@ class IFPipelineTesterMixin:
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)
@@ -257,7 +257,7 @@ class IFPipelineTesterMixin:
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/hunyuandit/test_hunyuan_dit.py
+++ b/tests/pipelines/hunyuandit/test_hunyuan_dit.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import gc
-import tempfile
 import unittest
 
 import numpy as np
@@ -28,6 +27,7 @@ from diffusers import (
     HunyuanDiTPipeline,
 )
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     enable_full_determinism,
     numpy_cosine_similarity_distance,
     require_torch_accelerator,
@@ -267,7 +267,7 @@ class HunyuanDiTPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/hunyuandit/test_hunyuan_dit.py
+++ b/tests/pipelines/hunyuandit/test_hunyuan_dit.py
@@ -267,7 +267,7 @@ class HunyuanDiTPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/latte/test_latte.py
+++ b/tests/pipelines/latte/test_latte.py
@@ -280,7 +280,7 @@ class LattePipelineFastTests(
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, safe_serialization=False)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/latte/test_latte.py
+++ b/tests/pipelines/latte/test_latte.py
@@ -15,7 +15,6 @@
 
 import gc
 import inspect
-import tempfile
 import unittest
 
 import numpy as np
@@ -32,6 +31,7 @@ from diffusers import (
 )
 from diffusers.utils.import_utils import is_xformers_available
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     numpy_cosine_similarity_distance,
@@ -280,7 +280,7 @@ class LattePipelineFastTests(
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, safe_serialization=False)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/pag/test_pag_hunyuan_dit.py
+++ b/tests/pipelines/pag/test_pag_hunyuan_dit.py
@@ -323,7 +323,7 @@ class HunyuanDiTPAGPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/pag/test_pag_hunyuan_dit.py
+++ b/tests/pipelines/pag/test_pag_hunyuan_dit.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import inspect
-import tempfile
 import unittest
 
 import numpy as np
@@ -28,7 +27,7 @@ from diffusers import (
     HunyuanDiTPAGPipeline,
     HunyuanDiTPipeline,
 )
-from diffusers.utils.testing_utils import enable_full_determinism, torch_device
+from diffusers.utils.testing_utils import TemporaryDirectory, enable_full_determinism, torch_device
 
 from ..pipeline_params import TEXT_TO_IMAGE_BATCH_PARAMS, TEXT_TO_IMAGE_IMAGE_PARAMS, TEXT_TO_IMAGE_PARAMS
 from ..test_pipelines_common import PipelineTesterMixin, to_np
@@ -323,7 +322,7 @@ class HunyuanDiTPAGPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/pag/test_pag_pixart_sigma.py
+++ b/tests/pipelines/pag/test_pag_pixart_sigma.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import inspect
-import tempfile
 import unittest
 
 import numpy as np
@@ -32,6 +31,7 @@ from diffusers import (
 from diffusers.utils import logging
 from diffusers.utils.testing_utils import (
     CaptureLogger,
+    TemporaryDirectory,
     enable_full_determinism,
     torch_device,
 )
@@ -200,7 +200,7 @@ class PixArtSigmaPAGPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         logger = logging.get_logger("diffusers.pipelines.pipeline_utils")
         logger.setLevel(diffusers.logging.INFO)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, safe_serialization=False)
 
             with CaptureLogger(logger) as cap_logger:

--- a/tests/pipelines/pag/test_pag_pixart_sigma.py
+++ b/tests/pipelines/pag/test_pag_pixart_sigma.py
@@ -200,7 +200,7 @@ class PixArtSigmaPAGPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         logger = logging.get_logger("diffusers.pipelines.pipeline_utils")
         logger.setLevel(diffusers.logging.INFO)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, safe_serialization=False)
 
             with CaptureLogger(logger) as cap_logger:

--- a/tests/pipelines/pixart_alpha/test_pixart.py
+++ b/tests/pipelines/pixart_alpha/test_pixart.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import gc
-import tempfile
 import unittest
 
 import numpy as np
@@ -28,6 +27,7 @@ from diffusers import (
     PixArtTransformer2DModel,
 )
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     numpy_cosine_similarity_distance,
@@ -183,7 +183,7 @@ class PixArtAlphaPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/pixart_alpha/test_pixart.py
+++ b/tests/pipelines/pixart_alpha/test_pixart.py
@@ -183,7 +183,7 @@ class PixArtAlphaPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/pixart_sigma/test_pixart.py
+++ b/tests/pipelines/pixart_sigma/test_pixart.py
@@ -184,7 +184,7 @@ class PixArtSigmaPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/pixart_sigma/test_pixart.py
+++ b/tests/pipelines/pixart_sigma/test_pixart.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import gc
-import tempfile
 import unittest
 
 import numpy as np
@@ -28,6 +27,7 @@ from diffusers import (
     PixArtTransformer2DModel,
 )
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     numpy_cosine_similarity_distance,
@@ -184,7 +184,7 @@ class PixArtSigmaPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/semantic_stable_diffusion/test_semantic_diffusion.py
+++ b/tests/pipelines/semantic_stable_diffusion/test_semantic_diffusion.py
@@ -229,7 +229,7 @@ class SafeDiffusionPipelineFastTests(unittest.TestCase):
         assert image is not None
 
         # check that there's no error when saving a pipeline with one of the models being None
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname)
             pipe = StableDiffusionPipeline.from_pretrained(tmpdirname)
 

--- a/tests/pipelines/semantic_stable_diffusion/test_semantic_diffusion.py
+++ b/tests/pipelines/semantic_stable_diffusion/test_semantic_diffusion.py
@@ -15,7 +15,6 @@
 
 import gc
 import random
-import tempfile
 import unittest
 
 import numpy as np
@@ -25,6 +24,7 @@ from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 from diffusers import AutoencoderKL, DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler, UNet2DConditionModel
 from diffusers.pipelines.semantic_stable_diffusion import SemanticStableDiffusionPipeline as StableDiffusionPipeline
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     enable_full_determinism,
     floats_tensor,
     nightly,
@@ -229,7 +229,7 @@ class SafeDiffusionPipelineFastTests(unittest.TestCase):
         assert image is not None
 
         # check that there's no error when saving a pipeline with one of the models being None
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname)
             pipe = StableDiffusionPipeline.from_pretrained(tmpdirname)
 

--- a/tests/pipelines/stable_diffusion/test_onnx_stable_diffusion.py
+++ b/tests/pipelines/stable_diffusion/test_onnx_stable_diffusion.py
@@ -366,7 +366,7 @@ class OnnxStableDiffusionPipelineIntegrationTests(unittest.TestCase):
         assert image is not None
 
         # check that there's no error when saving a pipeline with one of the models being None
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname)
             pipe = OnnxStableDiffusionPipeline.from_pretrained(tmpdirname)
 

--- a/tests/pipelines/stable_diffusion/test_onnx_stable_diffusion.py
+++ b/tests/pipelines/stable_diffusion/test_onnx_stable_diffusion.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tempfile
 import unittest
 
 import numpy as np
@@ -27,7 +26,13 @@ from diffusers import (
     OnnxStableDiffusionPipeline,
     PNDMScheduler,
 )
-from diffusers.utils.testing_utils import is_onnx_available, nightly, require_onnxruntime, require_torch_gpu
+from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
+    is_onnx_available,
+    nightly,
+    require_onnxruntime,
+    require_torch_gpu,
+)
 
 from ..test_pipelines_onnx_common import OnnxPipelineTesterMixin
 
@@ -366,7 +371,7 @@ class OnnxStableDiffusionPipelineIntegrationTests(unittest.TestCase):
         assert image is not None
 
         # check that there's no error when saving a pipeline with one of the models being None
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname)
             pipe = OnnxStableDiffusionPipeline.from_pretrained(tmpdirname)
 

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion.py
@@ -15,7 +15,6 @@
 
 
 import gc
-import tempfile
 import time
 import traceback
 import unittest
@@ -44,6 +43,7 @@ from diffusers import (
 )
 from diffusers.utils.testing_utils import (
     CaptureLogger,
+    TemporaryDirectory,
     backend_empty_cache,
     backend_max_memory_allocated,
     backend_reset_max_memory_allocated,
@@ -428,7 +428,7 @@ class StableDiffusionPipelineFastTests(
         assert image is not None
 
         # check that there's no error when saving a pipeline with one of the models being None
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname)
             pipe = StableDiffusionPipeline.from_pretrained(tmpdirname)
 

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion.py
@@ -428,7 +428,7 @@ class StableDiffusionPipelineFastTests(
         assert image is not None
 
         # check that there's no error when saving a pipeline with one of the models being None
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname)
             pipe = StableDiffusionPipeline.from_pretrained(tmpdirname)
 

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_depth.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_depth.py
@@ -186,7 +186,7 @@ class StableDiffusionDepth2ImgPipelineFastTests(
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)
@@ -212,7 +212,7 @@ class StableDiffusionDepth2ImgPipelineFastTests(
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir, torch_dtype=torch.float16)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_depth.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_depth.py
@@ -15,7 +15,6 @@
 
 import gc
 import random
-import tempfile
 import unittest
 
 import numpy as np
@@ -37,6 +36,7 @@ from diffusers import (
     UNet2DConditionModel,
 )
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     floats_tensor,
@@ -186,7 +186,7 @@ class StableDiffusionDepth2ImgPipelineFastTests(
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)
@@ -212,7 +212,7 @@ class StableDiffusionDepth2ImgPipelineFastTests(
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir, torch_dtype=torch.float16)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_diffedit.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_diffedit.py
@@ -210,7 +210,7 @@ class StableDiffusionDiffEditPipelineFastTests(
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_diffedit.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_diffedit.py
@@ -15,7 +15,6 @@
 
 import gc
 import random
-import tempfile
 import unittest
 
 import numpy as np
@@ -33,6 +32,7 @@ from diffusers import (
     UNet2DConditionModel,
 )
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     floats_tensor,
@@ -210,7 +210,7 @@ class StableDiffusionDiffEditPipelineFastTests(
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_upscale.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_upscale.py
@@ -15,7 +15,6 @@
 
 import gc
 import random
-import tempfile
 import unittest
 
 import numpy as np
@@ -25,6 +24,7 @@ from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
 from diffusers import AutoencoderKL, DDIMScheduler, DDPMScheduler, StableDiffusionUpscalePipeline, UNet2DConditionModel
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     backend_max_memory_allocated,
     backend_reset_max_memory_allocated,
@@ -358,7 +358,7 @@ class StableDiffusionUpscalePipelineFastTests(unittest.TestCase):
         sd_pipe = sd_pipe.to(device)
         pipes.append(sd_pipe)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             sd_pipe.save_pretrained(tmpdirname)
             sd_pipe = StableDiffusionUpscalePipeline.from_pretrained(tmpdirname).to(device)
         pipes.append(sd_pipe)

--- a/tests/pipelines/stable_diffusion_2/test_stable_diffusion_upscale.py
+++ b/tests/pipelines/stable_diffusion_2/test_stable_diffusion_upscale.py
@@ -358,7 +358,7 @@ class StableDiffusionUpscalePipelineFastTests(unittest.TestCase):
         sd_pipe = sd_pipe.to(device)
         pipes.append(sd_pipe)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             sd_pipe.save_pretrained(tmpdirname)
             sd_pipe = StableDiffusionUpscalePipeline.from_pretrained(tmpdirname).to(device)
         pipes.append(sd_pipe)

--- a/tests/pipelines/stable_diffusion_safe/test_safe_diffusion.py
+++ b/tests/pipelines/stable_diffusion_safe/test_safe_diffusion.py
@@ -219,7 +219,7 @@ class SafeDiffusionPipelineFastTests(unittest.TestCase):
         assert image is not None
 
         # check that there's no error when saving a pipeline with one of the models being None
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname)
             pipe = StableDiffusionPipeline.from_pretrained(tmpdirname)
 

--- a/tests/pipelines/stable_diffusion_safe/test_safe_diffusion.py
+++ b/tests/pipelines/stable_diffusion_safe/test_safe_diffusion.py
@@ -15,7 +15,6 @@
 
 import gc
 import random
-import tempfile
 import unittest
 
 import numpy as np
@@ -24,7 +23,14 @@ from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
 from diffusers import AutoencoderKL, DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler, UNet2DConditionModel
 from diffusers.pipelines.stable_diffusion_safe import StableDiffusionPipelineSafe as StableDiffusionPipeline
-from diffusers.utils.testing_utils import floats_tensor, nightly, require_accelerator, require_torch_gpu, torch_device
+from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
+    floats_tensor,
+    nightly,
+    require_accelerator,
+    require_torch_gpu,
+    torch_device,
+)
 
 
 class SafeDiffusionPipelineFastTests(unittest.TestCase):
@@ -219,7 +225,7 @@ class SafeDiffusionPipelineFastTests(unittest.TestCase):
         assert image is not None
 
         # check that there's no error when saving a pipeline with one of the models being None
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname)
             pipe = StableDiffusionPipeline.from_pretrained(tmpdirname)
 

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -15,7 +15,6 @@
 
 import copy
 import gc
-import tempfile
 import unittest
 
 import numpy as np
@@ -35,6 +34,7 @@ from diffusers import (
     UniPCMultistepScheduler,
 )
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     enable_full_determinism,
     load_image,
     numpy_cosine_similarity_distance,
@@ -866,7 +866,7 @@ class StableDiffusionXLPipelineFastTests(
         sd_pipe = StableDiffusionXLPipeline(**components).to(torch_device)
         pipes.append(sd_pipe)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             sd_pipe.save_pretrained(tmpdirname)
             sd_pipe = StableDiffusionXLPipeline.from_pretrained(tmpdirname).to(torch_device)
         pipes.append(sd_pipe)

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -866,7 +866,7 @@ class StableDiffusionXLPipelineFastTests(
         sd_pipe = StableDiffusionXLPipeline(**components).to(torch_device)
         pipes.append(sd_pipe)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             sd_pipe.save_pretrained(tmpdirname)
             sd_pipe = StableDiffusionXLPipeline.from_pretrained(tmpdirname).to(torch_device)
         pipes.append(sd_pipe)

--- a/tests/pipelines/stable_video_diffusion/test_stable_video_diffusion.py
+++ b/tests/pipelines/stable_video_diffusion/test_stable_video_diffusion.py
@@ -273,7 +273,7 @@ class StableVideoDiffusionPipelineFastTests(PipelineTesterMixin, unittest.TestCa
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs).frames[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir, torch_dtype=torch.float16)
             for component in pipe_loaded.components.values():
@@ -316,7 +316,7 @@ class StableVideoDiffusionPipelineFastTests(PipelineTesterMixin, unittest.TestCa
         inputs = self.get_dummy_inputs(generator_device)
         output = pipe(**inputs).frames[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, safe_serialization=False)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             for component in pipe_loaded.components.values():
@@ -353,7 +353,7 @@ class StableVideoDiffusionPipelineFastTests(PipelineTesterMixin, unittest.TestCa
         logger = logging.get_logger("diffusers.pipelines.pipeline_utils")
         logger.setLevel(diffusers.logging.INFO)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, safe_serialization=False)
 
             with CaptureLogger(logger) as cap_logger:

--- a/tests/pipelines/stable_video_diffusion/test_stable_video_diffusion.py
+++ b/tests/pipelines/stable_video_diffusion/test_stable_video_diffusion.py
@@ -1,6 +1,5 @@
 import gc
 import random
-import tempfile
 import unittest
 
 import numpy as np
@@ -22,6 +21,7 @@ from diffusers.utils import load_image, logging
 from diffusers.utils.import_utils import is_xformers_available
 from diffusers.utils.testing_utils import (
     CaptureLogger,
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     floats_tensor,
@@ -273,7 +273,7 @@ class StableVideoDiffusionPipelineFastTests(PipelineTesterMixin, unittest.TestCa
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs).frames[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir, torch_dtype=torch.float16)
             for component in pipe_loaded.components.values():
@@ -316,7 +316,7 @@ class StableVideoDiffusionPipelineFastTests(PipelineTesterMixin, unittest.TestCa
         inputs = self.get_dummy_inputs(generator_device)
         output = pipe(**inputs).frames[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, safe_serialization=False)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             for component in pipe_loaded.components.values():
@@ -353,7 +353,7 @@ class StableVideoDiffusionPipelineFastTests(PipelineTesterMixin, unittest.TestCa
         logger = logging.get_logger("diffusers.pipelines.pipeline_utils")
         logger.setLevel(diffusers.logging.INFO)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, safe_serialization=False)
 
             with CaptureLogger(logger) as cap_logger:

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -121,7 +121,7 @@ def _test_from_save_pretrained_dynamo(in_queue, out_queue, timeout):
         ddpm.to(torch_device)
         ddpm.set_progress_bar_config(disable=None)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             ddpm.save_pretrained(tmpdirname)
             new_ddpm = DDPMPipeline.from_pretrained(tmpdirname)
             new_ddpm.to(torch_device)
@@ -160,7 +160,7 @@ class DownloadTests(unittest.TestCase):
         if torch_device == "mps":
             return
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             with requests_mock.mock(real_http=True) as m:
                 DiffusionPipeline.download("hf-internal-testing/tiny-stable-diffusion-pipe", cache_dir=tmpdirname)
 
@@ -184,7 +184,7 @@ class DownloadTests(unittest.TestCase):
             ), "We should call only `model_info` to check for _commit hash and `send_telemetry`"
 
     def test_less_downloads_passed_object(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             cached_folder = DiffusionPipeline.download(
                 "hf-internal-testing/tiny-stable-diffusion-pipe", safety_checker=None, cache_dir=tmpdirname
             )
@@ -206,7 +206,7 @@ class DownloadTests(unittest.TestCase):
         if torch_device == "mps":
             return
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             with requests_mock.mock(real_http=True) as m:
                 DiffusionPipeline.download(
                     "hf-internal-testing/tiny-stable-diffusion-pipe", safety_checker=None, cache_dir=tmpdirname
@@ -234,7 +234,7 @@ class DownloadTests(unittest.TestCase):
             ), "We should call only `model_info` to check for _commit hash and `send_telemetry`"
 
     def test_download_only_pytorch(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             # pipeline has Flax weights
             tmpdirname = DiffusionPipeline.download(
                 "hf-internal-testing/tiny-stable-diffusion-pipe", safety_checker=None, cache_dir=tmpdirname
@@ -250,7 +250,7 @@ class DownloadTests(unittest.TestCase):
             assert not any(f.endswith(".safetensors") for f in files)
 
     def test_force_safetensors_error(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             # pipeline has Flax weights
             with self.assertRaises(EnvironmentError):
                 tmpdirname = DiffusionPipeline.download(
@@ -261,7 +261,7 @@ class DownloadTests(unittest.TestCase):
                 )
 
     def test_download_safetensors(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             # pipeline has Flax weights
             tmpdirname = DiffusionPipeline.download(
                 "hf-internal-testing/tiny-stable-diffusion-pipe-safetensors",
@@ -278,7 +278,7 @@ class DownloadTests(unittest.TestCase):
 
     def test_download_safetensors_index(self):
         for variant in ["fp16", None]:
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 tmpdirname = DiffusionPipeline.download(
                     "hf-internal-testing/tiny-stable-diffusion-pipe-indexes",
                     cache_dir=tmpdirname,
@@ -302,7 +302,7 @@ class DownloadTests(unittest.TestCase):
 
     def test_download_bin_index(self):
         for variant in ["fp16", None]:
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 tmpdirname = DiffusionPipeline.download(
                     "hf-internal-testing/tiny-stable-diffusion-pipe-indexes",
                     cache_dir=tmpdirname,
@@ -325,7 +325,7 @@ class DownloadTests(unittest.TestCase):
                 assert not any(".safetensors" in f for f in files)
 
     def test_download_no_openvino_by_default(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             tmpdirname = DiffusionPipeline.download(
                 "hf-internal-testing/tiny-stable-diffusion-open-vino",
                 cache_dir=tmpdirname,
@@ -339,7 +339,7 @@ class DownloadTests(unittest.TestCase):
             assert not any("openvino_" in f for f in files)
 
     def test_download_no_onnx_by_default(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             tmpdirname = DiffusionPipeline.download(
                 "hf-internal-testing/tiny-stable-diffusion-xl-pipe",
                 cache_dir=tmpdirname,
@@ -355,7 +355,7 @@ class DownloadTests(unittest.TestCase):
 
     @require_onnxruntime
     def test_download_onnx_by_default_for_onnx_pipelines(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             tmpdirname = DiffusionPipeline.download(
                 "hf-internal-testing/tiny-random-OnnxStableDiffusionPipeline",
                 cache_dir=tmpdirname,
@@ -394,7 +394,7 @@ class DownloadTests(unittest.TestCase):
         generator = torch.manual_seed(0)
         out = pipe(prompt, num_inference_steps=2, generator=generator, output_type="np").images
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname)
             pipe_2 = StableDiffusionPipeline.from_pretrained(tmpdirname, safety_checker=None)
             pipe_2 = pipe_2.to(torch_device)
@@ -413,7 +413,7 @@ class DownloadTests(unittest.TestCase):
         generator = torch.manual_seed(0)
         out = pipe(prompt, num_inference_steps=2, generator=generator, output_type="np").images
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname)
             pipe_2 = StableDiffusionPipeline.from_pretrained(tmpdirname)
             pipe_2 = pipe_2.to(torch_device)
@@ -461,7 +461,7 @@ class DownloadTests(unittest.TestCase):
 
         # first check that with local files only the pipeline can only be used if cached
         with self.assertRaises(FileNotFoundError):
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 orig_pipe = DiffusionPipeline.from_pretrained(
                     "hf-internal-testing/tiny-stable-diffusion-torch", local_files_only=True, cache_dir=tmpdirname
                 )
@@ -490,7 +490,7 @@ class DownloadTests(unittest.TestCase):
     def test_download_from_variant_folder(self):
         for use_safetensors in [False, True]:
             other_format = ".bin" if use_safetensors else ".safetensors"
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 tmpdirname = StableDiffusionPipeline.download(
                     "hf-internal-testing/stable-diffusion-all-variants",
                     cache_dir=tmpdirname,
@@ -512,7 +512,7 @@ class DownloadTests(unittest.TestCase):
             this_format = ".safetensors" if use_safetensors else ".bin"
             variant = "fp16"
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 tmpdirname = StableDiffusionPipeline.download(
                     "hf-internal-testing/stable-diffusion-all-variants",
                     cache_dir=tmpdirname,
@@ -537,7 +537,7 @@ class DownloadTests(unittest.TestCase):
             this_format = ".safetensors" if use_safetensors else ".bin"
             variant = "no_ema"
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 tmpdirname = StableDiffusionPipeline.download(
                     "hf-internal-testing/stable-diffusion-all-variants",
                     cache_dir=tmpdirname,
@@ -564,7 +564,7 @@ class DownloadTests(unittest.TestCase):
         # the `text_encoder`. Their checkpoints can be sharded.
         for use_safetensors in [True, False]:
             for variant in ["fp16", None]:
-                with tempfile.TemporaryDirectory() as tmpdirname:
+                with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                     tmpdirname = DiffusionPipeline.download(
                         "hf-internal-testing/tiny-stable-diffusion-pipe-variants-right-format",
                         safety_checker=None,
@@ -590,7 +590,7 @@ class DownloadTests(unittest.TestCase):
 
         for is_local in [True, False]:
             with CaptureLogger(logger) as cap_logger:
-                with tempfile.TemporaryDirectory() as tmpdirname:
+                with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                     local_repo_id = repo_id
                     if is_local:
                         local_repo_id = snapshot_download(repo_id, cache_dir=tmpdirname)
@@ -608,7 +608,7 @@ class DownloadTests(unittest.TestCase):
         use_safetensors = True
 
         # text encoder is missing no variant weights, so the following can't work
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             with self.assertRaises(OSError) as error_context:
                 tmpdirname = StableDiffusionPipeline.from_pretrained(
                     "hf-internal-testing/stable-diffusion-broken-variants",
@@ -619,7 +619,7 @@ class DownloadTests(unittest.TestCase):
             assert "Error no file name" in str(error_context.exception)
 
         # text encoder has fp16 variants so we can load it
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             tmpdirname = StableDiffusionPipeline.download(
                 "hf-internal-testing/stable-diffusion-broken-variants",
                 use_safetensors=use_safetensors,
@@ -637,7 +637,7 @@ class DownloadTests(unittest.TestCase):
         use_safetensors = False
 
         # text encoder is missing Non-variant weights, so the following can't work
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             with self.assertRaises(OSError) as error_context:
                 tmpdirname = StableDiffusionPipeline.from_pretrained(
                     "hf-internal-testing/stable-diffusion-broken-variants",
@@ -648,7 +648,7 @@ class DownloadTests(unittest.TestCase):
             assert "Error no file name" in str(error_context.exception)
 
         # text encoder has fp16 variants so we can load it
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             tmpdirname = StableDiffusionPipeline.download(
                 "hf-internal-testing/stable-diffusion-broken-variants",
                 use_safetensors=use_safetensors,
@@ -666,7 +666,7 @@ class DownloadTests(unittest.TestCase):
         use_safetensors = True
 
         # text encoder is missing no_ema variant weights, so the following can't work
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             with self.assertRaises(OSError) as error_context:
                 tmpdirname = StableDiffusionPipeline.from_pretrained(
                     "hf-internal-testing/stable-diffusion-broken-variants",
@@ -682,7 +682,7 @@ class DownloadTests(unittest.TestCase):
         use_safetensors = False
 
         # text encoder is missing no_ema variant weights, so the following can't work
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             with self.assertRaises(OSError) as error_context:
                 tmpdirname = StableDiffusionPipeline.from_pretrained(
                     "hf-internal-testing/stable-diffusion-broken-variants",
@@ -706,7 +706,7 @@ class DownloadTests(unittest.TestCase):
                 generator = torch.manual_seed(0)
                 out = pipe(prompt, num_inference_steps=2, generator=generator, output_type="np").images
 
-                with tempfile.TemporaryDirectory() as tmpdirname:
+                with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                     pipe.save_pretrained(tmpdirname, variant=variant, safe_serialization=use_safe)
                     pipe_2 = StableDiffusionPipeline.from_pretrained(
                         tmpdirname, safe_serialization=use_safe, variant=variant
@@ -728,7 +728,7 @@ class DownloadTests(unittest.TestCase):
         num_tokens = len(pipe.tokenizer)
 
         # single token load local
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             ten = {"<*>": torch.ones((32,))}
             torch.save(ten, os.path.join(tmpdirname, "learned_embeds.bin"))
 
@@ -744,7 +744,7 @@ class DownloadTests(unittest.TestCase):
             assert out.shape == (1, 128, 128, 3)
 
         # single token load local with weight name
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             ten = {"<**>": 2 * torch.ones((1, 32))}
             torch.save(ten, os.path.join(tmpdirname, "learned_embeds.bin"))
 
@@ -760,7 +760,7 @@ class DownloadTests(unittest.TestCase):
             assert out.shape == (1, 128, 128, 3)
 
         # multi token load
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             ten = {"<***>": torch.cat([3 * torch.ones((1, 32)), 4 * torch.ones((1, 32)), 5 * torch.ones((1, 32))])}
             torch.save(ten, os.path.join(tmpdirname, "learned_embeds.bin"))
 
@@ -783,7 +783,7 @@ class DownloadTests(unittest.TestCase):
             assert out.shape == (1, 128, 128, 3)
 
         # multi token load a1111
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             ten = {
                 "string_to_param": {
                     "*": torch.cat([3 * torch.ones((1, 32)), 4 * torch.ones((1, 32)), 5 * torch.ones((1, 32))])
@@ -811,8 +811,8 @@ class DownloadTests(unittest.TestCase):
             assert out.shape == (1, 128, 128, 3)
 
         # multi embedding load
-        with tempfile.TemporaryDirectory() as tmpdirname1:
-            with tempfile.TemporaryDirectory() as tmpdirname2:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname1:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname2:
                 ten = {"<*****>": torch.ones((32,))}
                 torch.save(ten, os.path.join(tmpdirname1, "learned_embeds.bin"))
 
@@ -977,7 +977,7 @@ class DownloadTests(unittest.TestCase):
 
     def test_download_ignore_files(self):
         # Check https://huggingface.co/hf-internal-testing/tiny-stable-diffusion-pipe-ignore-files/blob/72f58636e5508a218c6b3f60550dc96445547817/model_index.json#L4
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             # pipeline has Flax weights
             tmpdirname = DiffusionPipeline.download("hf-internal-testing/tiny-stable-diffusion-pipe-ignore-files")
             all_root_files = [t[-1] for t in os.walk(os.path.join(tmpdirname))]
@@ -1141,7 +1141,7 @@ class CustomPipelineTests(unittest.TestCase):
             scheduler=DDIMScheduler(),
         )
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname, safe_serialization=False)
 
             pipe_new = CustomPipeline.from_pretrained(tmpdirname)
@@ -1186,14 +1186,14 @@ class CustomPipelineTests(unittest.TestCase):
             "hf-internal-testing/tiny-stable-diffusion-torch", safety_checker=None
         )
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.save_pretrained(tmpdirname)
             pipe = DiffusionPipeline.from_pretrained(tmpdirname)
 
             assert pipe.scheduler.__class__.__name__ == "PNDMScheduler"
 
         # let's make sure that changing the scheduler is correctly reflected
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe.scheduler = DPMSolverMultistepScheduler.from_config(pipe.scheduler.config)
             pipe.save_pretrained(tmpdirname)
             pipe = DiffusionPipeline.from_pretrained(tmpdirname)
@@ -1546,7 +1546,7 @@ class PipelineFastTests(unittest.TestCase):
 
     def test_save_safe_serialization(self):
         pipeline = StableDiffusionPipeline.from_pretrained("hf-internal-testing/tiny-stable-diffusion-torch")
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipeline.save_pretrained(tmpdirname, safe_serialization=True)
 
             # Validate that the VAE safetensor exists and are of the correct format
@@ -1573,7 +1573,7 @@ class PipelineFastTests(unittest.TestCase):
 
     def test_no_pytorch_download_when_doing_safetensors(self):
         # by default we don't download
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             _ = StableDiffusionPipeline.from_pretrained(
                 "hf-internal-testing/diffusers-stable-diffusion-tiny-all", cache_dir=tmpdirname
             )
@@ -1593,7 +1593,7 @@ class PipelineFastTests(unittest.TestCase):
     def test_no_safetensors_download_when_doing_pytorch(self):
         use_safetensors = False
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             _ = StableDiffusionPipeline.from_pretrained(
                 "hf-internal-testing/diffusers-stable-diffusion-tiny-all",
                 cache_dir=tmpdirname,
@@ -1632,7 +1632,7 @@ class PipelineFastTests(unittest.TestCase):
 
         assert sd.config.requires_safety_checker is True
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             sd.save_pretrained(tmpdirname)
 
             # Test that passing None works
@@ -1644,7 +1644,7 @@ class PipelineFastTests(unittest.TestCase):
             assert sd.config.safety_checker == (None, None)
             assert sd.config.feature_extractor == (None, None)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             sd.save_pretrained(tmpdirname)
 
             # Test that loading previous None works
@@ -1686,7 +1686,7 @@ class PipelineFastTests(unittest.TestCase):
             assert sd.config.safety_checker == (None, None)
             assert sd.config.feature_extractor == (None, None)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             sd.save_pretrained(tmpdirname)
 
             # Test that partially loading works
@@ -1708,7 +1708,7 @@ class PipelineFastTests(unittest.TestCase):
             assert sd.config.safety_checker != (None, None)
             assert sd.config.feature_extractor != (None, None)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             sd.save_pretrained(tmpdirname)
             sd = StableDiffusionPipeline.from_pretrained(tmpdirname, feature_extractor=self.dummy_extractor)
 
@@ -1722,7 +1722,7 @@ class PipelineFastTests(unittest.TestCase):
 
         assert sd.name_or_path == model_path
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             sd.save_pretrained(tmpdirname)
             sd = DiffusionPipeline.from_pretrained(tmpdirname)
 
@@ -1825,7 +1825,7 @@ class PipelineFastTests(unittest.TestCase):
     @require_hf_hub_version_greater("0.26.5")
     @require_transformers_version_greater("4.47.1")
     def test_load_dduf_from_hub(self, dtype):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe = DiffusionPipeline.from_pretrained(
                 "DDUF/tiny-flux-dev-pipe-dduf", dduf_file="fluxpipeline.dduf", cache_dir=tmpdir, torch_dtype=dtype
             ).to(torch_device)
@@ -1843,7 +1843,7 @@ class PipelineFastTests(unittest.TestCase):
     @require_hf_hub_version_greater("0.26.5")
     @require_transformers_version_greater("4.47.1")
     def test_load_dduf_from_hub_local_files_only(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe = DiffusionPipeline.from_pretrained(
                 "DDUF/tiny-flux-dev-pipe-dduf", dduf_file="fluxpipeline.dduf", cache_dir=tmpdir
             ).to(torch_device)
@@ -1883,7 +1883,7 @@ class PipelineFastTests(unittest.TestCase):
     @require_hf_hub_version_greater("0.26.5")
     @require_transformers_version_greater("4.47.1")
     def test_dduf_load_sharded_checkpoint_diffusion_model(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe = DiffusionPipeline.from_pretrained(
                 "hf-internal-testing/tiny-flux-dev-pipe-sharded-checkpoint-DDUF",
                 dduf_file="tiny-flux-dev-pipe-sharded-checkpoint.dduf",
@@ -1919,7 +1919,7 @@ class PipelineSlowTests(unittest.TestCase):
 
     def test_smart_download(self):
         model_id = "hf-internal-testing/unet-pipeline-dummy"
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             _ = DiffusionPipeline.from_pretrained(model_id, cache_dir=tmpdirname, force_download=True)
             local_repo_name = "--".join(["models"] + model_id.split("/"))
             snapshot_dir = os.path.join(tmpdirname, local_repo_name, "snapshots")
@@ -1941,7 +1941,7 @@ class PipelineSlowTests(unittest.TestCase):
     def test_warning_unused_kwargs(self):
         model_id = "hf-internal-testing/unet-pipeline-dummy"
         logger = logging.get_logger("diffusers.pipelines")
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             with CaptureLogger(logger) as cap_logger:
                 DiffusionPipeline.from_pretrained(
                     model_id,
@@ -1972,7 +1972,7 @@ class PipelineSlowTests(unittest.TestCase):
         ddpm.to(torch_device)
         ddpm.set_progress_bar_config(disable=None)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             ddpm.save_pretrained(tmpdirname)
             new_ddpm = DDPMPipeline.from_pretrained(tmpdirname)
             new_ddpm.to(torch_device)
@@ -2069,14 +2069,14 @@ class PipelineSlowTests(unittest.TestCase):
 
         from diffusers import FlaxStableDiffusionPipeline
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe_pt.save_pretrained(tmpdirname)
 
             pipe_flax, params = FlaxStableDiffusionPipeline.from_pretrained(
                 tmpdirname, safety_checker=None, from_pt=True
             )
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             pipe_flax.save_pretrained(tmpdirname, params=params)
             pipe_pt_2 = StableDiffusionPipeline.from_pretrained(tmpdirname, safety_checker=None, from_flax=True)
             pipe_pt_2.to(torch_device)
@@ -2282,7 +2282,7 @@ class TestLoraHotSwappingForPipeline(unittest.TestCase):
         assert not (output0_before == 0).all()
         assert not (output1_before == 0).all()
 
-        with tempfile.TemporaryDirectory() as tmp_dirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dirname:
             # save the adapter checkpoints
             lora0_state_dicts = self.get_lora_state_dicts({"unet": pipeline.unet}, adapter_name="adapter0")
             StableDiffusionPipeline.save_lora_weights(
@@ -2413,7 +2413,7 @@ class TestLoraHotSwappingForPipeline(unittest.TestCase):
         pipeline.text_encoder.add_adapter(lora_config0, adapter_name="adapter0")
         pipeline.text_encoder.add_adapter(lora_config1, adapter_name="adapter1")
 
-        with tempfile.TemporaryDirectory() as tmp_dirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dirname:
             # save the adapter checkpoints
             lora0_state_dicts = self.get_lora_state_dicts(
                 {"text_encoder": pipeline.text_encoder}, adapter_name="adapter0"

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -1136,7 +1136,7 @@ class PipelineTesterMixin:
         logger = logging.get_logger("diffusers.pipelines.pipeline_utils")
         logger.setLevel(diffusers.logging.INFO)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, safe_serialization=False)
 
             with CaptureLogger(logger) as cap_logger:
@@ -1401,7 +1401,7 @@ class PipelineTesterMixin:
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir, torch_dtype=torch.float16)
             for component in pipe_loaded.components.values():
@@ -1444,7 +1444,7 @@ class PipelineTesterMixin:
         torch.manual_seed(0)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, safe_serialization=False)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
             for component in pipe_loaded.components.values():
@@ -1975,7 +1975,7 @@ class PipelineTesterMixin:
         ]
         variant = "fp16"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, variant=variant, safe_serialization=False)
 
             with open(f"{tmpdir}/model_index.json", "r") as f:
@@ -1999,7 +1999,7 @@ class PipelineTesterMixin:
                 has_nan = torch.isnan(tensor).any()
             return has_nan
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir, variant=variant, safe_serialization=False)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir, variant=variant)
 
@@ -2026,7 +2026,7 @@ class PipelineTesterMixin:
         pipe = self.pipeline_class(**components)
         variant = "fp16"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             # Don't save with variants.
             pipe.save_pretrained(tmpdir, safe_serialization=False)
 
@@ -2181,7 +2181,7 @@ class PipelineTesterMixin:
 
         pipeline_out = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             dduf_filename = os.path.join(tmpdir, f"{pipe.__class__.__name__.lower()}.dduf")
             pipe.save_pretrained(tmpdir, safe_serialization=True)
             export_folder_as_dduf(dduf_filename, folder_path=tmpdir)
@@ -2355,7 +2355,7 @@ class PipelinePushToHubTester(unittest.TestCase):
         )
         text_encoder = CLIPTextModel(text_encoder_config)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             dummy_vocab = {"<|startoftext|>": 0, "<|endoftext|>": 1, "!": 2}
             vocab_path = os.path.join(tmpdir, "vocab.json")
             with open(vocab_path, "w") as f:
@@ -2392,7 +2392,7 @@ class PipelinePushToHubTester(unittest.TestCase):
         delete_repo(token=TOKEN, repo_id=self.repo_id)
 
         # Push to hub via save_pretrained
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             pipeline.save_pretrained(tmp_dir, repo_id=self.repo_id, push_to_hub=True, token=TOKEN)
 
         new_model = UNet2DConditionModel.from_pretrained(f"{USER}/{self.repo_id}", subfolder="unet")
@@ -2416,7 +2416,7 @@ class PipelinePushToHubTester(unittest.TestCase):
         delete_repo(token=TOKEN, repo_id=self.org_repo_id)
 
         # Push to hub via save_pretrained
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             pipeline.save_pretrained(tmp_dir, push_to_hub=True, token=TOKEN, repo_id=self.org_repo_id)
 
         new_model = UNet2DConditionModel.from_pretrained(self.org_repo_id, subfolder="unet")

--- a/tests/pipelines/test_pipelines_flax.py
+++ b/tests/pipelines/test_pipelines_flax.py
@@ -35,7 +35,7 @@ if is_flax_available():
 @require_flax
 class DownloadTests(unittest.TestCase):
     def test_download_only_pytorch(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             # pipeline has Flax weights
             _ = FlaxDiffusionPipeline.from_pretrained(
                 "hf-internal-testing/tiny-stable-diffusion-pipe", safety_checker=None, cache_dir=tmpdirname

--- a/tests/pipelines/test_pipelines_flax.py
+++ b/tests/pipelines/test_pipelines_flax.py
@@ -14,13 +14,12 @@
 # limitations under the License.
 
 import os
-import tempfile
 import unittest
 
 import numpy as np
 
 from diffusers.utils import is_flax_available
-from diffusers.utils.testing_utils import require_flax, slow
+from diffusers.utils.testing_utils import TemporaryDirectory, require_flax, slow
 
 
 if is_flax_available():
@@ -35,7 +34,7 @@ if is_flax_available():
 @require_flax
 class DownloadTests(unittest.TestCase):
     def test_download_only_pytorch(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             # pipeline has Flax weights
             _ = FlaxDiffusionPipeline.from_pretrained(
                 "hf-internal-testing/tiny-stable-diffusion-pipe", safety_checker=None, cache_dir=tmpdirname

--- a/tests/pipelines/text_to_video_synthesis/test_text_to_video_zero_sdxl.py
+++ b/tests/pipelines/text_to_video_synthesis/test_text_to_video_zero_sdxl.py
@@ -15,7 +15,6 @@
 
 import gc
 import inspect
-import tempfile
 import unittest
 
 import numpy as np
@@ -24,6 +23,7 @@ from transformers import CLIPTextConfig, CLIPTextModel, CLIPTextModelWithProject
 
 from diffusers import AutoencoderKL, DDIMScheduler, TextToVideoZeroSDXLPipeline, UNet2DConditionModel
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     enable_full_determinism,
     nightly,
     require_accelerate_version_greater,
@@ -299,7 +299,7 @@ class TextToVideoZeroSDXLPipelineFastTests(PipelineTesterMixin, PipelineFromPipe
         inputs = self.get_dummy_inputs(self.generator_device)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir, torch_dtype=torch.float16)
             pipe_loaded.to(torch_device)

--- a/tests/pipelines/text_to_video_synthesis/test_text_to_video_zero_sdxl.py
+++ b/tests/pipelines/text_to_video_synthesis/test_text_to_video_zero_sdxl.py
@@ -299,7 +299,7 @@ class TextToVideoZeroSDXLPipelineFastTests(PipelineTesterMixin, PipelineFromPipe
         inputs = self.get_dummy_inputs(self.generator_device)
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             pipe.save_pretrained(tmpdir)
             pipe_loaded = self.pipeline_class.from_pretrained(tmpdir, torch_dtype=torch.float16)
             pipe_loaded.to(torch_device)

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -347,7 +347,7 @@ class BnB4BitBasicTests(Base4bitTests):
         r"""
         Test if loading with an incorrect state dict raises an error.
         """
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             nf4_config = BitsAndBytesConfig(load_in_4bit=True)
             model_4bit = SD3Transformer2DModel.from_pretrained(
                 self.model_name, subfolder="transformer", quantization_config=nf4_config, device_map=torch_device
@@ -778,7 +778,7 @@ class BaseBnb4BitSerializationTests(Base4bitTests):
             device_map=torch_device,
         )
         self.assertTrue("_pre_quantization_dtype" in model_0.config)
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model_0.save_pretrained(tmpdirname, safe_serialization=safe_serialization)
 
             config = SD3Transformer2DModel.load_config(tmpdirname)

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import gc
 import os
-import tempfile
 import unittest
 
 import numpy as np
@@ -33,6 +32,7 @@ from diffusers import (
 from diffusers.utils import is_accelerate_version, logging
 from diffusers.utils.testing_utils import (
     CaptureLogger,
+    TemporaryDirectory,
     backend_empty_cache,
     is_bitsandbytes_available,
     is_torch_available,
@@ -347,7 +347,7 @@ class BnB4BitBasicTests(Base4bitTests):
         r"""
         Test if loading with an incorrect state dict raises an error.
         """
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             nf4_config = BitsAndBytesConfig(load_in_4bit=True)
             model_4bit = SD3Transformer2DModel.from_pretrained(
                 self.model_name, subfolder="transformer", quantization_config=nf4_config, device_map=torch_device
@@ -778,7 +778,7 @@ class BaseBnb4BitSerializationTests(Base4bitTests):
             device_map=torch_device,
         )
         self.assertTrue("_pre_quantization_dtype" in model_0.config)
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             model_0.save_pretrained(tmpdirname, safe_serialization=safe_serialization)
 
             config = SD3Transformer2DModel.load_config(tmpdirname)

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import gc
-import tempfile
 import unittest
 
 import numpy as np
@@ -31,6 +30,7 @@ from diffusers import (
 from diffusers.utils import is_accelerate_version
 from diffusers.utils.testing_utils import (
     CaptureLogger,
+    TemporaryDirectory,
     backend_empty_cache,
     is_bitsandbytes_available,
     is_torch_available,
@@ -718,7 +718,7 @@ class BaseBnb8bitSerializationTests(Base8bitTests):
         Test whether it is possible to serialize a model in 8-bit. Uses most typical params as default.
         """
         self.assertTrue("_pre_quantization_dtype" in self.model_0.config)
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             self.model_0.save_pretrained(tmpdirname)
 
             config = SD3Transformer2DModel.load_config(tmpdirname)
@@ -749,7 +749,7 @@ class BaseBnb8bitSerializationTests(Base8bitTests):
         self.assertTrue(torch.equal(out_0, out_1))
 
     def test_serialization_sharded(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             self.model_0.save_pretrained(tmpdirname, max_shard_size="200MB")
 
             config = SD3Transformer2DModel.load_config(tmpdirname)

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -718,7 +718,7 @@ class BaseBnb8bitSerializationTests(Base8bitTests):
         Test whether it is possible to serialize a model in 8-bit. Uses most typical params as default.
         """
         self.assertTrue("_pre_quantization_dtype" in self.model_0.config)
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             self.model_0.save_pretrained(tmpdirname)
 
             config = SD3Transformer2DModel.load_config(tmpdirname)
@@ -749,7 +749,7 @@ class BaseBnb8bitSerializationTests(Base8bitTests):
         self.assertTrue(torch.equal(out_0, out_1))
 
     def test_serialization_sharded(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             self.model_0.save_pretrained(tmpdirname, max_shard_size="200MB")
 
             config = SD3Transformer2DModel.load_config(tmpdirname)

--- a/tests/quantization/quanto/test_quanto.py
+++ b/tests/quantization/quanto/test_quanto.py
@@ -143,7 +143,7 @@ class QuantoBaseTesterMixin:
         with torch.no_grad():
             model_output = model(**inputs)
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             model.save_pretrained(tmp_dir)
             saved_model = self.model_cls.from_pretrained(
                 tmp_dir,

--- a/tests/quantization/quanto/test_quanto.py
+++ b/tests/quantization/quanto/test_quanto.py
@@ -1,11 +1,11 @@
 import gc
-import tempfile
 import unittest
 
 from diffusers import FluxPipeline, FluxTransformer2DModel, QuantoConfig
 from diffusers.models.attention_processor import Attention
 from diffusers.utils import is_optimum_quanto_available, is_torch_available
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     nightly,
     numpy_cosine_similarity_distance,
     require_accelerate,
@@ -143,7 +143,7 @@ class QuantoBaseTesterMixin:
         with torch.no_grad():
             model_output = model(**inputs)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             model.save_pretrained(tmp_dir)
             saved_model = self.model_cls.from_pretrained(
                 tmp_dir,

--- a/tests/quantization/torchao/test_torchao.py
+++ b/tests/quantization/torchao/test_torchao.py
@@ -316,7 +316,7 @@ class TorchAoTest(unittest.TestCase):
                 expected_slice = expected_slice_auto
             else:
                 expected_slice = expected_slice_offload
-            with tempfile.TemporaryDirectory() as offload_folder:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as offload_folder:
                 quantization_config = TorchAoConfig("int4_weight_only", group_size=64)
                 quantized_model = FluxTransformer2DModel.from_pretrained(
                     "hf-internal-testing/tiny-flux-pipe",
@@ -340,7 +340,7 @@ class TorchAoTest(unittest.TestCase):
                 output_slice = output.flatten()[-9:].detach().float().cpu().numpy()
                 self.assertTrue(numpy_cosine_similarity_distance(output_slice, expected_slice) < 1e-3)
 
-            with tempfile.TemporaryDirectory() as offload_folder:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as offload_folder:
                 quantization_config = TorchAoConfig("int4_weight_only", group_size=64)
                 quantized_model = FluxTransformer2DModel.from_pretrained(
                     "hf-internal-testing/tiny-flux-sharded",
@@ -576,7 +576,7 @@ class TorchAoSerializationTest(unittest.TestCase):
     def _check_serialization_expected_slice(self, quant_method, quant_method_kwargs, expected_slice, device):
         quantized_model = self.get_dummy_model(quant_method, quant_method_kwargs, device)
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             quantized_model.save_pretrained(tmp_dir, safe_serialization=False)
             loaded_quantized_model = FluxTransformer2DModel.from_pretrained(
                 tmp_dir, torch_dtype=torch.bfloat16, use_safetensors=False
@@ -728,7 +728,7 @@ class SlowTorchAoTests(unittest.TestCase):
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0].flatten()[:128]
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             pipe.transformer.save_pretrained(tmp_dir, safe_serialization=False)
             pipe.remove_all_hooks()
             del pipe.transformer

--- a/tests/schedulers/test_scheduler_deis.py
+++ b/tests/schedulers/test_scheduler_deis.py
@@ -43,7 +43,7 @@ class DEISMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -77,7 +77,7 @@ class DEISMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_deis.py
+++ b/tests/schedulers/test_scheduler_deis.py
@@ -1,4 +1,3 @@
-import tempfile
 import unittest
 
 import torch
@@ -9,6 +8,7 @@ from diffusers import (
     DPMSolverSinglestepScheduler,
     UniPCMultistepScheduler,
 )
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 from .test_schedulers import SchedulerCommonTest
 
@@ -43,7 +43,7 @@ class DEISMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -77,7 +77,7 @@ class DEISMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_dpm_multi.py
+++ b/tests/schedulers/test_scheduler_dpm_multi.py
@@ -1,4 +1,3 @@
-import tempfile
 import unittest
 
 import torch
@@ -9,6 +8,7 @@ from diffusers import (
     DPMSolverSinglestepScheduler,
     UniPCMultistepScheduler,
 )
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 from .test_schedulers import SchedulerCommonTest
 
@@ -53,7 +53,7 @@ class DPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -87,7 +87,7 @@ class DPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_dpm_multi.py
+++ b/tests/schedulers/test_scheduler_dpm_multi.py
@@ -53,7 +53,7 @@ class DPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -87,7 +87,7 @@ class DPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_dpm_multi_inverse.py
+++ b/tests/schedulers/test_scheduler_dpm_multi_inverse.py
@@ -45,7 +45,7 @@ class DPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -78,7 +78,7 @@ class DPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_dpm_multi_inverse.py
+++ b/tests/schedulers/test_scheduler_dpm_multi_inverse.py
@@ -1,8 +1,7 @@
-import tempfile
-
 import torch
 
 from diffusers import DPMSolverMultistepInverseScheduler, DPMSolverMultistepScheduler
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 from .test_schedulers import SchedulerCommonTest
 
@@ -45,7 +44,7 @@ class DPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -78,7 +77,7 @@ class DPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_dpm_single.py
+++ b/tests/schedulers/test_scheduler_dpm_single.py
@@ -51,7 +51,7 @@ class DPMSolverSinglestepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -85,7 +85,7 @@ class DPMSolverSinglestepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_dpm_single.py
+++ b/tests/schedulers/test_scheduler_dpm_single.py
@@ -1,4 +1,3 @@
-import tempfile
 import unittest
 
 import torch
@@ -9,6 +8,7 @@ from diffusers import (
     DPMSolverSinglestepScheduler,
     UniPCMultistepScheduler,
 )
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 from .test_schedulers import SchedulerCommonTest
 
@@ -51,7 +51,7 @@ class DPMSolverSinglestepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -85,7 +85,7 @@ class DPMSolverSinglestepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_edm_dpmsolver_multistep.py
+++ b/tests/schedulers/test_scheduler_edm_dpmsolver_multistep.py
@@ -1,9 +1,9 @@
-import tempfile
 import unittest
 
 import torch
 
 from diffusers import EDMDPMSolverMultistepScheduler
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 from .test_schedulers import SchedulerCommonTest
 
@@ -46,7 +46,7 @@ class EDMDPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -80,7 +80,7 @@ class EDMDPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_edm_dpmsolver_multistep.py
+++ b/tests/schedulers/test_scheduler_edm_dpmsolver_multistep.py
@@ -46,7 +46,7 @@ class EDMDPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -80,7 +80,7 @@ class EDMDPMSolverMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_edm_euler.py
+++ b/tests/schedulers/test_scheduler_edm_euler.py
@@ -89,7 +89,7 @@ class EDMEulerSchedulerTest(SchedulerCommonTest):
             scheduler_config = self.get_scheduler_config()
             scheduler = scheduler_class(**scheduler_config)
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 

--- a/tests/schedulers/test_scheduler_edm_euler.py
+++ b/tests/schedulers/test_scheduler_edm_euler.py
@@ -1,11 +1,11 @@
 import inspect
-import tempfile
 import unittest
 from typing import Dict, List, Tuple
 
 import torch
 
 from diffusers import EDMEulerScheduler
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 from .test_schedulers import SchedulerCommonTest
 
@@ -89,7 +89,7 @@ class EDMEulerSchedulerTest(SchedulerCommonTest):
             scheduler_config = self.get_scheduler_config()
             scheduler = scheduler_class(**scheduler_config)
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 

--- a/tests/schedulers/test_scheduler_flax.py
+++ b/tests/schedulers/test_scheduler_flax.py
@@ -82,7 +82,7 @@ class FlaxSchedulerCommonTest(unittest.TestCase):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -111,7 +111,7 @@ class FlaxSchedulerCommonTest(unittest.TestCase):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -139,7 +139,7 @@ class FlaxSchedulerCommonTest(unittest.TestCase):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -394,7 +394,7 @@ class FlaxDDIMSchedulerTest(FlaxSchedulerCommonTest):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -422,7 +422,7 @@ class FlaxDDIMSchedulerTest(FlaxSchedulerCommonTest):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -451,7 +451,7 @@ class FlaxDDIMSchedulerTest(FlaxSchedulerCommonTest):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -658,7 +658,7 @@ class FlaxPNDMSchedulerTest(FlaxSchedulerCommonTest):
             # copy over dummy past residuals
             state = state.replace(ets=dummy_past_residuals[:])
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
                 new_state = new_scheduler.set_timesteps(new_state, num_inference_steps, shape=sample.shape)
@@ -746,7 +746,7 @@ class FlaxPNDMSchedulerTest(FlaxSchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.ets = dummy_past_residuals[:]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_flax.py
+++ b/tests/schedulers/test_scheduler_flax.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import inspect
-import tempfile
 import unittest
 from typing import Dict, List, Tuple
 
 from diffusers import FlaxDDIMScheduler, FlaxDDPMScheduler, FlaxPNDMScheduler
 from diffusers.utils import is_flax_available
-from diffusers.utils.testing_utils import require_flax
+from diffusers.utils.testing_utils import TemporaryDirectory, require_flax
 
 
 if is_flax_available():
@@ -82,7 +81,7 @@ class FlaxSchedulerCommonTest(unittest.TestCase):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -111,7 +110,7 @@ class FlaxSchedulerCommonTest(unittest.TestCase):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -139,7 +138,7 @@ class FlaxSchedulerCommonTest(unittest.TestCase):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -394,7 +393,7 @@ class FlaxDDIMSchedulerTest(FlaxSchedulerCommonTest):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -422,7 +421,7 @@ class FlaxDDIMSchedulerTest(FlaxSchedulerCommonTest):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -451,7 +450,7 @@ class FlaxDDIMSchedulerTest(FlaxSchedulerCommonTest):
             scheduler = scheduler_class(**scheduler_config)
             state = scheduler.create_state()
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
 
@@ -658,7 +657,7 @@ class FlaxPNDMSchedulerTest(FlaxSchedulerCommonTest):
             # copy over dummy past residuals
             state = state.replace(ets=dummy_past_residuals[:])
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
                 new_state = new_scheduler.set_timesteps(new_state, num_inference_steps, shape=sample.shape)
@@ -746,7 +745,7 @@ class FlaxPNDMSchedulerTest(FlaxSchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.ets = dummy_past_residuals[:]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler, new_state = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_ipndm.py
+++ b/tests/schedulers/test_scheduler_ipndm.py
@@ -1,9 +1,9 @@
-import tempfile
 import unittest
 
 import torch
 
 from diffusers import IPNDMScheduler
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 from .test_schedulers import SchedulerCommonTest
 
@@ -34,7 +34,7 @@ class IPNDMSchedulerTest(SchedulerCommonTest):
             if time_step is None:
                 time_step = scheduler.timesteps[len(scheduler.timesteps) // 2]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -73,7 +73,7 @@ class IPNDMSchedulerTest(SchedulerCommonTest):
             if time_step is None:
                 time_step = scheduler.timesteps[len(scheduler.timesteps) // 2]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_ipndm.py
+++ b/tests/schedulers/test_scheduler_ipndm.py
@@ -34,7 +34,7 @@ class IPNDMSchedulerTest(SchedulerCommonTest):
             if time_step is None:
                 time_step = scheduler.timesteps[len(scheduler.timesteps) // 2]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -73,7 +73,7 @@ class IPNDMSchedulerTest(SchedulerCommonTest):
             if time_step is None:
                 time_step = scheduler.timesteps[len(scheduler.timesteps) // 2]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_lcm.py
+++ b/tests/schedulers/test_scheduler_lcm.py
@@ -118,7 +118,7 @@ class LCMSchedulerTest(SchedulerCommonTest):
             sample = self.dummy_sample
             residual = 0.1 * sample
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 

--- a/tests/schedulers/test_scheduler_lcm.py
+++ b/tests/schedulers/test_scheduler_lcm.py
@@ -1,10 +1,9 @@
-import tempfile
 from typing import Dict, List, Tuple
 
 import torch
 
 from diffusers import LCMScheduler
-from diffusers.utils.testing_utils import torch_device
+from diffusers.utils.testing_utils import TemporaryDirectory, torch_device
 
 from .test_schedulers import SchedulerCommonTest
 
@@ -118,7 +117,7 @@ class LCMSchedulerTest(SchedulerCommonTest):
             sample = self.dummy_sample
             residual = 0.1 * sample
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 

--- a/tests/schedulers/test_scheduler_pndm.py
+++ b/tests/schedulers/test_scheduler_pndm.py
@@ -1,9 +1,9 @@
-import tempfile
 import unittest
 
 import torch
 
 from diffusers import PNDMScheduler
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 from .test_schedulers import SchedulerCommonTest
 
@@ -37,7 +37,7 @@ class PNDMSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.ets = dummy_past_residuals[:]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -73,7 +73,7 @@ class PNDMSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.ets = dummy_past_residuals[:]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_pndm.py
+++ b/tests/schedulers/test_scheduler_pndm.py
@@ -37,7 +37,7 @@ class PNDMSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.ets = dummy_past_residuals[:]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -73,7 +73,7 @@ class PNDMSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.ets = dummy_past_residuals[:]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_score_sde_ve.py
+++ b/tests/schedulers/test_scheduler_score_sde_ve.py
@@ -1,10 +1,10 @@
-import tempfile
 import unittest
 
 import numpy as np
 import torch
 
 from diffusers import ScoreSdeVeScheduler
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 class ScoreSdeVeSchedulerTest(unittest.TestCase):
@@ -66,7 +66,7 @@ class ScoreSdeVeSchedulerTest(unittest.TestCase):
             scheduler_config = self.get_scheduler_config(**config)
             scheduler = scheduler_class(**scheduler_config)
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -97,7 +97,7 @@ class ScoreSdeVeSchedulerTest(unittest.TestCase):
             scheduler_config = self.get_scheduler_config()
             scheduler = scheduler_class(**scheduler_config)
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 

--- a/tests/schedulers/test_scheduler_score_sde_ve.py
+++ b/tests/schedulers/test_scheduler_score_sde_ve.py
@@ -66,7 +66,7 @@ class ScoreSdeVeSchedulerTest(unittest.TestCase):
             scheduler_config = self.get_scheduler_config(**config)
             scheduler = scheduler_class(**scheduler_config)
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -97,7 +97,7 @@ class ScoreSdeVeSchedulerTest(unittest.TestCase):
             scheduler_config = self.get_scheduler_config()
             scheduler = scheduler_class(**scheduler_config)
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 

--- a/tests/schedulers/test_scheduler_unipc.py
+++ b/tests/schedulers/test_scheduler_unipc.py
@@ -44,7 +44,7 @@ class UniPCMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -74,7 +74,7 @@ class UniPCMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_scheduler_unipc.py
+++ b/tests/schedulers/test_scheduler_unipc.py
@@ -1,5 +1,3 @@
-import tempfile
-
 import torch
 
 from diffusers import (
@@ -8,6 +6,7 @@ from diffusers import (
     DPMSolverSinglestepScheduler,
     UniPCMultistepScheduler,
 )
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 from .test_schedulers import SchedulerCommonTest
 
@@ -44,7 +43,7 @@ class UniPCMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 new_scheduler.set_timesteps(num_inference_steps)
@@ -74,7 +73,7 @@ class UniPCMultistepSchedulerTest(SchedulerCommonTest):
             # copy over dummy past residuals (must be after setting timesteps)
             scheduler.model_outputs = dummy_past_residuals[: scheduler.config.solver_order]
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
                 # copy over dummy past residuals

--- a/tests/schedulers/test_schedulers.py
+++ b/tests/schedulers/test_schedulers.py
@@ -106,7 +106,7 @@ class SchedulerBaseTests(unittest.TestCase):
         setattr(diffusers, "SchedulerObject", SchedulerObject)
         logger = logging.get_logger("diffusers.configuration_utils")
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             obj.save_config(tmpdirname)
             with CaptureLogger(logger) as cap_logger_1:
                 config = SchedulerObject2.load_config(tmpdirname)
@@ -152,7 +152,7 @@ class SchedulerBaseTests(unittest.TestCase):
         setattr(diffusers, "SchedulerObject2", SchedulerObject2)
         logger = logging.get_logger("diffusers.configuration_utils")
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             obj.save_config(tmpdirname)
 
             # now save a config parameter that is expected by another class, but not origin class
@@ -191,7 +191,7 @@ class SchedulerBaseTests(unittest.TestCase):
         logger = logging.get_logger("diffusers.configuration_utils")
         logger.setLevel(diffusers.logging.INFO)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             obj.save_config(tmpdirname)
 
             with CaptureLogger(logger) as cap_logger_1:
@@ -398,7 +398,7 @@ class SchedulerCommonTest(unittest.TestCase):
                 sample = self.dummy_sample
                 residual = 0.1 * sample
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -451,7 +451,7 @@ class SchedulerCommonTest(unittest.TestCase):
                 sample = self.dummy_sample
                 residual = 0.1 * sample
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -497,7 +497,7 @@ class SchedulerCommonTest(unittest.TestCase):
                 sample = self.dummy_sample
                 residual = 0.1 * sample
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -547,7 +547,7 @@ class SchedulerCommonTest(unittest.TestCase):
 
             scheduler = scheduler_class(**scheduler_config)
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_pretrained(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -756,7 +756,7 @@ class SchedulerCommonTest(unittest.TestCase):
             scheduler_config = self.get_scheduler_config()
             scheduler = scheduler_class(**scheduler_config, trained_betas=np.array([0.1, 0.3]))
 
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_pretrained(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -830,7 +830,7 @@ class SchedulerPushToHubTester(unittest.TestCase):
         delete_repo(token=TOKEN, repo_id=self.repo_id)
 
         # Push to hub via save_config
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             scheduler.save_config(tmp_dir, repo_id=self.repo_id, push_to_hub=True, token=TOKEN)
 
         scheduler_loaded = DDIMScheduler.from_pretrained(f"{USER}/{self.repo_id}")
@@ -857,7 +857,7 @@ class SchedulerPushToHubTester(unittest.TestCase):
         delete_repo(token=TOKEN, repo_id=self.org_repo_id)
 
         # Push to hub via save_config
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             scheduler.save_config(tmp_dir, repo_id=self.org_repo_id, push_to_hub=True, token=TOKEN)
 
         scheduler_loaded = DDIMScheduler.from_pretrained(self.org_repo_id)

--- a/tests/schedulers/test_schedulers.py
+++ b/tests/schedulers/test_schedulers.py
@@ -15,7 +15,6 @@
 import inspect
 import json
 import os
-import tempfile
 import unittest
 import uuid
 from typing import Dict, List, Tuple
@@ -41,7 +40,7 @@ from diffusers import (
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.schedulers.scheduling_utils import SchedulerMixin
 from diffusers.utils import logging
-from diffusers.utils.testing_utils import CaptureLogger, torch_device
+from diffusers.utils.testing_utils import CaptureLogger, TemporaryDirectory, torch_device
 
 from ..others.test_utils import TOKEN, USER, is_staging_test
 
@@ -106,7 +105,7 @@ class SchedulerBaseTests(unittest.TestCase):
         setattr(diffusers, "SchedulerObject", SchedulerObject)
         logger = logging.get_logger("diffusers.configuration_utils")
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             obj.save_config(tmpdirname)
             with CaptureLogger(logger) as cap_logger_1:
                 config = SchedulerObject2.load_config(tmpdirname)
@@ -152,7 +151,7 @@ class SchedulerBaseTests(unittest.TestCase):
         setattr(diffusers, "SchedulerObject2", SchedulerObject2)
         logger = logging.get_logger("diffusers.configuration_utils")
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             obj.save_config(tmpdirname)
 
             # now save a config parameter that is expected by another class, but not origin class
@@ -191,7 +190,7 @@ class SchedulerBaseTests(unittest.TestCase):
         logger = logging.get_logger("diffusers.configuration_utils")
         logger.setLevel(diffusers.logging.INFO)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
             obj.save_config(tmpdirname)
 
             with CaptureLogger(logger) as cap_logger_1:
@@ -398,7 +397,7 @@ class SchedulerCommonTest(unittest.TestCase):
                 sample = self.dummy_sample
                 residual = 0.1 * sample
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -451,7 +450,7 @@ class SchedulerCommonTest(unittest.TestCase):
                 sample = self.dummy_sample
                 residual = 0.1 * sample
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -497,7 +496,7 @@ class SchedulerCommonTest(unittest.TestCase):
                 sample = self.dummy_sample
                 residual = 0.1 * sample
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_config(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -547,7 +546,7 @@ class SchedulerCommonTest(unittest.TestCase):
 
             scheduler = scheduler_class(**scheduler_config)
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_pretrained(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -756,7 +755,7 @@ class SchedulerCommonTest(unittest.TestCase):
             scheduler_config = self.get_scheduler_config()
             scheduler = scheduler_class(**scheduler_config, trained_betas=np.array([0.1, 0.3]))
 
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
                 scheduler.save_pretrained(tmpdirname)
                 new_scheduler = scheduler_class.from_pretrained(tmpdirname)
 
@@ -830,7 +829,7 @@ class SchedulerPushToHubTester(unittest.TestCase):
         delete_repo(token=TOKEN, repo_id=self.repo_id)
 
         # Push to hub via save_config
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             scheduler.save_config(tmp_dir, repo_id=self.repo_id, push_to_hub=True, token=TOKEN)
 
         scheduler_loaded = DDIMScheduler.from_pretrained(f"{USER}/{self.repo_id}")
@@ -857,7 +856,7 @@ class SchedulerPushToHubTester(unittest.TestCase):
         delete_repo(token=TOKEN, repo_id=self.org_repo_id)
 
         # Push to hub via save_config
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
             scheduler.save_config(tmp_dir, repo_id=self.org_repo_id, push_to_hub=True, token=TOKEN)
 
         scheduler_loaded = DDIMScheduler.from_pretrained(self.org_repo_id)

--- a/tests/single_file/single_file_testing_utils.py
+++ b/tests/single_file/single_file_testing_utils.py
@@ -1,4 +1,3 @@
-import tempfile
 from io import BytesIO
 
 import requests
@@ -8,6 +7,7 @@ from huggingface_hub import hf_hub_download, snapshot_download
 from diffusers.loaders.single_file_utils import _extract_repo_id_and_weights_name
 from diffusers.models.attention_processor import AttnProcessor
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     numpy_cosine_similarity_distance,
     torch_device,
 )
@@ -100,7 +100,7 @@ class SDSingleFileTesterMixin:
     def test_single_file_components_local_files_only(self, pipe=None, single_file_pipe=None):
         pipe = pipe or self.pipeline_class.from_pretrained(self.repo_id, safety_checker=None)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -140,7 +140,7 @@ class SDSingleFileTesterMixin:
         # we just pass it in here otherwise this test will fail
         upcast_attention = pipe.unet.config.upcast_attention
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)
@@ -193,7 +193,7 @@ class SDSingleFileTesterMixin:
     ):
         pipe = pipe or self.pipeline_class.from_pretrained(self.repo_id, safety_checker=None)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)
@@ -288,7 +288,7 @@ class SDXLSingleFileTesterMixin:
     ):
         pipe = pipe or self.pipeline_class.from_pretrained(self.repo_id, safety_checker=None)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -329,7 +329,7 @@ class SDXLSingleFileTesterMixin:
         # we just pass it in here otherwise this test will fail
         upcast_attention = pipe.unet.config.upcast_attention
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)
@@ -366,7 +366,7 @@ class SDXLSingleFileTesterMixin:
     ):
         pipe = pipe or self.pipeline_class.from_pretrained(self.repo_id, safety_checker=None)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)

--- a/tests/single_file/single_file_testing_utils.py
+++ b/tests/single_file/single_file_testing_utils.py
@@ -100,7 +100,7 @@ class SDSingleFileTesterMixin:
     def test_single_file_components_local_files_only(self, pipe=None, single_file_pipe=None):
         pipe = pipe or self.pipeline_class.from_pretrained(self.repo_id, safety_checker=None)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -140,7 +140,7 @@ class SDSingleFileTesterMixin:
         # we just pass it in here otherwise this test will fail
         upcast_attention = pipe.unet.config.upcast_attention
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)
@@ -193,7 +193,7 @@ class SDSingleFileTesterMixin:
     ):
         pipe = pipe or self.pipeline_class.from_pretrained(self.repo_id, safety_checker=None)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)
@@ -288,7 +288,7 @@ class SDXLSingleFileTesterMixin:
     ):
         pipe = pipe or self.pipeline_class.from_pretrained(self.repo_id, safety_checker=None)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -329,7 +329,7 @@ class SDXLSingleFileTesterMixin:
         # we just pass it in here otherwise this test will fail
         upcast_attention = pipe.unet.config.upcast_attention
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)
@@ -366,7 +366,7 @@ class SDXLSingleFileTesterMixin:
     ):
         pipe = pipe or self.pipeline_class.from_pretrained(self.repo_id, safety_checker=None)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)

--- a/tests/single_file/test_stable_diffusion_controlnet_img2img_single_file.py
+++ b/tests/single_file/test_stable_diffusion_controlnet_img2img_single_file.py
@@ -1,5 +1,4 @@
 import gc
-import tempfile
 import unittest
 
 import torch
@@ -8,6 +7,7 @@ from diffusers import ControlNetModel, StableDiffusionControlNetPipeline
 from diffusers.loaders.single_file_utils import _extract_repo_id_and_weights_name
 from diffusers.utils import load_image
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     numpy_cosine_similarity_distance,
@@ -111,7 +111,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
         controlnet = ControlNetModel.from_pretrained("lllyasviel/control_v11p_sd15_canny")
         pipe = self.pipeline_class.from_pretrained(self.repo_id, controlnet=controlnet)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weights_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weights_name, tmpdir)
 
@@ -139,7 +139,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
             controlnet=controlnet,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weights_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weights_name, tmpdir)
 
@@ -172,7 +172,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
             controlnet=controlnet,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weights_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weights_name, tmpdir)
 

--- a/tests/single_file/test_stable_diffusion_controlnet_img2img_single_file.py
+++ b/tests/single_file/test_stable_diffusion_controlnet_img2img_single_file.py
@@ -111,7 +111,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
         controlnet = ControlNetModel.from_pretrained("lllyasviel/control_v11p_sd15_canny")
         pipe = self.pipeline_class.from_pretrained(self.repo_id, controlnet=controlnet)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weights_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weights_name, tmpdir)
 
@@ -139,7 +139,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
             controlnet=controlnet,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weights_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weights_name, tmpdir)
 
@@ -172,7 +172,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
             controlnet=controlnet,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weights_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weights_name, tmpdir)
 

--- a/tests/single_file/test_stable_diffusion_controlnet_inpaint_single_file.py
+++ b/tests/single_file/test_stable_diffusion_controlnet_inpaint_single_file.py
@@ -105,7 +105,7 @@ class StableDiffusionControlNetInpaintPipelineSingleFileSlowTests(unittest.TestC
         controlnet = ControlNetModel.from_pretrained("lllyasviel/control_v11p_sd15_canny")
         pipe = self.pipeline_class.from_pretrained(self.repo_id, safety_checker=None, controlnet=controlnet)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -136,7 +136,7 @@ class StableDiffusionControlNetInpaintPipelineSingleFileSlowTests(unittest.TestC
             safety_checker=None,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)
@@ -173,7 +173,7 @@ class StableDiffusionControlNetInpaintPipelineSingleFileSlowTests(unittest.TestC
             safety_checker=None,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)

--- a/tests/single_file/test_stable_diffusion_controlnet_inpaint_single_file.py
+++ b/tests/single_file/test_stable_diffusion_controlnet_inpaint_single_file.py
@@ -1,5 +1,4 @@
 import gc
-import tempfile
 import unittest
 
 import torch
@@ -8,6 +7,7 @@ from diffusers import ControlNetModel, StableDiffusionControlNetInpaintPipeline
 from diffusers.loaders.single_file_utils import _extract_repo_id_and_weights_name
 from diffusers.utils import load_image
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     numpy_cosine_similarity_distance,
@@ -105,7 +105,7 @@ class StableDiffusionControlNetInpaintPipelineSingleFileSlowTests(unittest.TestC
         controlnet = ControlNetModel.from_pretrained("lllyasviel/control_v11p_sd15_canny")
         pipe = self.pipeline_class.from_pretrained(self.repo_id, safety_checker=None, controlnet=controlnet)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -136,7 +136,7 @@ class StableDiffusionControlNetInpaintPipelineSingleFileSlowTests(unittest.TestC
             safety_checker=None,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)
@@ -173,7 +173,7 @@ class StableDiffusionControlNetInpaintPipelineSingleFileSlowTests(unittest.TestC
             safety_checker=None,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)

--- a/tests/single_file/test_stable_diffusion_controlnet_single_file.py
+++ b/tests/single_file/test_stable_diffusion_controlnet_single_file.py
@@ -1,5 +1,4 @@
 import gc
-import tempfile
 import unittest
 
 import torch
@@ -8,6 +7,7 @@ from diffusers import ControlNetModel, StableDiffusionControlNetPipeline
 from diffusers.loaders.single_file_utils import _extract_repo_id_and_weights_name
 from diffusers.utils import load_image
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     numpy_cosine_similarity_distance,
@@ -102,7 +102,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
         controlnet = ControlNetModel.from_pretrained("lllyasviel/control_v11p_sd15_canny")
         pipe = self.pipeline_class.from_pretrained(self.repo_id, controlnet=controlnet)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -130,7 +130,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
             controlnet=controlnet,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)
@@ -161,7 +161,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
             safety_checker=None,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)

--- a/tests/single_file/test_stable_diffusion_controlnet_single_file.py
+++ b/tests/single_file/test_stable_diffusion_controlnet_single_file.py
@@ -102,7 +102,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
         controlnet = ControlNetModel.from_pretrained("lllyasviel/control_v11p_sd15_canny")
         pipe = self.pipeline_class.from_pretrained(self.repo_id, controlnet=controlnet)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -130,7 +130,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
             controlnet=controlnet,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)
@@ -161,7 +161,7 @@ class StableDiffusionControlNetPipelineSingleFileSlowTests(unittest.TestCase, SD
             safety_checker=None,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)

--- a/tests/single_file/test_stable_diffusion_single_file.py
+++ b/tests/single_file/test_stable_diffusion_single_file.py
@@ -64,7 +64,7 @@ class StableDiffusionPipelineSingleFileSlowTests(unittest.TestCase, SDSingleFile
         super().test_single_file_format_inference_is_same_as_pretrained(expected_max_diff=1e-3)
 
     def test_single_file_legacy_scheduler_loading(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)

--- a/tests/single_file/test_stable_diffusion_single_file.py
+++ b/tests/single_file/test_stable_diffusion_single_file.py
@@ -1,5 +1,4 @@
 import gc
-import tempfile
 import unittest
 
 import torch
@@ -8,6 +7,7 @@ from diffusers import EulerDiscreteScheduler, StableDiffusionInstructPix2PixPipe
 from diffusers.loaders.single_file_utils import _extract_repo_id_and_weights_name
 from diffusers.utils import load_image
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     nightly,
@@ -64,7 +64,7 @@ class StableDiffusionPipelineSingleFileSlowTests(unittest.TestCase, SDSingleFile
         super().test_single_file_format_inference_is_same_as_pretrained(expected_max_diff=1e-3)
 
     def test_single_file_legacy_scheduler_loading(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)

--- a/tests/single_file/test_stable_diffusion_xl_adapter_single_file.py
+++ b/tests/single_file/test_stable_diffusion_xl_adapter_single_file.py
@@ -120,7 +120,7 @@ class StableDiffusionXLAdapterPipelineSingleFileSlowTests(unittest.TestCase, SDX
             torch_dtype=torch.float16,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -152,7 +152,7 @@ class StableDiffusionXLAdapterPipelineSingleFileSlowTests(unittest.TestCase, SDX
             torch_dtype=torch.float16,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)
@@ -190,7 +190,7 @@ class StableDiffusionXLAdapterPipelineSingleFileSlowTests(unittest.TestCase, SDX
             torch_dtype=torch.float16,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)

--- a/tests/single_file/test_stable_diffusion_xl_adapter_single_file.py
+++ b/tests/single_file/test_stable_diffusion_xl_adapter_single_file.py
@@ -1,5 +1,4 @@
 import gc
-import tempfile
 import unittest
 
 import torch
@@ -11,6 +10,7 @@ from diffusers import (
 from diffusers.loaders.single_file_utils import _extract_repo_id_and_weights_name
 from diffusers.utils import load_image
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     numpy_cosine_similarity_distance,
@@ -120,7 +120,7 @@ class StableDiffusionXLAdapterPipelineSingleFileSlowTests(unittest.TestCase, SDX
             torch_dtype=torch.float16,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -152,7 +152,7 @@ class StableDiffusionXLAdapterPipelineSingleFileSlowTests(unittest.TestCase, SDX
             torch_dtype=torch.float16,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)
@@ -190,7 +190,7 @@ class StableDiffusionXLAdapterPipelineSingleFileSlowTests(unittest.TestCase, SDX
             torch_dtype=torch.float16,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_original_config = download_original_config(self.original_config, tmpdir)

--- a/tests/single_file/test_stable_diffusion_xl_controlnet_single_file.py
+++ b/tests/single_file/test_stable_diffusion_xl_controlnet_single_file.py
@@ -113,7 +113,7 @@ class StableDiffusionXLControlNetPipelineSingleFileSlowTests(unittest.TestCase, 
             torch_dtype=torch.float16,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -152,7 +152,7 @@ class StableDiffusionXLControlNetPipelineSingleFileSlowTests(unittest.TestCase, 
             torch_dtype=torch.float16,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -184,7 +184,7 @@ class StableDiffusionXLControlNetPipelineSingleFileSlowTests(unittest.TestCase, 
             controlnet=controlnet,
         )
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)

--- a/tests/single_file/test_stable_diffusion_xl_controlnet_single_file.py
+++ b/tests/single_file/test_stable_diffusion_xl_controlnet_single_file.py
@@ -1,5 +1,4 @@
 import gc
-import tempfile
 import unittest
 
 import torch
@@ -8,6 +7,7 @@ from diffusers import ControlNetModel, StableDiffusionXLControlNetPipeline
 from diffusers.loaders.single_file_utils import _extract_repo_id_and_weights_name
 from diffusers.utils import load_image
 from diffusers.utils.testing_utils import (
+    TemporaryDirectory,
     backend_empty_cache,
     enable_full_determinism,
     numpy_cosine_similarity_distance,
@@ -113,7 +113,7 @@ class StableDiffusionXLControlNetPipelineSingleFileSlowTests(unittest.TestCase, 
             torch_dtype=torch.float16,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -152,7 +152,7 @@ class StableDiffusionXLControlNetPipelineSingleFileSlowTests(unittest.TestCase, 
             torch_dtype=torch.float16,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
 
@@ -184,7 +184,7 @@ class StableDiffusionXLControlNetPipelineSingleFileSlowTests(unittest.TestCase, 
             controlnet=controlnet,
         )
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             repo_id, weight_name = _extract_repo_id_and_weights_name(self.ckpt_path)
             local_ckpt_path = download_single_file_checkpoint(repo_id, weight_name, tmpdir)
             local_diffusers_config = download_diffusers_config(self.repo_id, tmpdir)

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -27,7 +27,6 @@ https://github.com/huggingface/transformers/blob/main/utils/update_metadata.py
 
 import argparse
 import os
-import tempfile
 
 import pandas as pd
 from datasets import Dataset
@@ -38,6 +37,7 @@ from diffusers.pipelines.auto_pipeline import (
     AUTO_INPAINT_PIPELINES_MAPPING,
     AUTO_TEXT2IMAGE_PIPELINES_MAPPING,
 )
+from diffusers.utils.testing_utils import TemporaryDirectory
 
 
 PIPELINE_TAG_JSON = "pipeline_tags.json"
@@ -91,7 +91,7 @@ def update_metadata(commit_sha: str):
     with open(hub_pipeline_tags_json) as f:
         hub_pipeline_tags_json = f.read()
 
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
+    with TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
         pipelines_dataset.to_json(os.path.join(tmp_dir, PIPELINE_TAG_JSON))
 
         with open(os.path.join(tmp_dir, PIPELINE_TAG_JSON)) as f:

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -91,7 +91,7 @@ def update_metadata(commit_sha: str):
     with open(hub_pipeline_tags_json) as f:
         hub_pipeline_tags_json = f.read()
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
         pipelines_dataset.to_json(os.path.join(tmp_dir, PIPELINE_TAG_JSON))
 
         with open(os.path.join(tmp_dir, PIPELINE_TAG_JSON)) as f:


### PR DESCRIPTION
# What does this PR do?

Allows tests using `tempfile.TemporaryDirectory` to run on Windows, the parameter was introduced in 3.10 so we include our own `TemporaryDirectory` based on the 3.10 version.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
