### PR TITLE
Revert error to warning when loading LoRA from repo with multiple weights

### DIFF
--- a/src/diffusers/loaders/lora_base.py
+++ b/src/diffusers/loaders/lora_base.py
@@ -299,8 +299,8 @@ def _best_guess_weight_name(
         targeted_files = list(filter(lambda x: x.endswith(LORA_WEIGHT_NAME_SAFE), targeted_files))
 
     if len(targeted_files) > 1:
-        raise ValueError(
-            f"Provided path contains more than one weights file in the {file_extension} format. Either specify `weight_name` in `load_lora_weights` or make sure there's only one  `.safetensors` or `.bin` file in  {pretrained_model_name_or_path_or_dict}."
+        logger.warning(
+            f"Provided path contains more than one weights file in the {file_extension} format. `{targeted_files[0]}` is going to be loaded, for precise control, specify a `weight_name` in `load_lora_weights`."
         )
     weight_name = targeted_files[0]
     return weight_name


### PR DESCRIPTION
# What does this PR do?

Reverts back from a raised error to a warning if a LoRA repository contains multiple `*.safetensors` files. 

Pros: 
1. Avoids applications breaking if a 3rd party does an action, scenario: a LoRA repo had a single LoRA, so the codebase works. Then, the LoRa repo author uploads a second LoRA to the repo. Now the app breaks due to the action of the 3rd party 
2. More Hub-centric: users can just pass the Hub nicename of a LoRA without worrying too much about weight-names (not an obvious interaction on the Hub to get weight names)

I know there are pros and cons and I'm sure this has been discussed before. But this is such a simple PR that I just did it in case it's helpful. Feel free to reject/close if not aligned and happy to further discuss in case we can find some other solution. 

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@yiyixuxu @sayakpaul @BenjaminBossan
