### PR TITLE
Fix encoder difference between modular and standard pipelines for Qwen Image and consistency with other models

### DIFF
--- a/src/diffusers/modular_pipelines/qwenimage/encoders.py
+++ b/src/diffusers/modular_pipelines/qwenimage/encoders.py
@@ -764,12 +764,11 @@ class QwenImageTextEncoderStep(ModularPipelineBlocks):
 
         block_state.negative_prompt_embeds = None
         block_state.negative_prompt_embeds_mask = None
-        if components.requires_unconditional_embeds:
-            negative_prompt = block_state.negative_prompt or ""
+        if components.requires_unconditional_embeds and block_state.negative_prompt is not None:
             block_state.negative_prompt_embeds, block_state.negative_prompt_embeds_mask = get_qwen_prompt_embeds(
                 components.text_encoder,
                 components.tokenizer,
-                prompt=negative_prompt,
+                prompt=block_state.negative_prompt,
                 prompt_template_encode=self.prompt_template_encode,
                 prompt_template_encode_start_idx=self.prompt_template_encode_start_idx,
                 tokenizer_max_length=self.tokenizer_max_length,
@@ -893,12 +892,11 @@ class QwenImageEditTextEncoderStep(ModularPipelineBlocks):
 
         block_state.negative_prompt_embeds = None
         block_state.negative_prompt_embeds_mask = None
-        if components.requires_unconditional_embeds:
-            negative_prompt = block_state.negative_prompt or " "
+        if components.requires_unconditional_embeds and block_state.negative_prompt is not None:
             block_state.negative_prompt_embeds, block_state.negative_prompt_embeds_mask = get_qwen_prompt_embeds_edit(
                 components.text_encoder,
                 components.processor,
-                prompt=negative_prompt,
+                prompt=block_state.negative_prompt,
                 image=block_state.resized_image,
                 prompt_template_encode=self.prompt_template_encode,
                 prompt_template_encode_start_idx=self.prompt_template_encode_start_idx,
@@ -1022,13 +1020,12 @@ class QwenImageEditPlusTextEncoderStep(ModularPipelineBlocks):
 
         block_state.negative_prompt_embeds = None
         block_state.negative_prompt_embeds_mask = None
-        if components.requires_unconditional_embeds:
-            negative_prompt = block_state.negative_prompt or " "
+        if components.requires_unconditional_embeds and block_state.negative_prompt is not None:
             block_state.negative_prompt_embeds, block_state.negative_prompt_embeds_mask = (
                 get_qwen_prompt_embeds_edit_plus(
                     components.text_encoder,
                     components.processor,
-                    prompt=negative_prompt,
+                    prompt=block_state.negative_prompt,
                     image=block_state.resized_cond_image,
                     prompt_template_encode=self.prompt_template_encode,
                     img_template_encode=self.img_template_encode,


### PR DESCRIPTION
In standard pipeline, without negative prompt, the pipeline is run without CFG. 
In the modular pipeline, the absence of a negative_prompt is by default replaced by an empty string "", outputing negative_prompt_embeds. 

Better align for 
1/ migration to modular pipelines
2/ consistency with other models: Flux.2, Z-image, QwenImage (none of them return negative_prompt_embeds when negative_prompt is None) 

Thanks

--- 


The fix is consistent across all three QwenImage encoder pipelines. The change in all three:                   
                                                                                                             
  - Before: if components.requires_unconditional_embeds: → always True, falls back to "" or " " silently     
  - After: if components.requires_unconditional_embeds and block_state.negative_prompt is not None: → mirrors
   the non-modular pipeline's do_true_cfg = true_cfg_scale > 1 and has_neg_prompt logic                      
                                                                                                             
  The or "" / or " " fallback is also removed — there's no point encoding a silent fallback that the user    
  never asked for. If the user wants CFG, they pass a negative_prompt; if they don't, negative embeddings
  stay None.  