### PR TITLE
z-image-turbo controlnet correct device placement

### DIFF
--- a/src/diffusers/models/controlnets/controlnet_z_image.py
+++ b/src/diffusers/models/controlnets/controlnet_z_image.py
@@ -700,6 +700,7 @@ class ZImageControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
 
         control_context = self.patchify(control_context, patch_size, f_patch_size)
         control_context = torch.cat(control_context, dim=0)
+        self.control_all_x_embedder = self.control_all_x_embedder.to(control_context.device)
         control_context = self.control_all_x_embedder[f"{patch_size}-{f_patch_size}"](control_context)
 
         control_context[torch.cat(x_inner_pad_mask)] = self.x_pad_token
@@ -739,6 +740,7 @@ class ZImageControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
                         layer, control_context, x, x_attn_mask, x_freqs_cis, adaln_input
                     )
                 else:
+                    layer = layer.to(control_context.device)
                     control_context = layer(control_context, x, x_attn_mask, x_freqs_cis, adaln_input)
 
             hints = torch.unbind(control_context)[:-1]
@@ -818,6 +820,7 @@ class ZImageControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
                     )
             else:
                 for layer in self.control_noise_refiner:
+                    layer = layer.to(control_context.device)
                     control_context = layer(control_context, x_attn_mask, x_freqs_cis, adaln_input)
 
         # unified
@@ -834,6 +837,7 @@ class ZImageControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
                     layer, control_context_unified, unified, unified_attn_mask, unified_freqs_cis, adaln_input
                 )
             else:
+                layer = layer.to(control_context_unified.device)
                 control_context_unified = layer(
                     control_context_unified, unified, unified_attn_mask, unified_freqs_cis, adaln_input
                 )


### PR DESCRIPTION
z-image-turbo controlnet implementation in #12792 includes some manually created torch modules and dicts which by default are created on `cpu` while context used in the controlnet loop is on `gpu`

depending on offloading strategy and/or use of accelerate, this this results in typical error:

```log
/app/venv/lib/python3.12/site-packages/diffusers/models/controlnets/controlnet_z_image.py:818 in forward                                                                                              │
│                                                                                                                                                                                                      │
│  817 │   │   │   else:                                                                                                                                                                               │
│❱ 818 │   │   │   │   control_context_unified = layer(                                                                                                                                                │
│  819 │   │   │   │   │   control_context_unified, unified, unified_attn_mask, unified_freqs_cis, adaln_input                                                                                         │
│                                                                                                                                                                                                      │
│/app/venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1775 in _wrapped_call_impl                                                                                                          │
│                                                                                                                                                                                                      │
│  1774 │   │   else:                                                                                                                                                                                  │
│❱ 1775 │   │   │   return self._call_impl(*args, **kwargs)                                                                                                                                            │
│  1776                                                                                                                                                                                                │
│                                                                                                                                                                                                      │
│/app/venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1786 in _call_impl                                                                                                                  │
│                                                                                                                                                                                                      │
│  1785 │   │   │   │   or _global_forward_hooks or _global_forward_pre_hooks):                                                                                                                        │
│❱ 1786 │   │   │   return forward_call(*args, **kwargs)                                                                                                                                               │
│  1787                                                                                                                                                                                                │
│                                                                                                                                                                                                      │
│/app/venv/lib/python3.12/site-packages/diffusers/models/controlnets/controlnet_z_image.py:356 in forward                                                                                              │
│                                                                                                                                                                                                      │
│  355 │   │   if self.block_id == 0:                                                                                                                                                                  │
│❱ 356 │   │   │   c = self.before_proj(c) + x                                                                                                                                                         │
│  357 │   │   │   all_c = []                                                                                                                                                                          │
│                                                                                                                                                                                                      │
│/app/venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1775 in _wrapped_call_impl                                                                                                          │
│                                                                                                                                                                                                      │
│  1774 │   │   else:                                                                                                                                                                                  │
│❱ 1775 │   │   │   return self._call_impl(*args, **kwargs)                                                                                                                                            │
│  1776                                                                                                                                                                                                │
│                                                                                                                                                                                                      │
│/app/venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1786 in _call_impl                                                                                                                  │
│                                                                                                                                                                                                      │
│  1785 │   │   │   │   or _global_forward_hooks or _global_forward_pre_hooks):                                                                                                                        │
│❱ 1786 │   │   │   return forward_call(*args, **kwargs)                                                                                                                                               │
│  1787                                                                                                                                                                                                │
│                                                                                                                                                                                                      │
│/app/venv/lib/python3.12/site-packages/torch/nn/modules/linear.py:134 in forward                                                                                                                      │
│                                                                                                                                                                                                      │
│  133 │   │   """                                                                                                                                                                                     │
│❱ 134 │   │   return F.linear(input, self.weight, self.bias)                                                                                                                                          │
│  135                                                                                                                                                                                                 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
RuntimeError: Expected all tensors to be on the same device, but got mat1 is on cuda:0, different from other tensors on cpu (when checking argument in method wrapper_CUDA_addmm)
```

i've traced device placement to couple of critical execution paths which when corrected allow execution of z-image-turbo controlnet without issues.

cc: @hlky @yiyixuxu @DN6 @sayakpaul 