### PR TITLE
Fixing Kohya loras loading: Flux.1-dev loras with TE ("lora_te1_" prefix)

### DIFF
--- a/src/diffusers/loaders/lora_conversion_utils.py
+++ b/src/diffusers/loaders/lora_conversion_utils.py
@@ -824,7 +824,6 @@ def _convert_kohya_flux_lora_to_diffusers(state_dict):
     if not has_mixture:
         state_dict = {k.replace("diffusion_model.", "lora_unet_"): v for k, v in state_dict.items()}
         state_dict = {k.replace("text_encoders.clip_l.transformer.", "lora_te_"): v for k, v in state_dict.items()}
-        state_dict = {k.replace("text_encoders.clip_l.transformer.", "lora_te1_"): v for k, v in state_dict.items()}
 
         has_position_embedding = any("position_embedding" in k for k in state_dict)
         if has_position_embedding:


### PR DESCRIPTION
Text encoder lora layers are dropped for some loras such as [this one](https://huggingface.co/scenario-labs/big-head-kontext-lora/blob/main/flux_kontext_lora.safetensors)
A log message confirms it:
`No LoRA keys associated to CLIPTextModel found with the prefix='text_encoder'. This is safe to ignore if LoRA state dict didn't originally have any CLIPTextModel related params. You can also try specifying prefix=None to resolve the warning. Otherwise, open an issue if you think it's unexpected: https://github.com/huggingface/diffusers/issues/new
`
At least, this PR brings more consistency (wherever there is lora_te_, there should be also lora_te1_)

Closes https://github.com/huggingface/diffusers/issues/12053

Reproducers:


FLUX.1 Dev
```python
import torch
from diffusers import FluxPipeline

pipe = FluxPipeline.from_pretrained(
    "black-forest-labs/FLUX.1-dev", torch_dtype=torch.bfloat16
)

pipe.load_lora_weights(
    "scenario-labs/kohya-sd-scripts-loras", weight_name="flux_lora.safetensors",
)
```

FLUX.1 Kontext
```python
import torch
from diffusers import FluxKontextPipeline

pipe = FluxKontextPipeline.from_pretrained(
    "black-forest-labs/FLUX.1-Kontext-dev", torch_dtype=torch.bfloat16
)

pipe.load_lora_weights(
    "scenario-labs/big-head-kontext-lora", weight_name="flux_kontext_lora.safetensors",
)
```

The Loras have been trained with [Kohya/sd-scripts](https://github.com/kohya-ss/sd-scripts) framework.
With the fix of this PR, the warning message disappears, solving the drop of layers for the text encoder.

@sayakpaul 