### PR TITLE
Fix NameError in ZImageOmniPipeline when guidance_scale=0

### DIFF
--- a/src/diffusers/pipelines/z_image/pipeline_z_image_omni.py
+++ b/src/diffusers/pipelines/z_image/pipeline_z_image_omni.py
@@ -588,9 +588,10 @@ class ZImageOmniPipeline(DiffusionPipeline, ZImageLoraLoaderMixin, FromSingleFil
                 negative_prompt_embeds = [npe for npe in negative_prompt_embeds for _ in range(num_images_per_prompt)]
 
         condition_siglip_embeds = [None if sels == [] else sels + [None] for sels in condition_siglip_embeds]
-        negative_condition_siglip_embeds = [
-            None if sels == [] else sels + [None] for sels in negative_condition_siglip_embeds
-        ]
+        if self.do_classifier_free_guidance:
+            negative_condition_siglip_embeds = [
+                None if sels == [] else sels + [None] for sels in negative_condition_siglip_embeds
+            ]
 
         actual_batch_size = batch_size * num_images_per_prompt
         image_seq_len = (latents.shape[2] // 2) * (latents.shape[3] // 2)


### PR DESCRIPTION
## What this PR does

`ZImageOmniPipeline.__call__` defines `negative_condition_siglip_embeds` only inside the CFG guard:

https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/z_image/pipeline_z_image_omni.py#L581-L582

```python
if self.do_classifier_free_guidance:
    negative_condition_siglip_embeds = [[se.clone() for se in batch] for batch in condition_siglip_embeds]
```

but a few lines later reads the same name unconditionally:

https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/z_image/pipeline_z_image_omni.py#L590-L593

```python
condition_siglip_embeds = [None if sels == [] else sels + [None] for sels in condition_siglip_embeds]
negative_condition_siglip_embeds = [
    None if sels == [] else sels + [None] for sels in negative_condition_siglip_embeds
]
```

## Why this is a real bug

`do_classifier_free_guidance` is `self._guidance_scale > 0` (line 342), so any call with `guidance_scale=0.0` leaves `negative_condition_siglip_embeds` unbound → `NameError: name 'negative_condition_siglip_embeds' is not defined`.

This is the exact configuration the pipeline's own `EXAMPLE_DOC_STRING` uses:

https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/z_image/pipeline_z_image_omni.py#L51-L58

```python
>>> image = pipe(
...     prompt,
...     height=1024,
...     width=1024,
...     num_inference_steps=9,
...     guidance_scale=0.0,
...     generator=torch.Generator("cuda").manual_seed(42),
... ).images[0]
```

i.e. running the documented Z-Image-Turbo snippet crashes. The downstream consumption (line 648) is already guarded by `if apply_cfg:`, so the negative reshape only needs to fire when CFG is on.

## Fix

Wrap the negative reshape in the same `do_classifier_free_guidance` check — matching the symmetric treatment of `negative_condition_latents`, which is only defined *and* only consumed when CFG is on.

```diff
 condition_siglip_embeds = [None if sels == [] else sels + [None] for sels in condition_siglip_embeds]
-negative_condition_siglip_embeds = [
-    None if sels == [] else sels + [None] for sels in negative_condition_siglip_embeds
-]
+if self.do_classifier_free_guidance:
+    negative_condition_siglip_embeds = [
+        None if sels == [] else sels + [None] for sels in negative_condition_siglip_embeds
+    ]
```

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue or the forum? N/A — crashes the pipeline's own doc example.
- [x] Did you make sure to update the documentation with your changes? N/A.
- [x] Did you write any new necessary tests? N/A — restores behavior matching the doc example.

## Who can review?
@yiyixuxu @sayakpaul