### PR TITLE
[Modular] implement requirements validation for custom blocks

### DIFF
--- a/src/diffusers/commands/custom_blocks.py
+++ b/src/diffusers/commands/custom_blocks.py
@@ -89,8 +89,6 @@ class CustomBlocksCommand(BaseDiffusersCLICommand):
         # automap = self._create_automap(parent_class=parent_class, child_class=child_class)
         # with open(CONFIG, "w") as f:
         #     json.dump(automap, f)
-        with open("requirements.txt", "w") as f:
-            f.write("")
 
     def _choose_block(self, candidates, chosen=None):
         for cls, base in candidates:

--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -232,7 +232,7 @@ class ModularPipelineBlocks(ConfigMixin, PushToHubMixin):
 
     config_name = "modular_config.json"
     model_name = None
-    _requirements: Union[List[Tuple[str, str], Tuple[str, str]]] = None
+    _requirements: Union[List[Tuple[str, str]], Tuple[str, str]] = None
 
     @classmethod
     def _get_signature_keys(cls, obj):
@@ -275,7 +275,7 @@ class ModularPipelineBlocks(ConfigMixin, PushToHubMixin):
     def _get_requirements(self):
         if getattr(self, "_requirements", None) is not None:
             defined_reqs = self._requirements
-            if not isinstance(defined_reqs):
+            if not isinstance(defined_reqs, list):
                 defined_reqs = [defined_reqs]
 
             final_reqs = []
@@ -290,6 +290,7 @@ class ModularPipelineBlocks(ConfigMixin, PushToHubMixin):
                         f"Version for {pkg} was specified to be {specified_ver} whereas the actual version found is {pkg_actual_ver}. Ignore if this is not concerning."
                     )
                 final_reqs.append((pkg, specified_ver))
+            return final_reqs
 
         else:
             return None


### PR DESCRIPTION
# What does this PR do?

As discussed with Dhruv.

When implementing custom blocks (which we all believe will grow big :)), it can be useful for the block author and the users to have some kind of dependencies and their versions specified. This PR implements that feature. 

Sample output: https://huggingface.co/diffusers-internal-dev/gemini-prompt-expander/blob/main/modular_config.json.