### PR TITLE
Modular custom config object serialization

### DIFF
--- a/src/diffusers/configuration_utils.py
+++ b/src/diffusers/configuration_utils.py
@@ -601,6 +601,10 @@ class ConfigMixin:
                 value = value.tolist()
             elif isinstance(value, Path):
                 value = value.as_posix()
+            elif hasattr(value, "to_dict") and callable(value.to_dict):
+                value = value.to_dict()
+            elif isinstance(value, list):
+                value = [to_json_saveable(v) for v in value]
             return value
 
         if "quantization_config" in config_dict:

--- a/src/diffusers/guiders/auto_guidance.py
+++ b/src/diffusers/guiders/auto_guidance.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -66,7 +66,7 @@ class AutoGuidance(BaseGuidance):
         self,
         guidance_scale: float = 7.5,
         auto_guidance_layers: Optional[Union[int, List[int]]] = None,
-        auto_guidance_config: Union[LayerSkipConfig, List[LayerSkipConfig]] = None,
+        auto_guidance_config: Union[LayerSkipConfig, List[LayerSkipConfig], Dict[str, Any]] = None,
         dropout: Optional[float] = None,
         guidance_rescale: float = 0.0,
         use_original_formulation: bool = False,
@@ -104,6 +104,9 @@ class AutoGuidance(BaseGuidance):
                 LayerSkipConfig(layer, fqn="auto", dropout=dropout) for layer in auto_guidance_layers
             ]
 
+        if isinstance(auto_guidance_config, dict):
+            auto_guidance_config = LayerSkipConfig.from_dict(auto_guidance_config)
+
         if isinstance(auto_guidance_config, LayerSkipConfig):
             auto_guidance_config = [auto_guidance_config]
 
@@ -111,6 +114,8 @@ class AutoGuidance(BaseGuidance):
             raise ValueError(
                 f"Expected `auto_guidance_config` to be a LayerSkipConfig or a list of LayerSkipConfig, but got {type(auto_guidance_config)}."
             )
+        elif isinstance(next(iter(auto_guidance_config), None), dict):
+            auto_guidance_config = [LayerSkipConfig.from_dict(config) for config in auto_guidance_config]
 
         self.auto_guidance_config = auto_guidance_config
         self._auto_guidance_hook_names = [f"AutoGuidance_{i}" for i in range(len(self.auto_guidance_config))]

--- a/src/diffusers/guiders/perturbed_attention_guidance.py
+++ b/src/diffusers/guiders/perturbed_attention_guidance.py
@@ -118,9 +118,7 @@ class PerturbedAttentionGuidance(SkipLayerGuidance):
                 "`perturbed_guidance_config` must be a `LayerSkipConfig`, a list of `LayerSkipConfig`, or a dict that can be converted to a `LayerSkipConfig`."
             )
         elif isinstance(next(iter(perturbed_guidance_config), None), dict):
-                perturbed_guidance_config = [
-                    LayerSkipConfig.from_dict(config) for config in perturbed_guidance_config
-                ]
+            perturbed_guidance_config = [LayerSkipConfig.from_dict(config) for config in perturbed_guidance_config]
 
         for config in perturbed_guidance_config:
             if config.skip_attention or not config.skip_attention_scores or config.skip_ff:

--- a/src/diffusers/guiders/perturbed_attention_guidance.py
+++ b/src/diffusers/guiders/perturbed_attention_guidance.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from ..configuration_utils import register_to_config
 from ..hooks import LayerSkipConfig
+from ..utils import get_logger
 from .skip_layer_guidance import SkipLayerGuidance
+
+
+logger = get_logger(__name__)  # pylint: disable=invalid-name
 
 
 class PerturbedAttentionGuidance(SkipLayerGuidance):
@@ -48,8 +52,8 @@ class PerturbedAttentionGuidance(SkipLayerGuidance):
             The fraction of the total number of denoising steps after which perturbed attention guidance stops.
         perturbed_guidance_layers (`int` or `List[int]`, *optional*):
             The layer indices to apply perturbed attention guidance to. Can be a single integer or a list of integers.
