### PR TITLE
Fix AttributeError in Flux2 dreambooth: rename --validation_image to --validation_image_path

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
@@ -355,7 +355,7 @@ def parse_args(input_args=None):
         help="A prompt that is used during validation to verify that the model is learning.",
     )
     parser.add_argument(
-        "--validation_image",
+        "--validation_image_path",
         type=str,
         default=None,
         help="path to an image that is used during validation as the condition image to verify that the model is learning.",


### PR DESCRIPTION
## What does this PR do?

Fixes #12779

This PR fixes an  error in the Flux2 dreambooth training script.

## The Problem

The argument parser defined the argument as  (line 358):
```python
parser.add_argument(
    "--validation_image",
    type=str,
    default=None,
    help="path to an image that is used during validation as the condition image to verify that the model is learning.",
)
```

However, the code on line 1422 references :
```python
validation_image = load_image(args.validation_image_path).convert("RGB")
```

This naming mismatch causes an  when the script tries to access the non-existent attribute.

## The Solution

Renamed the argument from  to  to match what the code expects.

## Testing

The fix ensures that:
- ✅ The argument  can be properly parsed
- ✅ The code can access  without error
- ✅ The script no longer crashes with AttributeError when using validation images