### PR TITLE
Fix SanaCombinedTimestepGuidanceEmbeddings to handle missing guidance

### DIFF
--- a/src/diffusers/models/transformers/sana_transformer.py
+++ b/src/diffusers/models/transformers/sana_transformer.py
@@ -108,10 +108,14 @@ class SanaCombinedTimestepGuidanceEmbeddings(nn.Module):
         self.silu = nn.SiLU()
         self.linear = nn.Linear(embedding_dim, 6 * embedding_dim, bias=True)
 
-    def forward(self, timestep: torch.Tensor, guidance: torch.Tensor = None, hidden_dtype: torch.dtype = None):
+    def forward(
+        self, timestep: torch.Tensor, guidance: torch.Tensor = None, hidden_dtype: torch.dtype = None, **kwargs
+    ):
         timesteps_proj = self.time_proj(timestep)
         timesteps_emb = self.timestep_embedder(timesteps_proj.to(dtype=hidden_dtype))  # (N, D)
 
+        if guidance is None:
+            guidance = torch.ones_like(timestep)
         guidance_proj = self.guidance_condition_proj(guidance)
         guidance_emb = self.guidance_embedder(guidance_proj.to(dtype=hidden_dtype))
         conditioning = timesteps_emb + guidance_emb


### PR DESCRIPTION
## Summary
- Fix `SanaCombinedTimestepGuidanceEmbeddings.forward()` to handle the case where `guidance` is `None`
- When `guidance_embeds=True` but `guidance` is not provided at inference time, the forward call would crash trying to project `None` through the guidance condition projector
- Default to `ones_like(timestep)` when guidance is not provided
- Accept `**kwargs` for forward compatibility with callers that pass `batch_size`

Fixes #12540

## Test plan
- [ ] Verify SanaPipeline inference works with `guidance_embeds=True` and no guidance provided
- [ ] Verify no regression when guidance is provided normally