### PR TITLE
Fix DreamBooth LoRA fp16 training crash after validation

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora.py
+++ b/examples/dreambooth/train_dreambooth_lora.py
@@ -1398,6 +1398,16 @@ def main(args):
                     torch_dtype=weight_dtype,
                 )
 
+                # `log_validation` casts the pipeline (and with it the still-shared `unet`) to
+                # `weight_dtype`, clobbering the fp32 LoRA params set earlier and breaking the
+                # next fp16 backward with "Attempting to unscale FP16 gradients". Re-upcast so
+                # training can resume.
+                if args.mixed_precision == "fp16":
+                    models = [unet]
+                    if args.train_text_encoder:
+                        models.append(text_encoder)
+                    cast_training_params(models, dtype=torch.float32)
+
     # Save the lora layers
     accelerator.wait_for_everyone()
     if accelerator.is_main_process:


### PR DESCRIPTION
## What does this PR do?

Fixes a regression that aborts \`examples/dreambooth/train_dreambooth_lora.py\` on the first training step **after** the first validation, whenever the user combines \`--mixed_precision=fp16\` and \`--validation_prompt\`:

\`\`\`
ValueError: Attempting to unscale FP16 gradients.
\`\`\`

### Root cause

1. LoRA trainable params are upcast to fp32 once, before the training loop, via \`cast_training_params(models, dtype=torch.float32)\` (the pre-existing mitigation from #6514 / #6554).
2. Validation builds a pipeline with \`unet=unwrap_model(unet)\` (i.e. the **same** module object) and \`torch_dtype=weight_dtype\`.
3. \`log_validation\` then does \`pipeline = pipeline.to(accelerator.device, dtype=torch_dtype)\` (line 150 of the script), which casts every component in-place — including the shared \`unet\` — back down to fp16. The LoRA adapter weights are nested inside that module and get cast along with the rest.
4. On the next training step the backward pass produces fp16 grads, which \`accelerate\`'s \`GradScaler.unscale_\` refuses to process.

### Fix

Mirror the pre-training upcast immediately after \`log_validation\` returns: if \`args.mixed_precision == \"fp16\"\`, re-run \`cast_training_params(..., dtype=torch.float32)\` on the trainable modules. bf16 mixed-precision is unaffected because no grad scaler is involved there.

Only one file is touched; 10 lines added, 0 removed. No behavioral change when \`--validation_prompt\` is not set, or when mixed-precision is anything other than fp16.

Fixes #13124

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] This PR fixes a bug (linked above).
- [x] Minimal, targeted change — no refactor.

## Who can review?

cc @sayakpaul