### PR TITLE
[ci] hoping to fix is_flaky with wanvace.

### DIFF
--- a/tests/lora/test_lora_layers_wanvace.py
+++ b/tests/lora/test_lora_layers_wanvace.py
@@ -28,7 +28,6 @@ from diffusers.utils.import_utils import is_peft_available
 
 from ..testing_utils import (
     floats_tensor,
-    is_flaky,
     require_peft_backend,
     require_peft_version_greater,
     skip_mps,
@@ -46,7 +45,6 @@ from .utils import PeftLoraLoaderMixinTests  # noqa: E402
 
 @require_peft_backend
 @skip_mps
-@is_flaky(max_attempts=10, description="very flaky class")
 class WanVACELoRATests(unittest.TestCase, PeftLoraLoaderMixinTests):
     pipeline_class = WanVACEPipeline
     scheduler_cls = FlowMatchEulerDiscreteScheduler
@@ -73,8 +71,8 @@ class WanVACELoRATests(unittest.TestCase, PeftLoraLoaderMixinTests):
         "base_dim": 3,
         "z_dim": 4,
         "dim_mult": [1, 1, 1, 1],
-        "latents_mean": torch.randn(4).numpy().tolist(),
-        "latents_std": torch.randn(4).numpy().tolist(),
+        "latents_mean": [-0.7571, -0.7089, -0.9113, -0.7245],
+        "latents_std": [2.8184, 1.4541, 2.3275, 2.6558],
         "num_res_blocks": 1,
         "temperal_downsample": [False, True, True],
     }

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1235,12 +1235,10 @@ def is_flaky(max_attempts: int = 5, wait_before_retry: float | None = None, desc
     def decorator(obj):
         # If decorating a class, wrap each test method on it
         if inspect.isclass(obj):
-            # Use dir() instead of __dict__ to include inherited test methods from
-            # parent classes (e.g., mixin base classes). __dict__ only contains methods
-            # defined directly on the class, so inherited tests would not be retried.
-            for attr_name in list(dir(obj)):
-                if attr_name.startswith("test") and callable(getattr(obj, attr_name, None)):
-                    setattr(obj, attr_name, decorator(getattr(obj, attr_name)))
+            for attr_name, attr_value in list(obj.__dict__.items()):
+                if callable(attr_value) and attr_name.startswith("test"):
+                    # recursively decorate the method
+                    setattr(obj, attr_name, decorator(attr_value))
             return obj
 
         # Otherwise we're decorating a single test function / method


### PR DESCRIPTION
# What does this PR do?

The WanVACE LoRA test failures are the flakiest in nature. They have been making our CI red for a while now. This is another attempt getting rid of that:
https://github.com/huggingface/diffusers/actions/runs/23308255022/job/67788477319?pr=13290