### PR TITLE
Fix wrong `do_classifier_free_guidance` threshold in ZImagePipeline

### DIFF
--- a/src/diffusers/pipelines/z_image/pipeline_z_image.py
+++ b/src/diffusers/pipelines/z_image/pipeline_z_image.py
@@ -276,7 +276,7 @@ class ZImagePipeline(DiffusionPipeline, ZImageLoraLoaderMixin, FromSingleFileMix
 
     @property
     def do_classifier_free_guidance(self):
-        return self._guidance_scale > 1
+        return self._guidance_scale > 0
 
     @property
     def joint_attention_kwargs(self):


### PR DESCRIPTION
## Summary
- Z-Image uses a different CFG formula: `pred = pos + guidance_scale * (pos - neg)`, where `guidance_scale = 0` corresponds to no guidance
- The `do_classifier_free_guidance` property was checking `> 1` (standard diffusers convention), but for this formula it should be `> 0`
- This caused `guidance_scale` values between 0 and 1 (e.g. 0.5) to be silently ignored

Fixes #12905