### PR TITLE
Add low_cpu_mem_usage option to from_single_file to align with from_pretrained

### DIFF
--- a/src/diffusers/loaders/single_file_model.py
+++ b/src/diffusers/loaders/single_file_model.py
@@ -23,7 +23,7 @@ from typing_extensions import Self
 
 from .. import __version__
 from ..quantizers import DiffusersAutoQuantizer
-from ..utils import deprecate, is_accelerate_available, logging, is_torch_version
+from ..utils import deprecate, is_accelerate_available, is_torch_version, logging
 from ..utils.torch_utils import empty_device_cache
 from .single_file_utils import (
     SingleFileComponentError,
@@ -241,8 +241,8 @@ class FromOriginalModelMixin:
                 The specific model version to use. It can be a branch name, a tag name, a commit id, or any identifier
                 allowed by Git.
             low_cpu_mem_usage (`bool`, *optional*, defaults to `True` if torch version >= 1.9.0 and
-                is_accelerate_available() else `False`): Speed up model loading only loading the pretrained weights
-                and not initializing the weights. This also tries to not use more than 1x model size in CPU memory
+                is_accelerate_available() else `False`): Speed up model loading only loading the pretrained weights and
+                not initializing the weights. This also tries to not use more than 1x model size in CPU memory
                 (including peak memory) while loading the model. Only supported for PyTorch >= 1.9.0. If you are using
                 an older version of PyTorch, setting this argument to `True` will raise an error.
             disable_mmap ('bool', *optional*, defaults to 'False'):

--- a/src/diffusers/loaders/single_file_model.py
+++ b/src/diffusers/loaders/single_file_model.py
@@ -240,6 +240,11 @@ class FromOriginalModelMixin:
             revision (`str`, *optional*, defaults to `"main"`):
                 The specific model version to use. It can be a branch name, a tag name, a commit id, or any identifier
                 allowed by Git.
+            low_cpu_mem_usage (`bool`, *optional*, defaults to `True` if torch version >= 1.9.0 and
+                is_accelerate_available() else `False`): Speed up model loading only loading the pretrained weights
+                and not initializing the weights. This also tries to not use more than 1x model size in CPU memory
+                (including peak memory) while loading the model. Only supported for PyTorch >= 1.9.0. If you are using
+                an older version of PyTorch, setting this argument to `True` will raise an error.
             disable_mmap ('bool', *optional*, defaults to 'False'):
                 Whether to disable mmap when loading a Safetensors model. This option can perform better when the model
                 is on a network mount or hard drive, which may not handle the seeky-ness of mmap very well.


### PR DESCRIPTION
# What does this PR do?

`from_single_file` can lead to errors in training model:
```
File "/home/dongziyi/miniconda3/envs/pt25/lib/python3.11/site-packages/diffusers/loaders/single_file_model.py", line 447, in from_single_file                                       
    dispatch_model(model, **device_map_kwargs)                                                                                                                                        
  File "/home/dongziyi/miniconda3/envs/pt25/lib/python3.11/site-packages/accelerate/big_modeling.py", line 502, in dispatch_model                                                     
    model.to(device)                                                                                                                                                                  
  File "/home/dongziyi/miniconda3/envs/pt25/lib/python3.11/site-packages/diffusers/models/modeling_utils.py", line 1383, in to                                                        
    return super().to(*args, **kwargs)                                                                                                                                                
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                
  File "/home/dongziyi/miniconda3/envs/pt25/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1343, in to                                                                
    return self._apply(convert)                                                                                                                                                       
           ^^^^^^^^^^^^^^^^^^^^                                                                                                                                                       
  File "/home/dongziyi/miniconda3/envs/pt25/lib/python3.11/site-packages/torch/nn/modules/module.py", line 903, in _apply                                                             
    module._apply(fn)                                                                                                                                                                 
  File "/home/dongziyi/miniconda3/envs/pt25/lib/python3.11/site-packages/torch/nn/modules/module.py", line 903, in _apply                                                             
    module._apply(fn)                                                                                                                                                                 
  File "/home/dongziyi/miniconda3/envs/pt25/lib/python3.11/site-packages/torch/nn/modules/module.py", line 903, in _apply                                                             
    module._apply(fn)                                                                                                                                                                 
  [Previous line repeated 5 more times]                                                                                                                                               
  File "/home/dongziyi/miniconda3/envs/pt25/lib/python3.11/site-packages/torch/nn/modules/module.py", line 930, in _apply                                                             
    param_applied = fn(param)                                                                                                                                                         
                    ^^^^^^^^^                                                                                                                                                         
  File "/home/dongziyi/miniconda3/envs/pt25/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1336, in convert                                                           
    raise NotImplementedError(                                                                                                                                                        
NotImplementedError: Cannot copy out of meta tensor; no data! Please use torch.nn.Module.to_empty() instead of torch.nn.Module.to() when moving module from meta to a different device.                                                                   
```

Add `low_cpu_mem_usage` option for `from_single_file` to align with `from_pretrained`. Allow users to set not to create the model on the meta device.

Example:
```
UNet2DConditionModel.from_single_file(ckpt_path, torch_dtype=dtype, low_cpu_mem_usage=False)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