-            If not provided, `skip_layer_config` must be provided.
-        skip_layer_config (`LayerSkipConfig` or `List[LayerSkipConfig]`, *optional*):
+            If not provided, `perturbed_guidance_config` must be provided.
+        perturbed_guidance_config (`LayerSkipConfig` or `List[LayerSkipConfig]`, *optional*):
             The configuration for the perturbed attention guidance. Can be a single `LayerSkipConfig` or a list of
             `LayerSkipConfig`. If not provided, `perturbed_guidance_layers` must be provided.
         guidance_rescale (`float`, defaults to `0.0`):
@@ -79,19 +83,20 @@ class PerturbedAttentionGuidance(SkipLayerGuidance):
         perturbed_guidance_start: float = 0.01,
         perturbed_guidance_stop: float = 0.2,
         perturbed_guidance_layers: Optional[Union[int, List[int]]] = None,
-        skip_layer_config: Union[LayerSkipConfig, List[LayerSkipConfig]] = None,
+        perturbed_guidance_config: Union[LayerSkipConfig, List[LayerSkipConfig], Dict[str, Any]] = None,
         guidance_rescale: float = 0.0,
         use_original_formulation: bool = False,
         start: float = 0.0,
         stop: float = 1.0,
     ):
-        if skip_layer_config is None:
+        if perturbed_guidance_config is None:
             if perturbed_guidance_layers is None:
                 raise ValueError(
-                    "`perturbed_guidance_layers` must be provided if `skip_layer_config` is not specified."
+                    "`perturbed_guidance_layers` must be provided if `perturbed_guidance_config` is not specified."
                 )
