### PR TITLE
Fix missing raise before NotImplementedError in Flux SPMD example

### DIFF
--- a/examples/research_projects/pytorch_xla/inference/flux/flux_inference_spmd.py
+++ b/examples/research_projects/pytorch_xla/inference/flux/flux_inference_spmd.py
@@ -49,7 +49,7 @@ def main(args):
     if num_devices >= 4:
         mesh = xs.Mesh(np.arange(num_devices), (num_devices // 4, 4), ("data", "model"))
     else:
-        NotImplementedError
+        raise NotImplementedError(f"SPMD mesh requires at least 4 devices, got {num_devices}")
     xs.set_global_mesh(mesh)
     logger.info(f"SPMD mesh: {mesh.mesh_shape}, axes: {mesh.axis_names}, devices: {num_devices}")
 


### PR DESCRIPTION
## What does this PR do?

In `examples/research_projects/pytorch_xla/inference/flux/flux_inference_spmd.py`, the `NotImplementedError` exception object is created but never raised when `num_devices < 4`:

```python
# Before (bug):
else:
    NotImplementedError  # creates object, doesn't raise it

# After (fix):
else:
    raise NotImplementedError(f"SPMD mesh requires at least 4 devices, got {num_devices}")
```

Without `raise`, execution continues to the next line where `mesh` is undefined, causing a confusing `NameError` instead of the intended informative error.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?

## Who can review?
@yiyixuxu @sayakpaul