### PR TITLE
[CI] Add Workflow permissions to PR tests

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -16,6 +16,9 @@ on:
     branches:
       - ci-*
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/huggingface/diffusers/security/code-scanning/2147](https://github.com/huggingface/diffusers/security/code-scanning/2147)

In general, the fix is to explicitly set a `permissions` block in the workflow (at the top level or per job) so that `GITHUB_TOKEN` has only the minimal required scopes. Since all shown steps only need to read repository contents and do not interact with issues, pull requests, or other write-requiring APIs, the safest minimal configuration is `permissions: contents: read` at the workflow root, which applies to all jobs.

The best fix here, without changing existing functionality, is to add a top-level `permissions` section after the `on:` block (or before `concurrency:`), so every job gets read-only access to repository contents. No job currently appears to need write access, so this should not break anything. Concretely, in `.github/workflows/pr_tests.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block ending at line 17–18 and the `concurrency:` block starting at line 19. No imports or additional methods are needed, since this is purely YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
