### PR TITLE
fix: correct Z-Image guidance scale threshold from > 1 to > 0

### DIFF
--- a/src/diffusers/pipelines/z_image/pipeline_z_image.py
+++ b/src/diffusers/pipelines/z_image/pipeline_z_image.py
@@ -276,7 +276,7 @@ class ZImagePipeline(DiffusionPipeline, ZImageLoraLoaderMixin, FromSingleFileMix
 
     @property
     def do_classifier_free_guidance(self):
-        return self._guidance_scale > 1
+        return self._guidance_scale > 0
 
     @property
     def joint_attention_kwargs(self):
@@ -335,10 +335,9 @@ class ZImagePipeline(DiffusionPipeline, ZImageLoraLoaderMixin, FromSingleFileMix
                 will be used.
             guidance_scale (`float`, *optional*, defaults to 5.0):
                 Guidance scale as defined in [Classifier-Free Diffusion Guidance](https://arxiv.org/abs/2207.12598).
-                `guidance_scale` is defined as `w` of equation 2. of [Imagen
-                Paper](https://arxiv.org/pdf/2205.11487.pdf). Guidance scale is enabled by setting `guidance_scale >
-                1`. Higher guidance scale encourages to generate images that are closely linked to the text `prompt`,
-                usually at the expense of lower image quality.
+                Z-Image uses the formula `pred = pos + guidance_scale * (pos - neg)`, so guidance scale is enabled
+                by setting `guidance_scale > 0`. Higher guidance scale encourages to generate images that are closely
+                linked to the text `prompt`, usually at the expense of lower image quality.
             cfg_normalization (`bool`, *optional*, defaults to False):
                 Whether to apply configuration normalization.
             cfg_truncation (`float`, *optional*, defaults to 1.0):


### PR DESCRIPTION
## Summary
Fix incorrect `do_classifier_free_guidance` threshold check in Z-Image pipeline.

## Problem
Z-Image uses a non-standard CFG formula:
```python
pred = pos + guidance_scale * (pos - neg)
```

Unlike the standard formula:
```python
pred = neg + guidance_scale * (pos - neg)
```

With Z-Image's formula:
- `guidance_scale = 0`: `pred = pos` (conditional, no CFG)
- `guidance_scale = 0.5`: `pred = 1.5*pos - 0.5*neg` (partial CFG)
- `guidance_scale = 1`: `pred = 2*pos - neg` (standard CFG)

Any `guidance_scale > 0` applies a CFG effect. The previous `> 1` check was incorrect and caused CFG to be completely ignored when `0 < guidance_scale < 1`.

## Changes
1. Changed `do_classifier_free_guidance` property from `> 1` to `> 0`
2. Updated docstring to document the Z-Image specific CFG formula

Fixes #12905