### PR TITLE
Fix wrong dtype argument name as torch_dtype

### DIFF
--- a/src/diffusers/loaders/ip_adapter.py
+++ b/src/diffusers/loaders/ip_adapter.py
@@ -526,7 +526,7 @@ class FluxIPAdapterMixin:
                                 low_cpu_mem_usage=low_cpu_mem_usage,
                                 cache_dir=cache_dir,
                                 local_files_only=local_files_only,
-                                dtype=image_encoder_dtype,
+                                torch_dtype=image_encoder_dtype,
                             )
                             .to(self.device)
                             .eval()


### PR DESCRIPTION
# What does this PR do?

In PR [Improve load_ip_adapter RAM Usage](https://github.com/huggingface/diffusers/pull/10948), while indeed improving ram usage, I believe a small mistake was done in the usage of dtype argument instead of torch_dtype.
For instance when using code from [Flux documentation on IP Adapters](https://huggingface.co/docs/diffusers/using-diffusers/loading_adapters#ip-adapter) we can observe the 
> CLIPVisionModelWithProjection got an unexpected keyword argument 'dtype

In the example provided in original PR it is not using the method from load IP adapter directly but rather from 
```python
model = CLIPVisionModelWithProjection.from_pretrained("eramth/ip-adapter",subfolder="sdxl_models/image_encoder",torch_dtype=torch.float16)
```


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed.
@asomoza @hlky as reviewers of original PR
