### PR TITLE
cache packages_distributions

### DIFF
--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -38,7 +38,7 @@ else:
     import importlib.metadata as importlib_metadata
 try:
     package_map = importlib_metadata.packages_distributions() # load-once to avoid expensive calls
-except Exception as e:
+except Exception:
     package_map = None
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name

--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -37,7 +37,7 @@ if sys.version_info < (3, 8):
 else:
     import importlib.metadata as importlib_metadata
 try:
-    package_map = importlib_metadata.packages_distributions() # load-once to avoid expensive calls
+    package_map = importlib_metadata.packages_distributions()  # load-once to avoid expensive calls
 except Exception:
     package_map = None
 


### PR DESCRIPTION
pr <https://github.com/huggingface/diffusers/pull/11161> refactored `_is_package_available`,  
but it introduced a major performance regression.    
diffusers load now takes up to **~5sec** while it was taking **~0.5sec** earlier.  

```py
import time
t0 = time.time()

import torch # preload torch so its not part of diffusers import time
t1 = time.time()
print(f'torch: {t1-t0:.3f}')

import diffusers.utils.import_utils
t2 = time.time()
print(f'utils: {t2-t1:.3f}')
```

this is due to very expensive call to `importlib_metadata.packages_distributions()` which is done for every single installed package (each call can be ~0.2sec and it quickly adds up).

this pr simply changes the logic so the call is done once and cached.

result is that diffusers startup is back to 0.5sec as usual.

cc @yiyixuxu @sayakpaul @a-r-r-o-w 