### PR TITLE
Torchao int4 serialization

### DIFF
--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -1194,7 +1194,9 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
             ):
                 map_location = torch.device([d for d in device_map.values() if d not in ["cpu", "disk"]][0])
             # Time to load the checkpoint
-            state_dict = load_state_dict(resolved_model_file[0], disable_mmap=disable_mmap, dduf_entries=dduf_entries, map_location=map_location)
+            state_dict = load_state_dict(
+                resolved_model_file[0], disable_mmap=disable_mmap, dduf_entries=dduf_entries, map_location=map_location
+            )
             # We only fix it for non sharded checkpoints as we don't need it yet for sharded one.
             model._fix_state_dict_keys_on_load(state_dict)
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes torchao int4 checkpoint loading. We need to load the checkpoint directly on the device we quantized it. We make the assumption that we are loading the model on the right device at the start. 

Needed for this model https://huggingface.co/diffusers/FLUX.1-dev-torchao-int4
