### PR TITLE
chore: bump doc-builder SHA for main doc build workflow

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       commit_sha: ${{ github.sha }}
       install_libgl1: true


### PR DESCRIPTION
Bump the pinned doc-builder SHA so that main documentation builds also sync to the HF bucket (dual-write introduced in doc-builder PR #780, 2026-04-15). The current pin predates that change, so release docs never land in the bucket — only in the legacy dataset.