### PR TITLE
Improve docstrings and type hints in scheduling_pndm.py

### DIFF
--- a/src/diffusers/schedulers/scheduling_pndm.py
+++ b/src/diffusers/schedulers/scheduling_pndm.py
@@ -403,18 +403,8 @@ class PNDMScheduler(SchedulerMixin, ConfigMixin):
         self, sample: torch.Tensor, timestep: int, prev_timestep: int, model_output: torch.Tensor
     ) -> torch.Tensor:
         """
-        Compute the previous sample x_(t-δ) from the current sample x_t using formula (9) from the PNDM paper.
-
-        See formula (9) of [PNDM paper](https://huggingface.co/papers/2202.09778)
-
-        Notation (<variable name> -> <name in paper>):
-        - alpha_prod_t -> α_t
-        - alpha_prod_t_prev -> α_(t−δ)
-        - beta_prod_t -> (1 - α_t)
-        - beta_prod_t_prev -> (1 - α_(t−δ))
-        - sample -> x_t
-        - model_output -> e_θ(x_t, t)
-        - prev_sample -> x_(t−δ)
+        Compute the previous sample x_(t-δ) from the current sample x_t using formula (9) from the [PNDM
+        paper](https://huggingface.co/papers/2202.09778).
 
         Args:
             sample (`torch.Tensor`):


### PR DESCRIPTION
# What does this PR do?

This PR improves the docstrings and type hints in `src/diffusers/schedulers/scheduling_pndm.py` to follow the project conventions as described in #9567.

## Context

This is part of a broader effort to improve documentation across all scheduler files in `src/diffusers/schedulers/`. See issue #9567 for details.

## Testing
- [x] Code passes `make style`
- [x] Code passes `make quality`
- [x] Code passes  `make fix-copies`
- [x] Existing tests still pass

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? [issue](https://github.com/huggingface/diffusers/issues/9567).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? (N/A - documentation only changes)

## Who can review?

cc @stevhliu for review