### PR TITLE
[GGUF] feat: support loading diffusers format gguf checkpoints.

### DIFF
--- a/src/diffusers/loaders/single_file_utils.py
+++ b/src/diffusers/loaders/single_file_utils.py
@@ -2145,6 +2145,12 @@ def convert_flux_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
         if "model.diffusion_model." in k:
             checkpoint[k.replace("model.diffusion_model.", "")] = checkpoint.pop(k)
 
+    original_flux = any(k.startswith("double_blocks.") for k in checkpoint) or any(
+        k.startswith("single_blocks.") for k in checkpoint
+    )
+    if not original_flux:
+        return checkpoint
+
     num_layers = list(set(int(k.split(".", 2)[1]) for k in checkpoint if "double_blocks." in k))[-1] + 1  # noqa: C401
     num_single_layers = list(set(int(k.split(".", 2)[1]) for k in checkpoint if "single_blocks." in k))[-1] + 1  # noqa: C401
     mlp_ratio = 4.0


### PR DESCRIPTION
# What does this PR do?

Refer to https://github.com/ngxson/flux-to-gguf/pull/1 to know how to obtain the checkpoint. 

After the checkpoint is obtained, run the following code for inference:

<details>
<summary>Expand</summary>

```py
import torch
from diffusers import FluxPipeline, FluxTransformer2DModel, GGUFQuantizationConfig

ckpt_path = "model-Q4_0.gguf"
transformer = FluxTransformer2DModel.from_single_file(
    ckpt_path,
    quantization_config=GGUFQuantizationConfig(compute_dtype=torch.bfloat16),
    torch_dtype=torch.bfloat16,
    config="black-forest-labs/FLUX.1-dev",
    subfolder="transformer",
)
pipe = FluxPipeline.from_pretrained(
    "black-forest-labs/FLUX.1-dev",
    transformer=transformer,
    torch_dtype=torch.bfloat16,
).to("cuda")
prompt = "A cat holding a sign that says GGUF"
image = pipe(prompt, generator=torch.manual_seed(0)).images[0]
image.save("flux-gguf.png")
```

</details>

Currently, the entrypoint for the diffusers formatted GGUF checkpoint is through `from_single_file()`. It remains to be seen if after https://github.com/ngxson/flux-to-gguf, we wanna support them through `from_pretrained()`.

@DN6 please feel free to make any changes or even change the direction of the PR as you see fit.