### PR TITLE
Fix AuraFlow attn processors applying norm_added_q to key projection

### DIFF
--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -2140,7 +2140,7 @@ class AuraFlowAttnProcessor2_0:
             if attn.norm_added_q is not None:
                 encoder_hidden_states_query_proj = attn.norm_added_q(encoder_hidden_states_query_proj)
             if attn.norm_added_k is not None:
-                encoder_hidden_states_key_proj = attn.norm_added_q(encoder_hidden_states_key_proj)
+                encoder_hidden_states_key_proj = attn.norm_added_k(encoder_hidden_states_key_proj)
 
             query = torch.cat([encoder_hidden_states_query_proj, query], dim=1)
             key = torch.cat([encoder_hidden_states_key_proj, key], dim=1)
@@ -2237,7 +2237,7 @@ class FusedAuraFlowAttnProcessor2_0:
             if attn.norm_added_q is not None:
                 encoder_hidden_states_query_proj = attn.norm_added_q(encoder_hidden_states_query_proj)
             if attn.norm_added_k is not None:
-                encoder_hidden_states_key_proj = attn.norm_added_q(encoder_hidden_states_key_proj)
+                encoder_hidden_states_key_proj = attn.norm_added_k(encoder_hidden_states_key_proj)
 
             query = torch.cat([encoder_hidden_states_query_proj, query], dim=1)
             key = torch.cat([encoder_hidden_states_key_proj, key], dim=1)


### PR DESCRIPTION
## What does this PR do?

Both `AuraFlowAttnProcessor2_0` and `FusedAuraFlowAttnProcessor2_0` in `attention_processor.py` contain a copy-paste error where `attn.norm_added_q` is called on the encoder **key** projection while guarded by a check on `attn.norm_added_k`:

```python
if attn.norm_added_q is not None:
    encoder_hidden_states_query_proj = attn.norm_added_q(encoder_hidden_states_query_proj)
if attn.norm_added_k is not None:
    encoder_hidden_states_key_proj = attn.norm_added_q(encoder_hidden_states_key_proj)  # bug: should be norm_added_k
```

This silently applies the query's added-QK norm to the key projection, which is wrong whenever the two layers have different parameters (and is definitely wrong as a logical statement of the attention equations).

Every other attention processor in this file that defines both `norm_added_q` and `norm_added_k` (e.g. `FluxAttnProcessor`, `CogVideoXAttnProcessor`, `HunyuanAttnProcessor`, etc.) correctly applies `norm_added_k` to the key.

This PR fixes both occurrences (lines 2143 and 2240).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?

## Who can review?
@yiyixuxu @sayakpaul