### PR TITLE
[CI] Potential fix for code scanning alert no. 2150: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_tests_gpu.yml
+++ b/.github/workflows/pr_tests_gpu.yml
@@ -1,5 +1,8 @@
 name: Fast GPU Tests on PR
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: main


### PR DESCRIPTION
Potential fix for [https://github.com/huggingface/diffusers/security/code-scanning/2150](https://github.com/huggingface/diffusers/security/code-scanning/2150)

In general, this issue is fixed by adding an explicit `permissions` block to the workflow (at the root or per job) that grants only the scopes required. For a test/CI workflow that just checks out code, installs dependencies, runs tests, and uploads artifacts, `contents: read` is usually sufficient globally. If no job needs to write to the repo, issues, or PRs, you should not grant any write permissions.

For this specific workflow in `.github/workflows/pr_tests_gpu.yml`, the simplest and safest fix without changing functionality is to add a root-level `permissions` block that applies to all jobs. None of the shown jobs push commits, manage releases, or modify issues/PRs; they only read the repository contents and upload artifacts, which do not require additional token scopes. Therefore, add:

```yaml
permissions:
  contents: read
```

near the top of the file (after `name:` and before `on:`). This constrains the `GITHUB_TOKEN` for all jobs, resolving the CodeQL warning about `needs: check_code_quality` and ensuring least-privilege access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
