### PR TITLE
[bitsandbytes] improve dtype mismatch handling for bnb + lora.

### DIFF
--- a/src/diffusers/loaders/lora_pipeline.py
+++ b/src/diffusers/loaders/lora_pipeline.py
@@ -94,6 +94,11 @@ def _maybe_dequantize_weight_for_expanded_lora(model, module):
         weight_on_cpu = True
 
     if is_bnb_4bit_quantized:
+        if module.weight.quant_state.dtype != model.dtype:
+            raise ValueError(
+                f"Model is in {model.dtype} dtype while the current module weight will be dequantized to {module.weight.quant_state.dtype} dtype. "
+                f"Please pass {module.weight.quant_state.dtype} as `torch_dtype` in `from_pretrained()`."
+            )
         module_weight = dequantize_bnb_weight(
             module.weight.cuda() if weight_on_cpu else module.weight,
             state=module.weight.quant_state,

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -752,6 +752,20 @@ class SlowBnb4BitFluxControlWithLoraTests(Base4bitTests):
         max_diff = numpy_cosine_similarity_distance(expected_slice, out_slice)
         self.assertTrue(max_diff < 1e-3, msg=f"{out_slice=} != {expected_slice=}")
 
+    def test_loading_lora_with_incorrect_dtype_raises_error(self):
+        self.tearDown()
+        model_dtype = torch.bfloat16
+        #  https://huggingface.co/eramth/flux-4bit/blob/main/transformer/config.json#L23
+        actual_dtype = torch.float16
+        self.pipeline_4bit = FluxControlPipeline.from_pretrained("eramth/flux-4bit", torch_dtype=torch.bfloat16)
+        self.pipeline_4bit.enable_model_cpu_offload()
+        with self.assertRaises(ValueError) as err_context:
+            self.pipeline_4bit.load_lora_weights("black-forest-labs/FLUX.1-Canny-dev-lora")
+        assert (
+            f"Model is in {model_dtype} dtype while the current module weight will be dequantized to {actual_dtype} dtype."
+            in str(err_context.exception)
+        )
+
 
 @slow
 class BaseBnb4BitSerializationTests(Base4bitTests):


### PR DESCRIPTION
# What does this PR do?

If we try to do:

```py
from diffusers import DiffusionPipeline, FluxControlPipeline
from PIL import Image
import torch

pipe = FluxControlPipeline.from_pretrained("eramth/flux-4bit", torch_dtype=torch.bfloat16).to("cuda")
pipe.load_lora_weights("black-forest-labs/FLUX.1-Canny-dev-lora")

pipe("a dog", control_image=Image.new(mode="RGB", size=(256, 256)))
```

we will run into

<details>
<summary>Error</summary>

```bash
Traceback (most recent call last):
  File "/fsx/sayak/diffusers/bnb_torch_dtype.py", line 8, in <module>
    pipe("a dog", control_image=Image.new(mode="RGB", size=(256, 256)))
  File "/fsx/sayak/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/fsx/sayak/diffusers/src/diffusers/pipelines/flux/pipeline_flux_control.py", line 835, in __call__
    noise_pred = self.transformer(
  File "/fsx/sayak/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/fsx/sayak/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
  File "/fsx/sayak/diffusers/src/diffusers/models/transformers/transformer_flux.py", line 445, in forward
    hidden_states = self.x_embedder(hidden_states)
  File "/fsx/sayak/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/fsx/sayak/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
  File "/fsx/sayak/miniconda3/envs/diffusers/lib/python3.10/site-packages/peft/tuners/lora/layer.py", line 712, in forward
    result = self.base_layer(x, *args, **kwargs)
  File "/fsx/sayak/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/fsx/sayak/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
  File "/fsx/sayak/miniconda3/envs/diffusers/lib/python3.10/site-packages/torch/nn/modules/linear.py", line 125, in forward
    return F.linear(input, self.weight, self.bias)
RuntimeError: self and mat2 must have the same dtype, but got BFloat16 and Half
```

</details>

This is confusing. This PR handles it by raising an error when it finds that the dtype of the dequatized weight will not match the model dtype. The error is raised after the `load_lora_weights()` call so users won't have to wait till the pipeline is called saving time.

```bash
Model is in torch.bfloat16 dtype while the current module weight will be dequantized to torch.float16 dtype. Please pass torch.float16 as `torch_dtype` in `from_pretrained()`.
```