### PR TITLE
Fix double-shifted sigma_min/sigma_max in FlowMatchEulerDiscreteScheduler

### DIFF
--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -127,6 +127,11 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         timesteps = torch.from_numpy(timesteps).to(dtype=torch.float32)
 
         sigmas = timesteps / num_train_timesteps
+
+        # Store unshifted bounds so set_timesteps() applies the shift exactly once
+        self.sigma_min = sigmas[-1].item()
+        self.sigma_max = sigmas[0].item()
+
         if not use_dynamic_shifting:
             # when use_dynamic_shifting is True, we apply the timestep shifting on the fly based on the image resolution
             sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)
@@ -139,8 +144,6 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         self._shift = shift
 
         self.sigmas = sigmas.to("cpu")  # to avoid too much CPU/GPU communication
-        self.sigma_min = self.sigmas[-1].item()
-        self.sigma_max = self.sigmas[0].item()
 
     @property
     def shift(self):

--- a/tests/schedulers/test_scheduler_flow_match_euler_discrete.py
+++ b/tests/schedulers/test_scheduler_flow_match_euler_discrete.py
@@ -1,0 +1,46 @@
+import torch
+
+from diffusers import FlowMatchEulerDiscreteScheduler
+
+
+class TestFlowMatchEulerDiscreteSchedulerSigmaConsistency:
+    """Regression tests for https://github.com/huggingface/diffusers/issues/13243"""
+
+    def test_set_timesteps_no_double_shift(self):
+        """Calling set_timesteps(num_train_timesteps) should reproduce the same sigmas as __init__.
+
+        set_timesteps appends a terminal zero, so we compare only the first N values.
+        """
+        scheduler = FlowMatchEulerDiscreteScheduler(num_train_timesteps=1000, shift=3.0)
+        sigmas_init = scheduler.sigmas.clone()
+
+        scheduler.set_timesteps(1000)
+        sigmas_after = scheduler.sigmas[:-1]  # drop appended terminal zero
+
+        torch.testing.assert_close(sigmas_init, sigmas_after, atol=1e-6, rtol=1e-5)
+
+    def test_set_timesteps_no_double_shift_various_shifts(self):
+        """The fix holds for different shift values."""
+        for shift in [1.0, 2.0, 3.0, 5.0]:
+            scheduler = FlowMatchEulerDiscreteScheduler(num_train_timesteps=1000, shift=shift)
+            sigmas_init = scheduler.sigmas.clone()
+
+            scheduler.set_timesteps(1000)
+            sigmas_after = scheduler.sigmas[:-1]
+
+            torch.testing.assert_close(
+                sigmas_init,
+                sigmas_after,
+                atol=1e-6,
+                rtol=1e-5,
+                msg=f"Sigma mismatch after set_timesteps with shift={shift}",
+            )
+
+    def test_set_timesteps_fewer_steps(self):
+        """set_timesteps with fewer steps should produce sigmas within the original range."""
+        scheduler = FlowMatchEulerDiscreteScheduler(num_train_timesteps=1000, shift=3.0)
+        scheduler.set_timesteps(50)
+
+        # All sigmas should fall within [0, 1]
+        assert scheduler.sigmas.min() >= 0.0
+        assert scheduler.sigmas.max() <= 1.0 + 1e-6


### PR DESCRIPTION
# What does this PR do?

Fixes a bug where `sigma_min` and `sigma_max` were computed from already-shifted sigmas in `__init__`, causing `set_timesteps()` to apply the shift formula twice.

Fixes #13243

## Root cause

In `__init__`, the shift `sigma = shift * sigma / (1 + (shift - 1) * sigma)` is applied at line 132, then `sigma_min`/`sigma_max` are stored from the shifted values (lines 142-143). When `set_timesteps()` uses these bounds to build the default timestep linspace (lines 336-337) and then applies the same shift formula again (line 350), the sigmas get double-shifted.

## Changes

- **`scheduling_flow_match_euler_discrete.py`**: Move `sigma_min`/`sigma_max` assignment to before the shift is applied, so `set_timesteps()` applies it exactly once.
- **`test_scheduler_flow_match_euler_discrete.py`**: Add regression tests verifying sigmas are consistent before and after `set_timesteps()`.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue? #13243
- [x] Did you write any new necessary tests?

## Who can review?

@yiyixuxu @a-r-r-o-w (scheduler maintainers)