-            skip_layer_config = LayerSkipConfig(
+            perturbed_guidance_config = LayerSkipConfig(
                 indices=perturbed_guidance_layers,
+                fqn="auto",
                 skip_attention=False,
                 skip_attention_scores=True,
                 skip_ff=False,
@@ -99,8 +104,33 @@ class PerturbedAttentionGuidance(SkipLayerGuidance):
         else:
             if perturbed_guidance_layers is not None:
                 raise ValueError(
-                    "`perturbed_guidance_layers` should not be provided if `skip_layer_config` is specified."
+                    "`perturbed_guidance_layers` should not be provided if `perturbed_guidance_config` is specified."
                 )
+
+        if isinstance(perturbed_guidance_config, dict):
+            perturbed_guidance_config = LayerSkipConfig.from_dict(perturbed_guidance_config)
+
+        if isinstance(perturbed_guidance_config, LayerSkipConfig):
+            perturbed_guidance_config = [perturbed_guidance_config]
+
+        if not isinstance(perturbed_guidance_config, list):
+            raise ValueError(
+                "`perturbed_guidance_config` must be a `LayerSkipConfig`, a list of `LayerSkipConfig`, or a dict that can be converted to a `LayerSkipConfig`."
+            )
+        elif isinstance(next(iter(perturbed_guidance_config), None), dict):
+                perturbed_guidance_config = [
+                    LayerSkipConfig.from_dict(config) for config in perturbed_guidance_config
+                ]
+
+        for config in perturbed_guidance_config:
+            if config.skip_attention or not config.skip_attention_scores or config.skip_ff:
+                logger.warning(
+                    "Perturbed Attention Guidance is designed to perturb attention scores, so `skip_attention` should be False, `skip_attention_scores` should be True, and `skip_ff` should be False. "
+                    "Please check your configuration. Modifying the config to match the expected values."
+                )
+            config.skip_attention = False
+            config.skip_attention_scores = True
+            config.skip_ff = False
 
         super().__init__(
             guidance_scale=guidance_scale,
@@ -108,7 +138,7 @@ class PerturbedAttentionGuidance(SkipLayerGuidance):
             skip_layer_guidance_start=perturbed_guidance_start,
             skip_layer_guidance_stop=perturbed_guidance_stop,
             skip_layer_guidance_layers=perturbed_guidance_layers,
-            skip_layer_config=skip_layer_config,
+            skip_layer_config=perturbed_guidance_config,
             guidance_rescale=guidance_rescale,
             use_original_formulation=use_original_formulation,
             start=start,

--- a/src/diffusers/guiders/skip_layer_guidance.py
+++ b/src/diffusers/guiders/skip_layer_guidance.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
 
@@ -95,7 +95,7 @@ class SkipLayerGuidance(BaseGuidance):
         skip_layer_guidance_start: float = 0.01,
         skip_layer_guidance_stop: float = 0.2,
         skip_layer_guidance_layers: Optional[Union[int, List[int]]] = None,
-        skip_layer_config: Union[LayerSkipConfig, List[LayerSkipConfig]] = None,
+        skip_layer_config: Union[LayerSkipConfig, List[LayerSkipConfig], Dict[str, Any]] = None,
         guidance_rescale: float = 0.0,
         use_original_formulation: bool = False,
         start: float = 0.0,
@@ -135,6 +135,9 @@ class SkipLayerGuidance(BaseGuidance):
                 )
             skip_layer_config = [LayerSkipConfig(layer, fqn="auto") for layer in skip_layer_guidance_layers]
 
+        if isinstance(skip_layer_config, dict):
+            skip_layer_config = LayerSkipConfig.from_dict(skip_layer_config)
+
         if isinstance(skip_layer_config, LayerSkipConfig):
             skip_layer_config = [skip_layer_config]
 
@@ -142,6 +145,8 @@ class SkipLayerGuidance(BaseGuidance):
             raise ValueError(
                 f"Expected `skip_layer_config` to be a LayerSkipConfig or a list of LayerSkipConfig, but got {type(skip_layer_config)}."
             )
+        elif isinstance(next(iter(skip_layer_config), None), dict):
+            skip_layer_config = [LayerSkipConfig.from_dict(config) for config in skip_layer_config]
 
         self.skip_layer_config = skip_layer_config
         self._skip_layer_hook_names = [f"SkipLayerGuidance_{i}" for i in range(len(self.skip_layer_config))]

--- a/src/diffusers/guiders/smoothed_energy_guidance.py
+++ b/src/diffusers/guiders/smoothed_energy_guidance.py
@@ -125,6 +125,9 @@ class SmoothedEnergyGuidance(BaseGuidance):
                 )
             seg_guidance_config = [SmoothedEnergyGuidanceConfig(layer, fqn="auto") for layer in seg_guidance_layers]
 
+        if isinstance(seg_guidance_config, dict):
+            seg_guidance_config = SmoothedEnergyGuidanceConfig.from_dict(seg_guidance_config)
+
         if isinstance(seg_guidance_config, SmoothedEnergyGuidanceConfig):
             seg_guidance_config = [seg_guidance_config]
 
@@ -132,6 +135,8 @@ class SmoothedEnergyGuidance(BaseGuidance):
             raise ValueError(
                 f"Expected `seg_guidance_config` to be a SmoothedEnergyGuidanceConfig or a list of SmoothedEnergyGuidanceConfig, but got {type(seg_guidance_config)}."
             )
+        elif isinstance(next(iter(seg_guidance_config), None), dict):
+            seg_guidance_config = [SmoothedEnergyGuidanceConfig.from_dict(config) for config in seg_guidance_config]
 
         self.seg_guidance_config = seg_guidance_config
         self._seg_layer_hook_names = [f"SmoothedEnergyGuidance_{i}" for i in range(len(self.seg_guidance_config))]

--- a/src/diffusers/hooks/layer_skip.py
+++ b/src/diffusers/hooks/layer_skip.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Callable, List, Optional
 
 import torch
@@ -77,6 +77,13 @@ class LayerSkipConfig:
             raise ValueError(
                 "Cannot set `skip_attention_scores` to True when `dropout` is not 1.0. Please set `dropout` to 1.0."
             )
+
+    def to_dict(self):
+        return asdict(self)
+
+    @staticmethod
+    def from_dict(data: dict) -> "LayerSkipConfig":
+        return LayerSkipConfig(**data)
 
 
 class AttentionScoreSkipFunctionMode(torch.overrides.TorchFunctionMode):

--- a/src/diffusers/hooks/smoothed_energy_guidance_utils.py
+++ b/src/diffusers/hooks/smoothed_energy_guidance_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import List, Optional
 
 import torch
@@ -50,6 +50,13 @@ class SmoothedEnergyGuidanceConfig:
     indices: List[int]
     fqn: str = "auto"
     _query_proj_identifiers: List[str] = None
+
+    def to_dict(self):
+        return asdict(self)
+
+    @staticmethod
+    def from_dict(data: dict) -> "SmoothedEnergyGuidanceConfig":
+        return SmoothedEnergyGuidanceConfig(**data)
 
 
 class SmoothedEnergyGuidanceHook(ModelHook):


### PR DESCRIPTION
Adds support for serializing/deserializing custom config objects. LMK if this approach does not sound good.

@yiyixuxu Could you elaborate on https://github.com/huggingface/diffusers/pull/11862#issuecomment-3037797375?

> (I think we probably just don't need the special config class now that it is a ConfigMixin, but it is up to you)

Do you mean we completely get rid of LayerSkipConfig? And if so, how do we provide the users with the option to conditionally skip different layers/attention scores?

Testing code:

```python
import json
import torch
from diffusers import AutoGuidance, SkipLayerGuidance, ClassifierFreeGuidance, SmoothedEnergyGuidance, SmoothedEnergyGuidanceConfig, AdaptiveProjectedGuidance, PerturbedAttentionGuidance, ClassifierFreeZeroStarGuidance, TangentialClassifierFreeGuidance, LayerSkipConfig
from diffusers.modular_pipelines import SequentialPipelineBlocks, ComponentSpec
from diffusers.modular_pipelines.stable_diffusion_xl import TEXT2IMAGE_BLOCKS
from diffusers.utils.logging import set_verbosity_debug

set_verbosity_debug()

blocks = SequentialPipelineBlocks.from_blocks_dict(TEXT2IMAGE_BLOCKS)

modular_repo_id = "YiYiXu/modular-loader-t2i"
pipeline = blocks.init_pipeline(modular_repo_id)
pipeline.load_default_components(torch_dtype=torch.float16)
pipeline.to("cuda")

for guider_cls in [
    AutoGuidance,
    SkipLayerGuidance,
    ClassifierFreeGuidance,
    SmoothedEnergyGuidance,
    AdaptiveProjectedGuidance,
    PerturbedAttentionGuidance,
    ClassifierFreeZeroStarGuidance,
    TangentialClassifierFreeGuidance
]:
    print(f"Testing {guider_cls.__name__}...")
    
    kwargs = {"guidance_scale": 5.0}
    if guider_cls is AutoGuidance:
        kwargs.update({"auto_guidance_config": LayerSkipConfig(indices=[9, 10], fqn="mid_block.attentions.0.transformer_blocks", skip_attention=True, skip_ff=True, dropout=0.75)})
        kwargs.update({"stop": 0.6})
    elif guider_cls is SkipLayerGuidance:
        kwargs.update({"skip_layer_config": LayerSkipConfig(indices=[9, 10], fqn="mid_block.attentions.0.transformer_blocks", skip_attention=True, skip_ff=True)})
        kwargs.update({"skip_layer_guidance_stop": 0.4})
    elif guider_cls is SmoothedEnergyGuidance:
        kwargs.update({"seg_guidance_config": SmoothedEnergyGuidanceConfig(indices=[9, 10], fqn="mid_block.attentions.0.transformer_blocks")})
        kwargs.update({"seg_guidance_stop": 0.8})
    elif guider_cls is PerturbedAttentionGuidance:
        kwargs.update({"perturbed_guidance_config": LayerSkipConfig(indices=[9, 10], fqn="mid_block.attentions.0.transformer_blocks", skip_attention=False, skip_attention_scores=True, skip_ff=False)})
        kwargs.update({"perturbed_guidance_stop": 0.5})
    0
    pipeline.loader.update(
        guider=ComponentSpec(
            name="cfg",
            type_hint=guider_cls,
            config=kwargs,
            default_creation_method="from_config",
        )
    )
    pipeline.save_pretrained("test_modular_t2i_guider")
    pipeline.loader.guider.save_config("test_modular_t2i_guider/guider")
    
    with open("test_modular_t2i_guider/guider/guider_config.json", "r") as f:
        guider_config = json.load(f)
    guider_config["guidance_scale"] = 10.0
    with open("test_modular_t2i_guider/guider/guider_config.json", "w") as f:
        json.dump(guider_config, f, indent=2)
    
    guider_spec = ComponentSpec(
        name="cfg",
        type_hint=guider_cls,
        config=guider_cls.from_config("test_modular_t2i_guider/guider").config,
        default_creation_method="from_config",
    )
    pipeline.loader.update(guider=guider_spec.create())
    print(pipeline.loader.guider)

    image = pipeline(prompt="Astronaut in a jungle, cold color palette, muted colors, detailed, 8k", num_inference_steps=20, output="images", generator=torch.Generator().manual_seed(42))[0]
    output_filename = f"output_guider_{guider_cls.__name__.lower()}.png"
    image.save(output_filename)
```