### PR TITLE
[ci] enable hotswapping tests on our nightly CI.

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -193,24 +193,28 @@ jobs:
       run: |
         python -m venv /opt/venv && export PATH="/opt/venv/bin:$PATH"
         python -m uv pip install -e [quality,test,training]
+        python -m uv pip install peft@git+https://github.com/huggingface/peft.git
     - name: Environment
       run: |
         python utils/print_env.py
-    - name: Run torch compile tests on GPU
+    - name: Run torch hotswap + compile tests on GPU
       env:
         HF_TOKEN: ${{ secrets.DIFFUSERS_HF_HUB_READ_TOKEN }}
         RUN_COMPILE: yes
       run: |
         python -m pytest -n 1 --max-worker-restart=0 --dist=loadfile -s -v -k "compile" --make-reports=tests_torch_compile_cuda tests/
+        python -m pytest -n 1 --max-worker-restart=0 --dist=loadfile -s -v -k "hotswap" --make-reports=tests_torch_hotswap_cuda tests/
     - name: Failure short reports
       if: ${{ failure() }}
-      run: cat reports/tests_torch_compile_cuda_failures_short.txt
+      run: |
+        cat reports/tests_torch_compile_cuda_failures_short.txt
+        cat reports/tests_torch_hotswap_cuda_failures_short.txt
 
     - name: Test suite reports artifacts
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        name: torch_compile_test_reports
+        name: torch_compile_hotswap_test_reports
         path: reports
 
   run_big_gpu_torch_tests:

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -189,6 +189,7 @@ jobs:
       env:
         HF_TOKEN: ${{ secrets.DIFFUSERS_HF_HUB_READ_TOKEN }}
         RUN_COMPILE: yes
+        RUN_SLOW: yes
       run: |
         python -m pytest -n 1 --max-worker-restart=0 --dist=loadfile -s -v -k "compile" --make-reports=tests_torch_compile_cuda tests/
     - name: Failure short reports


### PR DESCRIPTION
# What does this PR do?

LoRA hotswapping with compilation is a crucial feature which deserves (at least nightly) testing. This PR enables that. 

This PR also sets the `RUN_SLOW` flag in `push_tests.yml` for the compilation test job as without it, those tests won't run. Should we enable hotswapping tests in that workflow, too? I am okay if not.

Additionally, a few questions:

* We have both `push_tests_fast.yml` and `push_tests.yml`. I am assuming the tests under `push_tests_fast.yml` would have already run before the changes made their way to `main`. So, I wonder if we should remove `push_tests_fast.yml`?
* Should we allow slow tests to run during `push_tests`? We should most definitely look into how we segregate slow and nightly our tests for this.

I believe this deserves attention as it would help us reduce our CI time.