### PR TITLE
Revert `AutoencoderKLWan`'s `dim_mult` default value back to list

### DIFF
--- a/src/diffusers/models/autoencoders/autoencoder_kl_wan.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_wan.py
@@ -971,7 +971,7 @@ class AutoencoderKLWan(ModelMixin, AutoencoderMixin, ConfigMixin, FromOriginalMo
         base_dim: int = 96,
         decoder_base_dim: Optional[int] = None,
         z_dim: int = 16,
-        dim_mult: Tuple[int, ...] = (1, 2, 4, 4),
+        dim_mult: List[int] = [1, 2, 4, 4],
         num_res_blocks: int = 2,
         attn_scales: List[float] = [],
         temperal_downsample: List[bool] = [False, True, True],


### PR DESCRIPTION
# What does this PR do?

This PR reverts the default value for the `dim_mult` argument to `AutoencoderKLWan.__init__` back to a `List` (e.g. `[1, 2, 4, 4]` instead of `(1, 2, 4, 4)`). The rationale behind this is that some code of the Wan VAE code assumes that `dim_mult` is type `List`, such as

https://github.com/huggingface/diffusers/blob/093cd3f040ee4f44908df8e1b441954f3f25c214/src/diffusers/models/autoencoders/autoencoder_kl_wan.py#L542

This causes errors when `dim_mult` is not explicitly set, such as in `convert_vae()` in `scripts/convert_wan_to_diffusers.py` and also in the `AutoencoderKLWan` tests.

`dim_mult` defaulted to a `List` prior to #12544, but was incorrectly annotated as type `Tuple[int]`, so I believe that PR inadvertently changed the default argument to a `Tuple`. I have changed the type annotation to `List[int]` in this PR.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yiyixuxu

