### PR TITLE
Add low precision attention API from torchao to TorchAoConfig

### DIFF
--- a/src/diffusers/quantizers/quantization_config.py
+++ b/src/diffusers/quantizers/quantization_config.py
@@ -433,14 +433,19 @@ class TorchAoConfig(QuantizationConfigMixin):
     """This is a config class for torchao quantization/sparsity techniques.
 
     Args:
-        quant_type (`AOBaseConfig`):
+        quant_type (`AOBaseConfig` | None):
             An `AOBaseConfig` subclass instance specifying the quantization type. See the [torchao
             documentation](https://docs.pytorch.org/ao/main/api_ref_quantization.html#inference-apis-for-quantize) for
             available config classes (e.g. `Int4WeightOnlyConfig`, `Int8WeightOnlyConfig`, `Float8WeightOnlyConfig`,
             `Float8DynamicActivationFloat8WeightConfig`, etc.).
+            Pass `None` when only `attention_backend` is used without weight quantization.
         modules_to_not_convert (`list[str]`, *optional*, default to `None`):
             The list of modules to not quantize, useful for quantizing models that explicitly require to have some
             modules left in their original precision.
+        attention_backend (`str`, *optional*, default to `None`):
+            Low-precision attention backend to use. Currently supported: `"fp8_fa3"` (FP8 attention using Flash
+            Attention 3, requires Hopper GPU with SM90+). This is orthogonal to weight quantization — you can use
+            either or both. When used with `torch.compile`, RoPE fusion is automatically enabled.
 
     Example:
         ```python
@@ -454,24 +459,41 @@ class TorchAoConfig(QuantizationConfigMixin):
             quantization_config=quantization_config,
             torch_dtype=torch.bfloat16,
         )
+
+        # FP8 attention only (no weight quantization)
+        quantization_config = TorchAoConfig(attention_backend="fp8_fa3")
+
+        # Combined: weight quantization + FP8 attention
+        quantization_config = TorchAoConfig(Int8WeightOnlyConfig(), attention_backend="fp8_fa3")
         ```
     """
 
     def __init__(
         self,
-        quant_type: "AOBaseConfig",  # noqa: F821
+        quant_type: "AOBaseConfig | None" = None,  # noqa: F821
         modules_to_not_convert: list[str] | None = None,
+        attention_backend: str | None = None,
         **kwargs,
     ) -> None:
         self.quant_method = QuantizationMethod.TORCHAO
         self.quant_type = quant_type
         self.modules_to_not_convert = modules_to_not_convert
+        self.attention_backend = attention_backend
 
         self.post_init()
 
     def post_init(self):
+        if self.quant_type is None and self.attention_backend is None:
+            raise ValueError(
+                "At least one of `quant_type` or `attention_backend` must be provided."
+            )
+
         if is_torchao_version("<", "0.15.0"):
             raise ValueError("TorchAoConfig requires torchao >= 0.15.0. Please upgrade with `pip install -U torchao`.")
+
+        # Skip quant_type validation when only attention_backend is used
+        if self.quant_type is None:
+            return
 
         from torchao.quantization.quant_api import AOBaseConfig
 
@@ -481,6 +503,12 @@ class TorchAoConfig(QuantizationConfigMixin):
     def to_dict(self):
         """Convert configuration to a dictionary."""
         d = super().to_dict()
+
+        if self.attention_backend is not None:
+            d["attention_backend"] = self.attention_backend
+
+        if self.quant_type is None:
+            return d
 
         # Handle AOBaseConfig serialization
         from torchao.core.config import config_to_dict
@@ -498,8 +526,11 @@ class TorchAoConfig(QuantizationConfigMixin):
         if not is_torchao_version(">=", "0.15.0"):
             raise NotImplementedError("TorchAoConfig requires torchao >= 0.15.0 for construction from dict")
         config_dict = config_dict.copy()
-        quant_type = config_dict.pop("quant_type")
+        quant_type = config_dict.pop("quant_type", None)
+        attention_backend = config_dict.pop("attention_backend", None)
 
