### PR TITLE
docs(flux2): clarify image= is reference conditioning, not img2img

### DIFF
--- a/docs/source/en/api/pipelines/flux2.md
+++ b/docs/source/en/api/pipelines/flux2.md
@@ -32,6 +32,26 @@ Flux.2 can potentially generate better better outputs with better prompts. We ca
 an input prompt by setting the `caption_upsample_temperature` argument in the pipeline call arguments.
 The [official implementation](https://github.com/black-forest-labs/flux2/blob/5a5d316b1b42f6b59a8c9194b77c8256be848432/src/flux2/text_encoder.py#L140) recommends this value to be 0.15.
 
+## Reference conditioning vs. img2img
+
+The `image` argument on `Flux2Pipeline` and `Flux2KleinPipeline` is **reference conditioning**, not
+img2img. Reference images are encoded into additional attention tokens that flow through the
+transformer alongside the text prompt — there is no noisy latent initialization, and so no `strength`
+parameter to scale.
+
+This differs from `StableDiffusionImg2ImgPipeline`, `FluxImg2ImgPipeline`, and
+`FluxKontextInpaintPipeline`, which add noise to a latent encoding of the input image and then
+partially denoise it. If you port code from those pipelines and pass `strength=...` to a Flux.2
+pipeline, you will see:
+
+```
+TypeError: Flux2Pipeline.__call__() got an unexpected keyword argument 'strength'
+```
+
+Drop the `strength` kwarg and pass references via `image=` (a single image, or a list for multiple
+references). For Flux.2 inpainting (which does add noise to a latent and therefore does take a
+`strength` parameter), use `Flux2KleinInpaintPipeline` instead.
+
 ## Flux2Pipeline
 
 [[autodoc]] Flux2Pipeline

--- a/docs/source/en/api/pipelines/flux2.md
+++ b/docs/source/en/api/pipelines/flux2.md
@@ -34,23 +34,14 @@ The [official implementation](https://github.com/black-forest-labs/flux2/blob/5a
 
 ## Reference conditioning vs. img2img
 
-The `image` argument on `Flux2Pipeline` and `Flux2KleinPipeline` is **reference conditioning**, not
-img2img. Reference images are encoded into additional attention tokens that flow through the
-transformer alongside the text prompt — there is no noisy latent initialization, and so no `strength`
-parameter to scale.
-
-This differs from `StableDiffusionImg2ImgPipeline`, `FluxImg2ImgPipeline`, and
-`FluxKontextInpaintPipeline`, which add noise to a latent encoding of the input image and then
-partially denoise it. If you port code from those pipelines and pass `strength=...` to a Flux.2
-pipeline, you will see:
+The `image` argument on [`Flux2Pipeline`] and [`Flux2KleinPipeline`] is a *reference conditioning*. Reference images are encoded as additional attention tokens that flow through the
+transformer alongside the text prompt. Flux.2 doesn't add noise to the input image unlike [`FluxImg2ImgPipeline`]. Passing `strength` to [`Flux2Pipeline`] raises:
 
 ```
 TypeError: Flux2Pipeline.__call__() got an unexpected keyword argument 'strength'
 ```
 
-Drop the `strength` kwarg and pass references via `image=` (a single image, or a list for multiple
-references). For Flux.2 inpainting (which does add noise to a latent and therefore does take a
-`strength` parameter), use `Flux2KleinInpaintPipeline` instead.
+Drop the `strength` argument and pass references with `image`. For inpainting, use [`Flux2KleinInpaintPipeline`] instead.
 
 ## Flux2Pipeline
 

--- a/src/diffusers/pipelines/flux2/pipeline_flux2.py
+++ b/src/diffusers/pipelines/flux2/pipeline_flux2.py
@@ -769,11 +769,15 @@ class Flux2Pipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
 
         Args:
             image (`torch.Tensor`, `PIL.Image.Image`, `np.ndarray`, `list[torch.Tensor]`, `list[PIL.Image.Image]`, or `list[np.ndarray]`):
-                `Image`, numpy array or tensor representing an image batch to be used as the starting point. For both
-                numpy array and pytorch tensor, the expected value range is between `[0, 1]` If it's a tensor or a list
-                or tensors, the expected shape should be `(B, C, H, W)` or `(C, H, W)`. If it is a numpy array or a
-                list of arrays, the expected shape should be `(B, H, W, C)` or `(H, W, C)` It can also accept image
-                latents as `image`, but if passing latents directly it is not encoded again.
+                Reference image(s) used to condition generation. Flux.2 encodes them as additional attention tokens that
+                flow through the transformer alongside the text prompt — this is **reference conditioning**, not
+                SD/Flux.1 style img2img, so there is no companion `strength` argument. Pass a list to provide multiple
+                references.
+
+                For both numpy array and pytorch tensor, the expected value range is between `[0, 1]`. If it's a tensor
+                or a list of tensors, the expected shape should be `(B, C, H, W)` or `(C, H, W)`. If it is a numpy
+                array or a list of arrays, the expected shape should be `(B, H, W, C)` or `(H, W, C)`. Can also accept
+                image latents directly, in which case they will not be re-encoded.
             prompt (`str` or `list[str]`, *optional*):
                 The prompt or prompts to guide the image generation. If not defined, one has to pass `prompt_embeds`.
                 instead.

--- a/src/diffusers/pipelines/flux2/pipeline_flux2_klein.py
+++ b/src/diffusers/pipelines/flux2/pipeline_flux2_klein.py
@@ -635,11 +635,15 @@ class Flux2KleinPipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
 
         Args:
             image (`torch.Tensor`, `PIL.Image.Image`, `np.ndarray`, `List[torch.Tensor]`, `List[PIL.Image.Image]`, or `List[np.ndarray]`):
-                `Image`, numpy array or tensor representing an image batch to be used as the starting point. For both
-                numpy array and pytorch tensor, the expected value range is between `[0, 1]` If it's a tensor or a list
-                or tensors, the expected shape should be `(B, C, H, W)` or `(C, H, W)`. If it is a numpy array or a
-                list of arrays, the expected shape should be `(B, H, W, C)` or `(H, W, C)` It can also accept image
-                latents as `image`, but if passing latents directly it is not encoded again.
+                Reference image(s) used to condition generation. Flux.2 encodes them as additional attention tokens that
+                flow through the transformer alongside the text prompt — this is **reference conditioning**, not
+                SD/Flux.1 style img2img, so there is no companion `strength` argument. Pass a list to provide multiple
+                references.
+
+                For both numpy array and pytorch tensor, the expected value range is between `[0, 1]`. If it's a tensor
+                or a list of tensors, the expected shape should be `(B, C, H, W)` or `(C, H, W)`. If it is a numpy
+                array or a list of arrays, the expected shape should be `(B, H, W, C)` or `(H, W, C)`. Can also accept
+                image latents directly, in which case they will not be re-encoded.
             prompt (`str` or `List[str]`, *optional*):
                 The prompt or prompts to guide the image generation. If not defined, one has to pass `prompt_embeds`.
                 instead.


### PR DESCRIPTION
# What does this PR do?

The `image=` parameter on `Flux2Pipeline` and `Flux2KleinPipeline` is currently described as a "starting point", which mirrors the SD/Flux.1 img2img wording:

> `Image`, numpy array or tensor representing an image batch to be used as the starting point. […] It can also accept image latents as `image`, but if passing latents directly it is not encoded again.

Flux.2 actually encodes reference images as additional attention conditioning tokens — there's no noisy-latent init, and so no `strength` parameter. The existing wording is easy to misread when porting code from `StableDiffusionImg2ImgPipeline`, `FluxImg2ImgPipeline`, or `FluxKontextInpaintPipeline`, all of which legitimately accept `strength`.

We had a production serving stack pass `strength=` alongside `image=` based on the existing wording and crashed with:

```
TypeError: Flux2Pipeline.__call__() got an unexpected keyword argument 'strength'
```

### Changes

- Rewrite the `image=` docstring on `Flux2Pipeline.__call__` and `Flux2KleinPipeline.__call__` to make it explicit that this is reference conditioning, not img2img, and that there is no `strength` knob.
- Add a short `## Reference conditioning vs. img2img` callout to `docs/source/en/api/pipelines/flux2.md` distinguishing the two modes, mentioning `Flux2KleinInpaintPipeline` as the right pipeline if you actually do need a `strength`-style noisy-latent init.

`Flux2KleinKVPipeline`'s docstring already correctly describes reference conditioning, so no change there. `Flux2KleinInpaintPipeline` does take `strength` and is left as-is.

### Out of scope (happy to add as a follow-up)

A small defensive check inside `__call__` that intercepts unknown img2img kwargs and raises a clear `TypeError` pointing at this section of the docs, e.g.:

```python
if "strength" in kwargs:
    raise TypeError(
        "Flux2Pipeline does not support `strength`. Flux.2 uses reference "
        "conditioning via `image=`, not noisy-latent img2img. See "
        "https://huggingface.co/docs/diffusers/api/pipelines/flux2 ."
    )
```

Left out of this PR to keep it docs-only; happy to push as a second commit if maintainers prefer.

### Behavioral change

None — docs only.

Fixes # (no related issue — surfaced in production)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? (N/A — docs only)


## Who can review?

Docs: @stevhliu @sayakpaul
