### PR TITLE
[Flux.1] improve pos embed for ascend npu by computing on npu

### DIFF
--- a/src/diffusers/models/transformers/transformer_flux.py
+++ b/src/diffusers/models/transformers/transformer_flux.py
@@ -22,7 +22,7 @@ import torch.nn.functional as F
 
 from ...configuration_utils import ConfigMixin, register_to_config
 from ...loaders import FluxTransformer2DLoadersMixin, FromOriginalModelMixin, PeftAdapterMixin
-from ...utils import USE_PEFT_BACKEND, is_torch_npu_available, logging, scale_lora_layers, unscale_lora_layers
+from ...utils import USE_PEFT_BACKEND, logging, scale_lora_layers, unscale_lora_layers
 from ...utils.torch_utils import maybe_allow_in_graph
 from .._modeling_parallel import ContextParallelInput, ContextParallelOutput
 from ..attention import AttentionMixin, AttentionModuleMixin, FeedForward

--- a/src/diffusers/models/transformers/transformer_flux2.py
+++ b/src/diffusers/models/transformers/transformer_flux2.py
@@ -21,7 +21,7 @@ import torch.nn.functional as F
 
 from ...configuration_utils import ConfigMixin, register_to_config
 from ...loaders import FluxTransformer2DLoadersMixin, FromOriginalModelMixin, PeftAdapterMixin
-from ...utils import USE_PEFT_BACKEND, is_torch_npu_available, logging, scale_lora_layers, unscale_lora_layers
+from ...utils import USE_PEFT_BACKEND, logging, scale_lora_layers, unscale_lora_layers
 from .._modeling_parallel import ContextParallelInput, ContextParallelOutput
 from ..attention import AttentionMixin, AttentionModuleMixin
 from ..attention_dispatch import dispatch_attention_fn

--- a/src/diffusers/models/transformers/transformer_longcat_image.py
+++ b/src/diffusers/models/transformers/transformer_longcat_image.py
@@ -21,7 +21,7 @@ import torch.nn.functional as F
 
 from ...configuration_utils import ConfigMixin, register_to_config
 from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
-from ...utils import is_torch_npu_available, logging
+from ...utils import logging
 from ...utils.torch_utils import maybe_allow_in_graph
 from ..attention import AttentionModuleMixin, FeedForward
 from ..attention_dispatch import dispatch_attention_fn

--- a/src/diffusers/models/transformers/transformer_ovis_image.py
+++ b/src/diffusers/models/transformers/transformer_ovis_image.py
@@ -21,7 +21,7 @@ import torch.nn.functional as F
 
 from ...configuration_utils import ConfigMixin, register_to_config
 from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
-from ...utils import is_torch_npu_available, logging
+from ...utils import logging
 from ...utils.torch_utils import maybe_allow_in_graph
 from ..attention import AttentionModuleMixin, FeedForward
 from ..attention_dispatch import dispatch_attention_fn


### PR DESCRIPTION
# What does this PR do?

Moving pos_embed computation from CPU back to NPU results in a 1.07x speedup in Flux.1's end-to-end latency.

Since CANN updated to 8.3.RC1, the bad performance of `torch.repeat_interleave` operator has been optimized. Results shown below:

| Model | Device |  Resolution | Steps | e2e latency |
| - | - | - | - | - |
| FLUX.1-DEV | npu | 1024 x 1024 | 28 | 25.54 |
| FLUX.1-DEV | cpu | 1024 x 1024 | 28 | 27.41 |
| FLUX.2-DEV | npu | 1024 x 1024 | 28 | 101.49 |
| FLUX.2-DEV | cpu | 1024 x 1024 | 28 | 118.22 |
| LongCat-Image | npu | 768x1344 | 28 | 31.87 |
| LongCat-Image | cpu | 768x1344 | 28 | 36.19 |
| Ovis-Image | npu | 1024 x 1024 | 28 | 27.16 |
| Ovis-Image | cpu | 1024 x 1024 | 28 | 40.47 |


# Tested Hardware
Ascend 910B3

