### PR TITLE
fix: remove duplicate words in error messages and docstrings

### DIFF
--- a/src/diffusers/models/unets/unet_spatio_temporal_condition.py
+++ b/src/diffusers/models/unets/unet_spatio_temporal_condition.py
@@ -49,7 +49,7 @@ class UNetSpatioTemporalConditionModel(ModelMixin, AttentionMixin, ConfigMixin, 
         block_out_channels (`tuple[int]`, *optional*, defaults to `(320, 640, 1280, 1280)`):
             The tuple of output channels for each block.
         addition_time_embed_dim: (`int`, defaults to 256):
-            Dimension to to encode the additional time ids.
+            Dimension to encode the additional time ids.
         projection_class_embeddings_input_dim (`int`, defaults to 768):
             The dimension of the projection of encoded `added_time_ids`.
         layers_per_block (`int`, *optional*, defaults to 2): The number of layers per block.

--- a/src/diffusers/modular_pipelines/flux/before_denoise.py
+++ b/src/diffusers/modular_pipelines/flux/before_denoise.py
@@ -470,7 +470,7 @@ class FluxImg2ImgPrepareLatentsStep(ModularPipelineBlocks):
     def check_inputs(image_latents, latents):
         if image_latents.shape[0] != latents.shape[0]:
             raise ValueError(
-                f"`image_latents` must have have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
+                f"`image_latents` must have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
             )
 
         if image_latents.ndim != 3:

--- a/src/diffusers/modular_pipelines/helios/before_denoise.py
+++ b/src/diffusers/modular_pipelines/helios/before_denoise.py
@@ -168,7 +168,7 @@ def repeat_tensor_to_batch_size(
         repeat_by = num_videos_per_prompt
     else:
         raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
+            f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
         )
 
     # expand the tensor to match the batch_size * num_videos_per_prompt

--- a/src/diffusers/modular_pipelines/qwenimage/before_denoise.py
+++ b/src/diffusers/modular_pipelines/qwenimage/before_denoise.py
@@ -426,7 +426,7 @@ class QwenImagePrepareLatentsWithStrengthStep(ModularPipelineBlocks):
     def check_inputs(image_latents, latents):
         if image_latents.shape[0] != latents.shape[0]:
             raise ValueError(
-                f"`image_latents` must have have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
+                f"`image_latents` must have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
             )
 
         if image_latents.ndim != 3:

--- a/src/diffusers/modular_pipelines/qwenimage/inputs.py
+++ b/src/diffusers/modular_pipelines/qwenimage/inputs.py
@@ -68,7 +68,7 @@ def repeat_tensor_to_batch_size(
         repeat_by = num_images_per_prompt
     else:
         raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
+            f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
         )
 
     # expand the tensor to match the batch_size * num_images_per_prompt

--- a/src/diffusers/modular_pipelines/wan/before_denoise.py
+++ b/src/diffusers/modular_pipelines/wan/before_denoise.py
@@ -81,7 +81,7 @@ def repeat_tensor_to_batch_size(
         repeat_by = num_videos_per_prompt
     else:
         raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
+            f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
         )
 
     # expand the tensor to match the batch_size * num_videos_per_prompt

--- a/src/diffusers/modular_pipelines/z_image/before_denoise.py
+++ b/src/diffusers/modular_pipelines/z_image/before_denoise.py
@@ -81,7 +81,7 @@ def repeat_tensor_to_batch_size(
         repeat_by = num_images_per_prompt
     else:
         raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
+            f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
         )
 
     # expand the tensor to match the batch_size * num_images_per_prompt

--- a/src/diffusers/pipelines/flux/pipeline_flux_kontext_inpaint.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_kontext_inpaint.py
@@ -981,7 +981,7 @@ class FluxKontextInpaintPipeline(
 
         Args:
             image (`torch.Tensor`, `PIL.Image.Image`, `np.ndarray`, `list[torch.Tensor]`, `list[PIL.Image.Image]`, or `list[np.ndarray]`):
-                `Image`, numpy array or tensor representing an image batch to be be inpainted (which parts of the image
+                `Image`, numpy array or tensor representing an image batch to be inpainted (which parts of the image
                 to be masked out with `mask_image` and repainted according to `prompt` and `image_reference`). For both
                 numpy array and pytorch tensor, the expected value range is between `[0, 1]` If it's a tensor or a list
                 or tensors, the expected shape should be `(B, C, H, W)` or `(C, H, W)`. If it is a numpy array or a


### PR DESCRIPTION
## Summary
- Fix 6 instances of `have have` → `have` in modular pipeline error messages
- Fix `to to` → `to` in UNet docstring
- Fix `be be` → `be` in Flux Kontext inpaint pipeline docstring

## Test plan
- [ ] Verify error messages read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)