### PR TITLE
Replace bare except with except Exception

### DIFF
--- a/src/diffusers/experimental/rl/value_guided_sampling.py
+++ b/src/diffusers/experimental/rl/value_guided_sampling.py
@@ -57,13 +57,13 @@ class ValueGuidedRLPipeline(DiffusionPipeline):
         for key in self.data.keys():
             try:
                 self.means[key] = self.data[key].mean()
-            except:  # noqa: E722
+            except Exception:
                 pass
         self.stds = {}
         for key in self.data.keys():
             try:
                 self.stds[key] = self.data[key].std()
-            except:  # noqa: E722
+            except Exception:
                 pass
         self.state_dim = env.observation_space.shape[0]
         self.action_dim = env.action_space.shape[0]

--- a/src/diffusers/utils/hub_utils.py
+++ b/src/diffusers/utils/hub_utils.py
@@ -298,7 +298,7 @@ def _get_model_file(
                     FutureWarning,
                 )
                 return model_file
-            except:  # noqa: E722
+            except Exception:
                 warnings.warn(
                     f"You are loading the variant {revision} from {pretrained_model_name_or_path} via `revision='{revision}'`. This behavior is deprecated and will be removed in diffusers v1. One should use `variant='{revision}'` instead. However, it appears that {pretrained_model_name_or_path} currently does not have a {_add_variant(weights_name, revision)} file in the 'main' branch of {pretrained_model_name_or_path}. \n The Diffusers team and community would be very grateful if you could open an issue: https://github.com/huggingface/diffusers/issues/new with the title '{pretrained_model_name_or_path} is missing {_add_variant(weights_name, revision)}' so that the correct variant file can be added.",
                     FutureWarning,


### PR DESCRIPTION
## What does this PR do?

Replaces 3 bare `except:` clauses with `except Exception:`.

Bare `except:` catches `SystemExit` and `KeyboardInterrupt`, which prevents graceful shutdown (e.g. `Ctrl+C` during a download in `hub_utils.py` would be silently swallowed instead of interrupting the process).

`except Exception:` preserves the original error-handling behavior while allowing system-exiting exceptions to propagate normally.

### Locations

| File | Line | Context |
|------|------|---------|
| `utils/hub_utils.py` | 301 | Fallback variant download path |
| `experimental/rl/value_guided_sampling.py` | 60 | Dataset mean computation |
| `experimental/rl/value_guided_sampling.py` | 66 | Dataset std computation |

## Who can review?

Anyone in the community is free to review the PR. @yiyixuxu @sayakpaul