### PR TITLE
Fix mutable default arguments, resource leak, and redundant assignment

### DIFF
--- a/src/diffusers/models/model_loading_utils.py
+++ b/src/diffusers/models/model_loading_utils.py
@@ -172,7 +172,8 @@ def load_state_dict(
                 with dduf_entries[checkpoint_file].as_mmap() as mm:
                     return safetensors.torch.load(mm)
             if disable_mmap:
-                return safetensors.torch.load(open(checkpoint_file, "rb").read())
+                with open(checkpoint_file, "rb") as f:
+                    return safetensors.torch.load(f.read())
             else:
                 return safetensors.torch.load_file(checkpoint_file, device=map_location)
         elif file_extension == GGUF_FILE_EXTENSION:

--- a/src/diffusers/models/unets/unet_stable_cascade.py
+++ b/src/diffusers/models/unets/unet_stable_cascade.py
@@ -38,7 +38,7 @@ class SDCascadeLayerNorm(nn.LayerNorm):
 
 
 class SDCascadeTimestepBlock(nn.Module):
-    def __init__(self, c, c_timestep, conds=[]):
+    def __init__(self, c, c_timestep, conds=()):
         super().__init__()
 
         self.mapper = nn.Linear(c_timestep, c * 2)

--- a/src/diffusers/modular_pipelines/stable_diffusion_xl/denoise.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_xl/denoise.py
@@ -341,7 +341,7 @@ class StableDiffusionXLControlNetLoopDenoiser(ModularPipelineBlocks):
         ]
 
     @staticmethod
-    def prepare_extra_kwargs(func, exclude_kwargs=[], **kwargs):
+    def prepare_extra_kwargs(func, exclude_kwargs=(), **kwargs):
         accepted_kwargs = set(inspect.signature(func).parameters.keys())
         extra_kwargs = {}
         for key, value in kwargs.items():
@@ -498,7 +498,7 @@ class StableDiffusionXLLoopAfterDenoiser(ModularPipelineBlocks):
 
     # YiYi TODO: move this out of here
     @staticmethod
-    def prepare_extra_kwargs(func, exclude_kwargs=[], **kwargs):
+    def prepare_extra_kwargs(func, exclude_kwargs=(), **kwargs):
         accepted_kwargs = set(inspect.signature(func).parameters.keys())
         extra_kwargs = {}
         for key, value in kwargs.items():
@@ -584,7 +584,7 @@ class StableDiffusionXLInpaintLoopAfterDenoiser(ModularPipelineBlocks):
         return [OutputParam("latents", type_hint=torch.Tensor, description="The denoised latents")]
 
     @staticmethod
-    def prepare_extra_kwargs(func, exclude_kwargs=[], **kwargs):
+    def prepare_extra_kwargs(func, exclude_kwargs=(), **kwargs):
         accepted_kwargs = set(inspect.signature(func).parameters.keys())
         extra_kwargs = {}
         for key, value in kwargs.items():

--- a/src/diffusers/quantizers/gguf/utils.py
+++ b/src/diffusers/quantizers/gguf/utils.py
@@ -124,7 +124,9 @@ def _create_accelerate_new_hook(old_hook):
     return new_hook
 
 
-def _replace_with_gguf_linear(model, compute_dtype, state_dict, prefix="", modules_to_not_convert=[]):
+def _replace_with_gguf_linear(model, compute_dtype, state_dict, prefix="", modules_to_not_convert=None):
+    if modules_to_not_convert is None:
+        modules_to_not_convert = []
     def _should_convert_to_gguf(state_dict, prefix):
         weight_key = prefix + "weight"
         return weight_key in state_dict and isinstance(state_dict[weight_key], GGUFParameter)
@@ -157,7 +159,9 @@ def _replace_with_gguf_linear(model, compute_dtype, state_dict, prefix="", modul
     return model
 
 
-def _dequantize_gguf_and_restore_linear(model, modules_to_not_convert=[]):
+def _dequantize_gguf_and_restore_linear(model, modules_to_not_convert=None):
+    if modules_to_not_convert is None:
+        modules_to_not_convert = []
     for name, module in model.named_children():
         if isinstance(module, GGUFLinear) and name not in modules_to_not_convert:
             device = module.weight.device

--- a/src/diffusers/utils/loading_utils.py
+++ b/src/diffusers/utils/loading_utils.py
@@ -38,7 +38,7 @@ def load_image(
                 f"Incorrect path or URL. URLs must start with `http://` or `https://`, and {image} is not a valid path."
             )
     elif isinstance(image, PIL.Image.Image):
-        image = image
+        pass
     else:
         raise ValueError(
             "Incorrect format used for the image. Should be a URL linking to an image, a local path, or a PIL image."


### PR DESCRIPTION
## What does this PR do?

Fixes several latent bugs across the codebase:

**Mutable default arguments** (shared state across calls):
- `_replace_with_gguf_linear`: `modules_to_not_convert=[]` -> `None` with guard
- `_dequantize_gguf_and_restore_linear`: same pattern
- `SDCascadeTimestepBlock.__init__`: `conds=[]` -> `conds=()`
- `prepare_extra_kwargs` (3 occurrences): `exclude_kwargs=[]` -> `exclude_kwargs=()`

**Resource leak**:
- `model_loading_utils.py`: `open(checkpoint_file, "rb").read()` never closes the file handle; wrapped with a context manager

**Dead code**:
- `loading_utils.py`: `image = image` self-assignment replaced with `pass`