### PR TITLE
fix: deduplicate timesteps in DPMSolverMultistep for squaredcos_cap_v2 + karras/lu sigmas

### DIFF
--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -442,15 +442,13 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_karras(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
-            if self.config.beta_schedule != "squaredcos_cap_v2":
-                timesteps = timesteps.round()
+            timesteps = timesteps.round()
         elif self.config.use_lu_lambdas:
             lambdas = np.flip(log_sigmas.copy())
             lambdas = self._convert_to_lu(in_lambdas=lambdas, num_inference_steps=num_inference_steps)
             sigmas = np.exp(lambdas)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
-            if self.config.beta_schedule != "squaredcos_cap_v2":
-                timesteps = timesteps.round()
+            timesteps = timesteps.round()
         elif self.config.use_exponential_sigmas:
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_exponential(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
@@ -466,6 +464,16 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
             timesteps = (sigmas * self.config.num_train_timesteps).copy()
         else:
             sigmas = np.interp(timesteps, np.arange(0, len(sigmas)), sigmas)
+
+        # When using karras or lu sigmas with certain beta schedules (e.g. squaredcos_cap_v2),
+        # the sigma-to-timestep mapping can produce duplicate integer timesteps. Deduplicate
+        # them to prevent the step index from drifting out of bounds during multistep updates.
+        timesteps_int = np.round(timesteps).astype(np.int64)
+        _, unique_indices = np.unique(timesteps_int, return_index=True)
+        if len(unique_indices) < len(timesteps_int):
+            unique_indices = np.sort(unique_indices)
+            timesteps = timesteps[unique_indices]
+            sigmas = sigmas[unique_indices]
 
         if self.config.final_sigmas_type == "sigma_min":
             sigma_last = ((1 - self.alphas_cumprod[0]) / self.alphas_cumprod[0]) ** 0.5


### PR DESCRIPTION
## Summary

Fixes #12771 — `DPMSolverMultistepScheduler` crashes with `IndexError: index 21 is out of bounds for dimension 0 with size 21` when using `beta_schedule='squaredcos_cap_v2'` with `use_karras_sigmas=True`.

## Root Cause

When using karras (or lu) sigmas with the cosine (`squaredcos_cap_v2`) beta schedule, `_sigma_to_t()` returns float timestep values that are extremely close together at the high end of the schedule:

```
[998.999, 998.903, 998.802, 998.696, 998.583, 998.464, 998.338, 998.203, 998.059, ...]
```

These were intentionally **not rounded** for the cosine schedule (unlike `linear` and `scaled_linear`), but since they're cast to `int64` downstream, they all collapse to the same value (998), creating 9 duplicate timesteps.

The duplicate timesteps cause `index_for_timestep()` to start at index 1 (it picks the second occurrence of duplicates). After 20 step iterations, `step_index` reaches 21, and the second-order update's `self.sigmas[self.step_index + 1]` goes out of bounds on a size-21 array.

## Fix

1. **Always round timesteps** for karras/lu sigma schedules — this matches the behavior of `DPMSolverSinglestepScheduler`, which already rounds unconditionally (line 386)
2. **Deduplicate timesteps and their corresponding sigmas** after rounding to prevent step index drift

When deduplication occurs, the number of effective inference steps is reduced (e.g., 20 requested → 12 unique). This is correct behavior since the redundant timesteps would have produced identical denoising steps anyway.

## Test Results

| Configuration | Before | After |
|---|---|---|
| `squaredcos_cap_v2` + `karras` (20 steps) | ❌ IndexError at step 19 | ✅ 12 unique steps, completes |
| `linear` + `karras` (20 steps) | ✅ | ✅ Unaffected (no duplicates) |
| `squaredcos_cap_v2` without karras | ✅ | ✅ Unaffected |
| `squaredcos_cap_v2` + `lu_lambdas` | ❌ Same index drift | ✅ 17 unique steps, completes |

## Reproduction

```python
from diffusers import DPMSolverMultistepScheduler
import torch

scheduler = DPMSolverMultistepScheduler(
    beta_schedule='squaredcos_cap_v2',
    use_karras_sigmas=True,
)
scheduler.set_timesteps(20)

latents = torch.randn(1, 4, 64, 64)
noise_pred = torch.randn_like(latents)
for i, t in enumerate(scheduler.timesteps):
    result = scheduler.step(noise_pred, t, latents)
    latents = result.prev_sample
# Before: IndexError at step 19
# After: Completes successfully
```
