### PR TITLE
Fix SDXL VAE decode latents dtype mismatch on non-MPS

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -1258,6 +1258,19 @@ class StableDiffusionXLPipeline(
                 if torch.backends.mps.is_available():
                     # some platforms (eg. apple mps) misbehave due to a pytorch bug: https://github.com/pytorch/pytorch/pull/99272
                     self.vae = self.vae.to(latents.dtype)
+                else:
+                    # On CUDA/CPU we still need to align the latents dtype/device to the VAE decode dtype/device.
+                    # Otherwise, if the VAE (or parts of it) are in fp32 while latents are fp16, group_norm/linear
+                    # will error with Half/Float dtype mismatch.
+                    try:
+                        decode_param = next(iter(self.vae.post_quant_conv.parameters()))
+                    except Exception:
+                        decode_param = next(iter(self.vae.parameters()))
+
+                    if latents.device != decode_param.device:
+                        latents = latents.to(device=decode_param.device)
+                    if latents.dtype != decode_param.dtype:
+                        latents = latents.to(dtype=decode_param.dtype)
 
             # unscale/denormalize the latents
             # denormalize with the mean and std if available and not None


### PR DESCRIPTION
#### Summary
On non-MPS platforms (CUDA/CPU), `StableDiffusionXLPipeline` can call `vae.decode()` with **fp16 latents** while the **VAE (or parts of it) are fp32**, which causes a hard runtime error in normalization/linear layers (e.g. `GroupNorm`): `expected scalar type Half but found Float`.

This happens because the pipeline currently only aligns `latents` dtype when `needs_upcasting` is `True` (fp16 VAE + `force_upcast`), and the `elif latents.dtype != self.vae.dtype:` branch only handles MPS by casting the VAE to the latents dtype. On CUDA/CPU there is no dtype/device alignment, so mixed dtype can reach VAE decode.

#### Reproduction
- Environment: `diffusers==0.36.0.dev0` (observed), CUDA or CPU (non-MPS)
- Steps (conceptual):
  1. Ensure VAE is fp32 (or has fp32 submodules) while latents become fp16.
  2. Run `StableDiffusionXLPipeline.__call__` with `output_type != "latent"`.
  3. Pipeline reaches `vae.decode(latents, ...)` and errors inside VAE decoder `GroupNorm/Linear` due to fp16 input + fp32 weights.

A concrete regression test is included to reproduce this without GPU:
- Force `pipe.vae` to fp32
- Use `callback_on_step_end` to force `latents` to fp16
- Assert that the pipeline aligns the dtype back to fp32 before calling `vae.decode`

#### Fix
When `needs_upcasting` is `False` but `latents.dtype != self.vae.dtype`, we now align `latents` **dtype/device** to the VAE decode dtype/device (preferring `vae.post_quant_conv` parameters when available) on non-MPS platforms. This prevents mixed dtype from reaching `vae.decode()` and matches the intent of the upcast path.

#### Tests
- Added `test_vae_decode_aligns_latents_dtype_when_vae_is_fp32` in `tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py`.

#### Why this is a bug
Users can legitimately end up with fp32 VAE (stability) while latents are fp16 (performance / callbacks / schedulers). The pipeline should not crash with dtype mismatch in this scenario; it should deterministically align latents to the VAE decode dtype.
