### PR TITLE
[tests] feat: add AoT compilation tests

### DIFF
--- a/tests/models/test_modeling_common.py
+++ b/tests/models/test_modeling_common.py
@@ -2142,17 +2142,9 @@ class TorchCompileTesterMixin:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             package_path = os.path.join(tmpdir, f"{self.model_class.__name__}.pt2")
-            _ = torch._inductor.aoti_compile_and_package(
-                exported_model,
-                package_path=package_path,
-                inductor_configs={
-                    "aot_inductor.package_constants_in_so": False,
-                    "aot_inductor.package_constants_on_disk": True,
-                    "aot_inductor.package": True,
-                },
-            )
+            _ = torch._inductor.aoti_compile_and_package(exported_model, package_path=package_path)
             assert os.path.exists(package_path)
-            loaded_binary = load_package(package_path)
+            loaded_binary = load_package(package_path, run_single_threaded=True)
 
         model.forward = loaded_binary
 


### PR DESCRIPTION
# What does this PR do?

AoT compilation is exciting because it helps cut the framework overhead. It also helps realize similar benefits as JiT compilation for environments where JiT might not be feasible (ZeroGPU Spaces, for example). For example, with AoT-compilation, we were able to obtain 1.7x speedups in latency on a ZeroGPU Space. Wouldn't have been feasible, otherwise.

To run, `RUN_SLOW=1 RUN_COMPILE=yes pytest tests/models/ -k "aot"`.