### PR TITLE
enable 2 test cases on XPU

### DIFF
--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -523,13 +523,15 @@ class SlowBnb8bitTests(Base8bitTests):
             torch_dtype=torch.float16,
             device_map=torch_device,
         )
+
         # CUDA device placement works.
+        device = torch_device if torch_device != "rocm" else "cuda"
         pipeline_8bit = DiffusionPipeline.from_pretrained(
             self.model_name,
             transformer=transformer_8bit,
             text_encoder_3=text_encoder_3_8bit,
             torch_dtype=torch.float16,
-        ).to("cuda")
+        ).to(device)
 
         # Check if inference works.
         _ = pipeline_8bit("table", max_sequence_length=20, num_inference_steps=2)

--- a/tests/quantization/utils.py
+++ b/tests/quantization/utils.py
@@ -1,10 +1,11 @@
 from diffusers.utils import is_torch_available
 from diffusers.utils.testing_utils import (
     backend_empty_cache,
-    backend_reset_peak_memory_stats,
     backend_max_memory_allocated,
+    backend_reset_peak_memory_stats,
     torch_device,
 )
+
 
 if is_torch_available():
     import torch

--- a/tests/quantization/utils.py
+++ b/tests/quantization/utils.py
@@ -1,5 +1,10 @@
 from diffusers.utils import is_torch_available
-
+from diffusers.utils.testing_utils import (
+    backend_empty_cache,
+    backend_reset_peak_memory_stats,
+    backend_max_memory_allocated,
+    torch_device,
+)
 
 if is_torch_available():
     import torch
@@ -30,9 +35,9 @@ if is_torch_available():
     @torch.no_grad()
     @torch.inference_mode()
     def get_memory_consumption_stat(model, inputs):
-        torch.cuda.reset_peak_memory_stats()
-        torch.cuda.empty_cache()
+        backend_reset_peak_memory_stats(torch_device)
+        backend_empty_cache(torch_device)
 
         model(**inputs)
-        max_memory_mem_allocated = torch.cuda.max_memory_allocated()
-        return max_memory_mem_allocated
+        max_mem_allocated = backend_max_memory_allocated(torch_device)
+        return max_mem_allocated


### PR DESCRIPTION
**test cases**
1. tests/quantization/bnb/test_mixed_int8.py::SlowBnb8bitTests::test_pipeline_cuda_placement_works_with_mixed_int8 PASS
2. tests/quantization/bnb/test_4bit.py::BnB4BitBasicTests::test_model_memory_usage FAIL, but it's ipex issue, validated success when ipex fixed, so still enable and once ipex fixed, it will naturally pass w/o modify test case.

**questions**
1. for `tests/quantization/bnb/test_mixed_int8.py`, I changed the hard-coding `"cuda"` to `device`. I tried directly it's OK to directly use `torch_device`, but I guess the reason you didn't use it is that maybe "rocm" system cannot work under "rocm" `to()`, but work on "cuda" `to`, so I added `+        device = torch_device if torch_device != "rocm" else "cuda"` to workaround. This is just a guess, @hlky, let me know if you think it's not correct.

@hlky , pls help review, thx.
