### PR TITLE
Fix Dynamo `lru_cache` warnings during `torch.compile`

### DIFF
--- a/src/diffusers/models/attention_dispatch.py
+++ b/src/diffusers/models/attention_dispatch.py
@@ -423,6 +423,8 @@ def dispatch_attention_fn(
         **attention_kwargs,
         "_parallel_config": parallel_config,
     }
+    # Equivalent to `is_torch_version(">=", "2.5.0")` — use module-level constant to avoid
+    # Dynamo tracing into the lru_cache-wrapped `is_torch_version` during torch.compile.
     if _CAN_USE_FLEX_ATTN:
         kwargs["enable_gqa"] = enable_gqa
 

--- a/src/diffusers/models/attention_dispatch.py
+++ b/src/diffusers/models/attention_dispatch.py
@@ -423,7 +423,7 @@ def dispatch_attention_fn(
         **attention_kwargs,
         "_parallel_config": parallel_config,
     }
-    if is_torch_version(">=", "2.5.0"):
+    if _CAN_USE_FLEX_ATTN:
         kwargs["enable_gqa"] = enable_gqa
 
     if _AttentionBackendRegistry._checks_enabled:

--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -347,7 +347,17 @@ def lru_cache_unless_export(maxsize=128, typed=False):
 
         @functools.wraps(fn)
         def inner_wrapper(*args: P.args, **kwargs: P.kwargs):
-            if torch.compiler.is_exporting():
+            compiler = getattr(torch, "compiler", None)
+            is_exporting = bool(compiler and hasattr(compiler, "is_exporting") and compiler.is_exporting())
+            is_compiling = bool(compiler and hasattr(compiler, "is_compiling") and compiler.is_compiling())
+
+            # Fallback for older builds where compiler.is_compiling is unavailable.
+            if not is_compiling:
+                dynamo = getattr(torch, "_dynamo", None)
+                if dynamo is not None and hasattr(dynamo, "is_compiling"):
+                    is_compiling = dynamo.is_compiling()
+
+            if is_exporting or is_compiling:
                 return fn(*args, **kwargs)
             return cached(*args, **kwargs)
 


### PR DESCRIPTION
## What does this PR do?

Fixes Dynamo `lru_cache` warnings when using `torch.compile` on diffusion pipelines. Two changes:

1. **`attention_dispatch.py`**: `dispatch_attention_fn` calls `is_torch_version(">=", "2.5.0")` at runtime, which is `@lru_cache`-wrapped. Replace with the existing module-level constant `_CAN_USE_FLEX_ATTN` so Dynamo never traces into it.

2. **`torch_utils.py`**: `lru_cache_unless_export` only bypasses `lru_cache` during `torch.export` (`is_exporting`). Add `is_compiling` check so `torch.compile` also bypasses the cache wrapper.

## Reproduce

```python
import torch
from diffusers import DiffusionPipeline

pipe = DiffusionPipeline.from_pretrained("black-forest-labs/FLUX.2-klein-4B", torch_dtype=torch.bfloat16).to("cpu")
pipe.transformer = torch.compile(pipe.transformer, backend="inductor")
pipe(prompt="a cat", height=256, width=256, num_inference_steps=1, generator=torch.Generator().manual_seed(0))
# Before: UserWarning about lru_cache in attention_dispatch.py / torch_utils.py
# After: no warning
```

out before fix:
```
/opt/venv/lib/python3.12/site-packages/torch/_dynamo/variables/functions.py:2435: UserWarning: Dynamo detected a call to a `functools.lru_cache`-wrapped function at 'attention_dispatch.py:426'. Dynamo ignores the cache wrapper and directly traces the wrapped function. Silent incorrectness is only a *potential* risk, not something we have observed. Enable TORCH_LOGS=+dynamo for a DEBUG stack trace.

This call originates from:
  File "/home/jiqing/diffusers/src/diffusers/models/attention_dispatch.py", line 426, in dispatch_attention_fn
    if is_torch_version(">=", "2.5.0"):

  torch._dynamo.utils.warn_once(msg)

Flux2PipelineOutput(images=[<PIL.Image.Image image mode=RGB size=256x256 at 0x7A540282FDA0>])
```

out after fix:
```
Flux2PipelineOutput(images=[<PIL.Image.Image image mode=RGB size=256x256 at 0x7A540282FDA0>])
```