### PR TITLE
[LoRA] improve LoRA fusion tests

### DIFF
--- a/src/diffusers/loaders/lora_base.py
+++ b/src/diffusers/loaders/lora_base.py
@@ -607,7 +607,10 @@ class LoraBaseMixin:
                         model, lora_scale=lora_scale, safe_fusing=safe_fusing, adapter_names=adapter_names
                     )
 
-        self.num_fused_loras += 1
+        if adapter_names is None:
+            self.num_fused_loras += 1
+        elif isinstance(adapter_names, list):
+            self.num_fused_loras += len(adapter_names)
 
     def unfuse_lora(self, components: List[str] = [], **kwargs):
         r"""
@@ -663,7 +666,7 @@ class LoraBaseMixin:
                         if isinstance(module, BaseTunerLayer):
                             module.unmerge()
 
-        self.num_fused_loras -= 1
+        self.num_fused_loras = 0
 
     def set_adapters(
         self,

--- a/tests/lora/utils.py
+++ b/tests/lora/utils.py
@@ -1766,8 +1766,7 @@ class PeftLoraLoaderMixinTests:
             pipe.set_adapters(["adapter-1"])
             outputs_lora_1 = pipe(**inputs, generator=torch.manual_seed(0))[0]
 
-            pipe.fuse_lora(components=self.pipeline_class._lora_loadable_modules)
-            # pipe.fuse_lora(components=self.pipeline_class._lora_loadable_modules, adapter_names=["adapter-1"])
+            pipe.fuse_lora(components=self.pipeline_class._lora_loadable_modules, adapter_names=["adapter-1"])
             assert pipe.num_fused_loras == 1
 
             # Fusing should still keep the LoRA layers so outpout should remain the same


### PR DESCRIPTION
# What does this PR do?

This PR improves our LoRA fusion tests by:

* Additionally checking the `pipe.num_fused_loras` argument. 
* Correctly determines `num_fused_loras` within `lora_base.py`.
* Adding a test `test_lora_scale_kwargs_match_fusion` that checks LoRA + scale outputs match with LoRA fusion with the same scale. 

@BenjaminBossan if I could pick your brain, the following tests are failing on a GPU but passing on a CPU:

```bash
FAILED tests/lora/test_lora_layers_sdxl.py::StableDiffusionXLLoRATests::test_simple_inference_with_text_denoiser_lora_unfused - AssertionError: False is not true : Fused lora should not change the output
FAILED tests/lora/test_lora_layers_sdxl.py::StableDiffusionXLLoRATests::test_simple_inference_with_text_lora_denoiser_fused_multi - AssertionError: False is not true : Fused lora should not change the output
FAILED tests/lora/test_lora_layers_sdxl.py::StableDiffusionXLLoRATests::test_lora_scale_kwargs_match_fusion_0 - AssertionError: False is not true : Fused lora should not change the output
FAILED tests/lora/test_lora_layers_sdxl.py::StableDiffusionXLLoRATests::test_lora_scale_kwargs_match_fusion_1 - AssertionError: False is not true : Fused lora should not change the output
```

Would you have any pointers? 