### PR TITLE
fix: align text_encoder_out_layers default with pipeline for Flux 2 Klein

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
@@ -358,7 +358,7 @@ def parse_args(input_args=None):
         "--text_encoder_out_layers",
         type=int,
         nargs="+",
-        default=[10, 20, 30],
+        default=[9, 18, 27],
         help="Text encoder hidden layers to compute the final text embeddings.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Problem

The `--text_encoder_out_layers` CLI argument in `train_dreambooth_lora_flux2_klein.py` defaults to `[10, 20, 30]`, but the pipeline implementation (`pipeline_flux2_klein.py`) uses `(9, 18, 27)`.

This off-by-one mismatch causes the training script to use different text encoder layers than what the pipeline expects at inference time, leading to silently degraded results.

## Fix

Change the CLI default from `[10, 20, 30]` to `[9, 18, 27]` to match the pipeline.

Fixes #13445