### PR TITLE
Fix typo in src/diffusers/pipelines/cosmos/pipeline_cosmos2_5_predict.py

### DIFF
--- a/src/diffusers/pipelines/cosmos/pipeline_cosmos2_5_predict.py
+++ b/src/diffusers/pipelines/cosmos/pipeline_cosmos2_5_predict.py
@@ -76,7 +76,7 @@ EXAMPLE_DOC_STRING = """
 
         >>> model_id = "nvidia/Cosmos-Predict2.5-2B"
         >>> pipe = Cosmos2_5_PredictBasePipeline.from_pretrained(
-        ...     model_id, revision="diffusers/base/pre-trianed", torch_dtype=torch.bfloat16
+        ...     model_id, revision="diffusers/base/post-trained", torch_dtype=torch.bfloat16
         ... )
         >>> pipe = pipe.to("cuda")
 


### PR DESCRIPTION
# What does this PR do?

A typo was noted in the documentation, see a reported issue here: https://github.com/nvidia-cosmos/cosmos-predict2.5/issues/89

## Who can review?

- Pipelines @yiyixuxu
- Docs: @sayakpaul 