### PR TITLE
Recognize onnxruntime-windowsml in onnxruntime version detection

### DIFF
--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -140,6 +140,7 @@ if _onnx_available:
         "onnxruntime-rocm",
         "onnxruntime-training",
         "onnxruntime-vitisai",
+        "onnxruntime-windowsml",
     )
     _onnxruntime_version = None
     # For the metadata, we have to look for both onnxruntime and onnxruntime-x


### PR DESCRIPTION
## What does this PR do?

Fixes #13062.

\`diffusers.utils.import_utils\` probes for onnxruntime by first calling \`find_spec(\"onnxruntime\")\` and then iterating a list of package names to resolve the installed version via \`importlib_metadata.version(pkg)\`. If none of the candidates match, \`_onnxruntime_version\` stays \`None\` and \`_onnx_available\` is reset to \`False\`, so ONNX-dependent code paths are silently disabled even though \`import onnxruntime\` succeeds.

Users who install \`onnxruntime-windowsml\` (the Windows ML variant, https://pypi.org/project/onnxruntime-windowsml/) hit exactly this case: the module is importable but the distribution name isn't in the candidate tuple.

Add \`onnxruntime-windowsml\` next to the other vendor-specific wheels (\`onnxruntime-directml\`, \`onnxruntime-cann\`, \`onnxruntime-openvino\`, \`onnxruntime-qnn\`, \`onnxruntime-rocm\`, …).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?
@asomoza @DN6