### PR TITLE
wan2.2 i2v FirstBlockCache fix

### DIFF
--- a/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
@@ -760,7 +760,6 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                         return_dict=False,
                     )[0]
 
-
                 if self.do_classifier_free_guidance:
                     with current_model.cache_context("uncond"):
                         noise_uncond = current_model(


### PR DESCRIPTION
# What does this PR do?

https://huggingface.co/posts/a-r-r-o-w/278025275110164

currently this cache does not work with the latest diffusers. the reason being is the cache context not being properly initialised in the WanImageToVideoPipeline.

Fixes #12012 (which was prematurely closed)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@yiyixuxu  @asomoza @a-r-r-o-w  @DN6 
