### PR TITLE
Fix TPU (torch_xla) compatibility Error about tensor repeat func along with empty dim.

### DIFF
--- a/src/diffusers/models/transformers/transformer_z_image.py
+++ b/src/diffusers/models/transformers/transformer_z_image.py
@@ -482,26 +482,23 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
             ).flatten(0, 2)
             all_cap_pos_ids.append(cap_padded_pos_ids)
             # pad mask
+            cap_pad_mask = torch.cat(
+                [
+                    torch.zeros((cap_ori_len,), dtype=torch.bool, device=device),
+                    torch.ones((cap_padding_len,), dtype=torch.bool, device=device),
+                ],
+                dim=0,
+            )
             all_cap_pad_mask.append(
-                torch.cat(
-                    [
-                        torch.zeros((cap_ori_len,), dtype=torch.bool, device=device),
-                        torch.ones((cap_padding_len,), dtype=torch.bool, device=device),
-                    ],
-                    dim=0,
-                )
-                if cap_padding_len > 0
-                else torch.zeros((cap_ori_len,), dtype=torch.bool, device=device)
+                cap_pad_mask if cap_padding_len > 0 else torch.zeros((cap_ori_len,), dtype=torch.bool, device=device)
             )
+
             # padded feature
-            all_cap_feats_out.append(
-                torch.cat(
-                    [cap_feat, cap_feat[-1:].repeat(cap_padding_len, 1)],
-                    dim=0,
-                )
-                if cap_padding_len > 0
-                else cap_feat
+            cap_padded_feat = torch.cat(
+                [cap_feat, cap_feat[-1:].repeat(cap_padding_len, 1)],
+                dim=0,
             )
+            all_cap_feats_out.append(cap_padded_feat if cap_padding_len > 0 else cap_feat)
 
             ### Process Image
             C, F, H, W = image.size()
@@ -520,36 +517,35 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
                 start=(cap_ori_len + cap_padding_len + 1, 0, 0),
                 device=device,
             ).flatten(0, 2)
