### PR TITLE
fix(attention): download hub kernel in AttentionModuleMixin.set_attention_backend

### DIFF
--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -159,13 +159,19 @@ class AttentionModuleMixin:
             return self.processor
 
     def set_attention_backend(self, backend: str):
-        from .attention_dispatch import AttentionBackendName
+        from .attention_dispatch import (
+            AttentionBackendName,
+            _check_attention_backend_requirements,
+            _maybe_download_kernel_for_backend,
+        )
 
         available_backends = {x.value for x in AttentionBackendName.__members__.values()}
         if backend not in available_backends:
             raise ValueError(f"`{backend=}` must be one of the following: " + ", ".join(available_backends))
 
         backend = AttentionBackendName(backend.lower())
+        _check_attention_backend_requirements(backend)
+        _maybe_download_kernel_for_backend(backend)
         self.processor._attention_backend = backend
 
     def set_use_npu_flash_attention(self, use_npu_flash_attention: bool) -> None:


### PR DESCRIPTION
## Summary

When `set_attention_backend()` is called directly on an individual attention submodule
(e.g. `pipe.transformer.attn1.set_attention_backend("sage_hub")`), hub-based kernels
are never downloaded and the backend silently falls back to the default.

## Root Cause

`AttentionModuleMixin.set_attention_backend()` in `attention.py` validates the backend
name but does not call `_check_attention_backend_requirements()` or
`_maybe_download_kernel_for_backend()`. The top-level `ModelMixin.set_attention_backend()`
in `modeling_utils.py` already calls both helpers correctly — the submodule path was simply
missing them.

## Fix

Add the two missing calls to `AttentionModuleMixin.set_attention_backend()`:

```diff
 def set_attention_backend(self, backend: str):
     from .attention_dispatch import (
         AttentionBackendName,
+        _check_attention_backend_requirements,
+        _maybe_download_kernel_for_backend,
     )
     ...
     backend = AttentionBackendName(backend.lower())
+    _check_attention_backend_requirements(backend)
+    _maybe_download_kernel_for_backend(backend)
     self.processor._attention_backend = backend
```

Fixes #13284
