### PR TITLE
fix: restore module buffers during stream-based group offload

### DIFF
--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -246,6 +246,8 @@ class ModuleGroup:
             for group_module in self.modules:
                 for param in group_module.parameters():
                     param.data = self.cpu_param_dict[param]
+                for buffer in group_module.buffers():
+                    buffer.data = self.cpu_param_dict[buffer]
             for param in self.parameters:
                 param.data = self.cpu_param_dict[param]
             for buffer in self.buffers:


### PR DESCRIPTION
## Description

In `_offload_to_memory()`, when using CUDA streams (`self.stream is not None`), module buffers from `self.modules` were not being restored to their CPU tensor copies during offload. This created an asymmetry with both `_build_cpu_param_dict()` and `_process_tensors_from_modules()` (used during onload), which correctly iterate over `group_module.buffers()`.

### The bug

| Method | `group_module.parameters()` | `group_module.buffers()` | `self.parameters` | `self.buffers` |
|--------|:---:|:---:|:---:|:---:|
| `_build_cpu_param_dict` | ✅ | ✅ | ✅ | ✅ |
| `_process_tensors_from_modules` (onload) | ✅ | ✅ | ✅ | ✅ |
| `_offload_to_memory` (stream path) | ✅ | ❌ **missing** | ✅ | ✅ |
| `_offload_to_memory` (non-stream path) | ✅ (via `.to()`) | ✅ (via `.to()`) | ✅ | ✅ |

The non-stream path uses `group_module.to(self.offload_device)` which correctly moves all parameters and buffers. The stream path manually iterates but was missing the buffer loop.

### Impact

- Module buffers (e.g., `running_mean`/`running_var` in normalization layers) remain on GPU after offload
- On the next onload cycle, stale GPU buffer data may be used instead of the correct CPU copies
- This could contribute to NaN values when using `record_stream=True` with group offloading (related: #12613)
- Minor GPU memory leak from unreleased buffer tensors

### Fix

Added the missing `group_module.buffers()` loop in the stream path of `_offload_to_memory()`, making it symmetric with the onload path.

### Related Issues

- #12613 (NaN latents with `record_stream=True` in group offloading)