### PR TITLE
Refactor image padding logic to pervent zero tensor in transformer_z_image

### DIFF
--- a/src/diffusers/models/transformers/transformer_z_image.py
+++ b/src/diffusers/models/transformers/transformer_z_image.py
@@ -526,7 +526,7 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
                     .repeat(image_padding_len, 1)
                 )
                 image_padded_pos_ids = torch.cat([image_ori_pos_ids, image_padding_pos_ids], dim=0)
-            else :
+            else:
                 image_padded_pos_ids = image_ori_pos_ids
             all_image_pos_ids.append(image_padded_pos_ids)
             # pad mask
@@ -537,10 +537,14 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
                         torch.ones((image_padding_len,), dtype=torch.bool, device=device),
                     ],
                     dim=0,
-                ) if image_padding_len > 0 else torch.zeros((image_ori_len,), dtype=torch.bool, device=device)
+                )
+                if image_padding_len > 0
+                else torch.zeros((image_ori_len,), dtype=torch.bool, device=device)
             )
             # padded feature
-            image_padded_feat = torch.cat([image, image[-1:].repeat(image_padding_len, 1)], dim=0) if image_padding_len > 0 else image
+            image_padded_feat = (
+                torch.cat([image, image[-1:].repeat(image_padding_len, 1)], dim=0) if image_padding_len > 0 else image
+            )
             all_image_out.append(image_padded_feat)
 
         return (


### PR DESCRIPTION

# What does this PR do?

In [‎src/diffusers/models/transformers/transformer_z_image.py](https://github.com/huggingface/diffusers/blob/b010a8ce0c5b5288045045f9f79c496899e80b5a/src/diffusers/models/transformers/transformer_z_image.py#L511), there exists a image_padding_len for padding image to be multiple of SEQ_MULTI_OF. However, when the image shape is already multiple of SEQ_MULTI_OF, this will create a tensor with zero shape. This triggers `INVALID_ARGUMENT: Concatenate expects at least one argument.` for PyTorch/XLA on TPU. It may also fail on other devices than cuda.  

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #12742 



## Who can review?

@yiyixuxu @asomoza 


<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
