### PR TITLE
[modular]pass hub_kwargs to load_config

### DIFF
--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -313,7 +313,7 @@ class ModularPipelineBlocks(ConfigMixin, PushToHubMixin):
         ]
         hub_kwargs = {name: kwargs.pop(name) for name in hub_kwargs_names if name in kwargs}
 
-        config = cls.load_config(pretrained_model_name_or_path)
+        config = cls.load_config(pretrained_model_name_or_path, **hub_kwargs)
         has_remote_code = "auto_map" in config and cls.__name__ in config["auto_map"]
         trust_remote_code = resolve_trust_remote_code(
             trust_remote_code, pretrained_model_name_or_path, has_remote_code


### PR DESCRIPTION
download the config file to local_dir too, so that this works

```
from diffusers import ModularPipelineBlocks

repo_id = "diffusers-internal-dev/krt"
local_dir = "krea-realtime-video"
blocks_1 = ModularPipelineBlocks.from_pretrained(repo_id, local_dir="krea-realtime-video", trust_remote_code=True)
blocks_2 = ModularPipelineBlocks.from_pretrained(local_dir, trust_remote_code=True)
print(f"blocks_1: {blocks_1}")
print(f"blocks_2: {blocks_2}")
```