### PR TITLE
Fix AttributeError in onnxruntime train_unconditional (args.report_to → args.logger)

### DIFF
--- a/examples/research_projects/onnxruntime/unconditional_image_generation/train_unconditional.py
+++ b/examples/research_projects/onnxruntime/unconditional_image_generation/train_unconditional.py
@@ -277,9 +277,9 @@ def parse_args():
 
 
 def main(args):
-    if args.report_to == "wandb" and args.hub_token is not None:
+    if args.logger == "wandb" and args.hub_token is not None:
         raise ValueError(
-            "You cannot use both --report_to=wandb and --hub_token due to a security risk of exposing your token."
+            "You cannot use both --logger=wandb and --hub_token due to a security risk of exposing your token."
             " Please use `hf auth login` to authenticate with the Hub."
         )
 
@@ -291,7 +291,7 @@ def main(args):
     accelerator = Accelerator(
         gradient_accumulation_steps=args.gradient_accumulation_steps,
         mixed_precision=args.mixed_precision,
-        log_with=args.report_to,
+        log_with=args.logger,
         project_config=accelerator_project_config,
     )
 


### PR DESCRIPTION
## What does this PR do?

The ORT variant of the unconditional training script,
`examples/research_projects/onnxruntime/unconditional_image_generation/train_unconditional.py`,
defines the tracker flag as `--logger` on the parser:

```python
parser.add_argument(
    \"--logger\",
    type=str,
    default=\"tensorboard\",
    choices=[\"tensorboard\", \"wandb\"],
    ...
)
```

…but `main()` references a non-existent `args.report_to` twice:

```python
if args.report_to == \"wandb\" and args.hub_token is not None:
    raise ValueError(
        \"You cannot use both --report_to=wandb and --hub_token ...\"
        \" Please use \`hf auth login\` to authenticate with the Hub.\"
    )

...

accelerator = Accelerator(
    gradient_accumulation_steps=args.gradient_accumulation_steps,
    mixed_precision=args.mixed_precision,
    log_with=args.report_to,
    project_config=accelerator_project_config,
)
```

Because no `--report_to` flag is registered, the `args` namespace never carries that attribute, so both references raise `AttributeError: 'Namespace' object has no attribute 'report_to'` at the very top of `main()`. The script can't run end-to-end.

The sibling non-ORT script `examples/unconditional_image_generation/train_unconditional.py` uses `args.logger` throughout. This PR aligns the ORT variant with that:

* `args.report_to` → `args.logger` at both call sites
* `--report_to=wandb` → `--logger=wandb` in the error message text

Trivial one-word fix; no behavior change beyond letting the script actually start.

## Before submitting

- [x] This PR fixes a typo or improves the docs.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the documentation with your changes? (N/A — error-message text only)
- [ ] Did you write any new necessary tests? (N/A — trivially verifiable attribute name)

## Who can review?

@sayakpaul @stevhliu