### PR TITLE
make test_stable_diffusion_karras_sigmas pass on XPU

### DIFF
--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_k_diffusion.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_k_diffusion.py
@@ -21,6 +21,7 @@ import torch
 
 from diffusers import StableDiffusionXLKDiffusionPipeline
 from diffusers.utils.testing_utils import (
+    Expectations,
     backend_empty_cache,
     enable_full_determinism,
     require_torch_accelerator,
@@ -106,7 +107,38 @@ class StableDiffusionXLKPipelineIntegrationTests(unittest.TestCase):
         image_slice = image[0, -3:, -3:, -1]
 
         assert image.shape == (1, 512, 512, 3)
-        expected_slice = np.array([0.6418, 0.6424, 0.6462, 0.6271, 0.6314, 0.6295, 0.6249, 0.6339, 0.6335])
+        expected_slices = Expectations(
+            {
+                ("xpu", 3): np.array(
+                    [
+                        0.6128,
+                        0.6108,
+                        0.6109,
+                        0.5997,
+                        0.5988,
+                        0.5948,
+                        0.5903,
+                        0.597,
+                        0.5973,
+                    ]
+                ),
+                ("cuda", 7): np.array(
+                    [
+                        0.6418,
+                        0.6424,
+                        0.6462,
+                        0.6271,
+                        0.6314,
+                        0.6295,
+                        0.6249,
+                        0.6339,
+                        0.6335,
+                    ]
+                ),
+            }
+        )
+
+        expected_slice = expected_slices.get_expectation()
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 


### PR DESCRIPTION
**test case**
`pytest -rA tests -k "StableDiffusionXLKPipelineIntegrationTests and test_stable_diffusion_karras_sigmas"`

**XPU**
![xpu](https://github.com/user-attachments/assets/d8ff04fe-41e5-4a7d-ae8e-001e50b93c1c)

**A100**
![cuda](https://github.com/user-attachments/assets/41232f0c-1aff-4398-ad49-8ff12efd88b2)

**Results**

XPU:    before this PR **fail**, after this PR **pass**
A100:  before this PR **pass**, after this PR **pass** 
