### PR TITLE
Fix double-shift in FlowMatchEulerDiscreteScheduler.__init__

### DIFF
--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -127,6 +127,13 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         timesteps = torch.from_numpy(timesteps).to(dtype=torch.float32)
 
         sigmas = timesteps / num_train_timesteps
+        # Store sigma_min / sigma_max from the *unshifted* sigmas. `set_timesteps` uses these
+        # to seed the per-call schedule and then re-applies `shift` itself — storing the
+        # post-shift values here would make `set_timesteps` shift a second time and produce
+        # sigmas that don't match `__init__`'s schedule (#13243).
+        self.sigma_min = sigmas[-1].item()
+        self.sigma_max = sigmas[0].item()
+
         if not use_dynamic_shifting:
             # when use_dynamic_shifting is True, we apply the timestep shifting on the fly based on the image resolution
             sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)
@@ -139,8 +146,6 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         self._shift = shift
 
         self.sigmas = sigmas.to("cpu")  # to avoid too much CPU/GPU communication
-        self.sigma_min = self.sigmas[-1].item()
-        self.sigma_max = self.sigmas[0].item()
 
     @property
     def shift(self):


### PR DESCRIPTION
## What does this PR do?

Fixes #13243.

When \`use_dynamic_shifting=False\` and \`shift != 1.0\` (the default SD3/FLUX-style config), calling \`scheduler.set_timesteps(num_train_timesteps)\` produced sigmas that were shifted **twice**, so the schedule visible to the sampler did not match the schedule \`__init__\` had already stored on \`self.sigmas\`.

### Root cause

In \`__init__\`:

\`\`\`python
sigmas = timesteps / num_train_timesteps
if not use_dynamic_shifting:
    sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)   # shift applied here
...
self.sigmas    = sigmas.to(\"cpu\")
self.sigma_min = self.sigmas[-1].item()                     # ← read from post-shift
self.sigma_max = self.sigmas[0].item()                      # ← read from post-shift
\`\`\`

\`set_timesteps\` later reseeds the schedule from those two values:

\`\`\`python
timesteps = np.linspace(self._sigma_to_t(self.sigma_max),
                        self._sigma_to_t(self.sigma_min),
                        num_inference_steps)
sigmas = timesteps / self.config.num_train_timesteps
...
if self.config.use_dynamic_shifting:
    sigmas = self.time_shift(mu, 1.0, sigmas)
else:
    sigmas = self.shift * sigmas / (1 + (self.shift - 1) * sigmas)  # shift applied AGAIN
\`\`\`

So the already-shifted \`sigma_min\`/\`sigma_max\` feed straight back into another pass of \`shift * x / (1 + (shift-1)*x)\`.

### Reproduction (from the issue)

With \`FlowMatchEulerDiscreteScheduler(num_train_timesteps=1000, shift=3.0)\`:

| quantity | value |
| --- | --- |
| \`__init__\` last sigma | \`3 · (1/1000) / (1 + 2 · 1/1000) ≈ 0.00299\` |
| \`set_timesteps(1000)\` last sigma (pre-fix) | \`≈ 0.00893\` (~3× off — shift applied on top of itself) |
| \`set_timesteps(1000)\` last sigma (post-fix) | \`≈ 0.00299\` — matches \`__init__\` |

### Fix

Record \`sigma_min\` / \`sigma_max\` from the **unshifted** sigmas (which by construction are \`1/num_train_timesteps\` and \`1.0\`). The shift is then applied exactly once — inside \`set_timesteps\`, on the caller's chosen inference schedule — and \`__init__\`'s stored schedule stops contradicting it.

### Safety check for external consumers

The only in-repo readers of \`scheduler.sigma_min\` / \`scheduler.sigma_max\` post-\`__init__\` are \`set_timesteps\` itself (fixed above) and the Z-Image pipelines, which *write* \`scheduler.sigma_min = 0.0\` before sampling and don't depend on the init value. So this is safe to change.

### Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] This PR fixes a bug (linked above).
- [x] Minimal, targeted change — 2 lines moved, one comment added.

### Who can review?

cc @yiyixuxu @sayakpaul @DN6