### PR TITLE
hooks/pyramid_attention_broadcast: fix redundant recompute at iteration 0 and free stale cache when outside timestep range

### DIFF
--- a/src/diffusers/hooks/pyramid_attention_broadcast.py
+++ b/src/diffusers/hooks/pyramid_attention_broadcast.py
@@ -181,6 +181,7 @@ class PyramidAttentionBroadcastHook(ModelHook):
         self.state.reset()
         return module
 
+
 def apply_pyramid_attention_broadcast(module: torch.nn.Module, config: PyramidAttentionBroadcastConfig):
     r"""
     Apply [Pyramid Attention Broadcast](https://huggingface.co/papers/2408.12588) to a given pipeline.

--- a/src/diffusers/hooks/pyramid_attention_broadcast.py
+++ b/src/diffusers/hooks/pyramid_attention_broadcast.py
@@ -158,24 +158,19 @@ class PyramidAttentionBroadcastHook(ModelHook):
             self.timestep_skip_range[0] < self.current_timestep_callback() < self.timestep_skip_range[1]
         )
         should_compute_attention = (
-            self.state.cache is None
-            or not is_within_timestep_range
-            or self.state.iteration % self.block_skip_range == 0
-        )
+    self.state.cache is None
+    or not is_within_timestep_range
+    or self.state.iteration % self.block_skip_range == 0
+)
 
-        if should_compute_attention:
-            output = self.fn_ref.original_forward(*args, **kwargs)
-            # When outside the active timestep window, release the cached tensor
-            # immediately so GPU memory is not held until the next reset_state().
-            if not is_within_timestep_range:
-                self.state.cache = None
-            else:
-                self.state.cache = output
-        else:
-            output = self.state.cache
+if should_compute_attention:
+    output = self.fn_ref.original_forward(*args, **kwargs)
+else:
+    output = self.state.cache
 
-        self.state.iteration += 1
-        return output
+self.state.cache = output
+self.state.iteration += 1
+return output
 
     def reset_state(self, module: torch.nn.Module) -> None:
         self.state.reset()

--- a/src/diffusers/hooks/pyramid_attention_broadcast.py
+++ b/src/diffusers/hooks/pyramid_attention_broadcast.py
@@ -159,24 +159,27 @@ class PyramidAttentionBroadcastHook(ModelHook):
         )
         should_compute_attention = (
             self.state.cache is None
-            or self.state.iteration == 0
             or not is_within_timestep_range
             or self.state.iteration % self.block_skip_range == 0
         )
 
         if should_compute_attention:
             output = self.fn_ref.original_forward(*args, **kwargs)
+            # When outside the active timestep window, release the cached tensor
+            # immediately so GPU memory is not held until the next reset_state().
+            if not is_within_timestep_range:
+                self.state.cache = None
+            else:
+                self.state.cache = output
         else:
             output = self.state.cache
 
-        self.state.cache = output
         self.state.iteration += 1
         return output
 
     def reset_state(self, module: torch.nn.Module) -> None:
         self.state.reset()
         return module
-
 
 def apply_pyramid_attention_broadcast(module: torch.nn.Module, config: PyramidAttentionBroadcastConfig):
     r"""


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in `PyramidAttentionBroadcastHook.new_forward`:

1. **Redundant `iteration == 0` condition** — `self.state.cache is None` already
   covers the first-call case after every `reset_state`, making the extra guard
   dead code that creates a misleading impression of two independent invariants.

2. **Stale cache leaking GPU VRAM** — when outside the active timestep range,
   the hook was still writing `self.state.cache = output`, holding a full
   hidden-state activation tensor on GPU until the next generation's
   `reset_state` call. For video transformers with dozens of PAB-hooked layers
   this accumulates hundreds of MBs of unreleased VRAM. The fix sets
   `self.state.cache = None` immediately when outside the range.

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline?
- [ ] Did you read our philosophy doc (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the forum?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?
@yiyixuxu @sayakpaul @DN6