### PR TITLE
Fix example server install instructions

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -9,8 +9,8 @@ This guide will show you how to use the [`StableDiffusion3Pipeline`] in a server
 Start by navigating to the `examples/server` folder and installing all of the dependencies.
 
 ```py
-pip install .
-pip install -f requirements.txt
+pip install diffusers
+pip install -r requirements.txt
 ```
 
 Launch the server with the following command.

--- a/examples/server/requirements.in
+++ b/examples/server/requirements.in
@@ -7,3 +7,4 @@ prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 fastapi
 uvicorn
+accelerate

--- a/examples/server/requirements.txt
+++ b/examples/server/requirements.txt
@@ -39,7 +39,7 @@ fsspec==2024.10.0
     #   torch
 h11==0.14.0
     # via uvicorn
-huggingface-hub==0.26.1
+huggingface-hub==0.35.0
     # via
     #   tokenizers
     #   transformers


### PR DESCRIPTION
This pull request fixes the server example's dependencies and installation instructions. 

```py
# from
pip install .
pip install -f requirements.txt

# to this
pip install diffusers
pip install -r requirements.txt
```

Dependency Updates:

* Updated `huggingface-hub` to version `0.35.0` in `requirements.txt` to ensure compatibility with recent features and bug fixes.
* Added `accelerate` to `requirements.in` to support efficient model inference and hardware utilization.
* Note: This follows the server-async instructions.

Installation Instructions:

* Updated the installation commands in `README.md` to explicitly install `diffusers` and corrected the requirements file flag to `-r` for clarity and correctness.

- Docs: @stevhliu and @sayakpaul
