### PR TITLE
Fix AdaLayerNormZeroSingle.forward return type annotation

### DIFF
--- a/src/diffusers/models/normalization.py
+++ b/src/diffusers/models/normalization.py
@@ -195,7 +195,7 @@ class AdaLayerNormZeroSingle(nn.Module):
         self,
         x: torch.Tensor,
         emb: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         emb = self.linear(self.silu(emb))
         shift_msa, scale_msa, gate_msa = emb.chunk(3, dim=1)
         x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]


### PR DESCRIPTION
## What does this PR do?

`AdaLayerNormZeroSingle.forward()` has a return type annotation declaring a 5-element tuple:

```python
def forward(self, x, emb=None) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
    ...
    return x, gate_msa  # actually returns 2 elements
```

The 5-element annotation was copied from `AdaLayerNormZero.forward()` which does return 5 elements (`x, gate_msa, shift_mlp, scale_mlp, gate_mlp`), but the "Single" variant only returns 2 (`x, gate_msa`).

All callers correctly unpack 2 elements (e.g., `norm_hidden_states, gate = self.norm(hidden_states, emb=temb)` in FluxSingleTransformerBlock), so this is just a type annotation fix.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?

## Who can review?
@yiyixuxu @sayakpaul