### PR TITLE
Fix CogVideoX scheduler prev_timestep for non-leading spacing

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddim_cogvideox.py
+++ b/src/diffusers/schedulers/scheduling_ddim_cogvideox.py
@@ -383,7 +383,7 @@ class CogVideoXDDIMScheduler(SchedulerMixin, ConfigMixin):
         # - pred_prev_sample -> "x_t-1"
 
         # 1. get previous step value (=t-1)
-        prev_timestep = timestep - self.config.num_train_timesteps // self.num_inference_steps
+        prev_timestep = self.previous_timestep(timestep)
 
         # 2. compute alphas, betas
         alpha_prod_t = self.alphas_cumprod[timestep]
@@ -499,6 +499,25 @@ class CogVideoXDDIMScheduler(SchedulerMixin, ConfigMixin):
 
         velocity = sqrt_alpha_prod * noise - sqrt_one_minus_alpha_prod * sample
         return velocity
+
+    def previous_timestep(self, timestep: int) -> torch.Tensor:
+        """
+        Find the previous timestep in the scheduler's timestep schedule.
+
+        Args:
+            timestep (`int`):
+                The current timestep.
+
+        Returns:
+            `torch.Tensor`:
+                The previous timestep. Returns -1 if the current timestep is the last one.
+        """
+        index = (self.timesteps == timestep).nonzero(as_tuple=True)[0][0]
+        if index == self.timesteps.shape[0] - 1:
+            prev_t = torch.tensor(-1)
+        else:
+            prev_t = self.timesteps[index + 1]
+        return prev_t
 
     def __len__(self) -> int:
         return self.config.num_train_timesteps

--- a/src/diffusers/schedulers/scheduling_dpm_cogvideox.py
+++ b/src/diffusers/schedulers/scheduling_dpm_cogvideox.py
@@ -467,7 +467,7 @@ class CogVideoXDPMScheduler(SchedulerMixin, ConfigMixin):
         # - pred_prev_sample -> "x_t-1"
 
         # 1. get previous step value (=t-1)
-        prev_timestep = timestep - self.config.num_train_timesteps // self.num_inference_steps
+        prev_timestep = self.previous_timestep(timestep)
 
         # 2. compute alphas, betas
         alpha_prod_t = self.alphas_cumprod[timestep]
@@ -598,6 +598,25 @@ class CogVideoXDPMScheduler(SchedulerMixin, ConfigMixin):
 
         velocity = sqrt_alpha_prod * noise - sqrt_one_minus_alpha_prod * sample
         return velocity
+
+    def previous_timestep(self, timestep: int) -> torch.Tensor:
+        """
+        Find the previous timestep in the scheduler's timestep schedule.
+
+        Args:
+            timestep (`int`):
+                The current timestep.
+
+        Returns:
+            `torch.Tensor`:
+                The previous timestep. Returns -1 if the current timestep is the last one.
+        """
+        index = (self.timesteps == timestep).nonzero(as_tuple=True)[0][0]
+        if index == self.timesteps.shape[0] - 1:
+            prev_t = torch.tensor(-1)
+        else:
+            prev_t = self.timesteps[index + 1]
+        return prev_t
 
     def __len__(self) -> int:
         return self.config.num_train_timesteps


### PR DESCRIPTION
## Summary

- **Bug:** `CogVideoXDDIMScheduler.step()` and `CogVideoXDPMScheduler.step()` compute `prev_timestep` using `timestep - num_train_timesteps // num_inference_steps`, which only works correctly when `timestep_spacing="leading"`. For `"linspace"` or `"trailing"` spacing, timesteps are not uniformly spaced by that stride, so the formula produces incorrect previous timestep values and wrong `alpha_prod_t_prev` lookups, leading to degraded or incorrect denoising.

- **Fix:** Replace the hardcoded arithmetic with a `previous_timestep()` method that looks up the actual next entry in `self.timesteps`, matching the approach already used by `DDPMScheduler.previous_timestep()`.

## Files Changed

- `src/diffusers/schedulers/scheduling_ddim_cogvideox.py` — use `previous_timestep()` in `step()`, add method
- `src/diffusers/schedulers/scheduling_dpm_cogvideox.py` — use `previous_timestep()` in `step()`, add method

## Test plan

- [ ] Verify existing CogVideoX scheduler tests pass with no regressions
- [ ] Run `CogVideoXDDIMScheduler` with `timestep_spacing="trailing"` and confirm `prev_timestep` values now match the actual timestep schedule
- [ ] Run `CogVideoXDPMScheduler` with `timestep_spacing="linspace"` and confirm correct behavior