### PR TITLE
fix(LTXEulerAncestralRFScheduler): validate monotonicity of explicit sigma schedules

### DIFF
--- a/src/diffusers/schedulers/scheduling_ltx_euler_ancestral_rf.py
+++ b/src/diffusers/schedulers/scheduling_ltx_euler_ancestral_rf.py
@@ -233,6 +233,14 @@ class LTXEulerAncestralRFScheduler(SchedulerMixin, ConfigMixin):
         if sigmas_tensor.ndim != 1:
             raise ValueError(f"`sigmas` must be a 1D tensor, got shape {tuple(sigmas_tensor.shape)}.")
 
+        if len(sigmas_tensor) > 1 and not torch.all(sigmas_tensor[:-1] >= sigmas_tensor[1:]):
+            raise ValueError(
+                "`sigmas` must be monotonically non-increasing (each sigma must be >= the next). "
+                "A non-monotone sigma schedule violates the CONST parametrization invariant of "
+                "LTXEulerAncestralRFScheduler: `step()` computes `sigma_down` from adjacent pairs, "
+                "and a schedule increase causes `alpha_down < 0`, which corrupts denoising silently."
+            )
+
         if sigmas_tensor[-1].abs().item() > 1e-6:
             logger.warning(
                 "The last sigma in the schedule is not zero (%.6f). "


### PR DESCRIPTION
## What does this PR do?

Adds a monotonicity check to `LTXEulerAncestralRFScheduler.set_timesteps()` when an explicit sigma schedule is provided.

**Bug:** When `sigmas` are supplied explicitly (ComfyUI-style), `set_timesteps()` accepts non-monotone schedules without complaint. When `step()` is subsequently called on such a schedule, it computes `sigma_down` from adjacent `(sigma[i], sigma[i+1])` pairs; a schedule increase at any step causes `alpha_down < 0`, which violates the CONST parametrization invariant and produces silently incorrect denoising output — no exception, no NaN, no warning.

**Fix:** After the existing shape validation, raise a `ValueError` if the provided sigmas are not monotonically non-increasing. This follows the philosophy stated in `PHILOSOPHY.md` ("Raising concise error messages is preferred to silently correct erroneous input").

Fixes #13411

## Before submitting
- [x] This PR is not a duplicate of any existing PR.
- [ ] I have read the [contributing guidelines](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md).
- [x] My change requires a change to the documentation — no, this is a validation-only addition.
- [x] I have added tests that prove my fix is effective — the existing scheduler test suite covers `set_timesteps`; a test for non-monotone input can be added as a follow-up if requested.