### PR TITLE
Ensure consistent dynamic module path for custom components

### DIFF
--- a/src/diffusers/utils/dynamic_modules_utils.py
+++ b/src/diffusers/utils/dynamic_modules_utils.py
@@ -27,6 +27,7 @@ from types import ModuleType
 from urllib import request
 
 from huggingface_hub import hf_hub_download, model_info
+from huggingface_hub.constants import HF_HUB_CACHE
 from huggingface_hub.utils import RevisionNotFoundError, validate_hf_hub_args
 from packaging import version
 
@@ -298,6 +299,7 @@ def get_cached_module_file(
     """
     # Download and cache module_file from the repo `pretrained_model_name_or_path` of grab it if it's a local file.
     pretrained_model_name_or_path = str(pretrained_model_name_or_path)
+    commit_hash = None
 
     if subfolder is not None:
         module_file_or_url = os.path.join(pretrained_model_name_or_path, subfolder, module_file)
@@ -306,7 +308,18 @@ def get_cached_module_file(
 
     if os.path.isfile(module_file_or_url):
         resolved_module_file = module_file_or_url
-        submodule = "local"
+        # When the local path is inside the HuggingFace Hub cache (e.g. a custom
+        # component downloaded as part of a whole pipeline via snapshot_download),
+        # extract the repo ID and commit hash so the submodule name and versioning
+        # match the behaviour of loading the component individually via AutoModel.
+        # HF cache layout: {hf_cache}/models--{org}--{repo}/snapshots/{hash}/…
+        hf_cache = str(cache_dir) if cache_dir is not None else HF_HUB_CACHE
+        hf_cache_prefix = os.path.join(hf_cache, "models--")
+        if module_file_or_url.startswith(hf_cache_prefix):
+            model_name, _, commit_hash, _ = module_file_or_url.replace(hf_cache_prefix, "").split(os.sep, 3)
+            submodule = os.path.join("local", model_name)
+        else:
+            submodule = "local"
     elif pretrained_model_name_or_path.count("/") == 0:
         available_versions = get_diffusers_versions()
         # cut ".dev0"
@@ -395,7 +408,8 @@ def get_cached_module_file(
     else:
         # Get the commit hash
         # TODO: we will get this info in the etag soon, so retrieve it from there and not here.
-        commit_hash = model_info(pretrained_model_name_or_path, revision=revision, token=token).sha
+        if commit_hash is None:
+            commit_hash = model_info(pretrained_model_name_or_path, revision=revision, token=token).sha
 
         # The module file will end up being placed in a subfolder with the git hash of the repo. This way we get the
         # benefit of versioning.


### PR DESCRIPTION
# What does this PR do?

Currently the behaviour/final module path of the are different in the following way:
- if it's a standalone custom `AutoModel`, the dynamic module is being loaded directly from the hub into `diffusers_modules.local.org--repo.hash.file.class`
- however if it's a custom component from a pipeline, hub files were already downloaded and cached from previous loading, and it's being passed as a "local dir", thus the dynamic module becomes `diffusers_modules.local.file.class`

This proposed change is to unify the second behaviour to be consistent with the first one where if it's being loaded from a local dir that's known to be a hub download cache; and as a bonus, it's more self contained and less likely to collide with other custom modules with the same file name sharing in the same local diffusers_modules.root folder/module

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- git blame author: @patrickvonplaten
- General functionalities: @sayakpaul @yiyixuxu @DN6

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
