### PR TITLE
Fix FluxControlNet img2img/inpainting with num_images_per_prompt>1

### DIFF
--- a/src/diffusers/pipelines/flux/pipeline_flux_controlnet_image_to_image.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_controlnet_image_to_image.py
@@ -818,8 +818,10 @@ class FluxControlNetImg2ImgPipeline(DiffusionPipeline, FluxLoraLoaderMixin, From
                 )
 
             if control_mode is not None:
+                if not isinstance(control_mode, int):
+                    raise ValueError("For `FluxControlNet`, `control_mode` should be an `int` or `None`")
                 control_mode = torch.tensor(control_mode).to(device, dtype=torch.long)
-                control_mode = control_mode.reshape([-1, 1])
+                control_mode = control_mode.view(-1, 1).expand(control_image.shape[0], 1)
 
         elif isinstance(self.controlnet, FluxMultiControlNetModel):
             control_images = []

--- a/src/diffusers/pipelines/flux/pipeline_flux_controlnet_inpainting.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_controlnet_inpainting.py
@@ -958,8 +958,10 @@ class FluxControlNetInpaintPipeline(DiffusionPipeline, FluxLoraLoaderMixin, From
 
             # set control mode
             if control_mode is not None:
+                if not isinstance(control_mode, int):
+                    raise ValueError("For `FluxControlNet`, `control_mode` should be an `int` or `None`")
                 control_mode = torch.tensor(control_mode).to(device, dtype=torch.long)
-                control_mode = control_mode.reshape([-1, 1])
+                control_mode = control_mode.view(-1, 1).expand(control_image.shape[0], 1)
 
         elif isinstance(self.controlnet, FluxMultiControlNetModel):
             control_images = []


### PR DESCRIPTION
## What does this PR do?

`FluxControlNetImg2ImgPipeline` and `FluxControlNetInpaintPipeline` already pre-resize `control_image` to `batch_size * num_images_per_prompt`, but only reshape `control_mode` to `[1, 1]`:

```python
if control_mode is not None:
    control_mode = torch.tensor(control_mode).to(device, dtype=torch.long)
    control_mode = control_mode.reshape([-1, 1])
```

Inside `FluxControlNetModel` the union branch feeds `control_mode` to `nn.Embedding` and concatenates the result to `encoder_hidden_states`:

```python
controlnet_mode_emb = self.controlnet_mode_embedder(controlnet_mode)
encoder_hidden_states = torch.cat([controlnet_mode_emb, encoder_hidden_states], dim=1)
```

So when `num_images_per_prompt > 1` the embedded mode stays at `[1, 1, inner_dim]` while `encoder_hidden_states` is `[B*num_images_per_prompt, seq, inner_dim]`, and the concat fails:

> RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 2 but got size 1 for tensor number 1 in the list.

This matches the behaviour already implemented in `FluxControlNetPipeline` (non-img2img), which validates that `control_mode` is a single `int` and broadcasts it to the full image batch:

```python
if not isinstance(control_mode, int):
    raise ValueError("For `FluxControlNet`, `control_mode` should be an `int` or `None`")
control_mode = torch.tensor(control_mode).to(device, dtype=torch.long)
control_mode = control_mode.view(-1, 1).expand(control_image.shape[0], 1)
```

This PR brings the img2img and inpainting pipelines in line with the same validation + broadcast so `num_images_per_prompt > 1` works end-to-end.

Fixes #10741

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@sayakpaul @yiyixuxu