### PR TITLE
Fix TypeError in LongCatImageEditPipeline truncation warning

### DIFF
--- a/src/diffusers/pipelines/longcat_image/pipeline_longcat_image_edit.py
+++ b/src/diffusers/pipelines/longcat_image/pipeline_longcat_image_edit.py
@@ -284,7 +284,7 @@ class LongCatImageEditPipeline(DiffusionPipeline, FromSingleFileMixin):
         if len(all_tokens) > self.tokenizer_max_length:
             logger.warning(
                 "Your input was truncated because `max_sequence_length` is set to "
-                f" {self.tokenizer_max_length} input token nums : {len(len(all_tokens))}"
+                f" {self.tokenizer_max_length} input token nums : {len(all_tokens)}"
             )
             all_tokens = all_tokens[: self.tokenizer_max_length]
 


### PR DESCRIPTION
## What this PR does

`LongCatImageEditPipeline._encode_prompt` calls `len()` twice on an `int` when building its truncation warning message:

https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/longcat_image/pipeline_longcat_image_edit.py#L284-L289

```python
if len(all_tokens) > self.tokenizer_max_length:
    logger.warning(
        "Your input was truncated because \`max_sequence_length\` is set to "
        f" {self.tokenizer_max_length} input token nums : {len(len(all_tokens))}"
    )
    all_tokens = all_tokens[: self.tokenizer_max_length]
```

`len(all_tokens)` already returns an `int`, so the outer `len()` raises `TypeError: object of type 'int' has no len()` — inside the f-string formatting — every time the branch fires.

## Why this is a real bug

The warning only executes when `len(all_tokens) > self.tokenizer_max_length` (default 512). That is the exact scenario the warning is supposed to inform the user about. Instead of informing them, the pipeline crashes with a `TypeError` during prompt encoding.

Minimal repro:

```python
pipe = LongCatImageEditPipeline.from_pretrained(...)
pipe(prompt="a very long prompt ..." * 200, image=image)
# TypeError: object of type 'int' has no len()
```

The sibling `LongCatImagePipeline._encode_prompt` has the correct form at [line 291](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/longcat_image/pipeline_longcat_image.py#L291) — this is a local typo in the edit pipeline only.

## Fix

Drop the extraneous `len()` call to match the sibling pipeline:

```diff
-                f" {self.tokenizer_max_length} input token nums : {len(len(all_tokens))}"
+                f" {self.tokenizer_max_length} input token nums : {len(all_tokens)}"
```

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue or the forum? N/A — single-character typo fix.
- [x] Did you make sure to update the documentation with your changes? N/A.
- [x] Did you write any new necessary tests? N/A — fixes a log-message crash; no behavior change.

## Who can review?
@yiyixuxu @sayakpaul