### PR TITLE
feat: accelerate longcat-image with regional compile

### DIFF
--- a/src/diffusers/models/transformers/transformer_longcat_image.py
+++ b/src/diffusers/models/transformers/transformer_longcat_image.py
@@ -406,6 +406,7 @@ class LongCatImageTransformer2DModel(
     """
 
     _supports_gradient_checkpointing = True
+    _repeated_blocks = ["LongCatImageTransformerBlock", "LongCatImageSingleTransformerBlock"]
 
     @register_to_config
     def __init__(


### PR DESCRIPTION
# What does this PR do?

Support longcat-image with regional rompile

<img width="1660" height="654" alt="image" src="https://github.com/user-attachments/assets/7ffa631b-4a90-490a-82bf-a2b6f4207fa9" />

with regional compile, we can get 2x speedup in 20 num_step image generation.
Also this compile is safety, because longcat transformerblock architecture is the same as flux transformer block.
<img width="2167" height="674" alt="image" src="https://github.com/user-attachments/assets/3c57337b-34c8-4171-9579-757b3fe614c0" />
FYI: https://arxiv.org/pdf/2512.07584

## Who can review?

@yiyixuxu and @sayakpaul 

