### PR TITLE
[torch.compile] Make HiDream torch.compile ready

### DIFF
--- a/src/diffusers/models/transformers/transformer_hidream_image.py
+++ b/src/diffusers/models/transformers/transformer_hidream_image.py
@@ -389,7 +389,9 @@ class MOEFeedForwardSwiGLU(nn.Module):
     def moe_infer(self, x, flat_expert_indices, flat_expert_weights):
         expert_cache = torch.zeros_like(x)
         idxs = flat_expert_indices.argsort()
-        tokens_per_expert = flat_expert_indices.bincount().cpu().numpy().cumsum(0)
+        count_freq = torch.bincount(flat_expert_indices, minlength=self.num_activated_experts)
+        tokens_per_expert = count_freq.cumsum(dim=0)
+
         token_idxs = idxs // self.num_activated_experts
         for i, end_idx in enumerate(tokens_per_expert):
             start_idx = 0 if i == 0 else tokens_per_expert[i - 1]

--- a/tests/models/transformers/test_models_transformer_hidream.py
+++ b/tests/models/transformers/test_models_transformer_hidream.py
@@ -82,6 +82,7 @@ class HiDreamTransformerTests(ModelTesterMixin, unittest.TestCase):
             "axes_dims_rope": (4, 2, 2),
             "max_resolution": (32, 32),
             "llama_layers": (0, 1),
+            "force_inference_output": True,  # TODO: as we don't implement MoE loss in training tests.
         }
         inputs_dict = self.dummy_input
         return init_dict, inputs_dict

--- a/tests/models/transformers/test_models_transformer_hidream.py
+++ b/tests/models/transformers/test_models_transformer_hidream.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+# Copyright 2024 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+
+from diffusers import HiDreamImageTransformer2DModel
+from diffusers.utils.testing_utils import (
+    enable_full_determinism,
+    torch_device,
+)
+
+from ..test_modeling_common import ModelTesterMixin
+
+
+enable_full_determinism()
+
+
+class HiDreamTransformerTests(ModelTesterMixin, unittest.TestCase):
+    model_class = HiDreamImageTransformer2DModel
+    main_input_name = "hidden_states"
+    model_split_percents = [0.8, 0.8, 0.9]
+
+    @property
+    def dummy_input(self):
+        batch_size = 2
+        num_channels = 4
+        height = width = 32
+        embedding_dim_t5, embedding_dim_llama, embedding_dim_pooled = 8, 4, 8
+        sequence_length = 8
+
+        hidden_states = torch.randn((batch_size, num_channels, height, width)).to(torch_device)
+        encoder_hidden_states_t5 = torch.randn((batch_size, sequence_length, embedding_dim_t5)).to(torch_device)
+        encoder_hidden_states_llama3 = torch.randn((batch_size, batch_size, sequence_length, embedding_dim_llama)).to(
+            torch_device
+        )
+        pooled_embeds = torch.randn((batch_size, embedding_dim_pooled)).to(torch_device)
+        timesteps = torch.randint(0, 1000, size=(batch_size,)).to(torch_device)
+
+        return {
+            "hidden_states": hidden_states,
+            "encoder_hidden_states_t5": encoder_hidden_states_t5,
+            "encoder_hidden_states_llama3": encoder_hidden_states_llama3,
+            "pooled_embeds": pooled_embeds,
+            "timesteps": timesteps,
+        }
+
+    @property
+    def input_shape(self):
+        return (4, 32, 32)
+
+    @property
+    def output_shape(self):
+        return (4, 32, 32)
+
+    def prepare_init_args_and_inputs_for_common(self):
+        init_dict = {
+            "patch_size": 2,
+            "in_channels": 4,
+            "out_channels": 4,
+            "num_layers": 1,
+            "num_single_layers": 1,
+            "attention_head_dim": 8,
+            "num_attention_heads": 4,
+            "caption_channels": [8, 4],
+            "text_emb_dim": 8,
+            "num_routed_experts": 2,
+            "num_activated_experts": 2,
+            "axes_dims_rope": (4, 2, 2),
+            "max_resolution": (32, 32),
+            "llama_layers": (0, 1),
+        }
+        inputs_dict = self.dummy_input
+        return init_dict, inputs_dict
+
+    @unittest.skip("HiDreamImageTransformer2DModel uses a dedicated attention processor. This test doesn't apply")
+    def test_set_attn_processor_for_determinism(self):
+        pass
+
+    def test_gradient_checkpointing_is_applied(self):
+        expected_set = {"HiDreamImageTransformer2DModel"}
+        super().test_gradient_checkpointing_is_applied(expected_set=expected_set)


### PR DESCRIPTION
# What does this PR do?

Trying to make the HiDream model fully compatible with `torch.compile()`  but it fails with:
https://pastebin.com/EbCFqBvw

To reproduce run the following from a GPU machine:

```bash
RUN_COMPILE=1 RUN_SLOW=1 pytest tests/models/transformers/test_models_transformer_hidream.py -k "test_torch_compile_recompilation_and_graph_break"
```

I am on the following env:

```bash
- 🤗 Diffusers version: 0.34.0.dev0
- Platform: Linux-6.8.0-55-generic-x86_64-with-glibc2.39
- Running on Google Colab?: No
- Python version: 3.10.12
- PyTorch version (GPU?): 2.7.0+cu126 (True)
- Flax version (CPU?/GPU?/TPU?): not installed (NA)
- Jax version: not installed
- JaxLib version: not installed
- Huggingface_hub version: 0.30.2
- Transformers version: 4.51.3
- Accelerate version: 1.6.0.dev0
- PEFT version: 0.15.2.dev0
- Bitsandbytes version: 0.45.3
- Safetensors version: 0.5.3
- xFormers version: not installed
- Accelerator: NVIDIA GeForce RTX 4090, 24564 MiB
NVIDIA GeForce RTX 4090, 24564 MiB
- Using GPU in script?: <fill in>
- Using distributed or parallel set-up in script?: <fill in>
```

@anijain2305 @StrongerXi would you have any pointers?