### PR TITLE
fix: QwenImage pipelines silently disable CFG with pre-computed negative_prompt_embeds

### DIFF
--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage.py
@@ -585,7 +585,7 @@ class QwenImagePipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
         device = self._execution_device
 
         has_neg_prompt = negative_prompt is not None or (
-            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+            negative_prompt_embeds is not None
         )
 
         if true_cfg_scale > 1 and not has_neg_prompt:

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_controlnet.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_controlnet.py
@@ -701,7 +701,7 @@ class QwenImageControlNetPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
         device = self._execution_device
 
         has_neg_prompt = negative_prompt is not None or (
-            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+            negative_prompt_embeds is not None
         )
 
         if true_cfg_scale > 1 and not has_neg_prompt:

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_controlnet_inpaint.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_controlnet_inpaint.py
@@ -740,7 +740,7 @@ class QwenImageControlNetInpaintPipeline(DiffusionPipeline, QwenImageLoraLoaderM
         device = self._execution_device
 
         has_neg_prompt = negative_prompt is not None or (
-            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+            negative_prompt_embeds is not None
         )
         do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
         prompt_embeds, prompt_embeds_mask = self.encode_prompt(

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit.py
@@ -706,7 +706,7 @@ class QwenImageEditPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
             image = image.unsqueeze(2)
 
         has_neg_prompt = negative_prompt is not None or (
-            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+            negative_prompt_embeds is not None
         )
 
         if true_cfg_scale > 1 and not has_neg_prompt:

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_inpaint.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_inpaint.py
@@ -879,7 +879,7 @@ class QwenImageEditInpaintPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
             image = image.to(dtype=torch.float32)
 
         has_neg_prompt = negative_prompt is not None or (
-            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+            negative_prompt_embeds is not None
         )
 
         if true_cfg_scale > 1 and not has_neg_prompt:

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_plus.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_plus.py
@@ -694,7 +694,7 @@ class QwenImageEditPlusPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
                 vae_images.append(self.image_processor.preprocess(img, vae_height, vae_width).unsqueeze(2))
 
         has_neg_prompt = negative_prompt is not None or (
-            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+            negative_prompt_embeds is not None
         )
 
         if true_cfg_scale > 1 and not has_neg_prompt:

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_img2img.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_img2img.py
@@ -678,7 +678,7 @@ class QwenImageImg2ImgPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
         device = self._execution_device
 
         has_neg_prompt = negative_prompt is not None or (
-            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+            negative_prompt_embeds is not None
         )
 
         if true_cfg_scale > 1 and not has_neg_prompt:

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_inpaint.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_inpaint.py
@@ -823,7 +823,7 @@ class QwenImageInpaintPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
         device = self._execution_device
 
         has_neg_prompt = negative_prompt is not None or (
-            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+            negative_prompt_embeds is not None
         )
 
         if true_cfg_scale > 1 and not has_neg_prompt:

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_layered.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_layered.py
@@ -698,7 +698,7 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
             batch_size = prompt_embeds.shape[0]
 
         has_neg_prompt = negative_prompt is not None or (
-            negative_prompt_embeds is not None and negative_prompt_embeds_mask is not None
+            negative_prompt_embeds is not None
         )
 
         if true_cfg_scale > 1 and not has_neg_prompt:


### PR DESCRIPTION
## Summary
- Fix all 9 QwenImage pipeline variants where CFG is silently disabled when passing `negative_prompt_embeds` with `None` mask
- `encode_prompt()` converts all-ones masks to `None` as an optimization (line 266-267), but `has_neg_prompt` required mask to be non-None — creating an inconsistency
- Remove the `and negative_prompt_embeds_mask is not None` check so `None` mask means "all tokens valid"

## Affected pipelines
- `pipeline_qwenimage.py`
- `pipeline_qwenimage_img2img.py`
- `pipeline_qwenimage_inpaint.py`
- `pipeline_qwenimage_layered.py`
- `pipeline_qwenimage_controlnet.py`
- `pipeline_qwenimage_controlnet_inpaint.py`
- `pipeline_qwenimage_edit.py`
- `pipeline_qwenimage_edit_inpaint.py`
- `pipeline_qwenimage_edit_plus.py`

## Test plan
- [x] Verified `encode_prompt()` converts all-ones mask to `None` (line 266-267)
- [x] Confirmed all 9 files updated consistently
- [x] No remaining instances of the old pattern in codebase

Fixes #13377

🤖 Generated with [Claude Code](https://claude.com/claude-code)