### PR TITLE
Fix error message in gguf_quantizer.py

### DIFF
--- a/src/diffusers/quantizers/gguf/gguf_quantizer.py
+++ b/src/diffusers/quantizers/gguf/gguf_quantizer.py
@@ -84,7 +84,7 @@ class GGUFQuantizer(DiffusersQuantizer):
         inferred_shape = _quant_shape_from_byte_shape(loaded_param_shape, type_size, block_size)
         if inferred_shape != current_param_shape:
             raise ValueError(
-                f"{param_name} has an expected quantized shape of: {inferred_shape}, but received shape: {loaded_param_shape}"
+                f"{param_name} has an expected quantized shape of: {current_param_shape}, but received shape: {inferred_shape} (inferred from byte shape {loaded_param_shape})"
             )
 
         return True


### PR DESCRIPTION
# What does this PR do?

I believe that the error message was wrong, since the shapes mentionned did not match the test trigering the error. I think that there is also an ambiguity on what is meant by "quantized" shape: the value returned by the function `_quant_shape_from_byte_shape()` is used in `dequantize_gguf_tensor()` as the shape of the dequantized tensor, but the name of `_quant_shape_from_byte_shape()` suggests that what it returns is the shape of the quantized tensor. I found it safer to remove the term "quantized" from the error message.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).


## Who can review?

@stevhliu @sayakpaul @DN6 

