### PR TITLE
Fix outdated peft version in example requirements

### DIFF
--- a/examples/text_to_image/requirements.txt
+++ b/examples/text_to_image/requirements.txt
@@ -5,4 +5,4 @@ datasets>=2.19.1
 ftfy
 tensorboard
 Jinja2
-peft==0.7.0
+peft>=0.17.0


### PR DESCRIPTION
# What does this PR do?

"from diffusers import StableDiffusionPipeline" throws error "ImportError: peft>=0.17.0 is required for a normal functioning of this module, but found peft==0.7.0." This is the script that is run when following tutorial for T2I training and should be updated.

Fixes # (issue)

- [X ] This PR fixes a typo or improves the docs.

