### PR TITLE
Teacache implemented into hunyuan video framepack transformer model

### DIFF
--- a/src/diffusers/models/transformers/transformer_hunyuan_video_framepack.py
+++ b/src/diffusers/models/transformers/transformer_hunyuan_video_framepack.py
@@ -312,7 +312,7 @@ class HunyuanVideoFramepackTransformer3DModel(
         if self.enable_teacache:
             hidden_states_ = hidden_states.clone()
             temb_ = temb.clone()
-            modulated_hidden_states = self.transformer_blocks[0].norm1(hidden_states_, emb=temb_)[0]
+            modulated_inp = self.transformer_blocks[0].norm1(hidden_states_, emb=temb_)[0]
             
             if self.cnt == 0 or self.cnt == self.num_steps-1:
                 should_calc = True
@@ -338,7 +338,7 @@ class HunyuanVideoFramepackTransformer3DModel(
                 self.cnt = 0
 
             if not should_calc:
-                hidden_states += self.previous_residual
+                    hidden_states += self.previous_residual
             else:
                 ori_hidden_states = hidden_states.clone()
                 

--- a/tests/models/transformers/test_models_transformer_hunyuan_video_framepack.py
+++ b/tests/models/transformers/test_models_transformer_hunyuan_video_framepack.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import patch, MagicMock
 
 import torch
 
@@ -115,28 +114,24 @@ class HunyuanVideoTransformer3DTests(ModelTesterMixin, unittest.TestCase):
     def test_gradient_checkpointing_is_applied(self):
         expected_set = {"HunyuanVideoFramepackTransformer3DModel"}
         super().test_gradient_checkpointing_is_applied(expected_set=expected_set)
-        
+
     def test_teacache_initialization(self):
         init_dict, inputs_dict = self.prepare_init_args_and_inputs_for_common()
         model = self.model_class(**init_dict)
         model.to(torch_device)
-        
+
         custom_num_steps = 50
         custom_thresh = 0.1
-        
-        model.initialize_teacache(
-            enable_teacache=True,
-            num_steps=custom_num_steps,
-            rel_l1_thresh=custom_thresh
-        )
-        
+
+        model.initialize_teacache(enable_teacache=True, num_steps=custom_num_steps, rel_l1_thresh=custom_thresh)
+
         self.assertTrue(model.enable_teacache)
         self.assertEqual(model.num_steps, custom_num_steps)
         self.assertEqual(model.rel_l1_thresh, custom_thresh)
-        
+
         self.assertEqual(model.cnt, 0)
         self.assertEqual(model.accumulated_rel_l1_distance, 0)
         self.assertIsNone(model.previous_modulated_input)
         self.assertIsNone(model.previous_residual)
-        self.assertTrue(hasattr(model, 'coeffs'))
-        self.assertTrue(hasattr(model, 'teacache_rescale_func'))
+        self.assertTrue(hasattr(model, "coeffs"))
+        self.assertTrue(hasattr(model, "teacache_rescale_func"))


### PR DESCRIPTION
# What does this PR do?

- This PR adds TeaCache support to HunyuanVideoFramepackTransformer3DModel, improving inference latency.

TeaCache is opt-in and can be enabled with:


```
transformer = HunyuanVideoFramepackTransformer3DModel.from_pretrained(
    "lllyasviel/FramePackI2V_HY", torch_dtype=torch.bfloat16
)
transformer.initialize_teacache()
```

# What’s changed

- Added TeaCache logic in the model’s forward method.
- Introduced initialize_teacache() method.
- Wrote an initialization test inside the existing test for Hunyuan FramePack.

@sayakpaul @yiyixuxu

Let me know the fixes required