# Repro Code
## 1. FLUX.1-dev
```python
import time

import torch
import torch_npu
from torch_npu.contrib import transfer_to_npu

from diffusers import FluxPipeline
pipe = FluxPipeline.from_pretrained("black-forest-labs/FLUX.1-dev", torch_dtype=torch.bfloat16).to("npu")

prompt = "A cat holding a sign that says hello world"

# Warmup
_ = pipe(prompt, height=1024, width=1024, guidance_scale=3.5, num_inference_steps=2, max_sequence_length=512, generator=torch.Generator("cpu").manual_seed(0))

# Inference
start_time = time.time()

image = pipe(prompt, height=1024, width=1024, guidance_scale=3.5, num_inference_steps=2, max_sequence_length=512, generator=torch.Generator("cpu").manual_seed(0)).images[0]
image.save("flux-dev.png")

end_time = time.time()
print(f"Time: {end_time - start_time:.2f}s")
```

## 2. FLUX.2-DEV
```python
import time

import torch
import torch_npu
from torch_npu.contrib import transfer_to_npu

from diffusers import Flux2Pipeline
pipe = Flux2Pipeline.from_pretrained("black-forest-labs/FLUX.2-dev", torch_dtype=torch.bfloat16)
pipe.enable_group_offload(
    onload_device=torch.device("npu"),
    offload_device=torch.device("cpu"),
    offload_type="leaf_level",
    use_stream=True
)

prompt = "A cat holding a sign that says hello world"

# Warmup
_ = pipe(prompt, height=1024, width=1024, guidance_scale=3.5, num_inference_steps=2, max_sequence_length=512, generator=torch.Generator("cpu").manual_seed(0))

# Inference
start_time = time.time()

image = pipe(prompt, height=1024, width=1024, guidance_scale=3.5, num_inference_steps=2, max_sequence_length=512, generator=torch.Generator("cpu").manual_seed(0)).images[0]
image.save("flux.2-dev.png")

end_time = time.time()
print(f"Time: {end_time - start_time:.2f}s")
```

## 3. LongCat-Image
```python
import time

import torch
import torch_npu
from torch_npu.contrib import transfer_to_npu

from diffusers import LongCatImagePipeline
pipe = LongCatImagePipeline.from_pretrained("meituan-longcat/LongCat-Image/", torch_dtype=torch.bfloat16)
pipe.enable_model_cpu_offload()

prompt = '一个年轻的亚裔女性，身穿黄色针织衫，搭配白色项链。她的双手放在膝盖上，表情恬静。背景是一堵粗糙的砖墙，午后的阳光温暖地洒在她身上，营造出一种宁静而温馨的氛围。镜头采用中距离视角，突出她的神态和服饰的细节。光线柔和地打在她的脸上，强调她的五官和饰品的质感，增加画面的层次感与亲和力。整个画面构图简洁，砖墙的纹理与阳光的光影效果相得益彰，突显出人物的优雅与从容。'

# WARMUP
image = pipe(prompt, height=768, width=1344, guidance_scale=4.0, num_inference_steps=2, num_images_per_prompt=1, generator=torch.Generator("cpu").manual_seed(43), enable_cfg_renorm=True, enable_prompt_rewrite=True).images[0]

# Inference
start_time = time.time()

image = pipe(prompt, height=768, width=1344, guidance_scale=4.0, num_inference_steps=28, num_images_per_prompt=1, generator=torch.Generator("cpu").manual_seed(43), enable_cfg_renorm=True, enable_prompt_rewrite=True).images[0]

image.save("longcat.png")

end_time = time.time()
print(f"Time: {end_time - start_time:.2f}s")
```

## 4. Ovis-Image
```python
import time

import torch
import torch_npu
from torch_npu.contrib import transfer_to_npu

from diffusers import OvisImagePipeline
pipe = OvisImagePipeline.from_pretrained("AIDC-AI/Ovis-Image-7B", torch_dtype=torch.bfloat16)
pipe.enable_model_cpu_offload()

prompt = "A creative 3D artistic render where the text \"OVIS-IMAGE\" is written in a bold, expressive handwritten brush style using thick, wet oil paint. The paint is a mix of vibrant rainbow colors (red, blue, yellow) swirling together like toothpaste or impasto art. You can see the ridges of the brush bristles and the glossy, wet texture of the paint. The background is a clean artist's canvas. Dynamic lighting creates soft shadows behind the floating paint strokes. Colorful, expressive, tactile texture, 4k detail."

# Warmup
image = pipe(prompt, negative_prompt="", num_inference_steps=2, guidance_scale=5.0).images[0]

# Inference
start_time = time.time()
image = pipe(prompt, negative_prompt="", num_inference_steps=28, guidance_scale=5.0).images[0]
image.save("ovis.png")

end_time = time.time()
print(f"Time: {end_time - start_time:.2f}s")
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
