### PR TITLE
fix(controlnet): Use deep copy in ZImageControlNet.from_transformer

### DIFF
--- a/src/diffusers/models/controlnets/controlnet_z_image.py
+++ b/src/diffusers/models/controlnets/controlnet_z_image.py
@@ -517,15 +517,19 @@ class ZImageControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
 
     @classmethod
     def from_transformer(cls, controlnet, transformer):
+        import copy
+
         controlnet.t_scale = transformer.t_scale
-        controlnet.t_embedder = transformer.t_embedder
-        controlnet.all_x_embedder = transformer.all_x_embedder
-        controlnet.cap_embedder = transformer.cap_embedder
-        controlnet.rope_embedder = transformer.rope_embedder
-        controlnet.noise_refiner = transformer.noise_refiner
-        controlnet.context_refiner = transformer.context_refiner
-        controlnet.x_pad_token = transformer.x_pad_token
-        controlnet.cap_pad_token = transformer.cap_pad_token
+        # Use deep copies to avoid sharing references with the transformer.
+        # This ensures modifying controlnet weights won't affect the transformer.
+        controlnet.t_embedder = copy.deepcopy(transformer.t_embedder)
+        controlnet.all_x_embedder = copy.deepcopy(transformer.all_x_embedder)
+        controlnet.cap_embedder = copy.deepcopy(transformer.cap_embedder)
+        controlnet.rope_embedder = copy.deepcopy(transformer.rope_embedder)
+        controlnet.noise_refiner = copy.deepcopy(transformer.noise_refiner)
+        controlnet.context_refiner = copy.deepcopy(transformer.context_refiner)
+        controlnet.x_pad_token = copy.deepcopy(transformer.x_pad_token)
+        controlnet.cap_pad_token = copy.deepcopy(transformer.cap_pad_token)
         return controlnet
 
     @staticmethod


### PR DESCRIPTION
## Summary
Use `copy.deepcopy()` instead of direct assignment in `ZImageControlNet.from_transformer()` to prevent weight sharing between controlnet and transformer.

## Problem
The `from_transformer` method was using direct assignment to copy modules from transformer to controlnet. This creates a shallow copy where both objects share the same underlying tensor references. Training the controlnet would inadvertently modify the original transformer weights.

## Solution
Changed all module assignments to use `copy.deepcopy()`:
- `t_embedder`
- `all_x_embedder`
- `cap_embedder`
- `rope_embedder`
- `noise_refiner`
- `context_refiner`
- `x_pad_token`
- `cap_pad_token`

Note: `t_scale` is a scalar value (not a module), so direct assignment is correct for it.

Fixes #13077