### PR TITLE
[Modular] Updates for Custom Pipeline Blocks

### DIFF
--- a/src/diffusers/commands/custom_blocks.py
+++ b/src/diffusers/commands/custom_blocks.py
@@ -27,7 +27,7 @@ from ..utils import logging
 from . import BaseDiffusersCLICommand
 
 
-EXPECTED_PARENT_CLASSES = ["ModularPipelineBlocks"]
+EXPECTED_PARENT_CLASSES = ["PipelineBlock"]
 CONFIG = "config.json"
 
 

--- a/src/diffusers/commands/custom_blocks.py
+++ b/src/diffusers/commands/custom_blocks.py
@@ -27,7 +27,7 @@ from ..utils import logging
 from . import BaseDiffusersCLICommand
 
 
-EXPECTED_PARENT_CLASSES = ["PipelineBlock"]
+EXPECTED_PARENT_CLASSES = ["ModularPipelineBlocks"]
 CONFIG = "config.json"
 
 

--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -360,7 +360,6 @@ class ModularPipelineBlocks(ConfigMixin, PushToHubMixin):
             "token",
         ]
         hub_kwargs = {name: kwargs.pop(name) for name in hub_kwargs_names if name in kwargs}
-        hub_kwargs.update({"trust_remote_code": trust_remote_code})
 
         config = cls.load_config(pretrained_model_name_or_path)
         has_remote_code = "auto_map" in config and cls.__name__ in config["auto_map"]

--- a/src/diffusers/modular_pipelines/modular_pipeline_utils.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline_utils.py
@@ -93,7 +93,7 @@ class ComponentSpec:
     config: Optional[FrozenDict] = None
     # YiYi Notes: should we change it to pretrained_model_name_or_path for consistency? a bit long for a field name
     repo: Optional[Union[str, List[str]]] = field(default=None, metadata={"loading": True})
-    subfolder: Optional[str] = field(default=None, metadata={"loading": True})
+    subfolder: Optional[str] = field(default="", metadata={"loading": True})
     variant: Optional[str] = field(default=None, metadata={"loading": True})
     revision: Optional[str] = field(default=None, metadata={"loading": True})
     default_creation_method: Literal["from_config", "from_pretrained"] = "from_pretrained"


### PR DESCRIPTION
# What does this PR do?
1. Updates ModularPipelineBlock serialization so that type hint, repo, subfolder, variant information gets saved when calling `block.save_pretrained`. Useful for when you have custom pipeline blocks that have components that use `from_pretrained`

2. Pass `trust_remote_code` to `hub_kwargs` so that it gets passed through to model loading. Useful when loading custom pipeline blocks with models that also have custom code. e.g. Florence2 in transformers

3. Makes subfolder default value an empty string in ComponentSpec because passing `subfolder=None` to transformer Auto classes does not work. [We also substitute `None` for an empty string](https://github.com/huggingface/diffusers/blame/9c13f8657986e68f5f05987912c54432fd28d86f/src/diffusers/models/modeling_utils.py#L1096) when running `from_pretrained` for diffusers models. So it should be a safe change.  

4. Updates the custom block repo creation CLI command to search for classes inheriting from `PipelineBlock`. Not sure here if custom pipeline blocks need to inherit from `ModularPipelineBlocks` or `PipelineBlock`. Can revert if needed, but from my understanding it should be PipelineBlock? cc: @yiyixuxu  

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
