### PR TITLE
Fix AttributeError in diffusion_dpo --loss_type ipo

### DIFF
--- a/examples/research_projects/diffusion_dpo/train_diffusion_dpo.py
+++ b/examples/research_projects/diffusion_dpo/train_diffusion_dpo.py
@@ -881,7 +881,7 @@ def main(args):
                 elif args.loss_type == "hinge":
                     loss = torch.relu(1 - args.beta_dpo * logits).mean()
                 elif args.loss_type == "ipo":
-                    losses = (logits - 1 / (2 * args.beta)) ** 2
+                    losses = (logits - 1 / (2 * args.beta_dpo)) ** 2
                     loss = losses.mean()
                 else:
                     raise ValueError(f"Unknown loss type {args.loss_type}")


### PR DESCRIPTION
## What does this PR do?

Fixes an `AttributeError` in `examples/research_projects/diffusion_dpo/train_diffusion_dpo.py` that crashes the IPO loss path.

The IPO branch references `args.beta`:

```python
elif args.loss_type == "ipo":
    losses = (logits - 1 / (2 * args.beta)) ** 2
    loss = losses.mean()
```

but this script only exposes `--beta_dpo`:

```python
parser.add_argument(
    \"--beta_dpo\",
    type=int,
    default=2500,
    help=\"DPO KL Divergence penalty.\",
)
```

So running with `--loss_type ipo` crashes immediately with:

```
AttributeError: 'Namespace' object has no attribute 'beta'
```

The `sigmoid` and `hinge` branches above correctly use `args.beta_dpo`, and the SDXL sibling `train_diffusion_dpo_sdxl.py` also only uses `args.beta_dpo`. This was clearly intended to use the same hyperparameter.

## Fix

```diff
 elif args.loss_type == \"ipo\":
-    losses = (logits - 1 / (2 * args.beta)) ** 2
+    losses = (logits - 1 / (2 * args.beta_dpo)) ** 2
     loss = losses.mean()
```

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?

## Who can review?

@sayakpaul