### PR TITLE
[BNB] Fix test_moving_to_cpu_throws_warning 

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -404,6 +404,11 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             if not is_accelerate_available() or is_accelerate_version("<", "0.14.0"):
                 return False
 
+            _, _, is_loaded_in_8bit_bnb = _check_bnb_status(module)
+
+            if is_loaded_in_8bit_bnb:
+                return False
+
             return hasattr(module, "_hf_hook") and (
                 isinstance(module._hf_hook, accelerate.hooks.AlignDevicesHook)
                 or hasattr(module._hf_hook, "hooks")


### PR DESCRIPTION
# What does this PR do?

Fixes tests/quantization/bnb/test_mixed_int8.py::SlowBnb8bitTests::test_moving_to_cpu_throws_warning due to this PR.
The issue is that since we used dispatch_model, when we load a 8-bit model, hooks will be attached to it (this is not the case for 4-bit). Due to that, `pipeline_is_sequentially_offloaded` is `True` -> `is_offloaded` also True. Thus, we didn't log the following : 
```python
            if (
                module.dtype == torch.float16
                and str(device) in ["cpu"]
                and not silence_dtype_warnings
                and not is_offloaded
            ):
                logger.warning(
                    "Pipelines loaded with `dtype=torch.float16` cannot run with `cpu` device. It"
                    " is not recommended to move them to `cpu` as running them will fail. Please make"
                    " sure to use an accelerator to run the pipeline in inference, due to the lack of"
                    " support for`float16` operations on this device in PyTorch. Please, remove the"
                    " `torch_dtype=torch.float16` argument, or use another device for inference."
                )
```

Traceback of the test before this PR 

```
================================ short test summary info ================================
FAILED tests/quantization/bnb/test_mixed_int8.py::SlowBnb8bitTests::test_moving_to_cpu_throws_warning - assert 'Pipelines loaded with `dtype=torch.float16`' in "The module 'SD3Transformer2DModel' has been loaded in `bitsandbytes` 8bit and moving it to cpu via `.to()` is not supported. Module is still on cuda:0.\n"
 +  where "The module 'SD3Transformer2DModel' has been loaded in `bitsandbytes` 8bit and moving it to cpu via `.to()` is not supported. Module is still on cuda:0.\n" = captured: The module 'SD3Transformer2DModel' has been loaded in `bitsandbytes` 8bit and moving it to cpu via `.to()` is not supported. Module is still on cuda:0.\n\n.out
```