### PR TITLE
Fix incorrect tile_latent_min_width calculation in AutoencoderKLMochi

### DIFF
--- a/src/diffusers/models/autoencoders/autoencoder_kl_mochi.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_mochi.py
@@ -909,7 +909,7 @@ class AutoencoderKLMochi(ModelMixin, ConfigMixin):
     def _decode(self, z: torch.Tensor, return_dict: bool = True) -> Union[DecoderOutput, torch.Tensor]:
         batch_size, num_channels, num_frames, height, width = z.shape
         tile_latent_min_height = self.tile_sample_min_height // self.spatial_compression_ratio
-        tile_latent_min_width = self.tile_sample_stride_width // self.spatial_compression_ratio
+        tile_latent_min_width = self.tile_sample_min_width // self.spatial_compression_ratio
 
         if self.use_tiling and (width > tile_latent_min_width or height > tile_latent_min_height):
             return self.tiled_decode(z, return_dict=return_dict)


### PR DESCRIPTION
# What does this PR do?
This PR fixes an inconsistency in the calculation of `tile_latent_min_width` inside the AutoencoderKLMochi decoder.

Previously, `tile_latent_min_width` was incorrectly calculated using `self.tile_sample_stride_width`:

```python
tile_latent_min_width = self.tile_sample_stride_width // self.spatial_compression_ratio
```

This led to a mismatch with the corresponding height calculation, which correctly used `self.tile_sample_min_height`. The corrected line now uses `self.tile_sample_min_width`.

This discrepancy did not raise errors under default settings (e.g., 848x480 resolution), but could cause incorrect conditional evaluations in edge cases, such as when profiling or testing different resolutions.



<!-- Remove if not applicable -->

Fixes #11291.

## Who can review?

@a-r-r-o-w 