### PR TITLE
Fix grammar in LoRA documentation

### DIFF
--- a/docs/source/en/quicktour.md
+++ b/docs/source/en/quicktour.md
@@ -101,9 +101,9 @@ export_to_video(video, "output.mp4", fps=16)
 
 ## LoRA
 
-Adapters insert a small number of trainable parameters to the original base model. Only the inserted parameters are fine-tuned while the rest of the model weights remain frozen. This makes it fast and cheap to fine-tune a model on a new style. Among adapters, [LoRA's](./tutorials/using_peft_for_inference) are the most popular.
+Adapters insert a small number of trainable parameters to the original base model. Only the inserted parameters are fine-tuned while the rest of the model weights remain frozen. This makes it fast and cheap to fine-tune a model on a new style. Among adapters, [LoRAs](./tutorials/using_peft_for_inference) are the most popular.
 
-Add a LoRA to a pipeline with the [`~loaders.QwenImageLoraLoaderMixin.load_lora_weights`] method. Some LoRA's require a special word to trigger it, such as `Realism`, in the example below. Check a LoRA's model card to see if it requires a trigger word.
+Add a LoRA to a pipeline with the [`~loaders.QwenImageLoraLoaderMixin.load_lora_weights`] method. Some LoRAs require a special word to trigger them, such as `Realism`, in the example below. Check a LoRA's model card to see if it requires a trigger word.
 
 ```py
 import torch


### PR DESCRIPTION
  ## Summary
  - Fix `LoRA's` → `LoRAs` in two places (lines 104 and 106) - plural, not possessive
  - Fix `trigger it` → `trigger them` (pronoun agreement: "Some LoRAs" is plural)

  ## Changes
  **Line 104:**
  > Among adapters, [LoRA's] are the most popular.
  → Among adapters, [LoRAs] are the most popular.

  **Line 106:**
  > Some LoRA's require a special word to trigger it
  → Some LoRAs require a special word to trigger them

  ## Location
  `docs/source/en/quicktour.md`, lines 104 and 106