### PR TITLE
Fix vae.Decoder prev_output_channel

### DIFF
--- a/src/diffusers/models/autoencoders/vae.py
+++ b/src/diffusers/models/autoencoders/vae.py
@@ -255,7 +255,7 @@ class Decoder(nn.Module):
                 num_layers=self.layers_per_block + 1,
                 in_channels=prev_output_channel,
                 out_channels=output_channel,
-                prev_output_channel=None,
+                prev_output_channel=prev_output_channel,
                 add_upsample=not is_final_block,
                 resnet_eps=1e-6,
                 resnet_act_fn=act_fn,


### PR DESCRIPTION
# What does this PR do?

Reproduction

```python
from diffusers.models.autoencoders.vae import Decoder

decoder = Decoder(
    up_block_types=["ResnetUpsampleBlock2D"],
)
```

Fixes #11275



## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
