### PR TITLE
Fix torch_dtype warning showing wrong value in from_single_file

### DIFF
--- a/src/diffusers/loaders/single_file.py
+++ b/src/diffusers/loaders/single_file.py
@@ -366,10 +366,10 @@ class FromSingleFileMixin:
         is_legacy_loading = False
 
         if torch_dtype is not None and not isinstance(torch_dtype, torch.dtype):
-            torch_dtype = torch.float32
             logger.warning(
                 f"Passed `torch_dtype` {torch_dtype} is not a `torch.dtype`. Defaulting to `torch.float32`."
             )
+            torch_dtype = torch.float32
 
         # We shouldn't allow configuring individual models components through a Pipeline creation method
         # These model kwargs should be deprecated


### PR DESCRIPTION
## What does this PR do?

In `FromSingleFileMixin.from_single_file()`, when an invalid `torch_dtype` is passed, the warning message always displays `torch.float32` instead of the actual invalid value:

```python
# Before (bug):
if torch_dtype is not None and not isinstance(torch_dtype, torch.dtype):
    torch_dtype = torch.float32  # reassigned BEFORE the warning
    logger.warning(
        f"Passed `torch_dtype` {torch_dtype} is not a `torch.dtype`. ..."
        # ^ always shows "torch.float32"
    )
```

This PR moves the reassignment after the warning so users can see what invalid value they actually passed:

```python
# After (fix):
if torch_dtype is not None and not isinstance(torch_dtype, torch.dtype):
    logger.warning(
        f"Passed `torch_dtype` {torch_dtype} is not a `torch.dtype`. ..."
        # ^ now shows the actual invalid value (e.g. "float16", "bf16", etc.)
    )
    torch_dtype = torch.float32
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?

## Who can review?
@yiyixuxu @sayakpaul