### PR TITLE
Fix AttributeError in train_t2i_adapter_sdxl checkpoint resume

### DIFF
--- a/examples/t2i_adapter/train_t2i_adapter_sdxl.py
+++ b/examples/t2i_adapter/train_t2i_adapter_sdxl.py
@@ -913,9 +913,7 @@ def main(args):
 
                 # load diffusers style into model
                 load_model = T2IAdapter.from_pretrained(os.path.join(input_dir, "t2iadapter"))
-
-                if args.control_type != "style":
-                    model.register_to_config(**load_model.config)
+                model.register_to_config(**load_model.config)
 
                 model.load_state_dict(load_model.state_dict())
                 del load_model


### PR DESCRIPTION
## What does this PR do?

Fixes a latent `AttributeError` in `examples/t2i_adapter/train_t2i_adapter_sdxl.py` that breaks `--resume_from_checkpoint`.

The accelerate `load_model_hook` references `args.control_type`, which is never declared as a CLI argument in this script:

```python
def load_model_hook(models, input_dir):
    while len(models) > 0:
        model = models.pop()

        # load diffusers style into model
        load_model = T2IAdapter.from_pretrained(os.path.join(input_dir, "t2iadapter"))

        if args.control_type != "style":
            model.register_to_config(**load_model.config)

        model.load_state_dict(load_model.state_dict())
        del load_model
```

So any resume (`accelerator.load_state(...)` triggered by `--resume_from_checkpoint`) crashes with:

```
AttributeError: 'Namespace' object has no attribute 'control_type'
```

The `args.control_type != "style"` gate looks like a copy-paste leftover from a controlnet variant that distinguished style adapters. This T2IAdapter training script has no such distinction, and the analogous hook in `examples/controlnet/train_controlnet_sdxl.py` calls `register_to_config` unconditionally. Dropping the broken gate aligns with that script and makes resume work.

## Fix

```diff
-                if args.control_type != "style":
-                    model.register_to_config(**load_model.config)
+                model.register_to_config(**load_model.config)
```

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?

## Who can review?

@sayakpaul