### PR TITLE
Fix AttributeError in textual_inversion_bf16 by adding --report_to arg

### DIFF
--- a/examples/research_projects/intel_opts/textual_inversion/textual_inversion_bf16.py
+++ b/examples/research_projects/intel_opts/textual_inversion/textual_inversion_bf16.py
@@ -203,6 +203,15 @@ def parse_args():
             "and an Nvidia Ampere GPU."
         ),
     )
+    parser.add_argument(
+        "--report_to",
+        type=str,
+        default="tensorboard",
+        help=(
+            'The integration to report the results and logs to. Supported platforms are `"tensorboard"`'
+            ' (default), `"wandb"` and `"comet_ml"`. Use `"all"` to report to all integrations.'
+        ),
+    )
     parser.add_argument("--local_rank", type=int, default=-1, help="For distributed training: local_rank")
 
     args = parser.parse_args()


### PR DESCRIPTION
## What this PR does

The Intel/BF16 `textual_inversion_bf16.py` script reads `args.report_to` at the top of `main()`:

https://github.com/huggingface/diffusers/blob/main/examples/research_projects/intel_opts/textual_inversion/textual_inversion_bf16.py#L366-L378

```python
def main():
    args = parse_args()

    if args.report_to == "wandb" and args.hub_token is not None:
        raise ValueError(
            "You cannot use both --report_to=wandb and --hub_token due to a security risk of exposing your token."
            " Please use \`hf auth login\` to authenticate with the Hub."
        )

    ...
    accelerator = Accelerator(
        gradient_accumulation_steps=args.gradient_accumulation_steps,
        mixed_precision=args.mixed_precision,
        log_with=args.report_to,
        project_config=accelerator_project_config,
    )
```

But `--report_to` is **never** defined on the parser (checked via `grep 'add_argument' textual_inversion_bf16.py`). Any invocation of the script therefore crashes immediately with:

```
AttributeError: 'Namespace' object has no attribute 'report_to'
```

## Why this is a real bug

The check fires at the start of `main()`, before any training setup — the script is non-runnable as shipped.

## Fix

The canonical `examples/textual_inversion/textual_inversion.py` already defines this exact argument with default `"tensorboard"` and the standard help text. Mirror that definition in the bf16 variant:

```python
parser.add_argument(
    "--report_to",
    type=str,
    default="tensorboard",
    help=(
        'The integration to report the results and logs to. Supported platforms are `"tensorboard"`'
        ' (default), `"wandb"` and `"comet_ml"`. Use `"all"` to report to all integrations.'
    ),
)
```

Value and default match the canonical script, keeping behavior consistent across the two scripts.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue or the forum? N/A — the script is dead-on-arrival.
- [x] Did you make sure to update the documentation with your changes? N/A.
- [x] Did you write any new necessary tests? N/A — restores baseline runnability.

## Who can review?
@sayakpaul