### PR TITLE
Fix Flux2ImageProcessor AttributeError in train_dreambooth_lora_flux2…

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
@@ -741,6 +741,9 @@ class DreamBoothDataset(Dataset):
 
         self.buckets = buckets
 
+        # Initialize image processor for condition image preprocessing
+        self.image_processor = Flux2ImageProcessor()
+
         # if --dataset_name is provided or a metadata jsonl file is provided in the local --instance_data directory,
         # we load the training data using load_dataset
         if args.dataset_name is not None:
@@ -827,13 +830,13 @@ class DreamBoothDataset(Dataset):
                 dest_image = self.cond_images[i]
                 image_width, image_height = dest_image.size
                 if image_width * image_height > 1024 * 1024:
-                    dest_image = Flux2ImageProcessor.image_processor._resize_to_target_area(dest_image, 1024 * 1024)
+                    dest_image = self.image_processor._resize_to_target_area(dest_image, 1024 * 1024)
                     image_width, image_height = dest_image.size
 
                 multiple_of = 2 ** (4 - 1)  # 2 ** (len(vae.config.block_out_channels) - 1), temp!
                 image_width = (image_width // multiple_of) * multiple_of
                 image_height = (image_height // multiple_of) * multiple_of
-                dest_image = Flux2ImageProcessor.image_processor.preprocess(
+                dest_image = self.image_processor.preprocess(
                     dest_image, height=image_height, width=image_width, resize_mode="crop"
                 )
 


### PR DESCRIPTION
…_img2img.py

The training script incorrectly accessed `Flux2ImageProcessor.image_processor` which doesn't exist as a class attribute, causing AttributeError when running Flux2 img2img DreamBooth training.

Changes:
- Initialize Flux2ImageProcessor instance in DreamBoothDataset.__init__
- Replace incorrect class attribute access with instance method calls

Fixes #12778

# What does this PR do?

 Title:
  Fix Flux2ImageProcessor AttributeError in train_dreambooth_lora_flux2_img2img.py

  Body:
  ## Summary

  Fix `AttributeError: type object 'Flux2ImageProcessor' has no attribute 'image_processor'` when
  running Flux2 img2img DreamBooth training script.

  ## Problem

  The training script incorrectly accesses `Flux2ImageProcessor.image_processor` which doesn't exist as
   a class attribute.

  ## Solution

  Initialize `Flux2ImageProcessor` instance in `DreamBoothDataset.__init__` and use instance methods.

  ## Changes

  - Initialize `Flux2ImageProcessor` instance in `DreamBoothDataset.__init__`
  - Replace incorrect class attribute access with instance method calls


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
