### PR TITLE
Fix missing function call in is_torch_xla_version

### DIFF
--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -708,7 +708,7 @@ def is_torch_xla_version(operation: str, version: str):
         version (`str`):
             A string version of torch_xla
     """
-    if not is_torch_xla_available:
+    if not _torch_xla_available:
         return False
     return compare_versions(parse(_torch_xla_version), operation, version)
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `is_torch_xla_version()` where `is_torch_xla_available` (a function) is referenced without parentheses. This checks the truthiness of the function object itself (always `True`) rather than calling it, so the guard never triggers when `torch_xla` is unavailable.

### The bug

```python
# Before (bug): checks function object truthiness, always True
if not is_torch_xla_available:
    return False

# After (fix): uses the module-level variable, consistent with other version checkers
if not _torch_xla_available:
    return False
```

The fix uses `_torch_xla_available` (the module-level boolean) for consistency with `is_transformers_version`, `is_accelerate_version`, and all other `is_*_version` functions in the same file.

## Who can review?

@yiyixuxu @DN6