### PR TITLE
Use float32 RoPE freqs in Wan with MPS backends

### DIFF
--- a/src/diffusers/models/transformers/transformer_wan.py
+++ b/src/diffusers/models/transformers/transformer_wan.py
@@ -72,7 +72,8 @@ class WanAttnProcessor2_0:
         if rotary_emb is not None:
 
             def apply_rotary_emb(hidden_states: torch.Tensor, freqs: torch.Tensor):
-                x_rotated = torch.view_as_complex(hidden_states.to(torch.float64).unflatten(3, (-1, 2)))
+                dtype = torch.float32 if hidden_states.device.type == "mps" else torch.float64
+                x_rotated = torch.view_as_complex(hidden_states.to(dtype).unflatten(3, (-1, 2)))
                 x_out = torch.view_as_real(x_rotated * freqs).flatten(3, 4)
                 return x_out.type_as(hidden_states)
 
@@ -190,9 +191,10 @@ class WanRotaryPosEmbed(nn.Module):
         t_dim = attention_head_dim - h_dim - w_dim
 
         freqs = []
+        freqs_dtype = torch.float32 if torch.backends.mps.is_available() else torch.float64
         for dim in [t_dim, h_dim, w_dim]:
             freq = get_1d_rotary_pos_embed(
-                dim, max_seq_len, theta, use_real=False, repeat_interleave_real=False, freqs_dtype=torch.float64
+                dim, max_seq_len, theta, use_real=False, repeat_interleave_real=False, freqs_dtype=freqs_dtype
             )
             freqs.append(freq)
         self.freqs = torch.cat(freqs, dim=1)


### PR DESCRIPTION
An issue was reported in PyTorch regarding dtype compat in the Wan model (see https://github.com/pytorch/pytorch/issues/148670) when using MPS as the backend. The issue is that Wan's RoPE implementation uses float64, which isn't a supported dtype on MPS and results in `TypeError: Trying to convert ComplexDouble to the MPS backend but it does not have support for that dtype.`

This PR proposes to downcast freqs on MPS backends. Looking at prior PRs (#10776, #9133, etc) this seems to be the preferred method, but please let me know if there's a different approach you'd like me to take and I'll amend as needed.

FYI; There's a separate issue with Wan when using MPS backends outlined in https://github.com/pytorch/pytorch/issues/148670#issuecomment-2928499989. My hunch is that this bug is a correctness issue in the MPS codebase in PyTorch, although that's not verified yet.

cc @a-r-r-o-w @asomoza @yiyixuxu 