### PR TITLE
fix(ddim): validate eta is in [0, 1] in DDIMPipeline

### DIFF
--- a/src/diffusers/pipelines/ddim/pipeline_ddim.py
+++ b/src/diffusers/pipelines/ddim/pipeline_ddim.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
+import logging
 
 import torch
 
@@ -21,6 +21,9 @@ from ...schedulers import DDIMScheduler
 from ...utils import is_torch_xla_available
 from ...utils.torch_utils import randn_tensor
 from ..pipeline_utils import DiffusionPipeline, ImagePipelineOutput
+
+
+logger = logging.getLogger(__name__)
 
 
 if is_torch_xla_available():
@@ -132,12 +135,10 @@ class DDIMPipeline(DiffusionPipeline):
             image_shape = (batch_size, self.unet.config.in_channels, *self.unet.config.sample_size)
 
         if not 0.0 <= eta <= 1.0:
-            warnings.warn(
+            logger.warning(
                 f"`eta` should be between 0 and 1 (inclusive), but received {eta}. "
                 "A value of 0 corresponds to DDIM and 1 corresponds to DDPM. "
-                "Unexpected results may occur for values outside this range.",
-                UserWarning,
-                stacklevel=2,
+                "Unexpected results may occur for values outside this range."
             )
 
         if isinstance(generator, list) and len(generator) != batch_size:


### PR DESCRIPTION
## What does this PR do?

Adds input validation for the `eta` parameter in `DDIMPipeline.__call__`.

Fixes #13362

### Context

The DDIM paper defines η (eta) as a value that lies strictly in [0, 1]:
- η = 0 → deterministic DDIM
- η = 1 → DDPM

The docstring already documents this constraint:
> *"eta corresponds to η in paper and should be between [0, 1]"*

However, no runtime check existed, so out-of-range values (negative or > 1) were silently accepted and could produce undefined/unintended sampling behaviour.

### Change

Add a `ValueError` guard immediately after the image-shape computation, before the denoising loop:

```python
if not 0.0 <= eta <= 1.0:
    raise ValueError(
        f"`eta` must be between 0 and 1 (inclusive), but received {eta}. "
        "A value of 0 corresponds to DDIM and 1 corresponds to DDPM."
    )
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? See #13362
- [ ] Did you write any new necessary tests?

## Who can review?

@pcuenca @DN6
