### PR TITLE
Fix image_seq_len computation in Lumina2Pipeline

### DIFF
--- a/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
+++ b/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
@@ -696,7 +696,12 @@ class Lumina2Pipeline(DiffusionPipeline, Lumina2LoraLoaderMixin):
 
         # 5. Prepare timesteps
         sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps) if sigmas is None else sigmas
-        image_seq_len = latents.shape[1]
+        # `image_seq_len` is the number of patch tokens the transformer will see, not the
+        # number of latent channels. Lumina2's latents are unpacked `(B, C, H, W)`, so
+        # `latents.shape[1]` gives the channel count (typically 16) instead of the post-patch
+        # sequence length. The transformer patchifies with `config.patch_size` (default 2).
+        patch_size = self.transformer.config.patch_size
+        image_seq_len = (latents.shape[-2] // patch_size) * (latents.shape[-1] // patch_size)
         mu = calculate_shift(
             image_seq_len,
             self.scheduler.config.get("base_image_seq_len", 256),


### PR DESCRIPTION
## What does this PR do?

Fixes #12913.

\`Lumina2Pipeline.__call__\` passes \`latents.shape[1]\` as \`image_seq_len\` when computing \`mu\` for the flow-match scheduler:

\`\`\`python
image_seq_len = latents.shape[1]
mu = calculate_shift(
    image_seq_len,
    self.scheduler.config.get(\"base_image_seq_len\", 256),
    self.scheduler.config.get(\"max_image_seq_len\", 4096),
    self.scheduler.config.get(\"base_shift\", 0.5),
    self.scheduler.config.get(\"max_shift\", 1.15),
)
\`\`\`

Unlike Flux / QwenImage / Chroma / LongCat / Ovis, **Lumina2 does not pack latents** before handing them to the transformer. Its \`prepare_latents\` returns shape \`(B, C, H, W)\`, so \`latents.shape[1]\` is the VAE channel count (typically 16), not a token sequence length.

The transformer itself computes the true sequence length inside its forward:

\`\`\`python
# src/diffusers/models/transformers/transformer_lumina2.py:263-267
batch_size, channels, height, width = hidden_states.shape
p = self.patch_size
post_patch_height, post_patch_width = height // p, width // p
image_seq_len = post_patch_height * post_patch_width
\`\`\`

At 512×512, VAE 8× downscale and \`patch_size=2\` → real \`image_seq_len = (64/2)·(64/2) = 1024\`. The pipeline was passing \`16\` instead. Since \`calculate_shift\` is a linear interpolation across \`[base_image_seq_len, max_image_seq_len] = [256, 4096]\`, any input below \`256\` is clamped to the \`base_shift = 0.5\` endpoint — so \`mu\` ends up constant and **independent of image resolution**, defeating \`use_dynamic_shifting\`.

### Fix

Compute the same expression the transformer uses, via \`self.transformer.config.patch_size\`:

\`\`\`python
patch_size = self.transformer.config.patch_size
image_seq_len = (latents.shape[-2] // patch_size) * (latents.shape[-1] // patch_size)
\`\`\`

This is a one-spot fix — Lumina2 only has a single pipeline file (\`pipeline_lumina2.py\`). No other pipeline with this pattern is affected, because all other flow-match pipelines in the repo (\`flux*\`, \`qwenimage*\`, \`longcat_image*\`, \`ovis_image\`, \`chroma\`, \`nucleusmoe_image\`, \`bria\`, \`flux2*\`) pack their latents via \`_pack_latents\` first, so \`latents.shape[1]\` is the correct sequence length for them.

### Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] This PR fixes a bug (linked above).
- [x] Minimal change, no refactor.

### Who can review?

cc @yiyixuxu @sayakpaul @DN6