### PR TITLE
fix: add PyTorch version check for torch.accelerator in gather_size_by_comm

### DIFF
--- a/src/diffusers/models/_modeling_parallel.py
+++ b/src/diffusers/models/_modeling_parallel.py
@@ -290,7 +290,12 @@ def gather_size_by_comm(size: int, group: dist.ProcessGroup) -> List[int]:
     # HACK: Use Gloo backend for all_gather to avoid H2D and D2H overhead
     comm_backends = str(dist.get_backend(group=group))
     # NOTE: e.g., dist.init_process_group(backend="cpu:gloo,cuda:nccl")
-    gather_device = "cpu" if "cpu" in comm_backends else torch.accelerator.current_accelerator()
+    if "cpu" in comm_backends:
+        gather_device = "cpu"
+    elif hasattr(torch, "accelerator"):
+        gather_device = torch.accelerator.current_accelerator()
+    else:
+        gather_device = "cuda"
     gathered_sizes = [torch.empty((1,), device=gather_device, dtype=torch.int64) for _ in range(world_size)]
     dist.all_gather(
         gathered_sizes,

--- a/src/diffusers/models/_modeling_parallel.py
+++ b/src/diffusers/models/_modeling_parallel.py
@@ -22,6 +22,7 @@ import torch
 import torch.distributed as dist
 
 from ..utils import get_logger
+from ..utils.torch_utils import get_device
 
 
 if TYPE_CHECKING:
@@ -290,12 +291,10 @@ def gather_size_by_comm(size: int, group: dist.ProcessGroup) -> List[int]:
     # HACK: Use Gloo backend for all_gather to avoid H2D and D2H overhead
     comm_backends = str(dist.get_backend(group=group))
     # NOTE: e.g., dist.init_process_group(backend="cpu:gloo,cuda:nccl")
-    if "cpu" in comm_backends:
-        gather_device = "cpu"
-    elif hasattr(torch, "accelerator"):
-        gather_device = torch.accelerator.current_accelerator()
-    else:
-        gather_device = "cuda"
+    # get_device() handles accelerator version compatibility internally
+    # (cuda/npu/xpu/mps/mlu/cpu), so we don't need the hasattr(torch, "accelerator")
+    # check here.
+    gather_device = "cpu" if "cpu" in comm_backends else get_device()
     gathered_sizes = [torch.empty((1,), device=gather_device, dtype=torch.int64) for _ in range(world_size)]
     dist.all_gather(
         gathered_sizes,


### PR DESCRIPTION
## Summary
Add backward compatibility check for `torch.accelerator.current_accelerator()` which only exists in PyTorch 2.6+.

## Problem
`gather_size_by_comm()` in `_modeling_parallel.py` uses `torch.accelerator.current_accelerator()` without checking if it exists. Since diffusers officially supports PyTorch 2.1+, this causes `AttributeError: module 'torch' has no attribute 'accelerator'` on PyTorch versions 2.1-2.5.

## Solution
Added `hasattr(torch, "accelerator")` check with fallback to `"cuda"` for older PyTorch versions. This matches the pattern already used in other parts of the codebase:
- `src/diffusers/loaders/lora_pipeline.py` (line 111)
- `src/diffusers/hooks/group_offloading.py` (lines 121-125)
- `src/diffusers/quantizers/gguf/gguf_quantizer.py` (lines 159-163)

Fixes #13074