### PR TITLE
Fix incorrect tile_latent_min_width calculations

### DIFF
--- a/src/diffusers/models/autoencoders/autoencoder_kl_hunyuan_video.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_hunyuan_video.py
@@ -829,7 +829,7 @@ class AutoencoderKLHunyuanVideo(ModelMixin, ConfigMixin):
     def _decode(self, z: torch.Tensor, return_dict: bool = True) -> Union[DecoderOutput, torch.Tensor]:
         batch_size, num_channels, num_frames, height, width = z.shape
         tile_latent_min_height = self.tile_sample_min_height // self.spatial_compression_ratio
-        tile_latent_min_width = self.tile_sample_stride_width // self.spatial_compression_ratio
+        tile_latent_min_width = self.tile_sample_min_width // self.spatial_compression_ratio
         tile_latent_min_num_frames = self.tile_sample_min_num_frames // self.temporal_compression_ratio
 
         if self.use_framewise_decoding and num_frames > tile_latent_min_num_frames:

--- a/src/diffusers/models/autoencoders/autoencoder_kl_ltx.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_ltx.py
@@ -1285,7 +1285,7 @@ class AutoencoderKLLTXVideo(ModelMixin, ConfigMixin, FromOriginalModelMixin):
     ) -> Union[DecoderOutput, torch.Tensor]:
         batch_size, num_channels, num_frames, height, width = z.shape
         tile_latent_min_height = self.tile_sample_min_height // self.spatial_compression_ratio
-        tile_latent_min_width = self.tile_sample_stride_width // self.spatial_compression_ratio
+        tile_latent_min_width = self.tile_sample_min_width // self.spatial_compression_ratio
         tile_latent_min_num_frames = self.tile_sample_min_num_frames // self.temporal_compression_ratio
 
         if self.use_framewise_decoding and num_frames > tile_latent_min_num_frames:

--- a/src/diffusers/models/autoencoders/autoencoder_kl_magvit.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_magvit.py
@@ -887,7 +887,7 @@ class AutoencoderKLMagvit(ModelMixin, ConfigMixin):
     def _decode(self, z: torch.Tensor, return_dict: bool = True) -> Union[DecoderOutput, torch.Tensor]:
         batch_size, num_channels, num_frames, height, width = z.shape
         tile_latent_min_height = self.tile_sample_min_height // self.spatial_compression_ratio
-        tile_latent_min_width = self.tile_sample_stride_width // self.spatial_compression_ratio
+        tile_latent_min_width = self.tile_sample_min_width // self.spatial_compression_ratio
 
         if self.use_tiling and (z.shape[-1] > tile_latent_min_height or z.shape[-2] > tile_latent_min_width):
             return self.tiled_decode(z, return_dict=return_dict)


### PR DESCRIPTION
# What does this PR do?
This PR fixes the same issue that was recently addressed in AutoencoderKLMochi, where `tile_latent_min_width` was incorrectly calculated using `tile_sample_stride_width` instead of `tile_sample_min_width`.

The same mistake was found in the following autoencoders:

- [AutoencoderKLMagvit](https://github.com/huggingface/diffusers/blob/bc261058eee74aa6f574e840af9295b78b379f51/src/diffusers/models/autoencoders/autoencoder_kl_magvit.py#L890)
- [AutoencoderKLLTXVideo](https://github.com/huggingface/diffusers/blob/bc261058eee74aa6f574e840af9295b78b379f51/src/diffusers/models/autoencoders/autoencoder_kl_ltx.py#L1288)
- [AutoencoderKLHunyuanVideo](https://github.com/huggingface/diffusers/blob/bc261058eee74aa6f574e840af9295b78b379f51/src/diffusers/models/autoencoders/autoencoder_kl_hunyuan_video.py#L832)

This update ensures consistent and correct behavior across all affected models when VAE tiling is enabled.

Fixes: #11291. 

## Who can review?

@a-r-r-o-w 
