### PR TITLE
Add warning when using CUDA random generator (#13298)

### DIFF
--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -176,6 +176,12 @@ def randn_tensor(
                 )
         elif gen_device_type != device.type and gen_device_type == "cuda":
             raise ValueError(f"Cannot generate a {device} tensor from a generator of type {gen_device_type}.")
+        elif gen_device_type == "cuda" and device.type == "cuda":
+            logger.warning(
+                "Using a CUDA random generator may produce different results than a CPU generator with the same seed."
+                " This is expected because PyTorch uses different random number generation algorithms on CPU and CUDA."
+                " If you need reproducible results across devices, use a CPU generator (e.g., torch.Generator('cpu'))."
+            )
 
     # make sure generator list of length 1 is treated like a non-list
     if isinstance(generator, list) and len(generator) == 1:


### PR DESCRIPTION
## What does this PR do?

Fixes #13298

When users pass a CUDA `torch.Generator` to diffusers pipelines, they may expect the same results as with a CPU generator given the same seed. However, PyTorch uses different random number generation algorithms on CPU and CUDA, so the generated images will differ.

This PR adds a warning in `randn_tensor` when a CUDA generator is used, informing users that:
- CUDA generators produce different random numbers than CPU generators with the same seed
- This is expected PyTorch behavior
- Use a CPU generator if reproducibility across devices is needed

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read the [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md)?

## Who can review?

@yiyixuxu @DN6 @sayakpaul