### PR TITLE
fix: support torchao >= 0.16.0 by importing renamed CamelCase Config classes

### DIFF
--- a/src/diffusers/quantizers/quantization_config.py
+++ b/src/diffusers/quantizers/quantization_config.py
@@ -626,16 +626,30 @@ class TorchAoConfig(QuantizationConfigMixin):
 
         if is_torchao_available():
             # TODO(aryan): Support sparsify
-            from torchao.quantization import (
-                float8_dynamic_activation_float8_weight,
-                float8_static_activation_float8_weight,
-                float8_weight_only,
-                int4_weight_only,
-                int8_dynamic_activation_int4_weight,
-                int8_dynamic_activation_int8_weight,
-                int8_weight_only,
-                uintx_weight_only,
-            )
+            # torchao >= 0.16.0 renamed snake_case functions to CamelCase Config classes.
+            # Use the new API when available, falling back to the old API for older versions.
+            if is_torchao_version(">=", "0.16.0"):
+                from torchao.quantization import (
+                    Float8DynamicActivationFloat8WeightConfig as float8_dynamic_activation_float8_weight,
+                    Float8StaticActivationFloat8WeightConfig as float8_static_activation_float8_weight,
+                    Float8WeightOnlyConfig as float8_weight_only,
+                    Int4WeightOnlyConfig as int4_weight_only,
+                    Int8DynamicActivationInt4WeightConfig as int8_dynamic_activation_int4_weight,
+                    Int8DynamicActivationInt8WeightConfig as int8_dynamic_activation_int8_weight,
+                    Int8WeightOnlyConfig as int8_weight_only,
+                    UIntXWeightOnlyConfig as uintx_weight_only,
+                )
+            else:
+                from torchao.quantization import (
+                    float8_dynamic_activation_float8_weight,
+                    float8_static_activation_float8_weight,
+                    float8_weight_only,
+                    int4_weight_only,
+                    int8_dynamic_activation_int4_weight,
+                    int8_dynamic_activation_int8_weight,
+                    int8_weight_only,
+                    uintx_weight_only,
+                )
 
             if is_torchao_version("<=", "0.14.1"):
                 from torchao.quantization import fpx_weight_only


### PR DESCRIPTION
## What does this PR do?

Fixes `ImportError` when using `TorchAoConfig` with torchao >= 0.16.0.

torchao 0.15.0 deprecated the snake_case quantization functions (`int4_weight_only`, `float8_weight_only`, etc.) with deprecation warnings, and 0.16.0 **removed them entirely**, replacing them with CamelCase Config classes (`Int4WeightOnlyConfig`, `Float8WeightOnlyConfig`, etc.).

The `TorchAoConfig._get_torchao_quant_type_to_method` method was unconditionally importing the old snake_case names, causing:

```
ImportError: cannot import name 'float8_dynamic_activation_float8_weight' from 'torchao.quantization'
```

**Fix:** Add a version guard in `_get_torchao_quant_type_to_method`:
- **torchao >= 0.16.0**: import new CamelCase Config classes, aliased to the old snake_case names so the rest of the method remains unchanged
- **torchao < 0.16.0**: keep importing the old snake_case functions as before

The aliasing approach keeps the change minimal and self-contained — no other code in the method needs to change.

Fixes #13286