### PR TITLE
Avoid DtoH sync from access of nonzero() item in scheduler

### DIFF
--- a/src/diffusers/pipelines/flux/pipeline_flux.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux.py
@@ -898,6 +898,7 @@ class FluxPipeline(
             )
 
         # 6. Denoising loop
+        self.scheduler.set_begin_index(0)
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:


### PR DESCRIPTION
# What does this PR do?

(discussed with @sayakpaul in Slack) I have been optimizing inference performance for the Flux model and saw a DtoH sync point in the performance trace coming from the use of nonzero() followed by item() in the scheduler's `index_for_timestep()` logic: https://github.com/huggingface/diffusers/blob/b0f7036d9af75c5df0f39d2d6353964e4c520534/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py#L351-L363

This sync causes a minor but non-negligible gap in GPU utilization during the first timestep, especially when torch.compile is utilized (due to cpu-side Dynamo cache lookup overhead after the sync point), as shown here:

![trace_with_nonzero2](https://github.com/user-attachments/assets/6076193d-ef15-4e97-96c9-01e2f462bd42)


AFAICT this can be avoided by manually calling `scheduler.set_begin_index(0)`, so this PR does that for `FluxPipeline`. Locally, I was able to see the sync point go away after this change.

Insights welcome regarding:
* A more robust alternative fix
* The best way to test this change (looks like [test_pipeline_flux.py](https://github.com/huggingface/diffusers/blob/main/tests/pipelines/flux/test_pipeline_flux.py) is a good place?)
* Should this fix be generalized beyond `FluxPipeline`?