### PR TITLE
fix(freeu): run FFT in float32 for float16 inputs to avoid ComplexHalf

### DIFF
--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -223,8 +223,10 @@ def fourier_filter(x_in: "torch.Tensor", threshold: int, scale: int) -> "torch.T
     # Non-power of 2 images must be float32
     if (W & (W - 1)) != 0 or (H & (H - 1)) != 0:
         x = x.to(dtype=torch.float32)
-    # fftn does not support bfloat16
-    elif x.dtype == torch.bfloat16:
+    # fftn does not support bfloat16, and produces the experimental ComplexHalf
+    # dtype (torch.complex32) when given float16, which is numerically unstable
+    # and triggers a UserWarning.
+    elif x.dtype in (torch.bfloat16, torch.float16):
         x = x.to(dtype=torch.float32)
 
     # FFT

--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -225,8 +225,8 @@ def fourier_filter(x_in: "torch.Tensor", threshold: int, scale: int) -> "torch.T
         x = x.to(dtype=torch.float32)
     # fftn does not support bfloat16, and produces the experimental ComplexHalf
     # dtype (torch.complex32) when given float16, which is numerically unstable
-    # and triggers a UserWarning.
-    elif x.dtype in (torch.bfloat16, torch.float16):
+    # and triggers a UserWarning. Upcast any non-float32 dtype to float32.
+    elif x.dtype != torch.float32:
         x = x.to(dtype=torch.float32)
 
     # FFT

--- a/tests/others/test_utils.py
+++ b/tests/others/test_utils.py
@@ -207,7 +207,7 @@ class DeprecateTester(unittest.TestCase):
 class FourierFilterTester(unittest.TestCase):
     """Tests for :func:`diffusers.utils.torch_utils.fourier_filter` (FreeU helper)."""
 
-    def _run_without_complexhalf_warning(self, dtype) -> "torch.Tensor":
+    def _run_without_complexhalf_warning(self, dtype):
         import torch
 
         from diffusers.utils.torch_utils import fourier_filter

--- a/tests/others/test_utils.py
+++ b/tests/others/test_utils.py
@@ -204,6 +204,49 @@ class DeprecateTester(unittest.TestCase):
         ), f"Expected deprecation message substring not found, got: {messages}"
 
 
+class FourierFilterTester(unittest.TestCase):
+    """Tests for :func:`diffusers.utils.torch_utils.fourier_filter` (FreeU helper)."""
+
+    def _run_without_complexhalf_warning(self, dtype) -> "torch.Tensor":
+        import torch
+
+        from diffusers.utils.torch_utils import fourier_filter
+
+        x = torch.randn(1, 4, 32, 32, dtype=dtype)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            out = fourier_filter(x, threshold=1, scale=0.5)
+
+        messages = [str(w.message) for w in caught]
+        assert not any("ComplexHalf" in m for m in messages), (
+            f"Unexpected ComplexHalf warning emitted by fourier_filter: {messages}"
+        )
+        return out
+
+    def test_fourier_filter_float16_no_complexhalf_warning(self):
+        import torch
+
+        out = self._run_without_complexhalf_warning(torch.float16)
+        assert out.dtype == torch.float16
+
+    def test_fourier_filter_bfloat16_no_complexhalf_warning(self):
+        import torch
+
+        out = self._run_without_complexhalf_warning(torch.bfloat16)
+        assert out.dtype == torch.bfloat16
+
+    def test_fourier_filter_preserves_dtype_and_shape(self):
+        import torch
+
+        from diffusers.utils.torch_utils import fourier_filter
+
+        for dtype in (torch.float32, torch.float16, torch.bfloat16):
+            x = torch.randn(2, 3, 16, 16, dtype=dtype)
+            out = fourier_filter(x, threshold=1, scale=0.5)
+            assert out.dtype == dtype
+            assert out.shape == x.shape
+
+
 # Copied from https://github.com/huggingface/transformers/blob/main/tests/utils/test_expectations.py
 class ExpectationsTester(unittest.TestCase):
     def test_expectations(self):


### PR DESCRIPTION
## What does this PR do?

Closes #12504.

`fourier_filter` (the FFT helper used by `enable_freeu`) already upcasts
`bfloat16` inputs to `float32` before calling `torch.fft.fftn`, because
PyTorch's FFT does not support bf16. The same is true for `float16`:
depending on the PyTorch version, `fftn` either

- produces the experimental `torch.complex32` (ComplexHalf) dtype and
  emits a `UserWarning: ComplexHalf support is experimental…` (the
  original symptom in #12504), or
- raises `RuntimeError: Unsupported dtype Half` outright (reproduced on
  CPU with `torch==2.9.0`).

Both paths were reachable from FreeU with half-precision models
(`sd-turbo` + `torch_dtype=torch.float16` + `enable_freeu(…)`).

### Fix

Extend the existing upcast branch to cover `float16` as well as
`bfloat16`. The function already downcasts back to `x_in.dtype` at the
end, so the externally observable dtype is unchanged.

```python
    # Non-power of 2 images must be float32
    if (W & (W - 1)) != 0 or (H & (H - 1)) != 0:
        x = x.to(dtype=torch.float32)
    # fftn does not support bfloat16, and produces the experimental ComplexHalf
    # dtype (torch.complex32) when given float16, which is numerically unstable
    # and triggers a UserWarning.
    elif x.dtype in (torch.bfloat16, torch.float16):
        x = x.to(dtype=torch.float32)
```

Running FFT in fp32 and downcasting is also more numerically accurate
than staying in fp16/complex32.

### Tests

Added `tests/others/test_utils.py::FourierFilterTester` with three
cases:

- `test_fourier_filter_float16_no_complexhalf_warning` — fp16 input
  produces no `ComplexHalf` warning and returns an fp16 tensor.
- `test_fourier_filter_bfloat16_no_complexhalf_warning` — regression
  guard for the existing bf16 path.
- `test_fourier_filter_preserves_dtype_and_shape` — verifies dtype and
  shape round-trip for all three supported dtypes.

Locally on `torch==2.9.0+cpu`, these tests fail without the patch
(RuntimeError for fp16) and pass with it.

```
tests/others/test_utils.py::FourierFilterTester::test_fourier_filter_bfloat16_no_complexhalf_warning PASSED
tests/others/test_utils.py::FourierFilterTester::test_fourier_filter_float16_no_complexhalf_warning PASSED
tests/others/test_utils.py::FourierFilterTester::test_fourier_filter_preserves_dtype_and_shape PASSED
```

### Why not PR #12511?

PR #12511 addresses the same warning by locally suppressing it with
`warnings.catch_warnings()` around `fftn`/`ifftn`. That hides the
warning but keeps the FFT running on ComplexHalf (or raising on
platforms where fp16 FFT is unsupported). This PR instead removes the
root cause: the FFT is run in fp32, matching the existing bf16 handling.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md)?
- [x] Was this discussed/approved via a GitHub issue? (See #12504.)
- [ ] Did you make sure to update the documentation with your changes? *(No docs touch API surface.)*
- [x] Did you write any new necessary tests?

## Who can review?

@sayakpaul @yiyixuxu

*AI assistance (Claude) was used to draft this patch. I reviewed every
line and ran the tests locally.*