### PR TITLE
Cross attention module to Wan Attention

### DIFF
--- a/src/diffusers/models/transformers/transformer_wan.py
+++ b/src/diffusers/models/transformers/transformer_wan.py
@@ -180,6 +180,7 @@ class WanAttention(torch.nn.Module, AttentionModuleMixin):
         added_kv_proj_dim: Optional[int] = None,
         cross_attention_dim_head: Optional[int] = None,
         processor=None,
+        is_cross_attention=None
     ):
         super().__init__()
 
@@ -206,6 +207,8 @@ class WanAttention(torch.nn.Module, AttentionModuleMixin):
             self.add_k_proj = torch.nn.Linear(added_kv_proj_dim, self.inner_dim, bias=True)
             self.add_v_proj = torch.nn.Linear(added_kv_proj_dim, self.inner_dim, bias=True)
             self.norm_added_k = torch.nn.RMSNorm(dim_head * heads, eps=eps)
+
+        self.is_cross_attention = cross_attention_dim_head is not None
 
         self.set_processor(processor)
 

--- a/src/diffusers/models/transformers/transformer_wan.py
+++ b/src/diffusers/models/transformers/transformer_wan.py
@@ -180,7 +180,7 @@ class WanAttention(torch.nn.Module, AttentionModuleMixin):
         added_kv_proj_dim: Optional[int] = None,
         cross_attention_dim_head: Optional[int] = None,
         processor=None,
-        is_cross_attention=None
+        is_cross_attention=None,
     ):
         super().__init__()
 


### PR DESCRIPTION
# What does this PR do?
Adds the cross attention module to the Wan Attention Class

Fixes # (issue)
Mirrors the previous Attention class and allows us to distinguish between attention instances