### PR TITLE
Add bounds check for AuraFlow positional embedding indices

### DIFF
--- a/src/diffusers/models/transformers/auraflow_transformer_2d.py
+++ b/src/diffusers/models/transformers/auraflow_transformer_2d.py
@@ -76,6 +76,12 @@ class AuraFlowPatchEmbed(nn.Module):
         h_p, w_p = h // self.patch_size, w // self.patch_size
         h_max, w_max = int(self.pos_embed_max_size**0.5), int(self.pos_embed_max_size**0.5)
 
+        if h_p > h_max or w_p > w_max:
+            raise ValueError(
+                f"Input latent size ({h_p}x{w_p} patches) exceeds the positional embedding grid "
+                f"({h_max}x{w_max}). Use a smaller resolution or increase pos_embed_max_size."
+            )
+
         # Calculate the top-left corner indices for the centered patch grid
         starth = h_max // 2 - h_p // 2
         startw = w_max // 2 - w_p // 2


### PR DESCRIPTION
## Summary
- Add a bounds check in `AuraFlowPatchEmbed.pe_selection_index_based_on_dim()` to prevent out-of-bounds positional embedding indices
- When the input latent dimensions exceed the PE grid size, the centered-crop index calculation produces negative or out-of-range indices, causing a fatal CUDA assertion error (`ind >= 0 && ind < ind_dim_size`) that destroys the CUDA context for the entire process
- Raise a clear `ValueError` with guidance on how to fix the issue, instead of silently producing invalid indices

Fixes #12656

## Test plan
- [ ] Verify that inputs within the PE grid size work as before
- [ ] Verify that inputs exceeding the PE grid raise a clear ValueError