### PR TITLE
fix norm not training in train_control_lora_flux.py

### DIFF
--- a/examples/flux-control/train_control_lora_flux.py
+++ b/examples/flux-control/train_control_lora_flux.py
@@ -837,11 +837,6 @@ def main(args):
     assert torch.all(flux_transformer.x_embedder.weight[:, initial_input_channels:].data == 0)
     flux_transformer.register_to_config(in_channels=initial_input_channels * 2, out_channels=initial_input_channels)
 
-    if args.train_norm_layers:
-        for name, param in flux_transformer.named_parameters():
-            if any(k in name for k in NORM_LAYER_PREFIXES):
-                param.requires_grad = True
-
     if args.lora_layers is not None:
         if args.lora_layers != "all-linear":
             target_modules = [layer.strip() for layer in args.lora_layers.split(",")]
@@ -878,6 +873,11 @@ def main(args):
         lora_bias=args.use_lora_bias,
     )
     flux_transformer.add_adapter(transformer_lora_config)
+
+    if args.train_norm_layers:
+        for name, param in flux_transformer.named_parameters():
+            if any(k in name for k in NORM_LAYER_PREFIXES):
+                param.requires_grad = True
 
     def unwrap_model(model):
         model = accelerator.unwrap_model(model)


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue in `examples/flux-control/train_control_lora_flux.py` where `train_norm_layers` **_(if set)_** were unintentionally disabled (`requires_grad = False`) after calling `flux_transformer.add_adapter(transformer_lora_config)`. As a result, the normalization layers were not being trained as expected.

This PR fixes that.

@sayakpaul — Appreciate it if you could take a look.  