### PR TITLE
fix the warning torch_dtype is deprecated

### DIFF
--- a/src/diffusers/pipelines/pipeline_loading_utils.py
+++ b/src/diffusers/pipelines/pipeline_loading_utils.py
@@ -801,7 +801,7 @@ def load_sub_model(
     # add kwargs to loading method
     diffusers_module = importlib.import_module(__name__.split(".")[0])
     loading_kwargs = {}
-    
+
     is_diffusers_model = issubclass(class_obj, diffusers_module.ModelMixin)
 
     if is_transformers_available():
@@ -814,7 +814,7 @@ def load_sub_model(
         and issubclass(class_obj, PreTrainedModel)
         and transformers_version >= version.parse("4.20.0")
     )
-    
+
     # For transformers models >= 4.56.0, use 'dtype' instead of 'torch_dtype' to avoid deprecation warnings
     if issubclass(class_obj, torch.nn.Module):
         if is_transformers_model and transformers_version >= version.parse("4.56.0"):


### PR DESCRIPTION
## Motivation

When users load pipelines like `QwenImageEditPipeline` with the `torch_dtype` parameter, they see a deprecation warning from the Transformers library. However, changing to `dtype` (as the warning suggests) causes errors because diffusers' `from_pretrained` doesn't accept `dtype` as a parameter.

This creates a confusing user experience where:
1. Users see a deprecation warning
2. Following the warning's advice breaks their code
3. There's no way to avoid the warning without modifying the diffusers library

## Solution

This PR internally converts `torch_dtype` to `dtype` when loading Transformers models (transformers >= 4.20.0), while keeping `torch_dtype` for diffusers models and other components.


Fixes #12840 


## Who can review?

- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza 