### PR TITLE
Allow SD pipeline to use newer schedulers, eg: FlowMatch

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -1034,7 +1034,8 @@ class StableDiffusionPipeline(
 
                 # expand the latents if we are doing classifier free guidance
                 latent_model_input = torch.cat([latents] * 2) if self.do_classifier_free_guidance else latents
-                latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
+                if hasattr(self.scheduler, "scale_model_input"):
+                    latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
 
                 # predict the noise residual
                 noise_pred = self.unet(


### PR DESCRIPTION
Allow SD pipeline to use newer schedulers, eg: FlowMatch,
by skipping attribute that doesnt exist there
(scale_model_input)

I am currently experimenting with SD + FlowMatchEuler, and had to do
an ugly hand hack in my training code to get the pipeline to continue:

```
print("HAND HACKING FLOWMATCH MODULE")
from diffusers import FlowMatchEulerDiscreteScheduler
def scale_model_input(self, sample, timestep):
    return sample

FlowMatchEulerDiscreteScheduler.scale_model_input = scale_model_input

```

Would be nice to have core diffusers handle this so I can share training results with people cleanly.


## Who can review?
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
