### PR TITLE
make test_dict_tuple_outputs_equivalent pass on XPU

### DIFF
--- a/tests/pipelines/i2vgen_xl/test_i2vgenxl.py
+++ b/tests/pipelines/i2vgen_xl/test_i2vgenxl.py
@@ -187,7 +187,7 @@ class I2VGenXLPipelineFastTests(SDFunctionTesterMixin, PipelineTesterMixin, unit
         super().test_sequential_cpu_offload_forward_pass(expected_max_diff=0.008)
 
     def test_dict_tuple_outputs_equivalent(self):
-        super().test_dict_tuple_outputs_equivalent(expected_max_difference=0.008)
+        super().test_dict_tuple_outputs_equivalent(expected_max_difference=0.009)
 
     def test_save_load_optional_components(self):
         super().test_save_load_optional_components(expected_max_difference=0.008)


### PR DESCRIPTION
**test case**
`pytest -rA tests/pipelines/i2vgen_xl/test_i2vgenxl.py::I2VGenXLPipelineFastTests::test_dict_tuple_outputs_equivalent`

**symptom on XPU**

> tests/pipelines/test_pipelines_common.py:1337: in test_dict_tuple_outputs_equivalent self.assertLess(max_diff, expected_max_difference) E   AssertionError: 0.008003175 not less than 0.008

**fix**
loose to `expected_max_difference` to 0.009, since XPU has a 0.000004+ w/ current 0.008 threshold.

@hlky, pls help review, thx. 