-            all_image_pos_ids.append(
-                torch.cat(
-                    [
-                        image_ori_pos_ids,
-                        self.create_coordinate_grid(size=(1, 1, 1), start=(0, 0, 0), device=device)
-                        .flatten(0, 2)
-                        .repeat(image_padding_len, 1),
-                    ],
-                    dim=0,
-                )
-                if image_padding_len > 0
-                else image_ori_pos_ids
+            image_padded_pos_ids = torch.cat(
+                [
+                    image_ori_pos_ids,
+                    self.create_coordinate_grid(size=(1, 1, 1), start=(0, 0, 0), device=device)
+                    .flatten(0, 2)
+                    .repeat(image_padding_len, 1),
+                ],
+                dim=0,
             )
+            all_image_pos_ids.append(image_padded_pos_ids if image_padding_len > 0 else image_ori_pos_ids)
             # pad mask
+            image_pad_mask = torch.cat(
+                [
+                    torch.zeros((image_ori_len,), dtype=torch.bool, device=device),
+                    torch.ones((image_padding_len,), dtype=torch.bool, device=device),
+                ],
+                dim=0,
+            )
             all_image_pad_mask.append(
-                torch.cat(
-                    [
-                        torch.zeros((image_ori_len,), dtype=torch.bool, device=device),
-                        torch.ones((image_padding_len,), dtype=torch.bool, device=device),
-                    ],
-                    dim=0,
-                )
+                image_pad_mask
                 if image_padding_len > 0
                 else torch.zeros((image_ori_len,), dtype=torch.bool, device=device)
             )
             # padded feature
-            image_padded_feat = (
-                torch.cat([image, image[-1:].repeat(image_padding_len, 1)], dim=0) if image_padding_len > 0 else image
+            image_padded_feat = torch.cat(
+                [image, image[-1:].repeat(image_padding_len, 1)],
+                dim=0,
             )
-            all_image_out.append(image_padded_feat)
+            all_image_out.append(image_padded_feat if image_padding_len > 0 else image)
 
         return (
             all_image_out,
@@ -599,10 +595,13 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
         adaln_input = t.type_as(x)
         x[torch.cat(x_inner_pad_mask)] = self.x_pad_token
         x = list(x.split(x_item_seqlens, dim=0))
-        x_freqs_cis = list(self.rope_embedder(torch.cat(x_pos_ids, dim=0)).split(x_item_seqlens, dim=0))
+        x_freqs_cis = list(self.rope_embedder(torch.cat(x_pos_ids, dim=0)).split([len(_) for _ in x_pos_ids], dim=0))
 
         x = pad_sequence(x, batch_first=True, padding_value=0.0)
         x_freqs_cis = pad_sequence(x_freqs_cis, batch_first=True, padding_value=0.0)
+        # Clarify the length matches to satisfy Dynamo due to "Symbolic Shape Inference" to avoid compilation errors
+        x_freqs_cis = x_freqs_cis[:, : x.shape[1]]
+
         x_attn_mask = torch.zeros((bsz, x_max_item_seqlen), dtype=torch.bool, device=device)
         for i, seq_len in enumerate(x_item_seqlens):
             x_attn_mask[i, :seq_len] = 1
@@ -616,17 +615,21 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
 
         # cap embed & refine
         cap_item_seqlens = [len(_) for _ in cap_feats]
-        assert all(_ % SEQ_MULTI_OF == 0 for _ in cap_item_seqlens)
         cap_max_item_seqlen = max(cap_item_seqlens)
 
         cap_feats = torch.cat(cap_feats, dim=0)
         cap_feats = self.cap_embedder(cap_feats)
         cap_feats[torch.cat(cap_inner_pad_mask)] = self.cap_pad_token
         cap_feats = list(cap_feats.split(cap_item_seqlens, dim=0))
-        cap_freqs_cis = list(self.rope_embedder(torch.cat(cap_pos_ids, dim=0)).split(cap_item_seqlens, dim=0))
+        cap_freqs_cis = list(
+            self.rope_embedder(torch.cat(cap_pos_ids, dim=0)).split([len(_) for _ in cap_pos_ids], dim=0)
+        )
 
         cap_feats = pad_sequence(cap_feats, batch_first=True, padding_value=0.0)
         cap_freqs_cis = pad_sequence(cap_freqs_cis, batch_first=True, padding_value=0.0)
+        # Clarify the length matches to satisfy Dynamo due to "Symbolic Shape Inference" to avoid compilation errors
+        cap_freqs_cis = cap_freqs_cis[:, : cap_feats.shape[1]]
+
         cap_attn_mask = torch.zeros((bsz, cap_max_item_seqlen), dtype=torch.bool, device=device)
         for i, seq_len in enumerate(cap_item_seqlens):
             cap_attn_mask[i, :seq_len] = 1


### PR DESCRIPTION
# What does this PR do?

In [‎src/diffusers/models/transformers/transformer_z_image.py](https://github.com/huggingface/diffusers/blob/b010a8ce0c5b5288045045f9f79c496899e80b5a/src/diffusers/models/transformers/transformer_z_image.py#L511), there exists a image_padding_len for padding image to be multiple of SEQ_MULTI_OF. However, when the image shape is already multiple of SEQ_MULTI_OF, this will create a tensor with zero shape. `This triggers INVALID_ARGUMENT: Concatenate expects at least one argument`. for `torch_xla.device()` on TPU.  This error currently won't emerge when changing device to `cpu` or `cuda`, but is in trouble with `xla` on TPU.

Fixes https://github.com/huggingface/diffusers/issues/12742 and https://github.com/huggingface/diffusers/pull/12743. And  it's a final version of https://github.com/huggingface/diffusers/pull/12743 and built upon it.

Fixes # (issue)
- [x] This PR fixes compatibility of torch.Tensor repeat func error with empty dim for TPU in `torch_xla`.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

This pr:

- Issue finder: @lime-j
- Bug fixer: @lime-j @JerryWu-code 
- Review: @yiyixuxu @JerryWu-code 
- Test Case: @JerryWu-code 

## Minimal Test Cases in TPU
You could try this on Colab when changing to TPU backend:
```python
import torch
import torch_xla
import torch_xla.core.xla_model as xm

def test_device(device_name, device):
    """Test repeat(0, 1) behavior"""
    print(f"\n{'='*60}")
    print(f"Device: {device_name} ({device})")
    print('='*60)
    
    tensor = torch.randn(64, 2048).to(device)
    
    # Test 1: repeat(0, 1)
    try:
        result = tensor[-1:].repeat(0, 1)
        print(f"✅ Success repeat(0, 1): {result.shape}")
    except RuntimeError as e:
        print(f"❌ Failed repeat(0, 1): {str(e)[:50]}")
    
    # Test 2: Avoid repeat(0)
    padding_len = 0
    result = tensor if padding_len == 0 else torch.cat([tensor, tensor[-1:].repeat(padding_len, 1)], dim=0)
    print(f"✅ Success fix: {result.shape}")

# (1) Test TPU
torch_xla.experimental.eager_mode(True)
test_device("TPU/XLA", torch_xla.device())

# (2) CUDA/CPU
if torch.cuda.is_available():
    test_device("CUDA", torch.device("cuda:0"))
else:
    test_device("CPU", torch.device("cpu"))
```

And you would get like:
```bash
============================================================
Device: TPU/XLA (xla:0)
============================================================
❌ Failed repeat(0, 1): Concatenate expects at least one argument.
✅ Success fix: torch.Size([64, 2048])

============================================================
Device: CPU (cpu)
============================================================
✅ Success repeat(0, 1): torch.Size([0, 2048])
✅ Success fix: torch.Size([64, 2048])
```
