### PR TITLE
Update README.md

### DIFF
--- a/examples/dreambooth/README.md
+++ b/examples/dreambooth/README.md
@@ -19,7 +19,7 @@ cd diffusers
 pip install -e .
 ```
 
-Then run
+Install the requirements in the `examples/dreambooth` folder as shown below.
 ```bash
 cd examples/dreambooth
 pip install -r requirements.txt


### PR DESCRIPTION
# What does this PR do?

This PR updates the **DreamBooth example installation instructions** to specify the full path to the `examples/dreambooth` directory.  

### Motivation
Previously, the documentation said:

```bash
Then cd in the example folder and run
pip install -r requirements.txt
```

This was unclear because users might not know which example folder to `cd` into.  

Now, the instructions are updated to explicitly show:

```bash
cd examples/dreambooth
pip install -r requirements.txt
```

This makes the installation process clearer and reduces confusion.

---

## Before submitting
- [x] This PR fixes a typo or improves the docs (dismiss the other checks if not applicable).

---

## Who can review?
@stevhliu @sayakpaul
