### PR TITLE
Set _torch_version to N/A if torch is disabled.

### DIFF
--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -99,6 +99,7 @@ if USE_TORCH in ENV_VARS_TRUE_AND_AUTO_VALUES and USE_TF not in ENV_VARS_TRUE_VA
 else:
     logger.info("Disabling PyTorch because USE_TORCH is set")
     _torch_available = False
+    _torch_version = "N/A"
 
 _jax_version = "N/A"
 _flax_version = "N/A"


### PR DESCRIPTION
# What does this PR do?

Set a default value for _torch_version if torch is disabled. This fixes an ImportError in hub_utils.py when it tries to import [_torch_version](https://github.com/huggingface/diffusers/blob/main/src/diffusers/utils/hub_utils.py#L61). This is not riased for Jax and Flax because they already set `_jax_version = "N/A"` as a default.

```
ImportError: cannot import name '_torch_version' from 'diffusers.utils.import_utils'
```


## Who can review?

Core library:
- General functionalities: @sayakpaul @yiyixuxu @DN6
