### PR TITLE
fix(randn_tensor): compare device.type, not torch.device, when suppressing MPS info log

### DIFF
--- a/src/diffusers/utils/torch_utils.py
+++ b/src/diffusers/utils/torch_utils.py
@@ -173,7 +173,7 @@ def randn_tensor(
         gen_device_type = generator.device.type if not isinstance(generator, list) else generator[0].device.type
         if gen_device_type != device.type and gen_device_type == "cpu":
             rand_device = "cpu"
-            if device != "mps":
+            if device.type != "mps":
                 logger.info(
                     f"The passed generator was created on 'cpu' even though a tensor on {device} was expected."
                     f" Tensors will be created on 'cpu' and then moved to {device}. Note that one can probably"

--- a/tests/others/test_utils.py
+++ b/tests/others/test_utils.py
@@ -247,6 +247,54 @@ class FourierFilterTester(unittest.TestCase):
             assert out.shape == x.shape
 
 
+class RandnTensorTester(unittest.TestCase):
+    """Tests for :func:`diffusers.utils.torch_utils.randn_tensor`."""
+
+    def test_mps_suppresses_cpu_generator_info_log(self):
+        """
+        When a CPU generator targets MPS, the informational log about falling back to CPU
+        should be suppressed — MPS does not support device-side generators, so the message
+        would be misleading. Prior to fixing the ``device != "mps"`` string/``torch.device``
+        comparison this log fired on every device, including MPS.
+        """
+        import logging as py_logging
+
+        import torch
+
+        from diffusers.utils import logging as diffusers_logging
+        from diffusers.utils import torch_utils
+
+        gen = torch.Generator(device="cpu")
+
+        diffusers_logging.set_verbosity_info()
+        prev_level = torch_utils.logger.level
+        torch_utils.logger.setLevel(py_logging.INFO)
+
+        def _capture(target_device):
+            with self.assertLogs(torch_utils.logger, level="INFO") as cm:
+                torch_utils.logger.info("sentinel")
+                try:
+                    torch_utils.randn_tensor((1, 2), generator=gen, device=target_device, dtype=torch.float32)
+                except (AssertionError, RuntimeError):
+                    pass
+            return [m for m in cm.output if "sentinel" not in m]
+
+        try:
+            mps_logs = _capture("mps")
+            self.assertFalse(
+                any("moved to" in m and "generator" in m for m in mps_logs),
+                f"MPS target should not emit the CPU-fallback info log, got: {mps_logs}",
+            )
+
+            cuda_logs = _capture("cuda")
+            self.assertTrue(
+                any("moved to" in m and "generator" in m for m in cuda_logs),
+                f"Non-MPS target should still emit the CPU-fallback info log, got: {cuda_logs}",
+            )
+        finally:
+            torch_utils.logger.setLevel(prev_level)
+
+
 # Copied from https://github.com/huggingface/transformers/blob/main/tests/utils/test_expectations.py
 class ExpectationsTester(unittest.TestCase):
     def test_expectations(self):

--- a/tests/others/test_utils.py
+++ b/tests/others/test_utils.py
@@ -251,48 +251,37 @@ class RandnTensorTester(unittest.TestCase):
     """Tests for :func:`diffusers.utils.torch_utils.randn_tensor`."""
 
     def test_mps_suppresses_cpu_generator_info_log(self):
-        """
-        When a CPU generator targets MPS, the informational log about falling back to CPU
-        should be suppressed — MPS does not support device-side generators, so the message
-        would be misleading. Prior to fixing the ``device != "mps"`` string/``torch.device``
-        comparison this log fired on every device, including MPS.
-        """
-        import logging as py_logging
-
         import torch
 
         from diffusers.utils import logging as diffusers_logging
         from diffusers.utils import torch_utils
 
-        gen = torch.Generator(device="cpu")
+        from ..testing_utils import CaptureLogger
 
+        gen = torch.Generator(device="cpu")
         diffusers_logging.set_verbosity_info()
-        prev_level = torch_utils.logger.level
-        torch_utils.logger.setLevel(py_logging.INFO)
 
         def _capture(target_device):
-            with self.assertLogs(torch_utils.logger, level="INFO") as cm:
-                torch_utils.logger.info("sentinel")
+            with CaptureLogger(torch_utils.logger) as cl:
                 try:
                     torch_utils.randn_tensor((1, 2), generator=gen, device=target_device, dtype=torch.float32)
                 except (AssertionError, RuntimeError):
                     pass
-            return [m for m in cm.output if "sentinel" not in m]
+            return cl.out
 
-        try:
-            mps_logs = _capture("mps")
-            self.assertFalse(
-                any("moved to" in m and "generator" in m for m in mps_logs),
-                f"MPS target should not emit the CPU-fallback info log, got: {mps_logs}",
-            )
+        mps_out = _capture("mps")
+        self.assertNotIn(
+            "moved to",
+            mps_out,
+            f"MPS target should not emit the CPU-fallback info log, got: {mps_out}",
+        )
 
-            cuda_logs = _capture("cuda")
-            self.assertTrue(
-                any("moved to" in m and "generator" in m for m in cuda_logs),
-                f"Non-MPS target should still emit the CPU-fallback info log, got: {cuda_logs}",
-            )
-        finally:
-            torch_utils.logger.setLevel(prev_level)
+        cuda_out = _capture("cuda")
+        self.assertIn(
+            "moved to",
+            cuda_out,
+            f"Non-MPS target should still emit the CPU-fallback info log, got: {cuda_out}",
+        )
 
 
 # Copied from https://github.com/huggingface/transformers/blob/main/tests/utils/test_expectations.py


### PR DESCRIPTION
## What does this PR do?

Fixes a latent bug in `randn_tensor` where the MPS-specific info-log suppression has been broken since PR #1902 (Jan 2023).

### The bug

```python
# src/diffusers/utils/torch_utils.py
if isinstance(device, str):
    device = torch.device(device)             # ← device is now a torch.device object
...
if generator is not None:
    gen_device_type = ...
    if gen_device_type != device.type and gen_device_type == "cpu":
        rand_device = "cpu"
        if device != "mps":                   # ← always True
            logger.info("The passed generator was created on 'cpu' ...")
```

The `if device != "mps":` guard was meant to silence the info log on MPS, because MPS doesn't support device-side generators — suggesting the user "create a generator on the mps device" would be misleading.

But by this point `device` is a `torch.device` object (coerced a few lines earlier). `torch.device("mps") == "mps"` is `False` — `torch.device.__eq__` returns `NotImplemented` when compared with a string, Python falls back to identity, and the two are different types. So the guard is effectively always true, and MPS users get the spurious log on every call where a CPU generator is passed — the opposite of the documented intent.

Sanity check:

```python
>>> import torch
>>> torch.device("mps") == "mps"
False
>>> torch.device("mps") != "mps"
True
>>> torch.device("mps").type == "mps"
True
```

### The fix

One-character change: compare `device.type` (a `str`) to `"mps"`.

```diff
-            if device != "mps":
+            if device.type != "mps":
```

### Test

Added `RandnTensorTester.test_mps_suppresses_cpu_generator_info_log` in `tests/others/test_utils.py`, which:

- Asserts **no** CPU-fallback info log is emitted when a CPU generator targets MPS.
- Asserts the log **is** emitted when a CPU generator targets a non-MPS accelerator.

Verified that the test fails on `main` and passes with this fix. All existing tests in `tests/others/test_utils.py` still pass (14/14).

## Before submitting
- [x] This PR fixes a bug that affects MPS users.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests? — Yes, regression test added.

## Who can review?

@sayakpaul @DN6