### PR TITLE
Fix AttributeError/TypeError in sana_sprint model-card save

### DIFF
--- a/examples/research_projects/sana/train_sana_sprint_diffusers.py
+++ b/examples/research_projects/sana/train_sana_sprint_diffusers.py
@@ -1760,7 +1760,6 @@ def main(args):
                 repo_id,
                 images=images,
                 base_model=args.pretrained_model_name_or_path,
-                instance_prompt=args.instance_prompt,
                 validation_prompt=args.validation_prompt,
                 repo_folder=args.output_dir,
             )


### PR DESCRIPTION
## What this PR does

`train_sana_sprint_diffusers.py` ends training (under `--push_to_hub`) with:

https://github.com/huggingface/diffusers/blob/main/examples/research_projects/sana/train_sana_sprint_diffusers.py#L1758-L1766

```python
if args.push_to_hub:
    save_model_card(
        repo_id,
        images=images,
        base_model=args.pretrained_model_name_or_path,
        instance_prompt=args.instance_prompt,
        validation_prompt=args.validation_prompt,
        repo_folder=args.output_dir,
    )
```

But the script has **neither**:

1. `--instance_prompt` on the parser (grep confirms zero `add_argument` call for it). `args.instance_prompt` raises `AttributeError: 'Namespace' object has no attribute 'instance_prompt'` when the kwarg value is evaluated.
2. An `instance_prompt` parameter on `save_model_card` ([line 217](https://github.com/huggingface/diffusers/blob/main/examples/research_projects/sana/train_sana_sprint_diffusers.py#L217-L223) accepts only `repo_id`, `images`, `base_model`, `validation_prompt`, `repo_folder` — no `**kwargs`). Even if the attribute existed, the call would fail with `TypeError: save_model_card() got an unexpected keyword argument 'instance_prompt'`.

## Why this is a real bug

This fires at the tail end of training with `--push_to_hub`, after the model has been saved locally — losing the hub upload for anyone running the documented workflow.

It's a dreambooth-pattern copy-paste leftover: Sana Sprint is not a dreambooth-style trainer — it takes `--validation_prompt`, not instance prompts. `instance_prompt` appears exactly once in the whole file (at this call site) and is never referenced inside `save_model_card`.

## Fix

Drop the stray kwarg:

```diff
 save_model_card(
     repo_id,
     images=images,
     base_model=args.pretrained_model_name_or_path,
-    instance_prompt=args.instance_prompt,
     validation_prompt=args.validation_prompt,
     repo_folder=args.output_dir,
 )
```

The remaining kwargs now match `save_model_card`'s signature exactly.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue or the forum? N/A — dead-on-push-to-hub crash.
- [x] Did you make sure to update the documentation with your changes? N/A.
- [x] Did you write any new necessary tests? N/A — restores working `--push_to_hub` path.

## Who can review?
@sayakpaul