### PR TITLE
[`Wan`] Fix VAE sampling mode in `WanVideoToVideoPipeline`

### DIFF
--- a/src/diffusers/pipelines/wan/pipeline_wan_video2video.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_video2video.py
@@ -419,12 +419,7 @@ class WanVideoToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         )
 
         if latents is None:
-            if isinstance(generator, list):
-                init_latents = [
-                    retrieve_latents(self.vae.encode(video[i].unsqueeze(0)), generator[i]) for i in range(batch_size)
-                ]
-            else:
-                init_latents = [retrieve_latents(self.vae.encode(vid.unsqueeze(0)), generator) for vid in video]
+            init_latents = [retrieve_latents(self.vae.encode(vid.unsqueeze(0)), sample_mode="argmax") for vid in video]
 
             init_latents = torch.cat(init_latents, dim=0).to(dtype)
 

--- a/src/diffusers/pipelines/wan/pipeline_wan_video2video.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_video2video.py
@@ -436,7 +436,7 @@ class WanVideoToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             if hasattr(self.scheduler, "add_noise"):
                 latents = self.scheduler.add_noise(init_latents, noise, timestep)
             else:
-                latents = self.scheduelr.scale_noise(init_latents, timestep, noise)
+                latents = self.scheduler.scale_noise(init_latents, timestep, noise)
         else:
             latents = latents.to(device)
 


### PR DESCRIPTION
While integrating SkyReels-V2 models, I came across this:  Major Wan-related repos including [Wan-Video/Wan2.1](https://github.com/Wan-Video/Wan2.1/blob/ec902046f6f8b264cff94bd8b2cb1d44c10090e3/wan/modules/vae.py#L535-L542), [modelscope/DiffSynth-Studio](https://github.com/modelscope/DiffSynth-Studio/blob/ef2a7abad478d6f91c0839be8f491587e36fda9f/diffsynth/models/wan_video_vae.py#L542-L550), and [SkyworkAI/SkyReels-V2](https://github.com/SkyworkAI/SkyReels-V2/blob/04253950ee88d884ba714e9da5110885cf93457f/skyreels_v2_infer/modules/vae.py#L495-L501) prefer `sample_mode == "argmax"` for the encoding's output of their VAEs. Also, at the other Wan pipelines in `diffusers`, too. Am I correct?
Also, fixes a typo.

<table>
  <tbody>
    <tr>
      <td align="center" colspan="2"><strong>Input Video</strong></td>
    </tr>
    <tr>
      <td align="center" colspan="2">
        <video src="https://github.com/user-attachments/assets/2acb8faf-60bc-4742-8d0c-03c87a9a04cf" width="111" controls muted loop> </video>
      </td>
    </tr>
    <tr>
      <td align="center"><strong>Previous</strong></td>
      <td align="center"><strong>Current</strong></td>
    </tr>
    <tr>
      <td align="center">
        <video src="https://github.com/user-attachments/assets/cdef9ee0-9711-4a96-873d-236a647ab8c0" width="111" controls muted loop> </video>
      </td>
      <td align="center">
        <video src="https://github.com/user-attachments/assets/649cdb73-8413-49a6-8c92-9d544650fd52" width="111" controls muted loop> </video>
      </td>
    </tr>
  </tbody>
</table>

I am unsure if there is supposed to be a visible fix :thinking:.

<details>
<summary><h3>Reproducer</h3></summary>

```py
#!pip uninstall diffusers -yq
#!pip install git+https://github.com/tolgacangoz/diffusers.git@fix-wanv2v-vae ftfy -q
import torch
from diffusers.utils import load_video, export_to_video
from diffusers import AutoencoderKLWan, WanVideoToVideoPipeline, UniPCMultistepScheduler

# Available models: Wan-AI/Wan2.1-T2V-14B-Diffusers, Wan-AI/Wan2.1-T2V-1.3B-Diffusers
model_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
vae = AutoencoderKLWan.from_pretrained(
    model_id, subfolder="vae", torch_dtype=torch.float32
)
pipe = WanVideoToVideoPipeline.from_pretrained(
    model_id, vae=vae, torch_dtype=torch.bfloat16
)
flow_shift = 3.0  # 5.0 for 720P, 3.0 for 480P
pipe.scheduler = UniPCMultistepScheduler.from_config(
    pipe.scheduler.config, flow_shift=flow_shift
)
#pipe.enable_model_cpu_offload()
pipe = pipe.to('cuda')

prompt = "A robot standing on a mountain top. The sun is setting in the background"
negative_prompt = "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"
video = load_video(
    "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/hiker.mp4"
)
output = pipe(
    video=video,
    prompt=prompt,
    negative_prompt=negative_prompt,
    height=480,
    width=512,
    guidance_scale=7.0,
    strength=0.7,
    generator=torch.Generator(device="cuda").manual_seed(0),
).frames[0]

export_to_video(output, "wan-v2v.mp4", fps=16)
```

</details>


@DN6 @a-r-r-o-w