### PR TITLE
fix(dreambooth): batch size mismatch with --with_prior_preservation in flux2 scripts

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux2.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2.py
@@ -1734,7 +1734,10 @@ def main(args):
                     prompt_embeds = prompt_embeds_cache[step]
                     text_ids = text_ids_cache[step]
                 else:
-                    num_repeat_elements = len(prompts)
+                    # With prior preservation, prompt_embeds already contains [instance, class] embeddings
+                    # from the cat above, but collate_fn also doubles the prompts list. Use half the
+                    # prompts count to avoid a 2x over-repeat that produces more embeddings than latents.
+                    num_repeat_elements = len(prompts) // 2 if args.with_prior_preservation else len(prompts)
                     prompt_embeds = prompt_embeds.repeat(num_repeat_elements, 1, 1)
                     text_ids = text_ids.repeat(num_repeat_elements, 1, 1)
 

--- a/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
@@ -1674,7 +1674,10 @@ def main(args):
                     prompt_embeds = prompt_embeds_cache[step]
                     text_ids = text_ids_cache[step]
                 else:
-                    num_repeat_elements = len(prompts)
+                    # With prior preservation, prompt_embeds already contains [instance, class] embeddings
+                    # from the cat above, but collate_fn also doubles the prompts list. Use half the
+                    # prompts count to avoid a 2x over-repeat that produces more embeddings than latents.
+                    num_repeat_elements = len(prompts) // 2 if args.with_prior_preservation else len(prompts)
                     prompt_embeds = prompt_embeds.repeat(num_repeat_elements, 1, 1)
                     text_ids = text_ids.repeat(num_repeat_elements, 1, 1)
 

--- a/examples/dreambooth/train_dreambooth_lora_flux2_klein_img2img.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_klein_img2img.py
@@ -1618,7 +1618,10 @@ def main(args):
                     prompt_embeds = prompt_embeds_cache[step]
                     text_ids = text_ids_cache[step]
                 else:
-                    num_repeat_elements = len(prompts)
+                    # With prior preservation, prompt_embeds already contains [instance, class] embeddings
+                    # from the cat above, but collate_fn also doubles the prompts list. Use half the
+                    # prompts count to avoid a 2x over-repeat that produces more embeddings than latents.
+                    num_repeat_elements = len(prompts) // 2 if args.with_prior_preservation else len(prompts)
                     prompt_embeds = prompt_embeds.repeat(num_repeat_elements, 1, 1)
                     text_ids = text_ids.repeat(num_repeat_elements, 1, 1)
 


### PR DESCRIPTION
## Summary

When `--with_prior_preservation` is enabled in the Flux2 dreambooth LoRA training scripts, the prompt embedding repeat logic double-counts the batch size, producing a shape mismatch against the latent tensor.

**Root cause:** `collate_fn` appends class prompts to the instance prompts list (doubling `len(prompts)`), but `prompt_embeds` is already doubled earlier via `torch.cat([instance_embeds, class_embeds])`. Using the full `len(prompts)` as the repeat count produces `4` embeddings for `2` latents at `batch_size=1`.

**Fix:** Use `len(prompts) // 2` when `args.with_prior_preservation` is active, so the repeat count matches the number of unique prompt groups rather than the doubled collated list.

Applied to all three affected scripts:
- `examples/dreambooth/train_dreambooth_lora_flux2_klein.py`
- `examples/dreambooth/train_dreambooth_lora_flux2.py`
- `examples/dreambooth/train_dreambooth_lora_flux2_klein_img2img.py`

## Test plan

Dimension trace verified for all four scenarios:

| `batch_size` | `with_prior_preservation` | `len(prompts)` | `prompt_embeds` pre-repeat | Repeat count (old → new) | Result (old → new) |
|---|---|---|---|---|---|
| 1 | True | 2 | [2, seq, H] | 2 → 1 | [4, seq, H] MISMATCH → [2, seq, H] OK |
| 2 | True | 4 | [2, seq, H] | 4 → 2 | [8, seq, H] MISMATCH → [4, seq, H] OK |
| 1 | False | 1 | [1, seq, H] | 1 → 1 | [1, seq, H] OK → [1, seq, H] OK |
| 2 | False | 2 | [1, seq, H] | 2 → 2 | [2, seq, H] OK → [2, seq, H] OK |

Fixes #13292