### PR TITLE
Fix for loading of Kohya's Musubi tuner's Flux.2 dev lora

### DIFF
--- a/src/diffusers/loaders/lora_pipeline.py
+++ b/src/diffusers/loaders/lora_pipeline.py
@@ -5476,6 +5476,16 @@ class Flux2LoraLoaderMixin(LoraBaseMixin):
         if is_peft_format:
             state_dict = {k.replace("base_model.model.", "diffusion_model."): v for k, v in state_dict.items()}
 
+        is_kohya = any(".lora_down.weight" in k for k in state_dict)
+        if is_kohya:
+            state_dict = _convert_kohya_flux_lora_to_diffusers(
+                state_dict, 
+                version_flux2=True,
+            )
+            # Kohya already takes care of scaling the LoRA parameters with alpha.
+            for k in  state_dict:
+                assert "alpha" not in k, f"Found key with alpha: {k}"
+
         is_ai_toolkit = any(k.startswith("diffusion_model.") for k in state_dict)
         if is_ai_toolkit:
             state_dict = _convert_non_diffusers_flux2_lora_to_diffusers(state_dict)


### PR DESCRIPTION
I added support for Kohya's Flux.2 loras to the PR as well.

Reproducer code is:

FLUX.2 Dev
```python
import torch
from diffusers import Flux2Pipeline

pipe = Flux2Pipeline.from_pretrained("black-forest-labs/FLUX.2-dev", torch_dtype=torch.bfloat16)
pipe.load_lora_weights(
    "scenario-labs/musubi-tuner-loras", weight_name="flux2-dev_lora.safetensors",
)
```

FLUX.2 Klein
```python
import torch
from diffusers import Flux2Pipeline

pipe = Flux2Pipeline.from_pretrained("black-forest-labs/FLUX.2-klein-4b", torch_dtype=torch.bfloat16)
pipe.load_lora_weights(
    "scenario-labs/musubi-tuner-loras", weight_name="flux2-klein-4b_lora.safetensors",
)
```

Without the fix, I previously got:
`No LoRA keys associated to Flux2Transformer2DModel found with the prefix='transformer'. This is safe to ignore if LoRA state dict didn't originally have any Flux2Transformer2DModel related params. You can also try specifying `prefix=None` to resolve the warning. Otherwise, open an issue if you think it's unexpected: https://github.com/huggingface/diffusers/issues/new`

With this PR, on-the-fly conversion now works for Flux.2-dev loras also.

In this implementation, I preserved the logic of `_convert_kohya_flux_lora_to_diffusers()`, with little differences: first I infer the max number of blocks from the state dict keys, second, I had to fix loras keys for the new modules `Flux2FeedForward `and `Flux2ParallelSelfAttnProcessor`.