### PR TITLE
LongCat Image pipeline: Allow offloading/quantization of text_encoder component

### DIFF
--- a/src/diffusers/pipelines/longcat_image/pipeline_longcat_image.py
+++ b/src/diffusers/pipelines/longcat_image/pipeline_longcat_image.py
@@ -260,7 +260,7 @@ class LongCatImagePipeline(DiffusionPipeline, FromSingleFileMixin):
             text = self.text_processor.apply_chat_template(message, tokenize=False, add_generation_prompt=True)
             all_text.append(text)
 
-        inputs = self.text_processor(text=all_text, padding=True, return_tensors="pt").to(device)
+        inputs = self.text_processor(text=all_text, padding=True, return_tensors="pt").to(self.text_encoder.device)
 
         generated_ids = self.text_encoder.generate(**inputs, max_new_tokens=self.tokenizer_max_length)
         generated_ids.to(device)


### PR DESCRIPTION
# What does this PR do?

Remove the attempt to move `text_encoder` to the same device as the rest of the pipeline in `pipeline_longcat_image.py`. The text encoder may not be movable (VRAM limitations), and more to the point, it's the user's prerogative where they load things, not the pipeline's. Instead, simply moves the tensor that `text_encoder` generates.

Also (and my main motivation) fixes quantization of the LongCat Image pipeline using bitsandbytes, which previously gave this exception:

```text
  File "/home/yahweasel/ComfyUI/venv/lib/python3.12/site-packages/diffusers/pipelines/longcat_image/pipeline_longcat_image.py", line 539, in __call__
    prompt = self.rewire_prompt(prompt, device)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yahweasel/ComfyUI/venv/lib/python3.12/site-packages/diffusers/pipelines/longcat_image/pipeline_longcat_image.py", line 265, in rewire_prompt
    self.text_encoder.to(device)
  File "/home/yahweasel/ComfyUI/venv/lib/python3.12/site-packages/transformers/modeling_utils.py", line 4328, in to
    raise ValueError(
ValueError: `.to` is not supported for `8-bit` bitsandbytes models. Please use the model as it is, since the model has already been set to the correct devices and casted to the correct `dtype`.
```

Here's a simple example with bitsandbytes, which now works:

```python3
qc = diffusers.PipelineQuantizationConfig(quant_backend="bitsandbytes-8bit", quant_kwargs={"load_in_8bit": True})
pipe = diffusers.LongCatImagePipeline("meituan-longcat/LongCat-Image", quantization_config=qc)
pipe("a man").images[0]
```

I did not submit an issue for this error, because the fix was trivial.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [X] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
      (There is no relevant documentation, as this is simply a tensor location)
- [ ] Did you write any new necessary tests?
      (Are new tests necessary for this?)


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@junqiangwu
