### PR TITLE
Fix variable naming typos in community FluxControlNetFillInpaintPipeline

### DIFF
--- a/examples/community/pipline_flux_fill_controlnet_Inpaint.py
+++ b/examples/community/pipline_flux_fill_controlnet_Inpaint.py
@@ -1168,12 +1168,12 @@ class FluxControlNetFillInpaintPipeline(DiffusionPipeline, FluxLoraLoaderMixin, 
             generator,
         )
 
-        mask_imagee = self.mask_processor.preprocess(mask_image, height=height, width=width)
-        masked_imagee = init_image * (1 - mask_imagee)
-        masked_imagee = masked_imagee.to(dtype=self.vae.dtype, device=device)
-        maskkk, masked_image_latentsss = self.prepare_mask_latents_fill(
-            mask_imagee,
-            masked_imagee,
+        mask_image_fill = self.mask_processor.preprocess(mask_image, height=height, width=width)
+        masked_image_fill = init_image * (1 - mask_image_fill)
+        masked_image_fill = masked_image_fill.to(dtype=self.vae.dtype, device=device)
+        mask_fill, masked_latents_fill = self.prepare_mask_latents_fill(
+            mask_image_fill,
+            masked_image_fill,
             batch_size,
             num_channels_latents,
             num_images_per_prompt,
@@ -1243,7 +1243,7 @@ class FluxControlNetFillInpaintPipeline(DiffusionPipeline, FluxLoraLoaderMixin, 
                 else:
                     guidance = None
 
-                masked_image_latents_fill = torch.cat((masked_image_latentsss, maskkk), dim=-1)
+                masked_image_latents_fill = torch.cat((masked_latents_fill, mask_fill), dim=-1)
                 latent_model_input = torch.cat([latents, masked_image_latents_fill], dim=2)
 
                 noise_pred = self.transformer(


### PR DESCRIPTION
  # What does this PR do?

  Fixes variable naming typos in the community pipeline `FluxControlNetFillInpaintPipeline`.

  ## Changes

  - Fixed variable naming typos to improve code readability:
    - `maskkk` → `mask_fill`
    - `mask_imagee` → `mask_image_fill`
    - `masked_imagee` → `masked_image_fill`
    - `masked_image_latentsss` → `masked_latents_fill`

  ## Impact

  These changes improve code readability without affecting functionality. All modifications are limited to the community pipeline.

  ## Before submitting
  - [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
  - [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
  - [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
  - [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)?
  - [ ] Did you make sure to update the documentation with your changes?
  - [ ] Did you write any new necessary tests?

  ## Who can review?

  @yiyixuxu @asomoza @DN6 @stevhliu @patil-suraj @takuma104 @anton-l - Simple variable naming typo fixes in community pipeline.