### PR TITLE
fix: wrap validation inference with torch.no_grad() in dreambooth examples

### DIFF
--- a/examples/dreambooth/train_dreambooth.py
+++ b/examples/dreambooth/train_dreambooth.py
@@ -175,16 +175,17 @@ def log_validation(
     # run inference
     generator = None if args.seed is None else torch.Generator(device=accelerator.device).manual_seed(args.seed)
     images = []
-    if args.validation_images is None:
-        for _ in range(args.num_validation_images):
-            with torch.autocast("cuda"):
-                image = pipeline(**pipeline_args, num_inference_steps=25, generator=generator).images[0]
-            images.append(image)
-    else:
-        for image in args.validation_images:
-            image = Image.open(image)
-            image = pipeline(**pipeline_args, image=image, generator=generator).images[0]
-            images.append(image)
+    with torch.no_grad():
+        if args.validation_images is None:
+            for _ in range(args.num_validation_images):
+                with torch.autocast("cuda"):
+                    image = pipeline(**pipeline_args, num_inference_steps=25, generator=generator).images[0]
+                images.append(image)
+        else:
+            for image in args.validation_images:
+                image = Image.open(image)
+                image = pipeline(**pipeline_args, image=image, generator=generator).images[0]
+                images.append(image)
 
     for tracker in accelerator.trackers:
         if tracker.name == "tensorboard":

--- a/examples/dreambooth/train_dreambooth_flux.py
+++ b/examples/dreambooth/train_dreambooth_flux.py
@@ -191,7 +191,7 @@ def log_validation(
     # autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
     autocast_ctx = nullcontext()
 
-    with autocast_ctx:
+    with torch.no_grad(), autocast_ctx:
         images = [pipeline(**pipeline_args, generator=generator).images[0] for _ in range(args.num_validation_images)]
 
     for tracker in accelerator.trackers:

--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -155,17 +155,19 @@ def log_validation(
 
     if args.validation_images is None:
         images = []
-        for _ in range(args.num_validation_images):
-            with torch.amp.autocast(accelerator.device.type):
-                image = pipeline(**pipeline_args, generator=generator).images[0]
-                images.append(image)
+        with torch.no_grad():
+            for _ in range(args.num_validation_images):
+                with torch.amp.autocast(accelerator.device.type):
+                    image = pipeline(**pipeline_args, generator=generator).images[0]
+                    images.append(image)
     else:
         images = []
-        for image in args.validation_images:
-            image = Image.open(image)
-            with torch.amp.autocast(accelerator.device.type):
-                image = pipeline(**pipeline_args, image=image, generator=generator).images[0]
-            images.append(image)
+        with torch.no_grad():
+            for image in args.validation_images:
+                image = Image.open(image)
+                with torch.amp.autocast(accelerator.device.type):
+                    image = pipeline(**pipeline_args, image=image, generator=generator).images[0]
+                images.append(image)
 
     for tracker in accelerator.trackers:
         phase_name = "test" if is_final_validation else "validation"

--- a/examples/dreambooth/train_dreambooth_lora_flux.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux.py
@@ -210,12 +210,13 @@ def log_validation(
             pipeline_args["prompt"], prompt_2=pipeline_args["prompt"]
         )
     images = []
-    for _ in range(args.num_validation_images):
-        with autocast_ctx:
-            image = pipeline(
-                prompt_embeds=prompt_embeds, pooled_prompt_embeds=pooled_prompt_embeds, generator=generator
-            ).images[0]
-            images.append(image)
+    with torch.no_grad():
+        for _ in range(args.num_validation_images):
+            with autocast_ctx:
+                image = pipeline(
+                    prompt_embeds=prompt_embeds, pooled_prompt_embeds=pooled_prompt_embeds, generator=generator
+                ).images[0]
+                images.append(image)
 
     for tracker in accelerator.trackers:
         phase_name = "test" if is_final_validation else "validation"

--- a/examples/dreambooth/train_dreambooth_lora_flux2.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2.py
@@ -209,13 +209,14 @@ def log_validation(
     autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
 
     images = []
-    for _ in range(args.num_validation_images):
-        with autocast_ctx:
-            image = pipeline(
-                prompt_embeds=pipeline_args["prompt_embeds"],
-                generator=generator,
-            ).images[0]
-            images.append(image)
+    with torch.no_grad():
+        for _ in range(args.num_validation_images):
+            with autocast_ctx:
+                image = pipeline(
+                    prompt_embeds=pipeline_args["prompt_embeds"],
+                    generator=generator,
+                ).images[0]
+                images.append(image)
 
     for tracker in accelerator.trackers:
         phase_name = "test" if is_final_validation else "validation"

--- a/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
@@ -209,14 +209,15 @@ def log_validation(
     autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
 
     images = []
-    for _ in range(args.num_validation_images):
-        with autocast_ctx:
-            image = pipeline(
-                image=pipeline_args["image"],
-                prompt_embeds=pipeline_args["prompt_embeds"],
-                generator=generator,
-            ).images[0]
-            images.append(image)
+    with torch.no_grad():
+        for _ in range(args.num_validation_images):
+            with autocast_ctx:
+                image = pipeline(
+                    image=pipeline_args["image"],
+                    prompt_embeds=pipeline_args["prompt_embeds"],
+                    generator=generator,
+                ).images[0]
+                images.append(image)
 
     for tracker in accelerator.trackers:
         phase_name = "test" if is_final_validation else "validation"

--- a/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
@@ -209,13 +209,14 @@ def log_validation(
     autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
 
     images = []
-    for _ in range(args.num_validation_images):
-        with autocast_ctx:
-            image = pipeline(
-                prompt_embeds=pipeline_args["prompt_embeds"],
-                generator=generator,
-            ).images[0]
-            images.append(image)
+    with torch.no_grad():
+        for _ in range(args.num_validation_images):
+            with autocast_ctx:
+                image = pipeline(
+                    prompt_embeds=pipeline_args["prompt_embeds"],
+                    generator=generator,
+                ).images[0]
+                images.append(image)
 
     for tracker in accelerator.trackers:
         phase_name = "test" if is_final_validation else "validation"

--- a/examples/dreambooth/train_dreambooth_lora_flux2_klein_img2img.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_klein_img2img.py
@@ -209,15 +209,16 @@ def log_validation(
     autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
 
     images = []
-    for _ in range(args.num_validation_images):
-        with autocast_ctx:
-            image = pipeline(
-                image=pipeline_args["image"],
-                prompt_embeds=pipeline_args["prompt_embeds"],
-                negative_prompt_embeds=pipeline_args["negative_prompt_embeds"],
-                generator=generator,
-            ).images[0]
-            images.append(image)
+    with torch.no_grad():
+        for _ in range(args.num_validation_images):
+            with autocast_ctx:
+                image = pipeline(
+                    image=pipeline_args["image"],
+                    prompt_embeds=pipeline_args["prompt_embeds"],
+                    negative_prompt_embeds=pipeline_args["negative_prompt_embeds"],
+                    generator=generator,
+                ).images[0]
+                images.append(image)
 
     for tracker in accelerator.trackers:
         phase_name = "test" if is_final_validation else "validation"

--- a/examples/dreambooth/train_dreambooth_lora_flux_kontext.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux_kontext.py
@@ -213,15 +213,16 @@ def log_validation(
         prompt = pipeline_args_cp.pop("prompt")
         prompt_embeds, pooled_prompt_embeds, text_ids = pipeline.encode_prompt(prompt, prompt_2=None)
     images = []
-    for _ in range(args.num_validation_images):
-        with autocast_ctx:
-            image = pipeline(
-                **pipeline_args_cp,
-                prompt_embeds=prompt_embeds,
-                pooled_prompt_embeds=pooled_prompt_embeds,
-                generator=generator,
-            ).images[0]
-            images.append(image)
+    with torch.no_grad():
+        for _ in range(args.num_validation_images):
+            with autocast_ctx:
+                image = pipeline(
+                    **pipeline_args_cp,
+                    prompt_embeds=prompt_embeds,
+                    pooled_prompt_embeds=pooled_prompt_embeds,
+                    generator=generator,
+                ).images[0]
+                images.append(image)
 
     for tracker in accelerator.trackers:
         phase_name = "test" if is_final_validation else "validation"

--- a/examples/dreambooth/train_dreambooth_lora_hidream.py
+++ b/examples/dreambooth/train_dreambooth_lora_hidream.py
@@ -212,18 +212,19 @@ def log_validation(
     autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
 
     images = []
-    for _ in range(args.num_validation_images):
-        with autocast_ctx:
-            image = pipeline(
-                prompt_embeds_t5=pipeline_args["prompt_embeds_t5"],
-                prompt_embeds_llama3=pipeline_args["prompt_embeds_llama3"],
-                negative_prompt_embeds_t5=pipeline_args["negative_prompt_embeds_t5"],
-                negative_prompt_embeds_llama3=pipeline_args["negative_prompt_embeds_llama3"],
-                pooled_prompt_embeds=pipeline_args["pooled_prompt_embeds"],
-                negative_pooled_prompt_embeds=pipeline_args["negative_pooled_prompt_embeds"],
-                generator=generator,
-            ).images[0]
-            images.append(image)
+    with torch.no_grad():
+        for _ in range(args.num_validation_images):
+            with autocast_ctx:
+                image = pipeline(
+                    prompt_embeds_t5=pipeline_args["prompt_embeds_t5"],
+                    prompt_embeds_llama3=pipeline_args["prompt_embeds_llama3"],
+                    negative_prompt_embeds_t5=pipeline_args["negative_prompt_embeds_t5"],
+                    negative_prompt_embeds_llama3=pipeline_args["negative_prompt_embeds_llama3"],
+                    pooled_prompt_embeds=pipeline_args["pooled_prompt_embeds"],
+                    negative_pooled_prompt_embeds=pipeline_args["negative_pooled_prompt_embeds"],
+                    generator=generator,
+                ).images[0]
+                images.append(image)
 
     for tracker in accelerator.trackers:
         phase_name = "test" if is_final_validation else "validation"

--- a/examples/dreambooth/train_dreambooth_lora_lumina2.py
+++ b/examples/dreambooth/train_dreambooth_lora_lumina2.py
@@ -171,7 +171,7 @@ def log_validation(
     generator = torch.Generator(device=accelerator.device).manual_seed(args.seed) if args.seed is not None else None
     autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
 
-    with autocast_ctx:
+    with torch.no_grad(), autocast_ctx:
         images = [pipeline(**pipeline_args, generator=generator).images[0] for _ in range(args.num_validation_images)]
 
     for tracker in accelerator.trackers:

--- a/examples/dreambooth/train_dreambooth_lora_qwen_image.py
+++ b/examples/dreambooth/train_dreambooth_lora_qwen_image.py
@@ -200,14 +200,15 @@ def log_validation(
     autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
 
     images = []
-    for _ in range(args.num_validation_images):
-        with autocast_ctx:
-            image = pipeline(
-                prompt_embeds=pipeline_args["prompt_embeds"],
-                prompt_embeds_mask=pipeline_args["prompt_embeds_mask"],
-                generator=generator,
-            ).images[0]
-            images.append(image)
+    with torch.no_grad():
+        for _ in range(args.num_validation_images):
+            with autocast_ctx:
+                image = pipeline(
+                    prompt_embeds=pipeline_args["prompt_embeds"],
+                    prompt_embeds_mask=pipeline_args["prompt_embeds_mask"],
+                    generator=generator,
+                ).images[0]
+                images.append(image)
 
     for tracker in accelerator.trackers:
         phase_name = "test" if is_final_validation else "validation"

--- a/examples/dreambooth/train_dreambooth_lora_sana.py
+++ b/examples/dreambooth/train_dreambooth_lora_sana.py
@@ -192,7 +192,8 @@ def log_validation(
     # run inference
     generator = torch.Generator(device=accelerator.device).manual_seed(args.seed) if args.seed is not None else None
 
-    images = [pipeline(**pipeline_args, generator=generator).images[0] for _ in range(args.num_validation_images)]
+    with torch.no_grad():
+        images = [pipeline(**pipeline_args, generator=generator).images[0] for _ in range(args.num_validation_images)]
 
     for tracker in accelerator.trackers:
         phase_name = "test" if is_final_validation else "validation"

--- a/examples/dreambooth/train_dreambooth_lora_sd3.py
+++ b/examples/dreambooth/train_dreambooth_lora_sd3.py
@@ -204,7 +204,7 @@ def log_validation(
     # autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
     autocast_ctx = nullcontext()
 
-    with autocast_ctx:
+    with torch.no_grad(), autocast_ctx:
         images = [pipeline(**pipeline_args, generator=generator).images[0] for _ in range(args.num_validation_images)]
 
     for tracker in accelerator.trackers:

--- a/examples/dreambooth/train_dreambooth_lora_sdxl.py
+++ b/examples/dreambooth/train_dreambooth_lora_sdxl.py
@@ -216,7 +216,7 @@ def log_validation(
     else:
         autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
 
-    with autocast_ctx:
+    with torch.no_grad(), autocast_ctx:
         images = [pipeline(**pipeline_args, generator=generator).images[0] for _ in range(args.num_validation_images)]
 
     for tracker in accelerator.trackers:

--- a/examples/dreambooth/train_dreambooth_lora_z_image.py
+++ b/examples/dreambooth/train_dreambooth_lora_z_image.py
@@ -208,14 +208,15 @@ def log_validation(
     autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
 
     images = []
-    for _ in range(args.num_validation_images):
-        with autocast_ctx:
-            image = pipeline(
-                prompt=args.validation_prompt,
-                prompt_embeds=pipeline_args["prompt_embeds"],
-                generator=generator,
-            ).images[0]
-            images.append(image)
+    with torch.no_grad():
+        for _ in range(args.num_validation_images):
+            with autocast_ctx:
+                image = pipeline(
+                    prompt=args.validation_prompt,
+                    prompt_embeds=pipeline_args["prompt_embeds"],
+                    generator=generator,
+                ).images[0]
+                images.append(image)
 
     for tracker in accelerator.trackers:
         phase_name = "test" if is_final_validation else "validation"

--- a/examples/dreambooth/train_dreambooth_sd3.py
+++ b/examples/dreambooth/train_dreambooth_sd3.py
@@ -180,7 +180,7 @@ def log_validation(
     # autocast_ctx = torch.autocast(accelerator.device.type) if not is_final_validation else nullcontext()
     autocast_ctx = nullcontext()
 
-    with autocast_ctx:
+    with torch.no_grad(), autocast_ctx:
         images = [pipeline(**pipeline_args, generator=generator).images[0] for _ in range(args.num_validation_images)]
 
     for tracker in accelerator.trackers:


### PR DESCRIPTION
## Summary

Fixes #13124

`log_validation()` in dreambooth training scripts runs pipeline inference using the same UNet/transformer that is being trained, without `torch.no_grad()`. With `--mixed_precision="fp16"`, gradients are computed and stored during validation inference. When the training loop resumes, the gradient scaler tries to unscale these FP16 gradients, causing:

```
ValueError: Attempting to unscale FP16 gradients.
```

This PR wraps all pipeline inference calls in `log_validation()` with `torch.no_grad()` across **all 17 dreambooth training scripts**, not just the one reported in the issue.

## Changes

- `train_dreambooth.py`
- `train_dreambooth_flux.py`
- `train_dreambooth_sd3.py`
- `train_dreambooth_lora.py`
- `train_dreambooth_lora_flux.py`
- `train_dreambooth_lora_flux2.py`
- `train_dreambooth_lora_flux2_img2img.py`
- `train_dreambooth_lora_flux2_klein.py`
- `train_dreambooth_lora_flux2_klein_img2img.py`
- `train_dreambooth_lora_flux_kontext.py`
- `train_dreambooth_lora_hidream.py`
- `train_dreambooth_lora_lumina2.py`
- `train_dreambooth_lora_qwen_image.py`
- `train_dreambooth_lora_sana.py`
- `train_dreambooth_lora_sd3.py`
- `train_dreambooth_lora_sdxl.py`
- `train_dreambooth_lora_z_image.py`

## Root Cause

Validation runs the pipeline which internally calls the UNet/transformer forward pass. Since `torch.no_grad()` is not set, autograd tracks operations and creates FP16 gradient tensors. The `GradScaler` in the training loop then fails because it expects FP32 gradients to unscale.

## Test Plan

- [ ] Verify `train_dreambooth_lora.py` with `--mixed_precision="fp16"` and `--validation_prompt` no longer crashes with `ValueError: Attempting to unscale FP16 gradients`
- [ ] Verify validation images are still generated correctly (inference output is identical with or without `no_grad`)