### PR TITLE
ENH: Improve speed of function expanding LoRA scales

### DIFF
--- a/src/diffusers/loaders/unet_loader_utils.py
+++ b/src/diffusers/loaders/unet_loader_utils.py
@@ -14,6 +14,8 @@
 import copy
 from typing import TYPE_CHECKING, Dict, List, Union
 
+from torch import nn
+
 from ..utils import logging
 
 
@@ -52,7 +54,7 @@ def _maybe_expand_lora_scales(
             weight_for_adapter,
             blocks_with_transformer,
             transformer_per_block,
-            unet.state_dict(),
+            model=unet,
             default_scale=default_scale,
         )
         for weight_for_adapter in weight_scales
@@ -65,7 +67,7 @@ def _maybe_expand_lora_scales_for_one_adapter(
     scales: Union[float, Dict],
     blocks_with_transformer: Dict[str, int],
     transformer_per_block: Dict[str, int],
-    state_dict: None,
+    model: nn.Module,
     default_scale: float = 1.0,
 ):
     """
@@ -155,7 +157,7 @@ def _maybe_expand_lora_scales_for_one_adapter(
         del scales[updown]
 
     for layer in scales.keys():
-        if not any(_translate_into_actual_layer_name(layer) in module for module in state_dict.keys()):
+        if not any(_translate_into_actual_layer_name(layer) in module for module in model.state_dict().keys()):
             raise ValueError(
                 f"Can't set lora scale for layer {layer}. It either doesn't exist in this unet or it has no attentions."
             )

--- a/src/diffusers/loaders/unet_loader_utils.py
+++ b/src/diffusers/loaders/unet_loader_utils.py
@@ -156,8 +156,9 @@ def _maybe_expand_lora_scales_for_one_adapter(
 
         del scales[updown]
 
+    state_dict = model.state_dict()
     for layer in scales.keys():
-        if not any(_translate_into_actual_layer_name(layer) in module for module in model.state_dict().keys()):
+        if not any(_translate_into_actual_layer_name(layer) in module for module in state_dict.keys()):
             raise ValueError(
                 f"Can't set lora scale for layer {layer}. It either doesn't exist in this unet or it has no attentions."
             )


### PR DESCRIPTION
# What does this PR do?

Resolves #11816

The following call proved to be a bottleneck when setting a lot of LoRA adapters in diffusers:

https://github.com/huggingface/diffusers/blob/cdaf84a708eadf17d731657f4be3fa39d09a12c0/src/diffusers/loaders/peft.py#L482

This is because we would repeatedly call `unet.state_dict()`, even though in the standard case, it is not necessary:

https://github.com/huggingface/diffusers/blob/cdaf84a708eadf17d731657f4be3fa39d09a12c0/src/diffusers/loaders/unet_loader_utils.py#L55

This PR fixes this by deferring this call, so that it is only run when it's necessary, not earlier.

Note: This PR doesn't change the fact that `set_adapters` becomes slower the more adapters are already loaded, but since it speeds up the whole process by a factor of approximately 10x, `set_adapters` is much less of a bottleneck.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?