### PR TITLE
fix: cast input to weight dtype in PatchEmbed and FluxTransformer2DModel to prevent dtype mismatch

### DIFF
--- a/src/diffusers/models/embeddings.py
+++ b/src/diffusers/models/embeddings.py
@@ -556,7 +556,7 @@ class PatchEmbed(nn.Module):
             height, width = latent.shape[-2:]
         else:
             height, width = latent.shape[-2] // self.patch_size, latent.shape[-1] // self.patch_size
-        latent = self.proj(latent)
+        latent = self.proj(latent.to(self.proj.weight.dtype))
         if self.flatten:
             latent = latent.flatten(2).transpose(1, 2)  # BCHW -> BNC
         if self.layer_norm:

--- a/src/diffusers/models/transformers/transformer_flux.py
+++ b/src/diffusers/models/transformers/transformer_flux.py
@@ -677,7 +677,7 @@ class FluxTransformer2DModel(
             `tuple` where the first element is the sample tensor.
         """
 
-        hidden_states = self.x_embedder(hidden_states)
+        hidden_states = self.x_embedder(hidden_states.to(self.x_embedder.weight.dtype))
 
         timestep = timestep.to(hidden_states.dtype) * 1000
         if guidance is not None:


### PR DESCRIPTION
## What does this PR do?

Fixes dtype mismatch errors when running SD3 or FLUX models on CPU with `torch_dtype=torch.float16`.

When the model's projection layers (Conv2d in `PatchEmbed`, Linear in `FluxTransformer2DModel`) are in float32 but receive float16 inputs, PyTorch raises a `RuntimeError` on CPU because autocast is not available there:

```
RuntimeError: Input type (c10::Half) and bias type (float) should be the same
```

The fix casts the input tensor to match the layer weight dtype before calling the projection:
- `PatchEmbed.forward`: `latent.to(self.proj.weight.dtype)` before Conv2d call
- `FluxTransformer2DModel.forward`: `hidden_states.to(self.x_embedder.weight.dtype)` before Linear call

Fixes #13300