### PR TITLE
[Context Parallel] fix: support PyTorch < 2.6 in distributed gather

### DIFF
--- a/src/diffusers/models/_modeling_parallel.py
+++ b/src/diffusers/models/_modeling_parallel.py
@@ -294,14 +294,10 @@ def gather_size_by_comm(size: int, group: dist.ProcessGroup) -> List[int]:
     if "cpu" in comm_backends:
         gather_device = "cpu"
     else:
-        gather_device = get_device()
+        gather_device = torch.device(get_device())
 
-        if gather_device == "cpu":
-            raise RuntimeError(
-                "Ulysses Anything Attention (UAA) requires an accelerator "
-                "(CUDA, NPU, XPU, etc.) to perform distributed gathering, "
-                "but only CPU was detected."
-            )
+        if gather_device.type == "cpu":
+            raise RuntimeError("No suitable accelerator found.")
 
     gathered_sizes = [torch.empty((1,), device=gather_device, dtype=torch.int64) for _ in range(world_size)]
     dist.all_gather(


### PR DESCRIPTION
# What does this PR do?
Replace unsafe `torch.accelerator` usage with an `hasattr` guard for backward compatibility.

Fixes #13074 

Original library don't face this issue as their minimum supported torch version is 2.7 :
https://github.com/vipshop/cache-dit/blob/main/pyproject.toml#L13


## Who can review?

@sayakpaul  @DN6

