### PR TITLE
Fix HunyuanVideo 1.5 modular glyph regex for curly quotes

### DIFF
--- a/src/diffusers/modular_pipelines/hunyuan_video1_5/encoders.py
+++ b/src/diffusers/modular_pipelines/hunyuan_video1_5/encoders.py
@@ -44,7 +44,7 @@ def format_text_input(prompt, system_message):
 
 
 def extract_glyph_texts(prompt):
-    pattern = r"\"(.*?)\"|\"(.*?)\""
+    pattern = r"\"(.*?)\"|“(.*?)”"
     matches = re.findall(pattern, prompt)
     result = [match[0] or match[1] for match in matches]
     result = list(dict.fromkeys(result)) if len(result) > 1 else result


### PR DESCRIPTION
## What does this PR do?

`extract_glyph_texts` in the HunyuanVideo 1.5 modular pipeline had a copy-paste typo in its regex:

```python
# src/diffusers/modular_pipelines/hunyuan_video1_5/encoders.py
pattern = r"\"(.*?)\"|\"(.*?)\""
```

Both alternatives match ASCII double quotes. The second branch is redundant, and any text quoted with Chinese / smart curly quotes (`“…”`) is silently dropped — no glyph extraction happens, so the model never receives the formatted `Text "..."` instruction.

The canonical, non-modular pipeline has the intended pattern (https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/hunyuan_video1_5/pipeline_hunyuan_video1_5.py#L93):

```python
pattern = r"\"(.*?)\"|“(.*?)”"
```

HunyuanVideo 1.5 is a bilingual Tencent model, so Chinese prompts that use `“…”` to mark on-screen text are a realistic and documented input shape. Under the modular path they currently skip glyph extraction entirely and produce mis-rendered poster/caption text.

### Reproduction

```python
import re

buggy = r"\"(.*?)\"|\"(.*?)\""          # modular path today
fixed = r"\"(.*?)\"|“(.*?)”"            # non-modular path / this fix

prompt = 'A poster with “你好”'
print(re.findall(buggy, prompt))  # -> []      (silently ignored)
print(re.findall(fixed, prompt))  # -> [('', '你好')]
```

### Fix

Align the modular pipeline's pattern with the existing, correct non-modular pattern. One-character change.

## Before submitting

- [x] This PR fixes a typo or improves the docs.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the documentation with your changes? (N/A — internal helper, no doc references)
- [ ] Did you write any new necessary tests? (N/A — trivially verifiable regex constant)

## Who can review?

@DN6 @yiyixuxu