### PR TITLE
torch.compile compatibility with varlen APIs

### DIFF
--- a/src/diffusers/models/transformers/transformer_flux.py
+++ b/src/diffusers/models/transformers/transformer_flux.py
@@ -263,6 +263,7 @@ class FluxIPAdapterAttnProcessor(torch.nn.Module):
             return hidden_states
 
 
+@maybe_allow_in_graph
 class FluxAttention(torch.nn.Module, AttentionModuleMixin):
     _default_processor_cls = FluxAttnProcessor
     _available_processors = [


### PR DESCRIPTION
Looks into #11957.

Some of the change related to key_valid/value_valid are removed. Removing padding tokens was probably incorrect (because of how the max_seq_lens and cu_seq_lens interact) and not required (because we know that a batch of data will not have varying sequence lengths).

I'm running into some other errors using the flags suggested by @StrongerXi

```python
import torch
import torch._dynamo.config
from diffusers import FluxPipeline, FluxTransformer2DModel

torch._dynamo.config.capture_scalar_outputs = True
# Recompilations because of attention processor id mismatch
torch._dynamo.config.cache_size_limit = 100

model_id = "black-forest-labs/FLUX.1-dev"
transformer = FluxTransformer2DModel.from_pretrained(model_id, subfolder="transformer", torch_dtype=torch.bfloat16, device_map="cuda")
pipe = FluxPipeline.from_pretrained("black-forest-labs/FLUX.1-dev", transformer=transformer, torch_dtype=torch.bfloat16)
pipe.text_encoder.to("cuda")
pipe.text_encoder_2.to("cuda")
pipe.vae.to("cuda")

# pipe.transformer.set_attention_backend("flash")
pipe.transformer.set_attention_backend("flash_varlen")

# pipe.transformer = torch.compile(pipe.transformer, mode="default", fullgraph=True, dynamic=False)
pipe.transformer.compile_repeated_blocks(fullgraph=True, dynamic=False)

prompt = "A cat holding a sign that says 'hello world'"
image = pipe(prompt, num_inference_steps=28, guidance_scale=4.0).images[0]

image.save("output.png")
```

- If using `torch.compile` with `flash` backend (which is FA2 from source): ✅ 

- If using `compile_repeated_blocks` with `flash` backend (multiple recompiles on attention processor): ❌ 

<details>
<summary> Stack trace </summary>

```python
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles] Recompiling function forward in /home/aryan/work/diffusers/src/diffusers/models/transformers/transformer_flux.py:381
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     triggered by the following guard failure(s):
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/36: ___check_obj_id(self._modules['attn'].processor, 140462015041104)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/35: ___check_obj_id(self._modules['attn'].processor, 140462015040240)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/34: ___check_obj_id(self._modules['attn'].processor, 140462015039376)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/33: ___check_obj_id(self._modules['attn'].processor, 140462015038512)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/32: ___check_obj_id(self._modules['attn'].processor, 140462015037648)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/31: ___check_obj_id(self._modules['attn'].processor, 140466393496880)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/30: ___check_obj_id(self._modules['attn'].processor, 140466393496016)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/29: ___check_obj_id(self._modules['attn'].processor, 140466393495152)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/28: ___check_obj_id(self._modules['attn'].processor, 140466393494288)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/27: ___check_obj_id(self._modules['attn'].processor, 140466393493424)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/26: ___check_obj_id(self._modules['attn'].processor, 140466393492560)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/25: ___check_obj_id(self._modules['attn'].processor, 140466393491696)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/24: ___check_obj_id(self._modules['attn'].processor, 140466393490832)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/23: ___check_obj_id(self._modules['attn'].processor, 140466393489968)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/22: ___check_obj_id(self._modules['attn'].processor, 140466393489104)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/21: ___check_obj_id(self._modules['attn'].processor, 140466393488240)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/20: ___check_obj_id(self._modules['attn'].processor, 140466393487376)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/19: ___check_obj_id(self._modules['attn'].processor, 140466393486512)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/18: ___check_obj_id(self._modules['attn'].processor, 140466393485648)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/17: ___check_obj_id(self._modules['attn'].processor, 140466393484784)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/16: ___check_obj_id(self._modules['attn'].processor, 140466393483920)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/15: ___check_obj_id(self._modules['attn'].processor, 140466393483056)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/14: ___check_obj_id(self._modules['attn'].processor, 140466393482192)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/13: ___check_obj_id(self._modules['attn'].processor, 140466393481328)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/12: ___check_obj_id(self._modules['attn'].processor, 140466392857808)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/11: ___check_obj_id(self._modules['attn'].processor, 140466392856944)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/10: ___check_obj_id(self._modules['attn'].processor, 140466392856080)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/9: ___check_obj_id(self._modules['attn'].processor, 140466392855216)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/8: ___check_obj_id(self._modules['attn'].processor, 140466392854352)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/7: ___check_obj_id(self._modules['attn'].processor, 140466392853488)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/6: ___check_obj_id(self._modules['attn'].processor, 140466392852624)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/5: ___check_obj_id(self._modules['attn'].processor, 140466392851760)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/4: ___check_obj_id(self._modules['attn'].processor, 140466392850896)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/3: ___check_obj_id(self._modules['attn'].processor, 140466392850032)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/2: ___check_obj_id(self._modules['attn'].processor, 140466392849168)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/1: ___check_obj_id(self._modules['attn'].processor, 140466392848304)
V0721 23:40:59.397000 2159156 torch/_dynamo/guards.py:3006] [1/37] [__recompiles]     - 1/0: ___check_obj_id(self._modules['attn'].processor, 140466392847440)
```

</details>

This makes sense because each block is making a call to a "different" function (processor object). Not sure how to fix this

- If using `flash_varlen` as backend: ✅ 

- If using `flash_varlen` as backend with `torch.compile`: ❌ 

<details>
<summary> stack trace </summary>

```python
Traceback (most recent call last):
  File "/home/aryan/work/diffusers/dump19.py", line 753, in <module>
    image = pipe(prompt, num_inference_steps=28, guidance_scale=4.0).images[0]
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/home/aryan/work/diffusers/src/diffusers/pipelines/flux/pipeline_flux.py", line 918, in __call__
    noise_pred = self.transformer(
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/aryan/work/diffusers/src/diffusers/models/transformers/transformer_flux.py", line 734, in forward
    encoder_hidden_states, hidden_states = block(
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1749, in _wrapped_call_impl
    return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_dynamo/eval_frame.py", line 655, in _fn
    return fn(*args, **kwargs)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/aryan/work/diffusers/src/diffusers/models/transformers/transformer_flux.py", line 441, in forward
    def forward(
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_dynamo/eval_frame.py", line 838, in _fn
    return fn(*args, **kwargs)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_functorch/aot_autograd.py", line 1209, in forward
    return compiled_fn(full_args)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 328, in runtime_wrapper
    all_outs = call_func_at_runtime_with_args(
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_functorch/_aot_autograd/utils.py", line 126, in call_func_at_runtime_with_args
    out = normalize_as_list(f(args))
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 689, in inner_fn
    outs = compiled_fn(args)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 495, in wrapper
    return compiled_fn(runtime_args)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_inductor/output_code.py", line 460, in __call__
    return self.current_callable(inputs)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_inductor/utils.py", line 2404, in run
    return model(new_inputs)
  File "/tmp/torchinductor_aryan/yj/cyjfbeabktf6xelcncgrwo5ggvp4ip2rlggvtozudr43y43udth3.py", line 1297, in call
    buf33 = torch.ops.flash_attn._flash_attn_varlen_forward.default(buf28, buf29, buf30, buf31, buf32, u0, u1, 0.0, 0.08838834764831845, False)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_ops.py", line 756, in __call__
    return self._op(*args, **kwargs)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_library/autograd.py", line 113, in autograd_impl
    result = forward_no_grad(*args, Metadata(keyset, keyword_only_args))
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_library/autograd.py", line 40, in forward_no_grad
    result = op.redispatch(keyset & _C._after_autograd_keyset, *args, **kwargs)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_ops.py", line 761, in redispatch
    return self._handle.redispatch_boxed(keyset, *args, **kwargs)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_library/custom_ops.py", line 335, in backend_impl
    result = self._backend_fns[device_type](*args, **kwargs)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_compile.py", line 51, in inner
    return disable_fn(*args, **kwargs)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_dynamo/eval_frame.py", line 838, in _fn
    return fn(*args, **kwargs)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/torch/_library/custom_ops.py", line 367, in wrapped_fn
    return fn(*args, **kwargs)
  File "/raid/aryan/nightly-venv/lib/python3.10/site-packages/flash_attn/flash_attn_interface.py", line 170, in _flash_attn_varlen_forward
    out, softmax_lse, S_dmask, rng_state = flash_attn_gpu.varlen_fwd(
RuntimeError: cu_seqlens_q must have dtype int32
```

</details>

FA2 requires cu_seq_lens to be `torch.int32` but instead we end up having `torch.int64`. It looks like inductor is generating incorrect code by optimizing out the cast to `torch.int32`.

<details>
<summary> relevant part of inductor code </summary>

```python
   with torch.cuda._DeviceGuard(0):
        torch.cuda.set_device(0)
        buf28 = empty_strided_cuda((4608, 24, 128), (3072, 128, 1), torch.bfloat16)
        buf29 = empty_strided_cuda((4608, 24, 128), (3072, 128, 1), torch.bfloat16)
        # Topologically Sorted Source Nodes: [cumsum, cu_seqlens_q, cumsum_1, cu_seqlens_k, _flash_attn_varlen_forward], Original ATen: [aten.cumsum, aten.constant_pad_nd, flash_attn._flash_attn_varlen_forward]
        stream0 = get_raw_stream(0)
        triton_poi_fused__flash_attn_varlen_forward_constant_pad_nd_cumsum_7.run(buf16, arg23_1, arg24_1, buf21, buf28, buf29, 14155776, stream=stream0)
        del arg23_1
        del arg24_1
        del buf16
        buf30 = reinterpret_tensor(buf21, (4608, 24, 128), (3072, 128, 1), 0); del buf21  # reuse
        # Topologically Sorted Source Nodes: [cumsum, cu_seqlens_q, cumsum_1, cu_seqlens_k, _flash_attn_varlen_forward], Original ATen: [aten.cumsum, aten.constant_pad_nd, flash_attn._flash_attn_varlen_forward]
        stream0 = get_raw_stream(0)
        triton_poi_fused__flash_attn_varlen_forward_constant_pad_nd_cumsum_8.run(buf22, buf23, buf30, 14155776, stream=stream0)
        buf31 = empty_strided_cuda((2, ), (1, ), torch.int64)
        # Topologically Sorted Source Nodes: [cumsum, cu_seqlens_q, cumsum_1, cu_seqlens_k, _flash_attn_varlen_forward], Original ATen: [aten.cumsum, aten.constant_pad_nd, flash_attn._flash_attn_varlen_forward]
        stream0 = get_raw_stream(0)
        triton_poi_fused__flash_attn_varlen_forward_constant_pad_nd_cumsum_9.run(buf31, 2, stream=stream0)
        buf32 = empty_strided_cuda((2, ), (1, ), torch.int64)
        # Topologically Sorted Source Nodes: [cumsum, cu_seqlens_q, cumsum_1, cu_seqlens_k, _flash_attn_varlen_forward], Original ATen: [aten.cumsum, aten.constant_pad_nd, flash_attn._flash_attn_varlen_forward]
        stream0 = get_raw_stream(0)
        triton_poi_fused__flash_attn_varlen_forward_constant_pad_nd_cumsum_9.run(buf32, 2, stream=stream0)
        # Topologically Sorted Source Nodes: [cumsum, cu_seqlens_q, cumsum_1, cu_seqlens_k, _flash_attn_varlen_forward], Original ATen: [aten.cumsum, aten.constant_pad_nd, flash_attn._flash_attn_varlen_forward]
        buf33 = torch.ops.flash_attn._flash_attn_varlen_forward.default(buf28, buf29, buf30, buf31, buf32, u0, u1, 0.0, 0.08838834764831845, False)
```

</details>

- If using `flash_varlen` as backend with `compile_repeated_blocks`: ❌ 

Same as above case.

Note: wherever I mentioned `torch.compile` to be used, it means I tested with `fullgraph=True` and `dynamic=False`