### PR TITLE
[chore] bring PipelineQuantizationConfig at the top of the import chain.

### DIFF
--- a/src/diffusers/__init__.py
+++ b/src/diffusers/__init__.py
@@ -692,6 +692,7 @@ else:
 
 if TYPE_CHECKING or DIFFUSERS_SLOW_IMPORT:
     from .configuration_utils import ConfigMixin
+    from .quantizers import PipelineQuantizationConfig
 
     try:
         if not is_bitsandbytes_available():


### PR DESCRIPTION
# What does this PR do?

Lets us do `from diffusers import PipelineQuantizationConfig` instead of `from diffusers.quantizers import PipelineQuantizationConfig`.