### PR TITLE
[fix] fix for prior preservation and mixed precision sampling

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux_kontext.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux_kontext.py
@@ -1193,6 +1193,7 @@ def main(args):
                 subfolder="transformer",
                 revision=args.revision,
                 variant=args.variant,
+                torch_dtype=torch_dtype,
             )
             pipeline = FluxKontextPipeline.from_pretrained(
                 args.pretrained_model_name_or_path,
@@ -1215,7 +1216,8 @@ def main(args):
             for example in tqdm(
                 sample_dataloader, desc="Generating class images", disable=not accelerator.is_local_main_process
             ):
-                images = pipeline(example["prompt"]).images
+                with torch.autocast(device_type=accelerator.device.type, dtype=torch_dtype):
+                    images = pipeline(prompt=example["prompt"]).images
 
                 for i, image in enumerate(images):
                     hash_image = insecure_hashlib.sha1(image.tobytes()).hexdigest()
@@ -1788,6 +1790,10 @@ def main(args):
                             max_sequence_length=args.max_sequence_length,
                             device=accelerator.device,
                             prompt=args.instance_prompt,
+                        )
+                    else:
+                        prompt_embeds, pooled_prompt_embeds, text_ids = compute_text_embeddings(
+                            prompts, text_encoders, tokenizers
                         )
 
                 # Convert images to latent space


### PR DESCRIPTION
There were 4 issues fixed:

1. When sampling with prior preservation, the prompt was not passed to the correct argument position, causing a generation error during sampling.
2. When sampling with prior preservation, the transformer passed to the pipeline did not have the torch_dtype argument, causing issues with mixed precision.
3. When sampling with prior preservation, the prompt was passed in fp32 without proper casting, leading to mixed precision mismatches.
4. When not args.train_text_encoder, prompt_embeds and pooled_prompt_embeds were None, leading to the same error as reported in https://github.com/huggingface/diffusers/issues/10722.