### PR TITLE
Fix context-parallel gather crash on PyTorch < 2.6

### DIFF
--- a/src/diffusers/models/_modeling_parallel.py
+++ b/src/diffusers/models/_modeling_parallel.py
@@ -299,7 +299,14 @@ def gather_size_by_comm(size: int, group: dist.ProcessGroup) -> list[int]:
     # HACK: Use Gloo backend for all_gather to avoid H2D and D2H overhead
     comm_backends = str(dist.get_backend(group=group))
     # NOTE: e.g., dist.init_process_group(backend="cpu:gloo,cuda:nccl")
-    gather_device = "cpu" if "cpu" in comm_backends else torch.accelerator.current_accelerator()
+    # `torch.accelerator` is only available in PyTorch >= 2.6; diffusers still supports
+    # older versions, so fall back to the current CUDA device when the module is missing.
+    if "cpu" in comm_backends:
+        gather_device = "cpu"
+    elif hasattr(torch, "accelerator"):
+        gather_device = torch.accelerator.current_accelerator()
+    else:
+        gather_device = torch.cuda.current_device()
     gathered_sizes = [torch.empty((1,), device=gather_device, dtype=torch.int64) for _ in range(world_size)]
     dist.all_gather(
         gathered_sizes,


### PR DESCRIPTION
## What does this PR do?

`gather_size_by_comm` in `src/diffusers/models/_modeling_parallel.py` unconditionally calls `torch.accelerator.current_accelerator()` whenever the backend isn't CPU:

```python
gather_device = "cpu" if "cpu" in comm_backends else torch.accelerator.current_accelerator()
```

`torch.accelerator` was only added in PyTorch 2.6. diffusers still supports 2.1+ (see `setup.py`), so on any older torch this line raises

```
AttributeError: module 'torch' has no attribute 'accelerator'
```

before a single collective runs, breaking context-parallel inference for everyone not yet on 2.6.

This PR guards the call with `hasattr(torch, "accelerator")` and falls back to `torch.cuda.current_device()` — the exact pattern already used in:

- `src/diffusers/loaders/lora_pipeline.py:112`
- `src/diffusers/quantizers/gguf/gguf_quantizer.py:162-164`
- `src/diffusers/hooks/group_offloading.py:169-173`

Fixes #13074

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@DN6 @sayakpaul