### PR TITLE
fix(fluX image validation): convert RGB to BGR for OpenPose images

### DIFF
--- a/examples/flux-control/train_control_lora_flux.py
+++ b/examples/flux-control/train_control_lora_flux.py
@@ -125,6 +125,9 @@ def log_validation(flux_transformer, args, accelerator, weight_dtype, step, is_f
 
     for validation_prompt, validation_image in zip(validation_prompts, validation_images):
         validation_image = load_image(validation_image)
+        # Convert RGB to BGR for OpenPose validation images
+        validation_image_np = np.array(validation_image)[:, :, ::-1]
+        validation_image = Image.fromarray(validation_image_np)
         # maybe need to inference on 1024 to get a good image
         validation_image = validation_image.resize((args.resolution, args.resolution))
 


### PR DESCRIPTION
- Add conversion from RGB to BGR for validation images in the fluX control example
- Ensure compatibility with OpenPose processing which expects BGR format

Fixes #12078 

@yiyixuxu