### PR TITLE
[Chore] add rule to ignore checking black line whitespace.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 119
 
 [tool.ruff.lint]
 # Never enforce `E501` (line length violations).
-ignore = ["C901", "E501", "E721", "E741", "F402", "F823"]
+ignore = ["C901", "E501", "E721", "E741", "F402", "F823", "W293"]
 select = ["C", "E", "F", "I", "W"]
 
 # Ignore import violations in all `__init__.py` files.


### PR DESCRIPTION
# What does this PR do?

To prevent stuff like:

```bash
src/diffusers/pipelines/modular_pipeline_utils.py:272:1: W293 Blank line contains whitespace
    |
270 |     """
271 |     Format input parameters into a string representation, with required params first followed by optional ones.
272 |     
    | ^^^^ W293
```