### PR TITLE
Fix non-deterministic T5 outputs in HiDream pipeline tests

### DIFF
--- a/tests/pipelines/hidream_image/test_pipeline_hidream.py
+++ b/tests/pipelines/hidream_image/test_pipeline_hidream.py
@@ -96,7 +96,7 @@ class HiDreamImagePipelineFastTests(PipelineTesterMixin, unittest.TestCase):
 
         torch.manual_seed(0)
         config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-t5")
-        text_encoder_3 = T5EncoderModel(config)
+        text_encoder_3 = T5EncoderModel(config).eval()
 
         torch.manual_seed(0)
         text_encoder_4 = LlamaForCausalLM.from_pretrained("hf-internal-testing/tiny-random-LlamaForCausalLM")


### PR DESCRIPTION
This PR tries to fix 2 failed test cases for hiream pipeline tests:
```
tests/pipelines/hidream_image/test_pipeline_hidream.py::HiDreamImagePipelineFastTests::test_cpu_offload_forward_pass_twice
tests/pipelines/hidream_image/test_pipeline_hidream.py::HiDreamImagePipelineFastTests::test_sequential_offload_forward_pass_twice
```
Root cause: In `get_dummy_components()`, T5EncoderModel(config) creates the model in training mode by default. The tiny-random-t5 config has dropout_rate=0.1, so each forward pass produces different embeddings due to active dropout — even under `torch.no_grad()`. In production this isn't an issue because `from_pretrained()` automatically calls `.eval()`, but we need to add this explicitly for `text_encoder_3 ` in the test file