### PR TITLE
Fix AuraFlow CUDA context crash when latent size exceeds pos_embed_max_size

### DIFF
--- a/src/diffusers/models/transformers/auraflow_transformer_2d.py
+++ b/src/diffusers/models/transformers/auraflow_transformer_2d.py
@@ -76,6 +76,19 @@ class AuraFlowPatchEmbed(nn.Module):
         h_p, w_p = h // self.patch_size, w // self.patch_size
         h_max, w_max = int(self.pos_embed_max_size**0.5), int(self.pos_embed_max_size**0.5)
 
+        # Guard against inputs larger than the pretrained positional embedding grid:
+        # without this check the centered crop produces negative / out-of-range
+        # indices, which silently corrupt the output on CPU and trigger a
+        # `vectorized_gather_kernel` device-side assert on CUDA that tears down
+        # the entire process (see #12656).
+        if h_p > h_max or w_p > w_max:
+            raise ValueError(
+                f"Input latent size ({h_p}, {w_p}) exceeds the pretrained positional "
+                f"embedding grid ({h_max}, {w_max}). The positional embedding supports "
+                f"latents up to ({h_max * self.patch_size}, {w_max * self.patch_size}) "
+                f"pixels at patch_size={self.patch_size}."
+            )
+
         # Calculate the top-left corner indices for the centered patch grid
         starth = h_max // 2 - h_p // 2
         startw = w_max // 2 - w_p // 2


### PR DESCRIPTION
## What does this PR do?

Fixes #12656.

\`AuraFlowPatchEmbed.pe_selection_index_based_on_dim\` silently produces negative / out-of-range gather indices when the input latent grid is larger than the pretrained positional-embedding grid (\`h_p > h_max\` or \`w_p > w_max\`). Centered-crop math:

\`\`\`python
starth = h_max // 2 - h_p // 2   # becomes negative when h_p > h_max
rows = torch.arange(starth, starth + h_p)
selected_indices = (row_indices * w_max + col_indices).flatten()
\`\`\`

The resulting gather into \`self.pos_embed[:, pe_index]\` trips \`vectorized_gather_kernel: Assertion \`ind >= 0 && ind < ind_dim_size\` failed\` on CUDA, which tears down the entire CUDA context for the process — the user must restart the Python interpreter to use the GPU again. On CPU the kernel silently wraps negative indices to garbage positions.

This PR validates the crop bounds up front and raises a \`ValueError\` with a clear message about the largest supported resolution. The check mirrors the guard already present in \`PatchEmbed.cropped_pos_embed\` for SD3 in \`models/embeddings.py\`.

### Reproducer (from #12656)

\`\`\`python
import torch
from diffusers.models.transformers.auraflow_transformer_2d import AuraFlowPatchEmbed

embed = AuraFlowPatchEmbed(height=16, width=16, patch_size=2, embed_dim=32, in_channels=4, pos_embed_max_size=64)
embed(torch.randn(1, 4, 32, 32))   # h_p=16 > h_max=8
\`\`\`

**Before:** silent garbage on CPU, CUDA-context-destroying device-side assert on GPU.
**After:**
\`\`\`
ValueError: Input latent size (16, 16) exceeds the pretrained positional embedding grid (8, 8).
The positional embedding supports latents up to (16, 16) pixels at patch_size=2.
\`\`\`

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?
@yiyixuxu @DN6