### PR TITLE
[CI] Fix `setuptools` `pkg_resources` Errors

### DIFF
--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -126,6 +126,11 @@ jobs:
 
     - name: Install dependencies
       run: |
+        # Install pkgs which depend on setuptools<81 for pkg_resources first with no build isolation
+        uv pip install pip==25.2 setuptools==80.10.2
+        uv pip install --no-build-isolation k-diffusion==0.0.12
+        uv pip install --upgrade pip setuptools
+        # Install the rest as normal
         uv pip install -e ".[quality]"
         uv pip install peft@git+https://github.com/huggingface/peft.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git


### PR DESCRIPTION
# What does this PR do?

`setuptools` removed the `pkg_resources` module in version 81 (see e.g. [this page in the `setuptools` docs](https://setuptools.pypa.io/en/latest/deprecated/pkg_resources.html)), but some dependencies have not migrated away from it yet and thus fail with an error like

```bash
ModuleNotFoundError: No module named 'pkg_resources'
```

when testing dependencies on the CI (example: https://github.com/huggingface/diffusers/actions/runs/21893622907/job/63204915410?pr=12976).

This PR attempts to fix these errors in the CI by installing those dependencies with a previous version of `setuptools` that does contain `pkg_resources`, while installing all other packages as normal.

Packages currently known to have this issue:
- `k-diffusion` (pinned at `k-diffusion==0.0.12`)


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul
@DN6

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
