### PR TITLE
Fix SDXL Refiner with Higher Order Schedulers

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -1175,8 +1175,10 @@ class StableDiffusionXLPipeline(
                     - (self.denoising_end * self.scheduler.config.num_train_timesteps)
                 )
             )
-            num_inference_steps = len(list(filter(lambda ts: ts >= discrete_timestep_cutoff, timesteps)))
-            timesteps = timesteps[:num_inference_steps]
+            num_inference_steps = (
+                (torch.as_tensor(timesteps)[:: self.scheduler.order] >= discrete_timestep_cutoff).sum().item()
+            )
+            timesteps = timesteps[: num_inference_steps * self.scheduler.order]
 
         # 9. Optionally get Guidance Scale Embedding
         timestep_cond = None

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -666,18 +666,11 @@ class StableDiffusionXLImg2ImgPipeline(
                 )
             )
 
-            num_inference_steps = (self.scheduler.timesteps < discrete_timestep_cutoff).sum().item()
-            if self.scheduler.order == 2 and num_inference_steps % 2 == 0:
-                # if the scheduler is a 2nd order scheduler we might have to do +1
-                # because `num_inference_steps` might be even given that every timestep
-                # (except the highest one) is duplicated. If `num_inference_steps` is even it would
-                # mean that we cut the timesteps in the middle of the denoising step
-                # (between 1st and 2nd derivative) which leads to incorrect results. By adding 1
-                # we ensure that the denoising process always ends after the 2nd derivate step of the scheduler
-                num_inference_steps = num_inference_steps + 1
+            real_timesteps = self.scheduler.timesteps[:: self.scheduler.order]
+            num_inference_steps = (real_timesteps < discrete_timestep_cutoff).sum().item()
 
             # because t_n+1 >= t_n, we slice the timesteps starting from the end
-            t_start = len(self.scheduler.timesteps) - num_inference_steps
+            t_start = (len(real_timesteps) - num_inference_steps) * self.scheduler.order
             timesteps = self.scheduler.timesteps[t_start:]
             if hasattr(self.scheduler, "set_begin_index"):
                 self.scheduler.set_begin_index(t_start)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes SDXL refiner w/ higher order schedulers by changing the strange hardcoded `order==2` check with a simple tensor stride.

Standalone script using a scheduler with `order=15`
```py
# /// script
# requires-python = ">=3.12"
# dependencies = [
#     "diffusers",
#     "skrample==0.6.*",
#     "torch>=2.11.0",
#     "transformers>=5.5.3",
# ]
#
# [tool.uv.sources]
# diffusers = { git = "https://github.com/Beinsezii/diffusers.git", rev = "beinsezii/fix_denoise_order" }
# ///

import torch
from skrample.diffusers import RKUltraWrapperScheduler

from diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl import StableDiffusionXLPipeline
from diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl_img2img import (
    StableDiffusionXLImg2ImgPipeline,
)


with torch.inference_mode():
    DEVICE = "cuda"
    DTYPE = torch.bfloat16
    BASE = "stabilityai/stable-diffusion-xl-base-1.0"
    REFINER = "stabilityai/stable-diffusion-xl-refiner-1.0"

    PROMPT = "bright high resolution dslr photograph of a kitten in a field of lavender flowers"
    CFG: float = 8
    RATIO: float = 0.6
    ORDER: int = 15

    base = StableDiffusionXLPipeline.from_pretrained(BASE).to(device=DEVICE, dtype=DTYPE)
    refiner = StableDiffusionXLImg2ImgPipeline.from_pretrained(
        REFINER,
        vae=base.vae,
        text_encoder_2=base.text_encoder_2,
    ).to(device=DEVICE, dtype=DTYPE)
    base.scheduler = RKUltraWrapperScheduler.from_diffusers_config(base.scheduler.config, sampler_order=ORDER)
    refiner.scheduler = RKUltraWrapperScheduler.from_diffusers_config(refiner.scheduler.config, sampler_order=ORDER)

    for steps in 5, 10:
        partial = base(
            prompt=PROMPT,
            guidance_scale=CFG,
            num_inference_steps=steps,
            denoising_end=RATIO,
            output_type="latent",
        ).images[0]
        refiner(
            image=partial,
            prompt=PROMPT,
            guidance_scale=CFG,
            num_inference_steps=steps,
            denoising_start=RATIO,
        ).images[0].save(f"order_{refiner.scheduler.order}_{steps}_steps.png")
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@yiyixuxu @sayakpaul 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
