### PR TITLE
hooks/pyramid_attention_broadcast: remove redundant iteration==0 guard and fix stale cache VRAM leak

### DIFF
--- a/src/diffusers/hooks/pyramid_attention_broadcast.py
+++ b/src/diffusers/hooks/pyramid_attention_broadcast.py
@@ -159,7 +159,6 @@ class PyramidAttentionBroadcastHook(ModelHook):
         )
         should_compute_attention = (
             self.state.cache is None
-            or self.state.iteration == 0
             or not is_within_timestep_range
             or self.state.iteration % self.block_skip_range == 0
         )
@@ -169,7 +168,7 @@ class PyramidAttentionBroadcastHook(ModelHook):
         else:
             output = self.state.cache
 
-        self.state.cache = output
+        self.state.cache = output if is_within_timestep_range else None
         self.state.iteration += 1
         return output
 


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in `PyramidAttentionBroadcastHook.new_forward`:

**1. Redundant `iteration == 0` condition**
After every `reset_state()`, both `iteration` and `cache` are reset to `0` and `None` respectively. So at iteration 0, `self.state.cache is None` is always `True`, making `self.state.iteration == 0` permanently dead code that creates a misleading impression of two independent invariants.

**2. Stale cache leaking GPU VRAM**
When outside the active timestep range, the hook was unconditionally writing `self.state.cache = output`, holding a full hidden-state activation tensor on GPU until the next generation's `reset_state()` call. For video transformers with dozens of PAB-hooked layers, this accumulates hundreds of MBs of unreleased VRAM. The fix sets `self.state.cache = None` immediately when outside the range.

This is a re-submission of #13467 (accidentally self-closed). Apologies for the noise, @sayakpaul!

## Checklist
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?
@sayakpaul @DN6