### PR TITLE
UniPC remove `order` short-circuit for `solve(R, b)`

### DIFF
--- a/src/diffusers/schedulers/scheduling_unipc_multistep.py
+++ b/src/diffusers/schedulers/scheduling_unipc_multistep.py
@@ -745,11 +745,7 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
 
         if len(D1s) > 0:
             D1s = torch.stack(D1s, dim=1)  # (B, K)
-            # cannot solve a 1x1 matrix
-            if len(rks) == 1:
-                rhos_p = torch.tensor([0.5], dtype=x.dtype, device=device)
-            else:
-                rhos_p = torch.linalg.solve(R[:-1, :-1], b[:-1]).to(device).to(x.dtype)
+            rhos_p = torch.linalg.solve(R[:-1, :-1], b[:-1]).to(device).to(x.dtype)
         else:
             D1s = None
 
@@ -883,11 +879,7 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
         else:
             D1s = None
 
-        # cannot solve a 1x1 matrix
-        if len(rks) == 1:
-            rhos_c = torch.tensor([0.5], dtype=x.dtype, device=device)
-        else:
-            rhos_c = torch.linalg.solve(R, b).to(device).to(x.dtype)
+        rhos_c = torch.linalg.solve(R, b).to(device).to(x.dtype)
 
         if self.predict_x0:
             x_t_ = sigma_t / sigma_s0 * x - alpha_t * h_phi_1 * m0

--- a/src/diffusers/schedulers/scheduling_unipc_multistep.py
+++ b/src/diffusers/schedulers/scheduling_unipc_multistep.py
@@ -745,8 +745,8 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
 
         if len(D1s) > 0:
             D1s = torch.stack(D1s, dim=1)  # (B, K)
-            # for order 2, we use a simplified version
-            if order == 2:
+            # cannot solve a 1x1 matrix
+            if len(rks) == 1:
                 rhos_p = torch.tensor([0.5], dtype=x.dtype, device=device)
             else:
                 rhos_p = torch.linalg.solve(R[:-1, :-1], b[:-1]).to(device).to(x.dtype)
@@ -883,8 +883,8 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
         else:
             D1s = None
 
-        # for order 1, we use a simplified version
-        if order == 1:
+        # cannot solve a 1x1 matrix
+        if len(rks) == 1:
             rhos_c = torch.tensor([0.5], dtype=x.dtype, device=device)
         else:
             rhos_c = torch.linalg.solve(R, b).to(device).to(x.dtype)


### PR DESCRIPTION
When unifying [skrample's UniP and UniC solvers](https://github.com/Beinsezii/skrample/pull/39#discussion_r2106955456) I noticed the rks matrix solve short circuits when it likely shouldn't.

I think it's because it appends to RKS

https://github.com/huggingface/diffusers/blob/b5c2050a16f71d018496f1abcb09da9428f8aa3e/src/diffusers/schedulers/scheduling_unipc_multistep.py#L853

but only checks by order

https://github.com/huggingface/diffusers/blob/b5c2050a16f71d018496f1abcb09da9428f8aa3e/src/diffusers/schedulers/scheduling_unipc_multistep.py#L886-L890

Reading the paper https://arxiv.org/abs/2302.04867 I don't see any 0.5 short circuits so I'm assuming this was added to stop a 1x1 solve from erring. The comments would imply the results should be equivalent, however because you're skipping actual 2x2 solves the results are quite different for high orders

`main`
![grid_00005](https://github.com/user-attachments/assets/b145176d-bc85-43a6-8b20-65fff32fe0b9)
`beinsezii/unipc_matrix_solve`
![grid_00009](https://github.com/user-attachments/assets/e32ce0bd-6217-48af-8681-33ffe5494251)

cc @yiyixuxu 

I'm not a mathematician so it might be prudent to double-check the paper yourself to make sure my homework is correct.