### PR TITLE
[wip] feat: cuda device_map for pipelines.

### DIFF
--- a/src/diffusers/pipelines/pipeline_loading_utils.py
+++ b/src/diffusers/pipelines/pipeline_loading_utils.py
@@ -613,6 +613,9 @@ def _assign_components_to_devices(
 
 
 def _get_final_device_map(device_map, pipeline_class, passed_class_obj, init_dict, library, max_memory, **kwargs):
+    # TODO: seperate out different device_map methods when it gets to it.
+    if device_map != "balanced":
+        return device_map
     # To avoid circular import problem.
     from diffusers import pipelines
 

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -108,7 +108,8 @@ LIBRARIES = []
 for library in LOADABLE_CLASSES:
     LIBRARIES.append(library)
 
-SUPPORTED_DEVICE_MAP = ["balanced"]
+# TODO: support single-device namings
+SUPPORTED_DEVICE_MAP = ["balanced", "cuda"]
 
 logger = logging.get_logger(__name__)
 
@@ -988,12 +989,15 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         _maybe_warn_for_wrong_component_in_quant_config(init_dict, quantization_config)
         for name, (library_name, class_name) in logging.tqdm(init_dict.items(), desc="Loading pipeline components..."):
             # 7.1 device_map shenanigans
-            if final_device_map is not None and len(final_device_map) > 0:
-                component_device = final_device_map.get(name, None)
-                if component_device is not None:
-                    current_device_map = {"": component_device}
-                else:
-                    current_device_map = None
+            if final_device_map is not None:
+                if isinstance(final_device_map, dict) and len(final_device_map) > 0:
+                    component_device = final_device_map.get(name, None)
+                    if component_device is not None:
+                        current_device_map = {"": component_device}
+                    else:
+                        current_device_map = None
+                elif isinstance(final_device_map, str):
+                    current_device_map = final_device_map
 
             # 7.2 - now that JAX/Flax is an official framework of the library, we might load from Flax names
             class_name = class_name[4:] if class_name.startswith("Flax") else class_name


### PR DESCRIPTION
# What does this PR do?

TL;DR: This PR adds a `device_map` option at the pipeline-level to speed up end-to-end pipeline loading on a target device.

To benefit from https://github.com/huggingface/diffusers/pull/11904, users have to follow this pattern:

```py
from diffusers import AutoModel, DiffusionPipeline
import torch 

# first initialize the model on device_map to benefit from fast loading
model = AutoModel.from_pretrained(..., device_map="cuda", torch_dtype=...)

# initialize the pipeline
pipe = DiffusionPipeline.from_pretrained(..., transformer=model, torch_dtype=...)

# place other stuff on cuda
for name, component in pipe.components.items():
     if name != "model_already_loaded_above":
         component.to("cuda")

# run inference
...
```

We could improve the UX a bit by letting the users pass a `device_map="cuda"` (or whatever valid value) WHILE initializing the `pipe`. This PR tackles that.

For pipelines like Flux, passing `device_map` for loading the text encoders might be as same as doing `to()`. However, for pipelines like Qwen-Image, that use a mid-range model like Qwen25VL-7B, passing `device_map="cuda"` while initializing the pipeline should be beneficial (of course, the target device should have enough VRAM to support this). Below are the results I got for Qwen-Image (with cold cache):

```bash
time: 8.494s (no device_map)
time: 6.678s (device_map)
```

<details>
<summary>Code</summary>

```py
import time
t_ini = time.time()

import torch
from diffusers import DiffusionPipeline
print(f"import time: {time.time() - t_ini:.3f}s")

model_id = "Qwen/Qwen-Image"

t0 = time.time()
torch.cuda.synchronize()
print(f"CUDA sync time: {time.time() - t0:.3f}s")

print("starting pipe load")
t1 = time.time()
pipe = DiffusionPipeline.from_pretrained(
    model_id, torch_dtype=torch.bfloat16, device_map="cuda"
)
torch.cuda.synchronize()
t2 = time.time()

diff = t2 - t1
print(f"time: {diff:.3f}s")

print(getattr(pipe, "hf_device_map", None))
_ = pipe("dog", num_inference_steps=2)
```

</details>

Any objections?