### PR TITLE
Refactor `AttentionProcessorSkipHook` to Support Custom STG Logic

### DIFF
--- a/src/diffusers/hooks/layer_skip.py
+++ b/src/diffusers/hooks/layer_skip.py
@@ -111,9 +111,9 @@ class AttentionProcessorSkipHook(ModelHook):
     def __init__(
         self,
         skip_processor_output_fn: Callable,
-        skip_attn_scores_fn: Callable | None = None,
         skip_attention_scores: bool = False,
         dropout: float = 1.0,
+        skip_attn_scores_fn: Callable | None = None,
     ):
         super().__init__()
         self.skip_processor_output_fn = skip_processor_output_fn


### PR DESCRIPTION
# What does this PR do?

This PR refactors `AttentionProcessorSkipHook` to support attention processors with a `_skip_attn_scores` flag, which is meant to allow attention processors to specify custom [spatio-temporal guidance (STG)](https://arxiv.org/abs/2411.18664)-like logic. The idea is that an `AttentionProcessor` could then be implemented as follows:

```python
class NewAttnProcessor:
    ...
    _skip_attn_scores = False
    _skip_attn_scores_fn = None

    def __call__(self, attn, hidden_states, ...):
        ...
        query = attn.to_q(hidden_states)
        key = attn.to_k(encoder_hidden_states)
        value = attn.to_v(encoder_hidden_states)
        ...
        if self._skip_attn_scores:
            # Defaults to returning `value` as in standard STG
            hidden_states = self._skip_attn_scores_fn(attn, query, key, value)
        else:
            ...
            hidden_states = dispatch_attention_fn(query, key, value, ...)
        ...
        hidden_states = attn.to_out[0](hidden_states)
        hidden_states = attn.to_out[1](hidden_states)
        return hidden_states
```

This is motivated by supporting the following use cases:

1. **Supporting all attention backends**: the current implementation intercepts calls to `F.scaled_dot_product_attention`. But other attention backends like `flash-attn` won't call this function. The PR allows `SkipLayerGuidance` to work with any attention backend. (If the `AttnProcessor` doesn't have a `_skip_attn_scores` attribute, we will fall back to the current intercept approach.)
2. **Custom Skip Logic**: we can define custom logic in the `_skip_attn_scores_fn`. For example, LTX-2.3 applies learned per-head gates to the `value`s before passing them to the attention output projection `to_out`. This can be implemented `_skip_attn_scores_fn`.

Inspired by #13217, particularly https://github.com/huggingface/diffusers/pull/13217#discussion_r2898260578.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yiyixuxu
@sayakpaul

