### PR TITLE
Fix huggingface-hub package name.

### DIFF
--- a/src/diffusers/utils/testing_utils.py
+++ b/src/diffusers/utils/testing_utils.py
@@ -555,10 +555,10 @@ def require_bitsandbytes_version_greater(bnb_version):
 def require_hf_hub_version_greater(hf_hub_version):
     def decorator(test_case):
         correct_hf_hub_version = version.parse(
-            version.parse(importlib.metadata.version("huggingface_hub")).base_version
+            version.parse(importlib.metadata.version("huggingface-hub")).base_version
         ) > version.parse(hf_hub_version)
         return unittest.skipUnless(
-            correct_hf_hub_version, f"Test requires huggingface_hub with the version greater than {hf_hub_version}."
+            correct_hf_hub_version, f"Test requires huggingface-hub with the version greater than {hf_hub_version}."
         )(test_case)
 
     return decorator


### PR DESCRIPTION
This checks for the actual Python package name, `huggingface-hub`.