### PR TITLE
Support Flux Klein peft (fal) lora format

### DIFF
--- a/src/diffusers/loaders/lora_pipeline.py
+++ b/src/diffusers/loaders/lora_pipeline.py
@@ -5472,6 +5472,10 @@ class Flux2LoraLoaderMixin(LoraBaseMixin):
             logger.warning(warn_msg)
             state_dict = {k: v for k, v in state_dict.items() if "dora_scale" not in k}
 
+        is_peft_format = any(k.startswith("base_model.model.") for k in state_dict)
+        if is_peft_format:
+            state_dict = {k.replace("base_model.model.", "diffusion_model."): v for k, v in state_dict.items()}
+
         is_ai_toolkit = any(k.startswith("diffusion_model.") for k in state_dict)
         if is_ai_toolkit:
             state_dict = _convert_non_diffusers_flux2_lora_to_diffusers(state_dict)


### PR DESCRIPTION
FAL trained loras use the default peft key naming, this PR just rename them to the diffusers naming.

Fixes #13162

Tested with [this lora](https://huggingface.co/fal/flux-2-klein-4b-spritesheet-lora)

### code

```python
import torch

from diffusers import Flux2KleinPipeline
from diffusers.utils import load_image


device = "cuda"
dtype = torch.bfloat16

pipe = Flux2KleinPipeline.from_pretrained("black-forest-labs/FLUX.2-klein-4b", torch_dtype=dtype)
pipe.load_lora_weights(
    "fal/flux-2-klein-4b-spritesheet-lora",
    weight_name="flux-spritesheet-lora.safetensors",
)
pipe.enable_model_cpu_offload()

prompt = "2x2 sprite sheet"
image = load_image(
    "https://huggingface.co/datasets/OzzyGT/testing-resources/resolve/main/edit/julian-hochgesang-1fDZ4BijtG0-unsplash.jpg"
)

image = pipe(
    prompt=prompt,
    image=image,
    height=1024,
    width=1024,
    guidance_scale=1.0,
    num_inference_steps=4,
    generator=torch.Generator(device=device).manual_seed(42),
).images[0]
image.save("flux-klein.png")

```

|source image|result|
|---|---|
|![julian-hochgesang-1fDZ4BijtG0-unsplash](https://github.com/user-attachments/assets/70555620-4760-4b5a-87f0-d5650cfc443f)|<img width="1024" height="1024" alt="flux-klein" src="https://github.com/user-attachments/assets/410178ae-beac-4f84-9816-50d418f4d9f9" />|

## Who can review?

@christopher5106 @sayakpaul 