### PR TITLE
[CI] Fix `setuptools` `pkg_resources` Bug for PR GPU Tests

### DIFF
--- a/.github/workflows/pr_tests_gpu.yml
+++ b/.github/workflows/pr_tests_gpu.yml
@@ -199,6 +199,11 @@ jobs:
 
     - name: Install dependencies
       run: |
+        # Install pkgs which depend on setuptools<81 for pkg_resources first with no build isolation
+        uv pip install pip==25.2 setuptools==80.10.2
+        uv pip install --no-build-isolation k-diffusion==0.0.12
+        uv pip install --upgrade pip setuptools
+        # Install the rest as normal
         uv pip install -e ".[quality]"
         uv pip install peft@git+https://github.com/huggingface/peft.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git


### PR DESCRIPTION
# What does this PR do?

This PR is a follow-up to #13129 which attempts to fix the same error for the `pr_tests_gpu.yml` workflow, which performs GPU tests for PRs.

The fix is currently the same as in the previous PR, but I'm not sure how to confirm that the previous fix is indeed working - I manually ran `push_tests.yml` in https://github.com/huggingface/diffusers/actions/runs/21971315738 on current `main` (5f3ea22513d63d0914cf8946d47722cda6180ff6) with that PR merged and it looks like `Torch CUDA Tests (others)` still has the same errors (https://github.com/huggingface/diffusers/actions/runs/21971315738/job/63473305519):

```bash
 =========================== short test summary info ============================
FAILED tests/others/test_dependencies.py::DependencyTester::test_backend_registration - RuntimeError: Failed to import diffusers.pipelines.stable_diffusion_k_diffusion.pipeline_stable_diffusion_k_diffusion because of the following error (look up to see its traceback):
No module named 'pkg_resources'
FAILED tests/others/test_dependencies.py::DependencyTester::test_pipeline_imports - RuntimeError: Failed to import diffusers.pipelines.stable_diffusion_k_diffusion.pipeline_stable_diffusion_k_diffusion because of the following error (look up to see its traceback):
No module named 'pkg_resources'
============ 2 failed, 69 passed, 11 skipped, 14 warnings in 21.42s ============
```

I think the fix is theoretically correct (assuming no mistakes or misunderstandings) but it seems like it might not have worked.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul
@DN6
