### PR TITLE
Improve TorchAO quantization test coverage and XPU support

### DIFF
--- a/src/diffusers/quantizers/torchao/torchao_quantizer.py
+++ b/src/diffusers/quantizers/torchao/torchao_quantizer.py
@@ -376,3 +376,17 @@ class TorchAoHfQuantizer(DiffusersQuantizer):
     @property
     def is_compileable(self) -> bool:
         return True
+
+    def _dequantize(self, model):
+        from torchao.utils import TorchAOBaseTensor
+
+        for name, module in model.named_modules():
+            if isinstance(module, nn.Linear) and isinstance(module.weight, TorchAOBaseTensor):
+                device = module.weight.device
+                dequantized_weight = module.weight.dequantize().to(device)
+                module.weight = nn.Parameter(dequantized_weight)
+                # Reset extra_repr if it was overridden
+                if hasattr(module.extra_repr, "__func__") and module.extra_repr.__func__ is not nn.Linear.extra_repr:
+                    module.extra_repr = types.MethodType(nn.Linear.extra_repr, module)
+
+        return model

--- a/tests/models/testing_utils/quantization.py
+++ b/tests/models/testing_utils/quantization.py
@@ -832,10 +832,6 @@ class TorchAoConfigMixin:
         assert isinstance(module, torch.nn.Linear), f"Layer {name} is not Linear, got {type(module)}"
 
 
-# int4wo requires CUDA-specific ops (_convert_weight_to_int4pack)
-_int4wo_skip = pytest.mark.skipif(torch_device != "cuda", reason="int4wo quantization requires CUDA")
-
-
 @is_torchao
 @require_accelerator
 @require_torchao_version_greater_or_equal("0.7.0")
