### PR TITLE
[Bugfix] Fix shape mismatch in LongCatAudioDiTTransformer conversion

### DIFF
--- a/scripts/convert_longcat_audio_dit_to_diffusers.py
+++ b/scripts/convert_longcat_audio_dit_to_diffusers.py
@@ -131,6 +131,7 @@ def convert_longcat_audio_dit(
         cross_attn_norm=config.get("dit_cross_attn_norm", False),
         eps=config.get("dit_eps", 1e-6),
         use_latent_condition=config.get("dit_use_latent_condition", True),
+        ff_mult=config.get("dit_ff_mult", 4),
     )
     transformer.load_state_dict(transformer_state_dict, strict=True)
     transformer = transformer.to(dtype=torch_dtype)

--- a/src/diffusers/models/transformers/transformer_longcat_audio_dit.py
+++ b/src/diffusers/models/transformers/transformer_longcat_audio_dit.py
@@ -475,6 +475,7 @@ class LongCatAudioDiTTransformer(ModelMixin, ConfigMixin):
         cross_attn_norm: bool = False,
         eps: float = 1e-6,
         use_latent_condition: bool = True,
+        ff_mult: float = 4.0,
     ):
         super().__init__()
         dim = dit_dim
@@ -498,7 +499,7 @@ class LongCatAudioDiTTransformer(ModelMixin, ConfigMixin):
                     cross_attn_norm=cross_attn_norm,
                     adaln_type=adaln_type,
                     adaln_use_text_cond=adaln_use_text_cond,
-                    ff_mult=4.0,
+                    ff_mult=ff_mult,
                 )
                 for _ in range(dit_depth)
             ]


### PR DESCRIPTION

Fixes # (issue)

```
RuntimeError: Error(s) in loading state_dict for LongCatAudioDiTTransformer:
        size mismatch for blocks.0.ffn.ff.0.weight: copying a param with shape torch.Size([9216, 2560]) from checkpoint, the shape in current model is torch.Size([10240, 2560]).
```

**Root cause:**
The `ff_mult` parameter was hardcoded to 4.0 in the transformer but the **LongCat-AudioDiT-3.5B** checkpoint uses `ff_mult=3.6`, causing FFN weight shape mismatch (9216 vs 10240).

Now reads `dit_ff_mult` from` config.json`, enabling conversion of models with non-default `ff_mult` (e.g., 3.5B model uses 3.6).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
