### PR TITLE
fix: skip pin_memory and non_blocking transfer for tensor subclasses in group offloading

### DIFF
--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -129,19 +129,25 @@ class ModuleGroup:
         if self.stream is None:
             return cpu_param_dict
 
+        def _maybe_pin(data):
+            # Only pin plain torch.Tensor instances. Subclasses (e.g. torchao
+            # AffineQuantizedTensor) may not support pin_memory() correctly and
+            # can silently lose their quantization metadata.
+            if self.low_cpu_mem_usage or type(data) is not torch.Tensor:
+                return data
+            return data.pin_memory()
+
         for module in self.modules:
             for param in module.parameters():
-                cpu_param_dict[param] = param.data.cpu() if self.low_cpu_mem_usage else param.data.cpu().pin_memory()
+                cpu_param_dict[param] = _maybe_pin(param.data.cpu())
             for buffer in module.buffers():
-                cpu_param_dict[buffer] = (
-                    buffer.data.cpu() if self.low_cpu_mem_usage else buffer.data.cpu().pin_memory()
-                )
+                cpu_param_dict[buffer] = _maybe_pin(buffer.data.cpu())
 
         for param in self.parameters:
-            cpu_param_dict[param] = param.data.cpu() if self.low_cpu_mem_usage else param.data.cpu().pin_memory()
+            cpu_param_dict[param] = _maybe_pin(param.data.cpu())
 
         for buffer in self.buffers:
-            cpu_param_dict[buffer] = buffer.data.cpu() if self.low_cpu_mem_usage else buffer.data.cpu().pin_memory()
+            cpu_param_dict[buffer] = _maybe_pin(buffer.data.cpu())
 
         return cpu_param_dict
 
@@ -149,7 +155,7 @@ class ModuleGroup:
     def _pinned_memory_tensors(self):
         try:
             pinned_dict = {
-                param: tensor.pin_memory() if not tensor.is_pinned() else tensor
+                param: (tensor.pin_memory() if not tensor.is_pinned() and type(tensor) is torch.Tensor else tensor)
                 for param, tensor in self.cpu_param_dict.items()
             }
             yield pinned_dict
@@ -157,8 +163,11 @@ class ModuleGroup:
             pinned_dict = None
 
     def _transfer_tensor_to_device(self, tensor, source_tensor, default_stream):
-        tensor.data = source_tensor.to(self.onload_device, non_blocking=self.non_blocking)
-        if self.record_stream:
+        # Tensor subclasses (e.g. torchao AffineQuantizedTensor) may not support
+        # non-blocking transfers correctly, so fall back to synchronous copy.
+        non_blocking = self.non_blocking and type(source_tensor) is torch.Tensor
+        tensor.data = source_tensor.to(self.onload_device, non_blocking=non_blocking)
+        if self.record_stream and type(tensor.data) is torch.Tensor:
             tensor.data.record_stream(default_stream)
 
     def _process_tensors_from_modules(self, pinned_memory=None, default_stream=None):


### PR DESCRIPTION
## What does this PR do?

Fixes #13281.

When combining torchao quantization (e.g. `Float8WeightOnlyConfig`) with group offloading (`use_stream=True`), inference fails with a device mismatch: the quantized weight remains on CPU while the input is on CUDA.

### Root cause

`GroupOffloadingHook._init_cpu_param_dict` calls `.pin_memory()` on every parameter/buffer, and `_pinned_memory_tensors` pins them again before the async host-to-device transfer. For plain `torch.Tensor` this works correctly, but for tensor subclasses such as torchao's `AffineQuantizedTensor`, `pin_memory()` may silently strip the quantization metadata, producing a plain CPU float tensor. The subsequent `.to(device, non_blocking=True)` then moves a plain float tensor instead of the quantized one, leaving the quantized weight behind on CPU.

Similarly, `_transfer_tensor_to_device` schedules `record_stream` for all results, but `AffineQuantizedTensor.to(...)` may not return a plain `torch.Tensor`, so `record_stream` could raise or be a no-op.

### Fix

- **`_init_cpu_param_dict`**: introduce `_maybe_pin()` helper that calls `pin_memory()` only when `type(data) is torch.Tensor`. Tensor subclasses are stored as-is (already on CPU).
- **`_pinned_memory_tensors`**: apply the same `type(tensor) is torch.Tensor` guard.
- **`_transfer_tensor_to_device`**: force synchronous (blocking) transfer for tensor subclasses, and skip `record_stream` when the result is not a plain tensor.

Plain-tensor performance is completely unaffected; the async-stream path is preserved for all non-quantized parameters.
