### PR TITLE
Fix ftfy name error in Wan pipeline

### DIFF
--- a/src/diffusers/pipelines/wan/pipeline_wan.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan.py
@@ -76,7 +76,8 @@ EXAMPLE_DOC_STRING = """
 
 
 def basic_clean(text):
-    text = ftfy.fix_text(text)
+    if is_ftfy_available():
+        text = ftfy.fix_text(text)
     text = html.unescape(html.unescape(text))
     return text.strip()
 


### PR DESCRIPTION
# What does this PR do?

Small fix for `ftfy` name error in Wan pipeline.  

**Before fix:**
If we don't have `ftfy` package, pipe will error out:
`NameError: name 'ftfy' is not defined`

**After fix:**
With or without `ftfy`, pipe runs OK