### PR TITLE
enable dit integration cases on xpu

### DIFF
--- a/tests/pipelines/dit/test_dit.py
+++ b/tests/pipelines/dit/test_dit.py
@@ -21,7 +21,15 @@ import torch
 
 from diffusers import AutoencoderKL, DDIMScheduler, DiTPipeline, DiTTransformer2DModel, DPMSolverMultistepScheduler
 from diffusers.utils import is_xformers_available
-from diffusers.utils.testing_utils import backend_empty_cache, enable_full_determinism, load_numpy, nightly, require_torch_accelerator, require_torch_gpu, torch_device, numpy_cosine_similarity_distance
+from diffusers.utils.testing_utils import (
+    backend_empty_cache,
+    enable_full_determinism,
+    load_numpy,
+    nightly,
+    numpy_cosine_similarity_distance,
+    require_torch_accelerator,
+    torch_device,
+)
 
 from ..pipeline_params import (
     CLASS_CONDITIONED_IMAGE_GENERATION_BATCH_PARAMS,


### PR DESCRIPTION
for `test_dit_512` case, both A100 and XPU don't pass with current pixel delta criteria(yes, as we noticed many times, there 2 have similar numerical behavior), I propose to use cosine similarity as some of other cases used(like `controlnet_impaint`). With proposed changes, both XPU and A100 passed.

@DN6 @a-r-r-o-w , pls help review, thx. 
