### PR TITLE
fix: deduplicate timesteps in DPMSolverMultistepScheduler to prevent IndexError

### DIFF
--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -442,15 +442,11 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_karras(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
-            if self.config.beta_schedule != "squaredcos_cap_v2":
-                timesteps = timesteps.round()
         elif self.config.use_lu_lambdas:
             lambdas = np.flip(log_sigmas.copy())
             lambdas = self._convert_to_lu(in_lambdas=lambdas, num_inference_steps=num_inference_steps)
             sigmas = np.exp(lambdas)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
-            if self.config.beta_schedule != "squaredcos_cap_v2":
-                timesteps = timesteps.round()
         elif self.config.use_exponential_sigmas:
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_exponential(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
@@ -475,6 +471,17 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
             raise ValueError(
                 f"`final_sigmas_type` must be one of 'zero', or 'sigma_min', but got {self.config.final_sigmas_type}"
             )
+
+        # When sigma-to-timestep mapping produces duplicates after rounding to integer
+        # (e.g. cosine schedule with karras/lu sigmas where many sigmas map to nearly the same timestep),
+        # deduplicate while preserving order to prevent index out-of-bounds errors in multistep solvers.
+        # This mirrors the same fix in DPMSolverMultistepInverseScheduler.
+        timesteps = np.round(timesteps).astype(np.int64)
+        _, unique_indices = np.unique(timesteps, return_index=True)
+        unique_indices = np.sort(unique_indices)
+        if len(unique_indices) < len(timesteps):
+            timesteps = timesteps[unique_indices]
+            sigmas = sigmas[unique_indices]
 
         sigmas = np.concatenate([sigmas, [sigma_last]]).astype(np.float32)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #12771 — `DPMSolverMultistepScheduler` crashes with `IndexError: index N is out of bounds` when using `beta_schedule='squaredcos_cap_v2'` with `use_karras_sigmas=True` (or `use_lu_lambdas=True`).

### Root cause

With the cosine (`squaredcos_cap_v2`) noise schedule, the sigma-to-timestep mapping (`_sigma_to_t`) produces many nearly identical float values near the end of the schedule (e.g., 998.90, 998.80, 998.70...) that collapse to the same integer timestep (998) after casting to int64. The current code intentionally skips rounding for cosine schedules, but this only defers the problem — values like 998.9 and 998.8 still become 998 when converted to int64.

These duplicate timesteps cause `index_for_timestep` to return incorrect indices, making `step_index` drift past the `sigmas` array bounds, crashing at `self.sigmas[self.step_index + 1]`.

### Fix

1. **Round timesteps unconditionally** — remove the `squaredcos_cap_v2` exception for karras/lu sigma paths, since rounding is now handled centrally
2. **Deduplicate timesteps** after rounding — keep only the first occurrence of each unique value, preserving order
3. **Filter sigmas** to match the deduplicated timesteps
4. **Update `num_inference_steps`** to reflect the actual number of unique steps

This mirrors the existing deduplication logic already present in `DPMSolverMultistepInverseScheduler` (lines 358-359).

### Test results

| Config | Before | After |
|--------|--------|-------|
| `squaredcos_cap_v2` + `use_karras_sigmas` (20 steps) | ❌ IndexError at step 19 | ✅ 12 unique steps, all complete |
| `squaredcos_cap_v2` + `use_lu_lambdas` (20 steps) | ❌ IndexError | ✅ 17 unique steps, all complete |
| `linear` + `use_karras_sigmas` (20 steps) | ✅ | ✅ 20 steps (no duplicates, no change) |
| Default config (20 steps) | ✅ | ✅ 20 steps (no change) |

> **Note:** The reduced step count (e.g. 20 → 12) is expected. With cosine schedules, many karras sigmas map to nearly the same timestep, so those steps were effectively redundant. The sigmas array is filtered to match, so the solver still uses the correct sigma values for each unique timestep.

### Who can review?

@yiyixuxu (who engaged with the original issue)