### PR TITLE
Fix AttributeError in Wuerstchen prior training model card

### DIFF
--- a/examples/research_projects/wuerstchen/text_to_image/train_text_to_image_lora_prior.py
+++ b/examples/research_projects/wuerstchen/text_to_image/train_text_to_image_lora_prior.py
@@ -102,10 +102,10 @@ from diffusers import DiffusionPipeline
 import torch
 
 pipeline = AutoPipelineForText2Image.from_pretrained(
-                "{args.pretrained_decoder_model_name_or_path}", torch_dtype={args.weight_dtype}
+                "{args.pretrained_decoder_model_name_or_path}", torch_dtype=torch.float16
             )
 # load lora weights from folder:
-pipeline.prior_pipe.load_lora_weights("{repo_id}", torch_dtype={args.weight_dtype})
+pipeline.prior_pipe.load_lora_weights("{repo_id}", torch_dtype=torch.float16)
 
 image = pipeline(prompt=prompt).images[0]
 image.save("my_image.png")

--- a/examples/research_projects/wuerstchen/text_to_image/train_text_to_image_prior.py
+++ b/examples/research_projects/wuerstchen/text_to_image/train_text_to_image_prior.py
@@ -101,8 +101,8 @@ You can use the pipeline like so:
 from diffusers import DiffusionPipeline
 import torch
 
-pipe_prior = DiffusionPipeline.from_pretrained("{repo_id}", torch_dtype={args.weight_dtype})
-pipe_t2i = DiffusionPipeline.from_pretrained("{args.pretrained_decoder_model_name_or_path}", torch_dtype={args.weight_dtype})
+pipe_prior = DiffusionPipeline.from_pretrained("{repo_id}", torch_dtype=torch.float16)
+pipe_t2i = DiffusionPipeline.from_pretrained("{args.pretrained_decoder_model_name_or_path}", torch_dtype=torch.float16)
 prompt = "{args.validation_prompts[0]}"
 (image_embeds,) = pipe_prior(prompt).to_tuple()
 image = pipe_t2i(image_embeddings=image_embeds, prompt=prompt).images[0]


### PR DESCRIPTION
## What this PR does

Both Wuerstchen prior training scripts build their HF Hub model card with an f-string that references `{args.weight_dtype}`:

**`train_text_to_image_prior.py`** (lines 104-105):
```python
pipe_prior = DiffusionPipeline.from_pretrained("{repo_id}", torch_dtype={args.weight_dtype})
pipe_t2i = DiffusionPipeline.from_pretrained("{args.pretrained_decoder_model_name_or_path}", torch_dtype={args.weight_dtype})
```

**`train_text_to_image_lora_prior.py`** (lines 105, 108):
```python
pipeline = AutoPipelineForText2Image.from_pretrained(
                "{args.pretrained_decoder_model_name_or_path}", torch_dtype={args.weight_dtype}
            )
pipeline.prior_pipe.load_lora_weights("{repo_id}", torch_dtype={args.weight_dtype})
```

## Why this is a real bug

`weight_dtype` is a local variable in `main()` (set from `args.mixed_precision`), **not** an attribute of the `args` namespace. `--weight_dtype` is never defined on the parser. So when `save_model_card(args, ...)` runs (triggered by `--push_to_hub` — line 925 of the prior script, line 938 of the LoRA variant), the f-string formatter raises:

```
AttributeError: 'Namespace' object has no attribute 'weight_dtype'
```

This fires at the tail end of training, right after the model has been saved locally — losing the hub upload for anyone who trained with `--push_to_hub`.

## Fix

The `torch_dtype=` argument in the model card's usage snippet is just an illustrative example. Mirror the canonical `examples/text_to_image/train_text_to_image.py:95`, which hardcodes `torch.float16` (the standard inference dtype) into the card template:

```diff
-pipe_prior = DiffusionPipeline.from_pretrained("{repo_id}", torch_dtype={args.weight_dtype})
-pipe_t2i = DiffusionPipeline.from_pretrained("{args.pretrained_decoder_model_name_or_path}", torch_dtype={args.weight_dtype})
+pipe_prior = DiffusionPipeline.from_pretrained("{repo_id}", torch_dtype=torch.float16)
+pipe_t2i = DiffusionPipeline.from_pretrained("{args.pretrained_decoder_model_name_or_path}", torch_dtype=torch.float16)
```

Same edit in the LoRA variant (2 occurrences).

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue or the forum? N/A — straightforward crash fix.
- [x] Did you make sure to update the documentation with your changes? N/A — only touches the generated model-card template, matches the canonical script's pattern.
- [x] Did you write any new necessary tests? N/A — restores `--push_to_hub` functionality.

## Who can review?
@sayakpaul