### PR TITLE
Fix MultiControlNet import

### DIFF
--- a/src/diffusers/modular_pipelines/stable_diffusion_xl/before_denoise.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_xl/before_denoise.py
@@ -22,7 +22,7 @@ from ...configuration_utils import FrozenDict
 from ...guiders import ClassifierFreeGuidance
 from ...image_processor import VaeImageProcessor
 from ...models import AutoencoderKL, ControlNetModel, ControlNetUnionModel, UNet2DConditionModel
-from ...pipelines.controlnet.multicontrolnet import MultiControlNetModel
+from ...models.controlnets.multicontrolnet import MultiControlNetModel
 from ...schedulers import EulerDiscreteScheduler
 from ...utils import logging
 from ...utils.torch_utils import randn_tensor, unwrap_module


### PR DESCRIPTION
# What does this PR do?

importing `MultiControlNetModel` from `...pipelines.controlnet.multicontrolnet` is deprecated but it is used in this file with that import, this PR fix this so it's also imported from `...models.controlnets.multicontrolnet` 

## Who can review?

@yiyixuxu 
