### PR TITLE
Raise warning instead of error for block offloading with streams

### DIFF
--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -499,7 +499,10 @@ def _apply_group_offloading_block_level(
             the CPU memory is a bottleneck but may counteract the benefits of using streams.
     """
     if stream is not None and num_blocks_per_group != 1:
-        raise ValueError(f"Using streams is only supported for num_blocks_per_group=1. Got {num_blocks_per_group=}.")
+        logger.warning(
+            f"Using streams is only supported for num_blocks_per_group=1. Got {num_blocks_per_group=}. Setting it to 1."
+        )
+        num_blocks_per_group = 1
 
     # Create module groups for ModuleList and Sequential blocks
     modules_with_group_offloading = set()


### PR DESCRIPTION
Addresses: https://github.com/huggingface/diffusers/pull/11375#discussion_r2061990877

Note that you could use `num_blocks_per_group > 1` when using streams (the previous implementation allowed that, but only if the initialization order of blocks was the same as invocation order), but typically the computation of a single block completes before the next block finishes onloading, so setting it to `1` and only supporting that case seems reasonable.