### PR TITLE
Fix HunyuanVideo 1.5 I2V by preprocessing image at pixel resolution i…

### DIFF
--- a/src/diffusers/pipelines/hunyuan_video1_5/pipeline_hunyuan_video1_5_image2video.py
+++ b/src/diffusers/pipelines/hunyuan_video1_5/pipeline_hunyuan_video1_5_image2video.py
@@ -611,7 +611,7 @@ class HunyuanVideo15ImageToVideoPipeline(DiffusionPipeline):
             tuple: (cond_latents_concat, mask_concat) - both are zero tensors for t2v
         """
 
-        batch, channels, frames, height, width = latents.shape
+        batch, channels, frames, latent_height, latent_width = latents.shape
 
         image_latents = self._get_image_latents(
             vae=self.vae,
@@ -626,7 +626,7 @@ class HunyuanVideo15ImageToVideoPipeline(DiffusionPipeline):
         latent_condition[:, :, 1:, :, :] = 0
         latent_condition = latent_condition.to(device=device, dtype=dtype)
 
-        latent_mask = torch.zeros(batch, 1, frames, height, width, dtype=dtype, device=device)
+        latent_mask = torch.zeros(batch, 1, frames, latent_height, latent_width, dtype=dtype, device=device)
         latent_mask[:, :, 0, :, :] = 1.0
 
         return latent_condition, latent_mask


### PR DESCRIPTION
…nstead of latent resolution

# What does this PR do?

Fixes #13439

prepare_cond_latents_and_mask shadows the pixel height/width parameters with latent dims from latents.shape (line 614):

```
batch, channels, frames, height, width = latents.shape  # overwrites pixel h/w with latent h/w
```

This causes _get_image_latents to preprocess the conditioning image at latent resolution (~30x44) instead of pixel resolution (480x704).

Renamed to latent_height/latent_width so the original pixel dims are preserved for image preprocessing.

The original Tencent implementation ([HunyuanVideo-1.5](https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5)) resizes at pixel resolution.

Found while working on the modular pipeline for HunyuanVideo 1.5 (#13389).

Fixes #13439


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@yiyixuxu @DN6 @sayakpaul 
