### PR TITLE
use deterministic to get stable result

### DIFF
--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -476,6 +476,7 @@ class SlowBnb4BitTests(Base4bitTests):
         r"""
         Test that loading the model and unquantize it produce correct results.
         """
+        torch.use_deterministic_algorithms(True)
         self.pipeline_4bit.transformer.dequantize()
         output = self.pipeline_4bit(
             prompt=self.prompt,

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -478,6 +478,7 @@ class SlowBnb8bitTests(Base8bitTests):
         r"""
         Test that loading the model and unquantize it produce correct results.
         """
+        torch.use_deterministic_algorithms(True)
         self.pipeline_8bit.transformer.dequantize()
         output = self.pipeline_8bit(
             prompt=self.prompt,


### PR DESCRIPTION
The test cannot always pass due to result unstable, so I use torch.use_deterministic_algorithms(True) just like [here](https://github.com/huggingface/diffusers/blob/c934720629837257b15fd84d27e8eddaa52b76e6/tests/models/test_modeling_common.py#L529) to get stable result so the test can always pass.