### PR TITLE
Add stochastic sampling to FlowMatchEulerDiscreteScheduler

### DIFF
--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -456,7 +456,6 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             next_sigma = sigma_next
             dt = sigma_next - sigma
 
-        
         if self.config.stochastic_sampling:
             x0 = sample - current_sigma * model_output
             noise = torch.randn_like(sample)

--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -443,10 +443,10 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             lower_mask = sigmas < per_token_sigmas[None] - 1e-6
             lower_sigmas = lower_mask * sigmas
             lower_sigmas, _ = lower_sigmas.max(dim=0)
-            
+
             current_sigma = per_token_sigmas[..., None]
             next_sigma = lower_sigmas[..., None]
-            dt = next_sigma - current_sigma # Equivalent to sigma_next - sigma
+            dt = next_sigma - current_sigma  # Equivalent to sigma_next - sigma
         else:
             sigma_idx = self.step_index
             sigma = self.sigmas[sigma_idx]

--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -404,8 +404,6 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
                 A random number generator.
             per_token_timesteps (`torch.Tensor`, *optional*):
                 The timesteps for each token in the sample.
-            stochastic_sampling (`bool`, *optional*):
-                Whether to use stochastic sampling. If None, defaults to the value set in the scheduler's config.
             return_dict (`bool`):
                 Whether or not to return a
                 [`~schedulers.scheduling_flow_match_euler_discrete.FlowMatchEulerDiscreteSchedulerOutput`] or tuple.

--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -381,7 +381,6 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         s_noise: float = 1.0,
         generator: Optional[torch.Generator] = None,
         per_token_timesteps: Optional[torch.Tensor] = None,
-        stochastic_sampling: Optional[bool] = None,
         return_dict: bool = True,
     ) -> Union[FlowMatchEulerDiscreteSchedulerOutput, Tuple]:
         """

--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -446,7 +446,7 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
 
             current_sigma = per_token_sigmas[..., None]
             next_sigma = lower_sigmas[..., None]
-            dt = next_sigma - current_sigma  # Equivalent to sigma_next - sigma
+            dt = current_sigma - next_sigma
         else:
             sigma_idx = self.step_index
             sigma = self.sigmas[sigma_idx]

--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -456,10 +456,8 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
             next_sigma = sigma_next
             dt = sigma_next - sigma
 
-        # Determine whether to use stochastic sampling for this step
-        use_stochastic = stochastic_sampling if stochastic_sampling is not None else self.config.stochastic_sampling
-
-        if use_stochastic:
+        
+        if self.config.stochastic_sampling:
             x0 = sample - current_sigma * model_output
             noise = torch.randn_like(sample)
             prev_sample = (1.0 - next_sigma) * x0 + next_sigma * noise


### PR DESCRIPTION
# What does this PR do?

This PR adds stochastic sampling to FlowMatchEulerDiscreteScheduler based on https://github.com/Lightricks/LTX-Video/commit/b1aeddd7ccac85e6d1b0d97762610ddb53c1b408 `ltx_video/schedulers/rf.py`, which was added with th release of 0.9.6-distilled. I decoupled the next and current sigma to try to get closer to the `rf.py` implementation of the stochastic sampling, but a second pair of eyes on this would be great.

To try it: 
```py
import torch
from diffusers import LTXVideoTransformer3DModel, FlowMatchEulerDiscreteScheduler, LTXPipeline
from diffusers.utils import export_to_video

transformer = LTXVideoTransformer3DModel.from_pretrained(
    "multimodalart/ltxv-2b-0.9.6-distilled",
    subfolder="transformer",
    torch_dtype=torch.bfloat16,
    variant="bf16"
)

scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
    "multimodalart/ltxv-2b-0.9.6-distilled",
    subfolder="scheduler"
)

pipe = LTXPipeline.from_pretrained(
    "Lightricks/LTX-Video-0.9.5",
    transformer=transformer,
    scheduler=scheduler, #add or remove the scheduler to see the difference
    torch_dtype=torch.bfloat16,
)
pipe.to("cuda")

prompt = "A woman eating a burger"
negative_prompt = "worst quality, inconsistent motion, blurry, jittery, distorted"
generator = torch.Generator(device="cuda").manual_seed(42)
video = pipe(
    prompt=prompt,
    negative_prompt=negative_prompt,
    width=1216,
    height=704,
    num_frames=121,
    num_inference_steps=8,
    guidance_scale=1,
    generator=generator
).frames[0]

export_to_video(video, "distilled_scheduler.mp4", fps=24)
```

## Who can review?

@yiyixuxu 