### PR TITLE
another fix for FlowMatchLCMScheduler forgotten import

### DIFF
--- a/src/diffusers/__init__.py
+++ b/src/diffusers/__init__.py
@@ -268,6 +268,7 @@ else:
             "EulerDiscreteScheduler",
             "FlowMatchEulerDiscreteScheduler",
             "FlowMatchHeunDiscreteScheduler",
+            "FlowMatchLCMScheduler",
             "HeunDiscreteScheduler",
             "IPNDMScheduler",
             "KarrasVeScheduler",


### PR DESCRIPTION
I had to switch systems to do the `fix-copies` and somehow this was not included to the original PR.

@yiyixuxu 