### PR TITLE
fix(pipeline): Preserve dtype in from_pipe() instead of defaulting to float32

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -2082,7 +2082,8 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         """
 
         original_config = dict(pipeline.config)
-        torch_dtype = kwargs.pop("torch_dtype", torch.float32)
+        # Preserve the source pipeline's dtype by default instead of converting to float32
+        torch_dtype = kwargs.pop("torch_dtype", pipeline.dtype)
 
         # derive the pipeline class to instantiate
         custom_pipeline = kwargs.pop("custom_pipeline", None)


### PR DESCRIPTION
## Summary

Fixes `from_pipe()` to preserve the source pipeline's dtype instead of defaulting to float32.

## Problem

When using `from_pipe()` to create a new pipeline from an existing one, the dtype was not preserved:

```python
pipe = StableDiffusionPipeline.from_pretrained(..., torch_dtype=torch.float16).to("cuda")
print(f"Before: {pipe.dtype}")  # torch.float16

i2i = StableDiffusionImg2ImgPipeline.from_pipe(pipe)
print(f"After:  {i2i.dtype}")   # torch.float32 (WRONG!)
```

This caused:
- Memory usage to double (from 2.6GB to 5.2GB in the example)
- Slower inference due to float32 computation

## Solution

Changed the default value for `torch_dtype` from `torch.float32` to `pipeline.dtype`:

```python
# Before
torch_dtype = kwargs.pop("torch_dtype", torch.float32)

# After  
torch_dtype = kwargs.pop("torch_dtype", pipeline.dtype)
```

Users can still override with `torch_dtype=torch.float32` if needed.

Fixes #12754