### PR TITLE
 Fix deprecation warnings in test_ltx_image2video.py

### DIFF
--- a/tests/pipelines/ltx/test_ltx_image2video.py
+++ b/tests/pipelines/ltx/test_ltx_image2video.py
@@ -109,7 +109,7 @@ class LTXImageToVideoPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         else:
             generator = torch.Generator(device=device).manual_seed(seed)
 
-        image = torch.randn((1, 3, 32, 32), generator=generator, device=device)
+        image = torch.rand((1, 3, 32, 32), generator=generator, device=device)
 
         inputs = {
             "image": image,
@@ -142,7 +142,7 @@ class LTXImageToVideoPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         self.assertEqual(generated_video.shape, (9, 3, 32, 32))
         expected_video = torch.randn(9, 3, 32, 32)
-        max_diff = np.abs(generated_video - expected_video).max()
+        max_diff = torch.amax(torch.abs(generated_video - expected_video))
         self.assertLessEqual(max_diff, 1e10)
 
     def test_callback_inputs(self):


### PR DESCRIPTION
# What does this PR do?

This PR fixes two warnings that appeared during testing:

- A FutureWarning related to image tensor value range in image_processor.py.
- A DeprecationWarning regarding __array_wrap__ usage in NumPy 2.0 in the test script.

These minor changes help clean up test output and ensure future compatibility.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ X] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
