### PR TITLE
Fixing Kohya loras loading: Flux.1-dev loras with TE ("lora_te1_" prefix) + Flux.2-dev loras

### DIFF
--- a/src/diffusers/loaders/lora_pipeline.py
+++ b/src/diffusers/loaders/lora_pipeline.py
@@ -5472,6 +5472,16 @@ class Flux2LoraLoaderMixin(LoraBaseMixin):
             logger.warning(warn_msg)
             state_dict = {k: v for k, v in state_dict.items() if "dora_scale" not in k}
 
+        is_kohya = any(".lora_down.weight" in k for k in state_dict)
+        if is_kohya:
+            state_dict = _convert_kohya_flux_lora_to_diffusers(
+                state_dict, 
+                version_flux2=True,
+            )
+            # Kohya already takes care of scaling the LoRA parameters with alpha.
+            for k in  state_dict:
+                assert "alpha" not in k, f"Found key with alpha: {k}"
+
         is_ai_toolkit = any(k.startswith("diffusion_model.") for k in state_dict)
         if is_ai_toolkit:
             state_dict = _convert_non_diffusers_flux2_lora_to_diffusers(state_dict)


### PR DESCRIPTION
Text encoder lora layers are dropped for some loras such as [this one](https://huggingface.co/scenario-labs/big-head-kontext-lora/blob/main/flux_kontext_lora.safetensors) 
A log message confirms it:
`No LoRA keys associated to CLIPTextModel found with the prefix='text_encoder'. This is safe to ignore if LoRA state dict didn't originally have any CLIPTextModel related params. You can also try specifying `prefix=None` to resolve the warning. Otherwise, open an issue if you think it's unexpected: https://github.com/huggingface/diffusers/issues/new`

At least, this PR brings more consistency (wherever there is `lora_te_`, there should be also `lora_te1_`)

Closes https://github.com/huggingface/diffusers/issues/12053

@sayakpaul