### PR TITLE
save_pretrained for serializing config.

### DIFF
--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -413,7 +413,7 @@ class ModularPipelineMixin(ConfigMixin):
         self._progress_bar_config = kwargs
 
 
-class PipelineBlock(ModularPipelineMixin, PushToHubMixin):
+class PipelineBlock(ModularPipelineMixin):
     
     model_name = None
     

--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -413,7 +413,7 @@ class ModularPipelineMixin(ConfigMixin):
         self._progress_bar_config = kwargs
 
 
-class PipelineBlock(ModularPipelineMixin):
+class PipelineBlock(ModularPipelineMixin, PushToHubMixin):
     
     model_name = None
     
@@ -617,6 +617,21 @@ class PipelineBlock(ModularPipelineMixin):
                     param = getattr(block_state, param_name)
                     if current_value is not param:  # Using identity comparison to check if object was modified
                         state.add_intermediate(param_name, param, input_param.kwargs_type)
+
+    def save_pretrained(self, save_directory, push_to_hub = False, **kwargs):
+        # TODO: factor out this logic.
+        cls_name = self.__class__.__name__
+        
+        full_mod = type(self).__module__ 
+        module = full_mod.rsplit(".", 1)[-1]
+        parent_module = self.save_pretrained.__func__.__qualname__.split(".", 1)[0]  
+        auto_map = {f"{parent_module}": f"{module}.{cls_name}"}
+        _component_names = [c.name for c in self.expected_components]
+        
+        self.register_to_config(auto_map=auto_map, _component_names=_component_names)
+        self.save_config(save_directory=save_directory, push_to_hub=push_to_hub, **kwargs)
+        config = dict(self.config)
+        self._internal_dict = FrozenDict(config)
 
 
 def combine_inputs(*named_input_lists: List[Tuple[str, List[InputParam]]]) -> List[InputParam]:


### PR DESCRIPTION
# What does this PR do?

Follow-up of https://github.com/huggingface/diffusers/pull/11539. 

Test code:

```py
from diffusers.modular_pipelines import PipelineBlock

block = PipelineBlock.from_pretrained(
    "diffusers-internal-dev/modular-depth-block-sayak", trust_remote_code=True
)
bloc.save_pretrained("dummy")
```

Currently, it serializes the `config.json`. I think we agreed to manually save the block module that implements the custom block. It looks like so:

```json
{
  "_class_name": "DepthProcessorBlock",
  "_component_names": [
    "depth_processor"
  ],
  "_diffusers_version": "0.34.0.dev0",
  "auto_map": {
    "PipelineBlock": "block.DepthProcessorBlock"
  }
}
```

I know that we are not serializing out-of-the-ordinary info that is very non-trivial. So, I would be completely okay if we decided to serialize the `config.json` manually.