### PR TITLE
Adding NPU for get device function

### DIFF
--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -17,8 +17,8 @@ PyTorch utilities: Utilities related to PyTorch
 
 from typing import List, Optional, Tuple, Union
 
-from . import logging
-from .import_utils import is_torch_available, is_torch_version
+from . import logging, is_torch_npu_available
+from .import_utils import is_torch_available, is_torch_npu_available, is_torch_version
 
 
 if is_torch_available():
@@ -166,6 +166,8 @@ def get_torch_cuda_device_capability():
 def get_device():
     if torch.cuda.is_available():
         return "cuda"
+    elif is_torch_npu_available():
+        return "npu"
     elif hasattr(torch, "xpu") and torch.xpu.is_available():
         return "xpu"
     else:

--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -17,7 +17,7 @@ PyTorch utilities: Utilities related to PyTorch
 
 from typing import List, Optional, Tuple, Union
 
-from . import logging, is_torch_npu_available
+from . import logging
 from .import_utils import is_torch_available, is_torch_npu_available, is_torch_version
 
 


### PR DESCRIPTION
# What does this PR do?

I added npu selection for get_device, otherwise the npu cannot be used for "pipe.enable_model_cpu_offload()" when doing the inference task

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
