### PR TITLE
[Modular] guard `ModularPipeline.blocks` attribute

### DIFF
--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -1603,7 +1603,9 @@ class ModularPipeline(ConfigMixin, PushToHubMixin):
         for name, config_spec in self._config_specs.items():
             default_configs[name] = config_spec.default
         self.register_to_config(**default_configs)
-        self.register_to_config(_blocks_class_name=self._blocks.__class__.__name__ if self._blocks is not None else None)
+        self.register_to_config(
+            _blocks_class_name=self._blocks.__class__.__name__ if self._blocks is not None else None
+        )
 
     @property
     def default_call_parameters(self) -> Dict[str, Any]:


### PR DESCRIPTION
pipeline blocks are definitions - they're dynamically composable. you can add, remove, combine, or swap blocks.
Pipelines are stateful, and modifying the `blocks` attribute on a pipeline directly won't update the pipeline's internal state correctly.

This change makes `blocks` a property that returns a deepcopy, so users can't change the blocks and expect it to work. e.g. if you do something like this, the original pipeline would still work (currently it does not)

```py
pipe = ModularPipeline.from_pretrained()
text_block = pipe.blocks.sub_blocks.pop("text_encoder")
```