@@ -861,7 +857,7 @@ class TorchAoTesterMixin(TorchAoConfigMixin, QuantizationTesterMixin):
     @pytest.mark.parametrize(
         "quant_type",
         [
-            pytest.param("int4wo", marks=_int4wo_skip),
+            "int4wo"
             "int8wo",
             "int8dq",
         ],
@@ -873,7 +869,7 @@ class TorchAoTesterMixin(TorchAoConfigMixin, QuantizationTesterMixin):
     @pytest.mark.parametrize(
         "quant_type",
         [
-            pytest.param("int4wo", marks=_int4wo_skip),
+            "int4wo"
             "int8wo",
             "int8dq",
         ],
@@ -888,7 +884,7 @@ class TorchAoTesterMixin(TorchAoConfigMixin, QuantizationTesterMixin):
     @pytest.mark.parametrize(
         "quant_type",
         [
-            pytest.param("int4wo", marks=_int4wo_skip),
+            "int4wo"
             "int8wo",
             "int8dq",
         ],

--- a/tests/models/testing_utils/quantization.py
+++ b/tests/models/testing_utils/quantization.py
@@ -824,7 +824,7 @@ class TorchAoConfigMixin:
     def _get_quant_config(config_name):
         config_cls = getattr(_torchao_quantization, config_name)
         # TorchAO int4 quantization requires plain_int32 packing format on Intel XPU
-        if torch_device == "xpu":
+        if config_name == "int4wo" and torch_device == "xpu":
             return TorchAoConfig(config_cls(int4_packing_format="plain_int32"))
 
         return TorchAoConfig(config_cls())

--- a/tests/models/testing_utils/quantization.py
+++ b/tests/models/testing_utils/quantization.py
@@ -824,7 +824,7 @@ class TorchAoConfigMixin:
     def _get_quant_config(config_name):
         config_cls = getattr(_torchao_quantization, config_name)
         # TorchAO int4 quantization requires plain_int32 packing format on Intel XPU
-        if config_name == "int4wo" and torch_device == "xpu":
+        if config_name == "Int4WeightOnlyConfig" and torch_device == "xpu":
             return TorchAoConfig(config_cls(int4_packing_format="plain_int32"))
 
         return TorchAoConfig(config_cls())

--- a/tests/models/testing_utils/quantization.py
+++ b/tests/models/testing_utils/quantization.py
@@ -419,7 +419,8 @@ class QuantizationTesterMixin:
         # Step 3: run forward and backward pass
         inputs = self._get_dummy_inputs_for_model(model)
 
-        with torch.amp.autocast(torch_device, dtype=torch.float16):
+        # Use bfloat16 instead of float16 to avoid gradient underflow with quantized layers
+        with torch.amp.autocast(torch_device, dtype=torch.bfloat16):
             out = model(**inputs, return_dict=False)[0]
             out.norm().backward()
 
@@ -838,7 +839,12 @@ class TorchAoConfigMixin:
         return self.model_class.from_pretrained(self.pretrained_model_name_or_path, **kwargs)
 
     def _verify_if_layer_quantized(self, name, module, config_kwargs):
+        from torchao.utils import TorchAOBaseTensor
+
         assert isinstance(module, torch.nn.Linear), f"Layer {name} is not Linear, got {type(module)}"
+        assert isinstance(module.weight, TorchAOBaseTensor), (
+            f"Layer {name} weight is {type(module.weight)}, expected TorchAOBaseTensor"
+        )
 
 
 @is_torchao

--- a/tests/models/testing_utils/quantization.py
+++ b/tests/models/testing_utils/quantization.py
@@ -142,6 +142,14 @@ class QuantizationTesterMixin:
         except (AssertionError, AttributeError):
             return False
 
+    def _get_dummy_inputs_for_model(self, model):
+        inputs = self.get_dummy_inputs()
+        model_dtype = next(model.parameters()).dtype
+        return {
+            k: v.to(model_dtype) if isinstance(v, torch.Tensor) and v.is_floating_point() else v
+            for k, v in inputs.items()
+        }
+
     def _load_unquantized_model(self):
         kwargs = getattr(self, "pretrained_model_kwargs", {})
         return self.model_class.from_pretrained(self.pretrained_model_name_or_path, **kwargs)
@@ -174,7 +182,7 @@ class QuantizationTesterMixin:
         model_quantized = self._create_quantized_model(config_kwargs)
         model_quantized.to(torch_device)
 
-        inputs = self.get_dummy_inputs()
+        inputs = self._get_dummy_inputs_for_model(model_quantized)
         output = model_quantized(**inputs, return_dict=False)[0]
 
         assert output is not None, "Model output is None"
@@ -222,7 +230,8 @@ class QuantizationTesterMixin:
         # Move LoRA adapter weights to device (they default to CPU)
         model.to(torch_device)
 
-        inputs = self.get_dummy_inputs()
+        inputs = self._get_dummy_inputs_for_model(model)
+
         output = model(**inputs, return_dict=False)[0]
 
         assert output is not None, "Model output is None with LoRA"
@@ -236,7 +245,8 @@ class QuantizationTesterMixin:
 
         model_loaded = self.model_class.from_pretrained(str(tmp_path))
 
-        inputs = self.get_dummy_inputs()
+        inputs = self._get_dummy_inputs_for_model(model_loaded)
+
         output = model_loaded(**inputs, return_dict=False)[0]
         assert not torch.isnan(output).any(), "Loaded model output contains NaN"
 
@@ -334,7 +344,8 @@ class QuantizationTesterMixin:
         assert hasattr(model, "hf_device_map"), "Model should have hf_device_map attribute"
         assert model.hf_device_map is not None, "hf_device_map should not be None"
 
-        inputs = self.get_dummy_inputs()
+        inputs = self._get_dummy_inputs_for_model(model)
+
         output = model(**inputs, return_dict=False)[0]
         assert output is not None, "Model output is None"
         assert not torch.isnan(output).any(), "Model output contains NaN"
@@ -360,14 +371,7 @@ class QuantizationTesterMixin:
                 assert not self._is_module_quantized(module), f"Module {name} is still quantized after dequantize()"
 
         # Get model dtype from first parameter
-        model_dtype = next(model.parameters()).dtype
-
-        inputs = self.get_dummy_inputs()
-        # Cast inputs to model dtype
-        inputs = {
-            k: v.to(model_dtype) if isinstance(v, torch.Tensor) and v.is_floating_point() else v
-            for k, v in inputs.items()
-        }
+        inputs = self._get_dummy_inputs_for_model(model)
         output = model(**inputs, return_dict=False)[0]
         assert output is not None, "Model output is None after dequantization"
         assert not torch.isnan(output).any(), "Model output contains NaN after dequantization"
@@ -413,7 +417,7 @@ class QuantizationTesterMixin:
             pytest.skip("No attention layers found in model for adapter training test")
 
         # Step 3: run forward and backward pass
-        inputs = self.get_dummy_inputs()
+        inputs = self._get_dummy_inputs_for_model(model)
 
         with torch.amp.autocast(torch_device, dtype=torch.float16):
             out = model(**inputs, return_dict=False)[0]
@@ -597,7 +601,8 @@ class BitsAndBytesTesterMixin(BitsAndBytesConfigMixin, QuantizationTesterMixin):
                             f"Module {name} should be uint8 but is {module.weight.dtype}"
                         )
 
-            inputs = self.get_dummy_inputs()
+            inputs = self._get_dummy_inputs_for_model(model)
+
             _ = model(**inputs)
         finally:
             if original_fp32_modules is not None:
@@ -911,7 +916,8 @@ class TorchAoTesterMixin(TorchAoConfigMixin, QuantizationTesterMixin):
 
         model_loaded = self.model_class.from_pretrained(str(tmp_path), device_map=str(torch_device))
 
-        inputs = self.get_dummy_inputs()
+        inputs = self._get_dummy_inputs_for_model(model_loaded)
+
         output = model_loaded(**inputs, return_dict=False)[0]
         assert not torch.isnan(output).any(), "Loaded model output contains NaN"
 
@@ -1168,6 +1174,14 @@ class QuantizationCompileTesterMixin:
         - get_dummy_inputs(): Returns dict of inputs to pass to the model forward pass
     """
 
+    def _get_dummy_inputs_for_model(self, model):
+        inputs = self.get_dummy_inputs()
+        model_dtype = next(model.parameters()).dtype
+        return {
+            k: v.to(model_dtype) if isinstance(v, torch.Tensor) and v.is_floating_point() else v
+            for k, v in inputs.items()
+        }
+
     def setup_method(self):
         gc.collect()
         backend_empty_cache(torch_device)
@@ -1193,7 +1207,8 @@ class QuantizationCompileTesterMixin:
         model = torch.compile(model, fullgraph=True)
 
         with torch._dynamo.config.patch(error_on_recompile=True):
-            inputs = self.get_dummy_inputs()
+            inputs = self._get_dummy_inputs_for_model(model)
+
             output = model(**inputs, return_dict=False)[0]
             assert output is not None, "Model output is None"
             assert not torch.isnan(output).any(), "Model output contains NaN"
@@ -1224,7 +1239,8 @@ class QuantizationCompileTesterMixin:
         model.enable_group_offload(**group_offload_kwargs)
         model = torch.compile(model)
 
-        inputs = self.get_dummy_inputs()
+        inputs = self._get_dummy_inputs_for_model(model)
+
         output = model(**inputs, return_dict=False)[0]
         assert output is not None, "Model output is None"
         assert not torch.isnan(output).any(), "Model output contains NaN"

--- a/tests/models/testing_utils/quantization.py
+++ b/tests/models/testing_utils/quantization.py
@@ -857,7 +857,7 @@ class TorchAoTesterMixin(TorchAoConfigMixin, QuantizationTesterMixin):
     @pytest.mark.parametrize(
         "quant_type",
         [
-            "int4wo"
+            "int4wo",
             "int8wo",
             "int8dq",
         ],
@@ -869,7 +869,7 @@ class TorchAoTesterMixin(TorchAoConfigMixin, QuantizationTesterMixin):
     @pytest.mark.parametrize(
         "quant_type",
         [
-            "int4wo"
+            "int4wo",
             "int8wo",
             "int8dq",
         ],
@@ -884,7 +884,7 @@ class TorchAoTesterMixin(TorchAoConfigMixin, QuantizationTesterMixin):
     @pytest.mark.parametrize(
         "quant_type",
         [
-            "int4wo"
+            "int4wo",
             "int8wo",
             "int8dq",
         ],

--- a/tests/models/testing_utils/quantization.py
+++ b/tests/models/testing_utils/quantization.py
@@ -823,6 +823,9 @@ class TorchAoConfigMixin:
     @staticmethod
     def _get_quant_config(config_name):
         config_cls = getattr(_torchao_quantization, config_name)
+        # TorchAO int4 quantization requires plain_int32 packing format on Intel XPU
+        if torch_device == "xpu":
+            config_cls.int4_packing_format = "plain_int32"
         return TorchAoConfig(config_cls())
 
     def _create_quantized_model(self, config_name, **extra_kwargs):

--- a/tests/models/testing_utils/quantization.py
+++ b/tests/models/testing_utils/quantization.py
@@ -825,7 +825,8 @@ class TorchAoConfigMixin:
         config_cls = getattr(_torchao_quantization, config_name)
         # TorchAO int4 quantization requires plain_int32 packing format on Intel XPU
         if torch_device == "xpu":
-            config_cls.int4_packing_format = "plain_int32"
+            return TorchAoConfig(config_cls(int4_packing_format="plain_int32"))
+
         return TorchAoConfig(config_cls())
 
     def _create_quantized_model(self, config_name, **extra_kwargs):

--- a/tests/models/transformers/test_models_transformer_wan_animate.py
+++ b/tests/models/transformers/test_models_transformer_wan_animate.py
@@ -219,7 +219,7 @@ class TestWanAnimateTransformer3DTorchAo(WanAnimateTransformer3DTesterConfig, To
         """Override to provide inputs matching the tiny Wan Animate model dimensions."""
         return {
             "hidden_states": randn_tensor(
-                (1, 36, 21, 64, 64), generator=self.generator, device=torch_device, dtype=self.torch_dtype
+                (1, 36, 5, 16, 16), generator=self.generator, device=torch_device, dtype=self.torch_dtype
             ),
             "encoder_hidden_states": randn_tensor(
                 (1, 512, 4096), generator=self.generator, device=torch_device, dtype=self.torch_dtype
@@ -228,10 +228,10 @@ class TestWanAnimateTransformer3DTorchAo(WanAnimateTransformer3DTesterConfig, To
                 (1, 257, 1280), generator=self.generator, device=torch_device, dtype=self.torch_dtype
             ),
             "pose_hidden_states": randn_tensor(
-                (1, 16, 20, 64, 64), generator=self.generator, device=torch_device, dtype=self.torch_dtype
+                (1, 16, 4, 16, 16), generator=self.generator, device=torch_device, dtype=self.torch_dtype
             ),
             "face_pixel_values": randn_tensor(
-                (1, 3, 77, 512, 512), generator=self.generator, device=torch_device, dtype=self.torch_dtype
+                (1, 3, 5, 512, 512), generator=self.generator, device=torch_device, dtype=self.torch_dtype
             ),
             "timestep": torch.tensor([1.0]).to(torch_device, self.torch_dtype),
         }

--- a/tests/models/transformers/test_models_transformer_wan_animate.py
+++ b/tests/models/transformers/test_models_transformer_wan_animate.py
@@ -231,7 +231,7 @@ class TestWanAnimateTransformer3DTorchAo(WanAnimateTransformer3DTesterConfig, To
                 (1, 16, 4, 16, 16), generator=self.generator, device=torch_device, dtype=self.torch_dtype
             ),
             "face_pixel_values": randn_tensor(
-                (1, 3, 5, 512, 512), generator=self.generator, device=torch_device, dtype=self.torch_dtype
+                (1, 3, 13, 512, 512), generator=self.generator, device=torch_device, dtype=self.torch_dtype
             ),
             "timestep": torch.tensor([1.0]).to(torch_device, self.torch_dtype),
         }


### PR DESCRIPTION
## What does this PR do?

This PR improves the TorchAO quantization testing infrastructure with several fixes: enabling `int4wo` tests on Intel XPU, implementing `_dequantize` for TorchAO, fixing input dtype mismatches, and fixing training gradient underflow.

### Changes

1. **Enable int4wo tests on XPU**: Removed the `_int4wo_skip` marker that restricted `int4wo` tests to CUDA only, allowing them to run on all accelerator backends.

2. **XPU-specific int4 packing format**: Added XPU-specific handling in `_get_quant_config()` — Intel XPU requires `int4_packing_format="plain_int32"` for `Int4WeightOnlyConfig`.

3. **Fix input dtype casting**: Introduced `_get_dummy_inputs_for_model(model)` helper in `QuantizationTesterMixin` to automatically cast floating-point input tensors to the model's parameter dtype, preventing dtype mismatches during quantized model inference.

4. **Implement `_dequantize` for TorchAO**: Added `_dequantize()` method in `TorchAoHfQuantizer` that iterates all `nn.Linear` modules, calls `weight.dequantize()` on `TorchAOBaseTensor` weights, and replaces them with standard `nn.Parameter`. Also fixed `_verify_if_layer_quantized` to check `isinstance(module.weight, TorchAOBaseTensor)` so dequantized layers are correctly detected as non-quantized.

5. **Fix training gradient underflow**: Changed autocast dtype from `float16` to `bfloat16` in `_test_quantization_training`. Float16's limited dynamic range (max ~65504, min subnormal ~5.96e-8) causes gradients to underflow to zero when passing through quantized tensor subclass operations; bfloat16 shares float32's exponent range and avoids this issue.

6. **Reduce WanAnimate TorchAO test input sizes**: Shrunk dummy inputs in `TestWanAnimateTransformer3DTorchAo` to avoid OOM on devices without FlashAttention (e.g. XPU, which falls back to math SDPA and materializes the full O(S²) attention matrix). Reduced `hidden_states` from (1,36,21,64,64) to (1,36,5,16,16) and `face_pixel_values` from (1,3,77,512,512) to (1,3,13,512,512), bringing self-attention sequence length from 21,504 to 320 and peak attention memory from ~74 GiB to ~16 MB. Face frame count (13) is chosen so the face encoder's two stride-2 convolutions produce temporal output 4, plus 1 padding = 5, matching `hidden_states` temporal dim.