### PR TITLE
Normalize negative_prompt in LongCatAudioDiT pipeline for CFG symmetry

### DIFF
--- a/src/diffusers/pipelines/longcat_audio_dit/pipeline_longcat_audio_dit.py
+++ b/src/diffusers/pipelines/longcat_audio_dit/pipeline_longcat_audio_dit.py
@@ -291,7 +291,10 @@ class LongCatAudioDiTPipeline(DiffusionPipeline):
                 negative_prompt = [negative_prompt] * batch_size
             else:
                 negative_prompt = list(negative_prompt)
-            negative_prompt_embeds, negative_prompt_embeds_len = self.encode_prompt(negative_prompt, device)
+            normalized_negative_prompts = [_normalize_text(text) for text in negative_prompt]
+            negative_prompt_embeds, negative_prompt_embeds_len = self.encode_prompt(
+                normalized_negative_prompts, device
+            )
             negative_prompt_embeds_mask = _lens_to_mask(
                 negative_prompt_embeds_len, length=negative_prompt_embeds.shape[1]
             )


### PR DESCRIPTION
## What this PR does

In `LongCatAudioDiTPipeline.__call__`, positive prompts are normalized via `_normalize_text` before being encoded:

```python
normalized_prompts = [_normalize_text(text) for text in prompt]
...
prompt_embeds, prompt_embeds_len = self.encode_prompt(normalized_prompts, device)
```

`_normalize_text` lowercases the string, strips ASCII and curly quote characters (`"“”‘’`), and collapses whitespace. The upstream reference implementation [`meituan-longcat/LongCat-AudioDiT`](https://github.com/meituan-longcat/LongCat-AudioDiT) applies the same `normalize_text` pass to **every** piece of text it feeds to the UMT5 text encoder.

However, when a user passes a `negative_prompt`, the pipeline currently encodes it raw:

```python
negative_prompt_embeds, negative_prompt_embeds_len = self.encode_prompt(negative_prompt, device)
```

## Why this is a bug

The model was trained with normalized text on both branches, so a raw negative prompt lands off-distribution relative to the normalized positive prompt. In classifier-free guidance

```
noise = neg + guidance_scale * (pos - neg)
```

the `(pos - neg)` delta no longer represents a clean "target − avoid" direction — it's partly absorbing normalization noise (case, quote glyphs, whitespace). That weakens/distorts guidance rather than guiding away from what the user described.

Examples that currently fail to behave symmetrically:
- `negative_prompt="Loud Noise"` encodes differently from the positive path's `"loud noise"`
- `negative_prompt='"speech"'` keeps the quote glyphs that the positive path would strip
- `negative_prompt="multiple   speakers"` keeps the extra whitespace

The empty/`None` branch is unaffected — it already uses a zero tensor to match the reference model.

## Fix

Apply the same `_normalize_text` pass to user-supplied negative prompts before encoding, restoring symmetry with the positive branch and with the reference pipeline.

```diff
 if negative_prompt is None or (isinstance(negative_prompt, str) and negative_prompt == ""):
     negative_prompt_embeds = torch.zeros(...)
     negative_prompt_embeds_len = torch.tensor([1] * batch_size, device=device)
 else:
-    negative_prompt_embeds, negative_prompt_embeds_len = self.encode_prompt(negative_prompt, device)
+    normalized_negative_prompts = [_normalize_text(text) for text in negative_prompt]
+    negative_prompt_embeds, negative_prompt_embeds_len = self.encode_prompt(
+        normalized_negative_prompts, device
+    )
```

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers)? N/A — small consistency fix.
- [x] Did you make sure to update the documentation with your changes? N/A — no public API change.
- [x] Did you write any new necessary tests? N/A — mirrors the existing positive-prompt path.

## Who can review?
@yiyixuxu @sayakpaul