+        if quant_type is None:
+            return cls(quant_type=quant_type, attention_backend=attention_backend, **config_dict)
         # Check if we only have one key which is "default"
         # In the future we may update this
         assert len(quant_type) == 1 and "default" in quant_type, (
@@ -512,7 +543,7 @@ class TorchAoConfig(QuantizationConfigMixin):
 
         quant_type = config_from_dict(quant_type)
 
-        return cls(quant_type=quant_type, **config_dict)
+        return cls(quant_type=quant_type, attention_backend=attention_backend, **config_dict)
 
     def get_apply_tensor_subclass(self):
         """Create the appropriate quantization method based on configuration."""

--- a/src/diffusers/quantizers/torchao/torchao_quantizer.py
+++ b/src/diffusers/quantizers/torchao/torchao_quantizer.py
@@ -188,8 +188,19 @@ class TorchAoHfQuantizer(DiffusersQuantizer):
                         f"In order to use TorchAO pre-quantized model, you need to have torch>=2.5.0. However, the current version is {torch_version}."
                     )
 
+        if self.quantization_config.attention_backend is not None:
+            from torchao.prototype.attention import AttentionBackend
+
+            AttentionBackend(self.quantization_config.attention_backend.upper())
+
     def update_torch_dtype(self, torch_dtype):
-        config_name = self.quantization_config.quant_type.__class__.__name__
+        quant_type = self.quantization_config.quant_type
+        if quant_type is None:
+            if torch_dtype is None:
+                torch_dtype = torch.bfloat16
+            return torch_dtype
+
+        config_name = quant_type.__class__.__name__
         is_int_quant = config_name.startswith("Int") or config_name.startswith("Uint")
         if is_int_quant and torch_dtype is not None and torch_dtype != torch.bfloat16:
             logger.warning(
@@ -209,9 +220,12 @@ class TorchAoHfQuantizer(DiffusersQuantizer):
         return torch_dtype
 
     def adjust_target_dtype(self, target_dtype: "torch.dtype") -> "torch.dtype":
+        quant_type = self.quantization_config.quant_type
+        if quant_type is None:
+            return target_dtype
+
         from accelerate.utils import CustomDtype
 
-        quant_type = self.quantization_config.quant_type
         config_name = quant_type.__class__.__name__
         size_digit = fuzzy_match_size(config_name)
 
@@ -244,6 +258,9 @@ class TorchAoHfQuantizer(DiffusersQuantizer):
         state_dict: dict[str, Any],
         **kwargs,
     ) -> bool:
+        if self.quantization_config.quant_type is None:
+            return False
+
         param_device = kwargs.pop("param_device", None)
         # Check if the param_name is not in self.modules_to_not_convert
         if any((key + "." in param_name) or (key == param_name) for key in self.modules_to_not_convert):
