### PR TITLE
fix: use .get() for alpha keys in lora_conversion_utils.py

### DIFF
--- a/src/diffusers/loaders/lora_conversion_utils.py
+++ b/src/diffusers/loaders/lora_conversion_utils.py
@@ -2538,8 +2538,12 @@ def _convert_non_diffusers_z_image_lora_to_diffusers(state_dict):
 
     def get_alpha_scales(down_weight, alpha_key):
         rank = down_weight.shape[0]
-        alpha = state_dict.pop(alpha_key).item()
-        scale = alpha / rank  # LoRA is scaled by 'alpha / rank' in forward pass, so we need to scale it back here
+        alpha_tensor = state_dict.pop(alpha_key, None)
+        if alpha_tensor is None:
+            return 1.0, 1.0
+        scale = (
+            alpha_tensor.item() / rank
+        )  # LoRA is scaled by 'alpha / rank' in forward pass, so we need to scale it back here
         scale_down = scale
         scale_up = 1.0
         while scale_down * 2 < scale_up:


### PR DESCRIPTION
## Summary
Use safe dict access for alpha keys when converting non-diffusers Z-Image LoRA to diffusers format. Some LoRA formats use different alpha key naming (e.g. `layers.0.adaLN_modulation.0.alpha`), causing KeyError.

## Root Cause
`state_dict.pop(alpha_key)` raises KeyError when the alpha key doesn't exist in the expected format.

## Fix
Use `state_dict.pop(alpha_key, None)` and fall back to rank when alpha is missing.

Fixes #13249