### PR TITLE
Use SDP on BF16 in GPU/HPU migration

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -507,7 +507,9 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             if dtype in (torch.bfloat16, None) and kwargs.pop("sdp_on_bf16", True):
                 if hasattr(torch._C, "_set_math_sdp_allow_fp16_bf16_reduction"):
                     torch._C._set_math_sdp_allow_fp16_bf16_reduction(True)
-                    logger.warning(f"Enabled SDP with BF16 precision on HPU. To disable, please use `.to('hpu', sdp_on_bf16=False)`")
+                    logger.warning(
+                        "Enabled SDP with BF16 precision on HPU. To disable, please use `.to('hpu', sdp_on_bf16=False)`"
+                    )
 
         module_names, _ = self._get_signature_keys(self)
         modules = [getattr(self, n, None) for n in module_names]


### PR DESCRIPTION
# What does this PR do?

The latest Gaudi stack now defaults to eager mode, where HPU/GPU Migration uses the default SDP kernel in FP32 precision. Previously, the default lazy mode used SDP in BF16 precision.

To improve performance on HPU devices, this PR changes the default to SDP with BF16 precision when running on HPU, provided that the dtype is BF16 or unset.