### PR TITLE
Change timestep device to cpu for xla

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -989,8 +989,11 @@ class StableDiffusionPipeline(
             )
 
         # 4. Prepare timesteps
+        timestep_device = device
+        if XLA_AVAILABLE:
+            timestep_device = 'cpu'
         timesteps, num_inference_steps = retrieve_timesteps(
-            self.scheduler, num_inference_steps, device, timesteps, sigmas
+            self.scheduler, num_inference_steps, timestep_device, timesteps, sigmas
         )
 
         # 5. Prepare latent variables
@@ -1092,6 +1095,8 @@ class StableDiffusionPipeline(
             do_denormalize = [True] * image.shape[0]
         else:
             do_denormalize = [not has_nsfw for has_nsfw in has_nsfw_concept]
+        if XLA_AVAILABLE:
+            xm.mark_step()
         image = self.image_processor.postprocess(image, output_type=output_type, do_denormalize=do_denormalize)
 
         # Offload all models


### PR DESCRIPTION
# What does this PR do?

Change the timestep device to 'cpu' if we're using an xla device. This is needed because the diffusion schedulers generally loop over the timestep variable and it is used to index into other tensors. When using XLA, it is important that the timestep tensor resides on the cpu to avoid expensive compile operations.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case. Not associate with a github issue
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation). Not needed
- [x] Did you write any new necessary tests? No new tests needed


## Who can review?
@sayakpaul @yiyixuxu 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

