### PR TITLE
Fix AttributeError of `VisualClozeProcessor`

### DIFF
--- a/src/diffusers/pipelines/visualcloze/visualcloze_utils.py
+++ b/src/diffusers/pipelines/visualcloze/visualcloze_utils.py
@@ -110,7 +110,7 @@ class VisualClozeProcessor(VaeImageProcessor):
                         new_h = int(processed_images[i][j].height * (new_w / processed_images[i][j].width))
                         new_w = int(new_w / 16) * 16
                         new_h = int(new_h / 16) * 16
-                        processed_images[i][j] = self.height(processed_images[i][j], new_h, new_w)
+                        processed_images[i][j] = self._resize_and_crop(processed_images[i][j], new_h, new_w)
 
         # Convert to tensors and normalize
         image_sizes = []


### PR DESCRIPTION
### Summary

Fixes an AttributeError in VisualClozePipeline where the code attempted to access a non-existent `height` function on VisualClozeProcessor. The pipeline now calls the correct resizing utility (`_resize_and_crop`) during preprocessing.

https://github.com/huggingface/diffusers/blob/f442955c6e871dcaf7d4003f74970e0905c2ff27/src/diffusers/pipelines/visualcloze/visualcloze_utils.py#L105-L113

> This error occurs only when generating more than one image.

### Reproduction

```python
from diffusers import VisualClozePipeline
from PIL import Image
import torch

image_paths = [
    [
        Image.new("RGB", (384, 384), (0, 0, 0)),
        Image.new("RGB", (384, 384), (0, 0, 0)),
        Image.new("RGB", (384, 384), (0, 0, 0)),
    ],
    [
        Image.new("RGB", (384, 384), (0, 0, 0)),
        None,
        None,
    ],
]

task_prompt = "test"
content_prompt = None

pipe = VisualClozePipeline.from_pretrained(
    "VisualCloze/VisualClozePipeline-384", resolution=384, torch_dtype=torch.bfloat16
).to("cuda")

image_result = pipe(
    task_prompt=task_prompt,
    content_prompt=content_prompt,
    image=image_paths,
    upsampling_width=512,
    upsampling_height=512,
    upsampling_strength=0.0,
    guidance_scale=30,
    num_inference_steps=30,
    max_sequence_length=512,
    generator=torch.Generator("cuda").manual_seed(0),
).images[0]
```

* Error: 

```
AttributeError: 'VisualClozeProcessor' object has no attribute 'height'
```

@yiyixuxu @asomoza
