### PR TITLE
lora_conversion_utils: replace lora up/down with a/b even if `transformer.` in key

### DIFF
--- a/src/diffusers/loaders/lora_conversion_utils.py
+++ b/src/diffusers/loaders/lora_conversion_utils.py
@@ -817,7 +817,11 @@ def _convert_kohya_flux_lora_to_diffusers(state_dict):
     # has both `peft` and non-peft state dict.
     has_peft_state_dict = any(k.startswith("transformer.") for k in state_dict)
     if has_peft_state_dict:
-        state_dict = {k: v for k, v in state_dict.items() if k.startswith("transformer.")}
+        state_dict = {
+            k.replace("lora_down.weight", "lora_A.weight").replace("lora_up.weight", "lora_B.weight"): v
+            for k, v in state_dict.items()
+            if k.startswith("transformer.")
+        }
         return state_dict
 
     # Another weird one.


### PR DESCRIPTION
# What does this PR do?
Saw some Flux.DEV loras in our DB with keys like

```
transformer.single_transformer_blocks.0.attn.to_k.alpha : Tensor @ torch.Size([])
transformer.single_transformer_blocks.0.attn.to_k.lora_down.weight : Tensor @ torch.Size([10, 3072])
transformer.single_transformer_blocks.0.attn.to_k.lora_up.weight : Tensor @ torch.Size([3072, 10])
transformer.single_transformer_blocks.0.attn.to_q.alpha : Tensor @ torch.Size([])
transformer.single_transformer_blocks.0.attn.to_q.lora_down.weight : Tensor @ torch.Size([8, 3072])
transformer.single_transformer_blocks.0.attn.to_q.lora_up.weight : Tensor @ torch.Size([3072, 8])
transformer.single_transformer_blocks.0.attn.to_v.alpha : Tensor @ torch.Size([])
transformer.single_transformer_blocks.0.attn.to_v.lora_down.weight : Tensor @ torch.Size([8, 3072])
transformer.single_transformer_blocks.0.attn.to_v.lora_up.weight : Tensor @ torch.Size([3072, 8])
transformer.single_transformer_blocks.0.norm.linear.alpha : Tensor @ torch.Size([])
transformer.single_transformer_blocks.0.norm.linear.lora_down.weight : Tensor @ torch.Size([9, 3072])
transformer.single_transformer_blocks.0.norm.linear.lora_up.weight : Tensor @ torch.Size([9216, 9])
transformer.single_transformer_blocks.0.proj_mlp.alpha : Tensor @ torch.Size([])
transformer.single_transformer_blocks.0.proj_mlp.lora_down.weight : Tensor @ torch.Size([9, 3072])
transformer.single_transformer_blocks.0.proj_mlp.lora_up.weight : Tensor @ torch.Size([12288, 9])
transformer.single_transformer_blocks.0.proj_out.alpha : Tensor @ torch.Size([])
transformer.single_transformer_blocks.0.proj_out.lora_down.weight : Tensor @ torch.Size([7, 15360])
transformer.single_transformer_blocks.0.proj_out.lora_up.weight : Tensor @ torch.Size([3072, 7])
```

So basically PEFT layers but Kohya adapter names. This might be a mistake on the trainer part but after picking around in the converter for a bit I figured out it can be an easy one line fix so that's what I've done here. I don't have the civit.ai URLs at the moment so I don't have a public link to weights.

The `proj_out` layers still fail but so does every other peft lora with proj out layers against `main` currently so I think that's an unrelated bug.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [X] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@sayakpaul