### PR TITLE
fix: correct AttributeError in TangentialCFG and NameError in FrequencyDecoupledGuidance

### DIFF
--- a/src/diffusers/guiders/frequency_decoupled_guidance.py
+++ b/src/diffusers/guiders/frequency_decoupled_guidance.py
@@ -275,7 +275,7 @@ class FrequencyDecoupledGuidance(BaseGuidance):
                     pred_guided_pyramid.append(pred)
                 else:
                     # Add the current pred_cond_pyramid level as the "non-FDG" prediction
-                    pred_guided_pyramid.append(pred_cond_freq)
+                    pred_guided_pyramid.append(pred_cond_pyramid[level])
 
             # Convert from frequency space back to data (e.g. pixel) space by applying inverse freq transform
             pred = build_image_from_pyramid(pred_guided_pyramid)

--- a/src/diffusers/guiders/tangential_classifier_free_guidance.py
+++ b/src/diffusers/guiders/tangential_classifier_free_guidance.py
@@ -101,7 +101,7 @@ class TangentialClassifierFreeGuidance(BaseGuidance):
 
     @property
     def is_conditional(self) -> bool:
-        return self._num_outputs_prepared == 1
+        return self._count_prepared == 1
 
     @property
     def num_conditions(self) -> int:


### PR DESCRIPTION
## Summary

Fixes two functional bugs in the experimental guiders module, both introduced in #11311 (Modular Diffusers Guiders):

### Bug 1: `TangentialClassifierFreeGuidance.is_conditional` — AttributeError

The `is_conditional` property references `self._num_outputs_prepared`, which does not exist on the class or its base class `BaseGuidance`. Every other guider uses `self._count_prepared` (defined and managed by `BaseGuidance`). Accessing `is_conditional` on a `TangentialClassifierFreeGuidance` instance raises:

```
AttributeError: 'TangentialClassifierFreeGuidance' object has no attribute '_num_outputs_prepared'
```

**Fix:** Replace `self._num_outputs_prepared` with `self._count_prepared`.

### Bug 2: `FrequencyDecoupledGuidance.forward` — NameError / wrong pyramid level

In the `forward` method's loop over pyramid levels, the `else` branch (when FDG is disabled for a level) appends `pred_cond_freq` to the guided pyramid. However, `pred_cond_freq` is only assigned inside the `if` branch. This causes:

- **NameError** if the very first pyramid level has FDG disabled (variable never assigned)
- **Silent wrong results** if a prior level assigned it — the wrong level's frequency data gets used

**Fix:** Replace `pred_cond_freq` with `pred_cond_pyramid[level]` to correctly reference the current level's conditional prediction.

## Test plan

- [x] Verified `_num_outputs_prepared` is not defined anywhere in the codebase; `_count_prepared` is the correct attribute used by all other guiders
- [x] Verified `pred_cond_freq` is only assigned inside the `if` branch, confirming the `else` branch will fail or use stale data
- [x] Checked no existing open PRs address these issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)