### PR TITLE
Fix WanVACEPipeline to allow prompt to be None and skip encoding step

### DIFF
--- a/src/diffusers/pipelines/wan/pipeline_wan_vace.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_vace.py
@@ -774,7 +774,7 @@ class WanVACEPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             callback_on_step_end_tensor_inputs = callback_on_step_end.tensor_inputs
 
         # Simplification of implementation for now
-        if not isinstance(prompt, str):
+        if prompt is not None and not isinstance(prompt, str):
             raise ValueError("Passing a list of prompts is not yet supported. This may be supported in the future.")
         if num_videos_per_prompt != 1:
             raise ValueError(


### PR DESCRIPTION
# What does this PR do?
Fixes #11821

The current implementation of the WanVACEPipeline.__call__ method seems to prevent the use of more than a single prompt. However the check is also preventing the ability to pass `prompt=None` and instead directly provide the `prompt_embeds` to skip the text encoding step. This is especially useful when working with limited hardware where the text encoder and tokenizer could free some memory before inference.


@yiyixuxu and @asomoza