### PR TITLE
skip invalid test case for helios pipeline

### DIFF
--- a/tests/pipelines/helios/test_helios.py
+++ b/tests/pipelines/helios/test_helios.py
@@ -139,7 +139,7 @@ class HeliosPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         generated_slice = torch.cat([generated_slice[:8], generated_slice[-8:]])
         self.assertTrue(torch.allclose(generated_slice, expected_slice, atol=1e-3))
 
-    @unittest.skip("Latents are always processed in FP32. Save/Load the entire pipeline in FP16 will result in errors")
+    @unittest.skip("Helios uses a lot of mixed precision internally, which is not suitable for this test case")
     def test_save_load_float16(self):
         pass
 


### PR DESCRIPTION
In helios pipeline, the latents are always in FP32 format: [L798](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/helios/pipeline_helios.py#L798), hence we should skip the test_save_load_float16 test case, rather than adjust the tolerance.