### PR TITLE
fix input shape for WanGGUFTexttoVideoSingleFileTests

### DIFF
--- a/tests/quantization/gguf/test_gguf.py
+++ b/tests/quantization/gguf/test_gguf.py
@@ -650,7 +650,7 @@ class WanGGUFTexttoVideoSingleFileTests(GGUFSingleFileTesterMixin, unittest.Test
 
     def get_dummy_inputs(self):
         return {
-            "hidden_states": torch.randn((1, 36, 2, 64, 64), generator=torch.Generator("cpu").manual_seed(0)).to(
+            "hidden_states": torch.randn((1, 16, 2, 64, 64), generator=torch.Generator("cpu").manual_seed(0)).to(
                 torch_device, self.torch_dtype
             ),
             "encoder_hidden_states": torch.randn(


### PR DESCRIPTION
Fix input shape for WanGGUFTexttoVideoSingleFileTests.

The error comes from `RUN_NIGHTLY=1 pytest tests/quantization/gguf/test_gguf.py::WanGGUFTexttoVideoSingleFileTests::test_gguf_memory_usage`

error:
```
RuntimeError: Given groups=1, weight of size [5120, 16, 1, 2, 2], expected input[1, 36, 2, 64, 64] to have 16 channels, but got 36 channels instead
```

Hi @sayakpaul . Would you please review this PR? Thanks!