### PR TITLE
Fix None dereference crashes and mutable default feat_idx in Wan/Cosmos autoencoders

### DIFF
--- a/src/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_cosmos.py
@@ -111,7 +111,10 @@ class CosmosPatchEmbed3d(nn.Module):
         self.patch_size = patch_size
         self.patch_method = patch_method
 
-        wavelets = _WAVELETS.get(patch_method).clone()
+        wavelets = _WAVELETS.get(patch_method)
+        if wavelets is None:
+            raise ValueError(f"Unknown patch_method '{patch_method}'. Supported methods: {list(_WAVELETS.keys())}")
+        wavelets = wavelets.clone()
         arange = torch.arange(wavelets.shape[0])
 
         self.register_buffer("wavelets", wavelets, persistent=False)
@@ -191,7 +194,10 @@ class CosmosUnpatcher3d(nn.Module):
         self.patch_size = patch_size
         self.patch_method = patch_method
 
-        wavelets = _WAVELETS.get(patch_method).clone()
+        wavelets = _WAVELETS.get(patch_method)
+        if wavelets is None:
+            raise ValueError(f"Unknown patch_method '{patch_method}'. Supported methods: {list(_WAVELETS.keys())}")
+        wavelets = wavelets.clone()
         arange = torch.arange(wavelets.shape[0])
 
         self.register_buffer("wavelets", wavelets, persistent=False)

--- a/src/diffusers/models/autoencoders/autoencoder_kl_wan.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_wan.py
@@ -259,7 +259,9 @@ class WanResample(nn.Module):
         else:
             self.resample = nn.Identity()
 
-    def forward(self, x, feat_cache=None, feat_idx=[0]):
+    def forward(self, x, feat_cache=None, feat_idx=None):
+        if feat_idx is None:
+            feat_idx = [0]
         b, c, t, h, w = x.size()
         if self.mode == "upsample3d":
             if feat_cache is not None:
@@ -336,7 +338,9 @@ class WanResidualBlock(nn.Module):
         self.conv2 = WanCausalConv3d(out_dim, out_dim, 3, padding=1)
         self.conv_shortcut = WanCausalConv3d(in_dim, out_dim, 1) if in_dim != out_dim else nn.Identity()
 
-    def forward(self, x, feat_cache=None, feat_idx=[0]):
+    def forward(self, x, feat_cache=None, feat_idx=None):
+        if feat_idx is None:
+            feat_idx = [0]
         # Apply shortcut connection
         h = self.conv_shortcut(x)
 
@@ -449,7 +453,9 @@ class WanMidBlock(nn.Module):
 
         self.gradient_checkpointing = False
 
-    def forward(self, x, feat_cache=None, feat_idx=[0]):
+    def forward(self, x, feat_cache=None, feat_idx=None):
+        if feat_idx is None:
+            feat_idx = [0]
         # First residual block
         x = self.resnets[0](x, feat_cache=feat_cache, feat_idx=feat_idx)
 
@@ -489,7 +495,9 @@ class WanResidualDownBlock(nn.Module):
         else:
             self.downsampler = None
 
-    def forward(self, x, feat_cache=None, feat_idx=[0]):
+    def forward(self, x, feat_cache=None, feat_idx=None):
+        if feat_idx is None:
+            feat_idx = [0]
         x_copy = x.clone()
         for resnet in self.resnets:
             x = resnet(x, feat_cache=feat_cache, feat_idx=feat_idx)
@@ -580,7 +588,9 @@ class WanEncoder3d(nn.Module):
 
         self.gradient_checkpointing = False
 
-    def forward(self, x, feat_cache=None, feat_idx=[0]):
+    def forward(self, x, feat_cache=None, feat_idx=None):
+        if feat_idx is None:
+            feat_idx = [0]
         if feat_cache is not None:
             idx = feat_idx[0]
             cache_x = x[:, :, -CACHE_T:, :, :].clone()
@@ -677,7 +687,7 @@ class WanResidualUpBlock(nn.Module):
 
         self.gradient_checkpointing = False
 
-    def forward(self, x, feat_cache=None, feat_idx=[0], first_chunk=False):
+    def forward(self, x, feat_cache=None, feat_idx=None, first_chunk=False):
         """
         Forward pass through the upsampling block.
 
@@ -689,6 +699,8 @@ class WanResidualUpBlock(nn.Module):
         Returns:
             torch.Tensor: Output tensor
         """
+        if feat_idx is None:
+            feat_idx = [0]
         x_copy = x.clone()
 
         for resnet in self.resnets:
@@ -752,7 +764,7 @@ class WanUpBlock(nn.Module):
 
         self.gradient_checkpointing = False
 
-    def forward(self, x, feat_cache=None, feat_idx=[0], first_chunk=None):
+    def forward(self, x, feat_cache=None, feat_idx=None, first_chunk=None):
         """
         Forward pass through the upsampling block.
 
@@ -764,6 +776,8 @@ class WanUpBlock(nn.Module):
         Returns:
             torch.Tensor: Output tensor
         """
+        if feat_idx is None:
+            feat_idx = [0]
         for resnet in self.resnets:
             if feat_cache is not None:
                 x = resnet(x, feat_cache=feat_cache, feat_idx=feat_idx)
@@ -869,7 +883,9 @@ class WanDecoder3d(nn.Module):
 
         self.gradient_checkpointing = False
 
-    def forward(self, x, feat_cache=None, feat_idx=[0], first_chunk=False):
+    def forward(self, x, feat_cache=None, feat_idx=None, first_chunk=False):
+        if feat_idx is None:
+            feat_idx = [0]
         ## conv1
         if feat_cache is not None:
             idx = feat_idx[0]

--- a/src/diffusers/models/model_loading_utils.py
+++ b/src/diffusers/models/model_loading_utils.py
@@ -117,7 +117,7 @@ def _determine_device_map(
 
 def _fetch_remapped_cls_from_config(config, old_class):
     previous_class_name = old_class.__name__
-    remapped_class_name = _CLASS_REMAPPING_DICT.get(previous_class_name).get(config["norm_type"], None)
+    remapped_class_name = _CLASS_REMAPPING_DICT.get(previous_class_name, {}).get(config["norm_type"], None)
 
     # Details:
     # https://github.com/huggingface/diffusers/pull/7647#discussion_r1621344818


### PR DESCRIPTION
## What does this PR do?

Fixes None dereference crashes and a mutable default argument bug:

**1. `models/model_loading_utils.py`** - `_fetch_remapped_cls_from_config` used chained `.get().get()` without a fallback on the first call. If `previous_class_name` is not in `_CLASS_REMAPPING_DICT`, the first `.get()` returns `None` and the second `.get()` crashes with `AttributeError`.

**2. `models/autoencoders/autoencoder_kl_cosmos.py`** - Both `CosmosPatchEmbed3d` and `CosmosUnpatcher3d` call `_WAVELETS.get(patch_method).clone()`. If `patch_method` is not a recognized wavelet type, `.get()` returns `None` and `.clone()` crashes with `AttributeError`.

**3. `models/autoencoders/autoencoder_kl_wan.py`** - 8 `forward()` methods used `feat_idx=[0]` as a mutable default argument. Since the list is actively mutated via `feat_idx[0] += 1` during forward passes, the shared default list accumulates state across calls, corrupting the cache index on subsequent invocations.