@@ -298,6 +315,9 @@ class TorchAoHfQuantizer(DiffusersQuantizer):
         - Use a division factor of 8 for int4 weights
         - Use a division factor of 4 for int8 weights
         """
+        if self.quantization_config.quant_type is None:
+            return 4
+
         quant_type = self.quantization_config.quant_type
         config_name = quant_type.__class__.__name__
         size_digit = fuzzy_match_size(config_name)
@@ -314,6 +334,13 @@ class TorchAoHfQuantizer(DiffusersQuantizer):
         keep_in_fp32_modules: list[str] = [],
         **kwargs,
     ):
+        model.config.quantization_config = self.quantization_config
+
+        if self.quantization_config.quant_type is None:
+            # Attention-only mode: no weight quantization setup needed
+            self.modules_to_not_convert = []
+            return
+
         self.modules_to_not_convert = self.quantization_config.modules_to_not_convert
 
         if not isinstance(self.modules_to_not_convert, list):
@@ -332,10 +359,72 @@ class TorchAoHfQuantizer(DiffusersQuantizer):
         # and tied modules are usually kept in FP32.
         self.modules_to_not_convert = [module for module in self.modules_to_not_convert if module is not None]
 
-        model.config.quantization_config = self.quantization_config
-
     def _process_model_after_weight_loading(self, model: "ModelMixin"):
+        if self.quantization_config.attention_backend is not None:
+            from torchao.prototype.attention import AttentionBackend, apply_low_precision_attention
+
+            backend = AttentionBackend(self.quantization_config.attention_backend.upper())
+            modules_to_not_convert = self.quantization_config.modules_to_not_convert or []
+
+            if not modules_to_not_convert:
+                apply_low_precision_attention(model, backend=backend, inplace=True)
+            else:
+                parent_name, excluded_names = self._parse_attention_exclusions(modules_to_not_convert, model)
+                if parent_name is None:
+                    apply_low_precision_attention(model, backend=backend, inplace=True)
+                else:
+                    parent_module = model.get_submodule(parent_name)
+                    for name, child in parent_module.named_children():
+                        if name not in excluded_names:
+                            apply_low_precision_attention(child, backend=backend, inplace=True)
+
         return model
+
+    def _parse_attention_exclusions(self, modules_to_not_convert, model):
+        """Parse and validate modules_to_not_convert for attention exclusion.
+
+        Returns (parent_name, excluded_child_names) or (None, None) if validation fails with a warning.
+        """
+        # Check all keys have a parent (contain a dot)
+        for key in modules_to_not_convert:
+            if "." not in key:
+                logger.warning(
+                    f"modules_to_not_convert key {key!r} is a top-level module and cannot be used for "
+                    f"selective attention exclusion. Low-precision attention will be applied to the entire model."
+                )
+                return None, None
+
+        # Check all keys share the same parent
+        parents = {key.rsplit(".", 1)[0] for key in modules_to_not_convert}
+        if len(parents) > 1:
+            logger.warning(
+                f"modules_to_not_convert keys have different parent modules: {sorted(parents)}. "
+                f"All keys must share the same parent for selective attention exclusion. "
+                f"Low-precision attention will be applied to the entire model."
+            )
+            return None, None
+
+        parent_name = parents.pop()
+
+        # Check parent exists
+        try:
+            parent_module = model.get_submodule(parent_name)
+        except AttributeError:
+            raise ValueError(
+                f"Parent module {parent_name!r} (from modules_to_not_convert) does not exist in the model."
+            )
+
+        # Check all excluded children exist
+        child_names = {name for name, _ in parent_module.named_children()}
+        excluded_names = {key.rsplit(".", 1)[1] for key in modules_to_not_convert}
+        invalid = excluded_names - child_names
+        if invalid:
+            raise ValueError(
+                f"modules_to_not_convert references non-existent modules: {sorted(invalid)}. "
+                f"Available children of {parent_name!r}: {sorted(child_names)}"
+            )
+
+        return parent_name, excluded_names
 
     def is_serializable(self, safe_serialization=None):
         # TODO(aryan): needs to be tested
@@ -371,7 +460,10 @@ class TorchAoHfQuantizer(DiffusersQuantizer):
 
     @property
     def is_trainable(self):
-        return self.quantization_config.quant_type.__class__.__name__ in self._TRAINABLE_QUANTIZATION_CONFIGS
+        quant_type = self.quantization_config.quant_type
+        if quant_type is None:
+            return False
+        return quant_type.__class__.__name__ in self._TRAINABLE_QUANTIZATION_CONFIGS
 
     @property
     def is_compileable(self) -> bool:


### PR DESCRIPTION
# What does this PR do?
Adds low precision attention API from TorchAO to diffusers by updating TorchAoConfig with attn_backend option.
Note: this will require torchao 0.17.0

## Todo:
- [ ] Need to add new necessary tests
- [ ] Need to update the documentation: 
    - [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs)
    - [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).

## Results:

#### flux.1-dev with 2048x2048 image size

| Config | Median Time (s) | Speedup |
| --- | --- | --- |
| bf16 baseline + torch.compile | 3.17 | 1.00x |
| fp8_attn + compile | 2.66 | **1.07x** |

#### Wan2.1-14B-Diffusers with 1280x720 frame size and 81 frames

| Config | Median Time (s) | Speedup |
| --- | --- | --- |
| bf16 baseline + torch.compile | 81.32 | 1.00x |
| fp8_attn + compile | 46.88 | **1.18x** |

Note that these results use a naive scheme, where every layer is quantized. Doing so results in subpar results when doing many inference steps (50 for WAN2.1). Using a better scheme (such as skipping early and late layers, quantizing 36/40 total layers) results in **1.12x** speedup with much better quality. The VBench benchmarks for that are below:

<img width="687" height="230" alt="image" src="https://github.com/user-attachments/assets/e4a15d58-66f4-4c16-b7f6-74c00dfdb15b" />
