### PR TITLE
Fix: Exclude module handling in LoRA weight loading

### DIFF
--- a/src/diffusers/utils/peft_utils.py
+++ b/src/diffusers/utils/peft_utils.py
@@ -409,6 +409,10 @@ def _derive_exclude_modules(model_state_dict, peft_state_dict, adapter_name=None
             all_modules.add(module_name)
 
     target_modules_set = {name.split(".lora")[0] for name in peft_state_dict.keys()}
-    exclude_modules = list(all_modules - target_modules_set)
+    exclude_modules_set = set(all_modules - target_modules_set)
+    exclude_modules = []
+    for module_name in exclude_modules_set:
+        if all(module_name not in target_module_name for target_module_name in target_modules_set):
+            exclude_modules.append(module_name)
 
     return exclude_modules


### PR DESCRIPTION
There is a bug in src/diffusers/utils/peft_utils.py when loading LoRA weights: if an excluded module name is a substring of a target module name, it unintentionally prevents the target module from being loaded.

A simple reproduction example:

```
import torch
from diffusers import FluxPipeline

pipe = FluxPipeline.from_pretrained("black-forest-labs/FLUX.1-dev", torch_dtype=torch.bfloat16)
pipe.load_lora_weights("Shakker-Labs/FLUX.1-dev-LoRA-AntiBlur", weight_name="FLUX-dev-lora-AntiBlur.safetensors")
```

This is a known issue, as discussed in:
- https://github.com/huggingface/diffusers/issues/11885
- https://github.com/huggingface/diffusers/issues/11874

Although the PEFT library is preparing a fix (see https://github.com/huggingface/peft/pull/2637#issue-3215581913), it's uncertain when that change will be released as part of a stable version. In the meantime, this bug exists in the current main branch of Diffusers and needs to be addressed immediately.

The proposed fix modifies the logic in Diffusers to ensure that exclude_modules are not substring of any target module name, preventing incorrect exclusions. This change may be rolled back in the future once the PEFT-side fix is available and adopted, but until then, it ensures correct and stable behavior for users.