### PR TITLE
docs: api-pipelines-qwenimage typo fix

### DIFF
--- a/docs/source/en/api/pipelines/qwenimage.md
+++ b/docs/source/en/api/pipelines/qwenimage.md
@@ -109,7 +109,7 @@ image_1 = load_image("https://huggingface.co/datasets/huggingface/documentation-
 image_2 = load_image("https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/peng.png")
 image = pipe(
     image=[image_1, image_2], 
-    prompt="put the penguin and the cat at a game show called "Qwen Edit Plus Games"", 
+    prompt='''put the penguin and the cat at a game show called "Qwen Edit Plus Games"''', 
     num_inference_steps=50
 ).images[0]
 ```


### PR DESCRIPTION
Fixes a minor documentation typo in the Qwen-Image pipeline example:

https://huggingface.co/docs/diffusers/main/api/pipelines/qwenimage


<img width="1855" height="868" alt="screenshot-2025-10-10_12-34-33" src="https://github.com/user-attachments/assets/3ea68e88-2f08-4d41-9645-995cf166427a" />

<br/><br/>

A problem in this line
```py
    prompt="put the penguin and the cat at a game show called "Qwen Edit Plus Games"", 
```

The quotation marks break the syntax.

<br/>


There are number of ways to fix the problem. But I used already used the below method of 3 single quotes in the Qwen-Image page
https://huggingface.co/Qwen/Qwen-Image



<img width="996" height="688" alt="image" src="https://github.com/user-attachments/assets/eb5d3730-fcfc-493f-972e-036541d30940" />




I fix syntax problem by 

```py
    prompt='''put the penguin and the cat at a game show called "Qwen Edit Plus Games"''', 
```

@stevhliu and @sayakpaul