### PR TITLE
Fix missing .unsqueeze(1) in attention mask for HunyuanVideo VAE

### DIFF
--- a/src/diffusers/models/autoencoders/autoencoder_kl_hunyuanvideo15.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_hunyuanvideo15.py
@@ -145,7 +145,7 @@ class HunyuanVideo15AttnBlock(nn.Module):
             frames, height * width, query.dtype, query.device, batch_size=batch_size
         )
 
-        x = nn.functional.scaled_dot_product_attention(query, key, value, attn_mask=attention_mask)
+        x = nn.functional.scaled_dot_product_attention(query, key, value, attn_mask=attention_mask.unsqueeze(1))
 
         # batch_size, 1, frames * height * width, channels
 


### PR DESCRIPTION

# What does this PR do?
This PR fixes a dimension mismatch in the attention mask handling for the HunyuanVideo1.5 VAE implementation in `autoencoder_kl_hunyuanvideo15.py`.  

#### Problem  
In the current implementation (line 148 of `autoencoder_kl_hunyuanvideo15.py`), the `attention_mask` is passed directly to `scaled_dot_product_attention` without reshaping:  
```python
x = nn.functional.scaled_dot_product_attention(query, key, value, attn_mask=attention_mask)
```  
However, the original HuanyuanVideo implementation (line 211 of `huanyuanvideo_15_vae.py`) correctly applies `.unsqueeze(1)` to the mask:  
```python
h_ = nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=attention_mask.unsqueeze(1))
```  
This ensures the attention mask has the correct shape for batched attention computation. Without this, the mask dimensions may not align with the query/key/value tensors, leading to potential runtime errors or incorrect attention behavior.  

#### Fix  
Add `.unsqueeze(1)` to the `attention_mask` argument in the `scaled_dot_product_attention` call to match the original implementation.  

---

### Changes  
- **File**: `src/diffusers/models/autoencoder_kl_hunyuanvideo15.py`  
- **Line**: 148  
- **Before**:  
  ```python
  x = nn.functional.scaled_dot_product_attention(query, key, value, attn_mask=attention_mask)
  ```  
- **After**:  
  ```python
  x = nn.functional.scaled_dot_product_attention(query, key, value, attn_mask=attention_mask.unsqueeze(1))
  ```  

---

# Who can review?
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yiyixuxu 
@asomoza 
@sayakpaul  
@DN6