### PR TITLE
fix guider 

### DIFF
--- a/src/diffusers/guiders/guider_utils.py
+++ b/src/diffusers/guiders/guider_utils.py
@@ -54,7 +54,7 @@ class BaseGuidance(ConfigMixin, PushToHubMixin):
         self._timestep: torch.LongTensor = None
         self._count_prepared = 0
         self._input_fields: dict[str, str | tuple[str, str]] = None
-        self._enabled = True
+        self._enabled = enabled
 
         if not (0.0 <= start < 1.0):
             raise ValueError(f"Expected `start` to be between 0.0 and 1.0, but got {start}.")


### PR DESCRIPTION
was reverted in https://github.com/huggingface/diffusers/pull/12524/changes#r2807900601
z-image generate blury image otherwise 

```
import torch
from diffusers import ModularPipeline

device = "cuda"

# 1. Load the pipeline
# Use bfloat16 for optimal performance on supported GPUs
pipe = ModularPipeline.from_pretrained("Tongyi-MAI/Z-Image-Turbo")
print(f" pipe: {pipe}")
pipe.load_components(torch_dtype=torch.bfloat16)
pipe.to(device)

prompt = "Young Chinese woman in red Hanfu, intricate embroidery. Impeccable makeup, red floral forehead pattern. Elaborate high bun, golden phoenix headdress, red flowers, beads. Holds round folding fan with lady, trees, bird. Neon lightning-bolt lamp (⚡️), bright yellow glow, above extended left palm. Soft-lit outdoor night background, silhouetted tiered pagoda (西安大雁塔), blurred colorful distant lights."

# 2. Generate Image
out1 = pipe(
    prompt=prompt,
    height=1024,
    width=1024,
    generator=torch.Generator(device=device).manual_seed(42),
).images[0]

out1.save(f"{output_folder}/t2i_output.png")
print(f" saved t2i output to {output_folder}/t2i_output.png")
```