### PR TITLE
Fix AttributeError in train_dreambooth_lora_flux2_img2img validation

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
@@ -1483,7 +1483,7 @@ def main(args):
                 )
 
     if args.validation_prompt is not None:
-        validation_image = load_image(args.validation_image_path).convert("RGB")
+        validation_image = load_image(args.validation_image).convert("RGB")
         validation_kwargs = {"image": validation_image}
         if args.remote_text_encoder:
             validation_kwargs["prompt_embeds"] = compute_remote_text_embeddings(args.validation_prompt)


### PR DESCRIPTION
## What does this PR do?

Fixes an `AttributeError` in `examples/dreambooth/train_dreambooth_lora_flux2_img2img.py` that makes the validation flow unusable.

The validation block references `args.validation_image_path`:

```python
if args.validation_prompt is not None:
    validation_image = load_image(args.validation_image_path).convert(\"RGB\")
```

But the CLI argument is defined as `--validation_image`:

```python
parser.add_argument(
    \"--validation_image\",
    type=str,
    default=None,
    help=\"path to an image that is used during validation as the condition image ...\",
)
```

Argparse stores it as `args.validation_image`, so accessing `args.validation_image_path` raises `AttributeError: 'Namespace' object has no attribute 'validation_image_path'` the moment a user passes `--validation_prompt`, before any training actually starts.

Sibling scripts like `train_dreambooth_lora_flux2_klein_img2img.py` (L1437) and `train_dreambooth_lora_flux_kontext.py` already use the correct `args.validation_image`; this aligns this script with them.

## Fixes

```diff
-        validation_image = load_image(args.validation_image_path).convert(\"RGB\")
+        validation_image = load_image(args.validation_image).convert(\"RGB\")
```

## Before submitting
- [x] This PR fixes a typo or improves the docs.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?

## Who can review?

@sayakpaul @linoytsaban