### PR TITLE
fix CI bug for kandinsky3_img2img case

### DIFF
--- a/src/diffusers/pipelines/kandinsky3/pipeline_kandinsky3_img2img.py
+++ b/src/diffusers/pipelines/kandinsky3/pipeline_kandinsky3_img2img.py
@@ -113,7 +113,7 @@ class Kandinsky3Img2ImgPipeline(DiffusionPipeline, StableDiffusionLoraLoaderMixi
         negative_prompt=None,
         prompt_embeds: Optional[torch.Tensor] = None,
         negative_prompt_embeds: Optional[torch.Tensor] = None,
-        _cut_context=False,
+        _cut_context=True,
         attention_mask: Optional[torch.Tensor] = None,
         negative_attention_mask: Optional[torch.Tensor] = None,
     ):

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -2124,10 +2124,6 @@ class PipelineTesterMixin:
                         f"encode_prompt has no default in either encode_prompt or __call__."
                     )
 
-        if "_cut_context" in encode_prompt_param_names and "_cut_context" not in encode_prompt_inputs:
-            # As in full_pipeline, `_cut_context` is set to True.
-            encode_prompt_inputs["_cut_context"] = True
-
         # Compute `encode_prompt()`.
         with torch.no_grad():
             encoded_prompt_outputs = pipe_with_just_text_encoder.encode_prompt(**encode_prompt_inputs)


### PR DESCRIPTION
For full pipeline, related `cut_context` is set to `True` in [L511](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/kandinsky3/pipeline_kandinsky3_img2img.py#L511],) while for  pipe_without_text_encoders, this param is set to `False` by default [L116](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/kandinsky3/pipeline_kandinsky3_img2img.py#L116]),  hence there will be some minor difference between their outputs(in UNet [L492](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/unets/unet_kandinsky3.py#L492],) the mean value w/ and w/o `cut_context` is different). For platforms such as Intel XPU, they use their seperate generator [L145](https://github.com/huggingface/diffusers/blob/main/tests/pipelines/kandinsky3/test_kandinsky3_img2img.py#L145), hence the default tolerance value `1e-4` is not enough. Here we explicitly set `encode_prompt_inputs["_cut_context"] = True` to align with the behavior of full pipeline. @DN6 , pls help review, Thx!