### PR TITLE
Enable regional compilation on z-image transformer model

### DIFF
--- a/src/diffusers/models/transformers/transformer_z_image.py
+++ b/src/diffusers/models/transformers/transformer_z_image.py
@@ -328,6 +328,7 @@ class RopeEmbedder:
 class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin):
     _supports_gradient_checkpointing = True
     _no_split_modules = ["ZImageTransformerBlock"]
+    _repeated_blocks = ["ZImageTransformerBlock"]
     _skip_layerwise_casting_patterns = ["t_embedder", "cap_embedder"]  # precision sensitive layers
 
     @register_to_config


### PR DESCRIPTION
Cc: @apolinario 

Model-specific tests for Z-image are missing. I will add them, along with their compilation tests ([example](https://github.com/huggingface/diffusers/blob/6bf668c4d217ebc96065e673d8a257fd79950d34/tests/models/transformers/test_models_transformer_qwenimage.py#L95)), in a separate PR.