### PR TITLE
PRX Set downscale_freq_shift to 0 for consistency with internal implementation

### DIFF
--- a/src/diffusers/models/transformers/transformer_prx.py
+++ b/src/diffusers/models/transformers/transformer_prx.py
@@ -694,6 +694,7 @@ class PRXTransformer2DModel(ModelMixin, ConfigMixin, AttentionMixin):
                 max_period=self.time_max_period,
                 scale=self.time_factor,
                 flip_sin_to_cos=True,  # Match original cos, sin order
+                downscale_freq_shift=0.0,
             ).to(dtype)
         )
 


### PR DESCRIPTION

# What does this PR do?

Realized there was a discrepancy between our internal timestep embedding and the version used in Diffusers.
Setting `downscale_freq_shift = 0` aligns both implementations and makes the embeddings fully equivalent.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@sayakpaul, @yiyixuxu and @asomoza

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

