### PR TITLE
Fix SanaTransformer2DModel crash when guidance_embeds=True with non-guidance pipelines

### DIFF
--- a/src/diffusers/models/transformers/sana_transformer.py
+++ b/src/diffusers/models/transformers/sana_transformer.py
@@ -457,7 +457,19 @@ class SanaTransformer2DModel(ModelMixin, AttentionMixin, ConfigMixin, PeftAdapte
 
         hidden_states = self.patch_embed(hidden_states)
 
-        if guidance is not None:
+        # Dispatch on the embedding *type* rather than on whether `guidance` was
+        # passed: `SanaCombinedTimestepGuidanceEmbeddings` does not accept
+        # `batch_size`, and `AdaLayerNormSingle` does not accept `guidance`,
+        # so routing by input would silently misbehave when the model is built
+        # with `guidance_embeds=True` but the pipeline does not thread guidance
+        # through (e.g. SanaPipeline / SanaPAGPipeline — see #12540).
+        if isinstance(self.time_embed, SanaCombinedTimestepGuidanceEmbeddings):
+            if guidance is None:
+                raise ValueError(
+                    "SanaTransformer2DModel was configured with `guidance_embeds=True`, but `guidance` "
+                    "was not provided. Either pass `guidance` to the transformer or rebuild the model "
+                    "with `guidance_embeds=False`."
+                )
             timestep, embedded_timestep = self.time_embed(
                 timestep, guidance=guidance, hidden_dtype=hidden_states.dtype
             )


### PR DESCRIPTION
## What does this PR do?

Fixes #12540.

When \`SanaTransformer2DModel\` is built with \`guidance_embeds=True\` and then driven by a pipeline that does not thread \`guidance\` through (\`SanaPipeline\`, \`SanaPAGPipeline\`), the transformer forward crashes with:

\`\`\`
TypeError: SanaCombinedTimestepGuidanceEmbeddings.forward() got an unexpected keyword argument 'batch_size'
\`\`\`

### Root cause

\`SanaTransformer2DModel.forward\` routed the time-embedding call on whether \`guidance\` was passed:

\`\`\`python
if guidance is not None:
    timestep, embedded_timestep = self.time_embed(timestep, guidance=guidance, hidden_dtype=...)
else:
    timestep, embedded_timestep = self.time_embed(timestep, batch_size=batch_size, hidden_dtype=...)
\`\`\`

But the two embedding classes have incompatible signatures:

- \`AdaLayerNormSingle.forward\` takes \`batch_size\` and does not accept \`guidance\`
- \`SanaCombinedTimestepGuidanceEmbeddings.forward\` takes \`guidance\` and does not accept \`batch_size\`

So with \`guidance_embeds=True\` and no guidance kwarg, the \`batch_size\` branch is hit against the wrong embedder and blows up.

### Fix

Dispatch on the embedding *type* instead of on the input. If the model was configured with guidance embeddings but the caller omitted \`guidance\`, raise a clear \`ValueError\` naming the misconfiguration rather than surfacing a cryptic kwargs error from deeper in the embedder.

### Reproducer (from #12540)

\`\`\`python
from diffusers import SanaTransformer2DModel, SanaPAGPipeline
import torch

config = SanaTransformer2DModel.load_config('Efficient-Large-Model/Sana_600M_512px_diffusers', subfolder='transformer')
config['guidance_embeds'] = True
new_transformer = SanaTransformer2DModel.from_config(config)

pipe = SanaPAGPipeline.from_pretrained(
    'Efficient-Large-Model/Sana_1600M_512px_MultiLing_diffusers',
    pag_applied_layers=['transformer_blocks.8'],
    transformer=new_transformer,
    torch_dtype=torch.bfloat16,
    vae=None,
).to('cuda')
pipe(prompt='cat', output_type='latent', height=768, width=512, pag_scale=1.0, guidance_scale=4.0, num_inference_steps=20)
\`\`\`

**Before:** \`TypeError: SanaCombinedTimestepGuidanceEmbeddings.forward() got an unexpected keyword argument 'batch_size'\`
**After:** \`ValueError: SanaTransformer2DModel was configured with guidance_embeds=True, but guidance was not provided. Either pass guidance to the transformer or rebuild the model with guidance_embeds=False.\`

### Testing

Manually built tiny SanaTransformer2DModel instances and confirmed:
1. \`guidance_embeds=True\` without \`guidance\` → clear ValueError
2. \`guidance_embeds=True\` with \`guidance\` → works
3. \`guidance_embeds=False\` (default, AdaLayerNormSingle) → unchanged, works

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?
@yiyixuxu @DN6 @dg845