### PR TITLE
Perform in-place zeroing instead of creating new tensors

### DIFF
--- a/src/diffusers/pipelines/wan/pipeline_wan.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan.py
@@ -184,10 +184,8 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
         prompt_embeds = self.text_encoder(text_input_ids.to(device), mask.to(device)).last_hidden_state
         prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
-        prompt_embeds = [u[:v] for u, v in zip(prompt_embeds, seq_lens)]
-        prompt_embeds = torch.stack(
-            [torch.cat([u, u.new_zeros(max_sequence_length - u.size(0), u.size(1))]) for u in prompt_embeds], dim=0
-        )
+        for i, seq_len in enumerate(seq_lens):
+            prompt_embeds[i, seq_len:] = 0
 
         # duplicate text embeddings for each generation per prompt, using mps friendly method
         _, seq_len, _ = prompt_embeds.shape


### PR DESCRIPTION
I came across this code snippet while reading the pipeline code:

```py
prompt_embeds = [u[:v] for u, v in zip(prompt_embeds, seq_lens)]
prompt_embeds = torch.stack(
    [torch.cat([u, u.new_zeros(max_sequence_length - u.size(0), u.size(1))]) for u in prompt_embeds], dim=0
)
```

It took me some time to understand what it was doing, and once I did, I noticed that it can be simplified to the following:

```py
for i, seq_len in enumerate(seq_lens):
    prompt_embeds[i, seq_len:] = 0
```

This achieves the same result, while being more readable and more efficient (in-place operation, fewer allocations and copies).

I realize the performance gain may not be significant in most cases, but the simpler approach improves clarity and reduces unnecessary tensor operations. There are likely other similar instances in the pipelines that could benefit from the same refactor.

I'd be interested to hear your thoughts on this change and whether it would be worth applying more broadly.