### PR TITLE
feat(loading): detect Git LFS pointer files and raise a clear error

### DIFF
--- a/src/diffusers/models/model_loading_utils.py
+++ b/src/diffusers/models/model_loading_utils.py
@@ -38,6 +38,7 @@ from ..utils import (
     WEIGHTS_INDEX_NAME,
     _add_variant,
     _get_model_file,
+    _is_lfs_pointer,
     deprecate,
     is_accelerate_available,
     is_accelerate_version,
@@ -164,6 +165,22 @@ def load_state_dict(
     # TODO: maybe refactor a bit this part where we pass a dict here
     if isinstance(checkpoint_file, dict):
         return checkpoint_file
+
+    # Detect Git LFS pointer stubs before attempting to load. Without this, safetensors /
+    # torch.load fails far away from the real cause with a confusing deserialization error.
+    # The check covers both `git clone` without `git lfs pull` and bucket mirrors created
+    # with `gsutil rsync` / `aws s3 sync` that copied the LFS pointer text rather than
+    # the underlying weights.
+    if dduf_entries is None and _is_lfs_pointer(checkpoint_file):
+        raise OSError(
+            f"`{checkpoint_file}` is a Git LFS pointer file, not the actual weights. This typically "
+            f"happens when a Hugging Face repository was mirrored without LFS-aware copying — for "
+            f"example, `git clone` without a subsequent `git lfs pull`, or `gsutil rsync` / "
+            f"`aws s3 sync` from a bucket that holds the original git checkout. Re-mirror with "
+            f"`git lfs pull` (or with an LFS-aware tool such as "
+            f"`huggingface-cli download <repo_id> --local-dir <dir>`) and try again."
+        )
+
     try:
         file_extension = os.path.basename(checkpoint_file).split(".")[-1]
         if file_extension == SAFETENSORS_FILE_EXTENSION:

--- a/src/diffusers/utils/__init__.py
+++ b/src/diffusers/utils/__init__.py
@@ -50,6 +50,7 @@ from .hub_utils import (
     _add_variant,
     _get_checkpoint_shard_files,
     _get_model_file,
+    _is_lfs_pointer,
     extract_commit_hash,
     http_user_agent,
 )

--- a/src/diffusers/utils/hub_utils.py
+++ b/src/diffusers/utils/hub_utils.py
@@ -224,6 +224,38 @@ def _add_variant(weights_name: str, variant: str | None = None) -> str:
     return weights_name
 
 
+# Real `.safetensors` / `.bin` weight files are MB-to-GB. Git LFS pointer stubs are
+# tiny text files (~130 bytes). Anything under this size that starts with the LFS
+# pointer marker is, with extremely high confidence, a pointer rather than weights.
+_LFS_POINTER_MAX_SIZE = 1024
+_LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"
+
+
+def _is_lfs_pointer(path: str | os.PathLike) -> bool:
+    """
+    Return ``True`` if ``path`` is a Git LFS pointer stub rather than the actual file content.
+
+    LFS pointer files are small text files (~130 bytes) of the form::
+
+        version https://git-lfs.github.com/spec/v1
+        oid sha256:<hash>
+        size <bytes>
+
+    They are produced by ``git clone`` of an LFS-backed repository without ``git lfs pull``,
+    or by tools such as ``gsutil rsync`` / ``aws s3 sync`` that mirror an HF repository
+    without LFS-aware copying. Loading a pointer file as if it were the actual weights
+    leads to a confusing safetensors / pickle deserialization error far away from the
+    real cause.
+    """
+    try:
+        if os.path.getsize(path) > _LFS_POINTER_MAX_SIZE:
+            return False
+        with open(path, "rb") as f:
+            return f.read(len(_LFS_POINTER_PREFIX)) == _LFS_POINTER_PREFIX
+    except OSError:
+        return False
+
+
 @validate_hf_hub_args
 def _get_model_file(
     pretrained_model_name_or_path: str | Path,

--- a/tests/others/test_hub_utils.py
+++ b/tests/others/test_hub_utils.py
@@ -16,7 +16,7 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from diffusers.utils.hub_utils import load_or_create_model_card, populate_model_card
+from diffusers.utils.hub_utils import _is_lfs_pointer, load_or_create_model_card, populate_model_card
 
 
 class CreateModelCardTest(unittest.TestCase):
@@ -27,3 +27,42 @@ class CreateModelCardTest(unittest.TestCase):
             model_card = load_or_create_model_card(file_path)
             populate_model_card(model_card)
             assert model_card.data.library_name == "foo"
+
+
+class IsLFSPointerTest(unittest.TestCase):
+    LFS_POINTER_TEXT = (
+        "version https://git-lfs.github.com/spec/v1\n"
+        "oid sha256:0000000000000000000000000000000000000000000000000000000000000000\n"
+        "size 17000000000\n"
+    )
+
+    def test_detects_lfs_pointer(self):
+        with TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "diffusion_pytorch_model.safetensors"
+            file_path.write_text(self.LFS_POINTER_TEXT)
+            assert _is_lfs_pointer(file_path) is True
+
+    def test_real_safetensors_not_flagged(self):
+        # safetensors files start with an 8-byte little-endian header length and JSON metadata,
+        # never with the LFS pointer marker. Synthesise a small payload to confirm.
+        with TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "diffusion_pytorch_model.safetensors"
+            file_path.write_bytes(b"\x08\x00\x00\x00\x00\x00\x00\x00{}      ")
+            assert _is_lfs_pointer(file_path) is False
+
+    def test_large_file_not_flagged(self):
+        # A file larger than the pointer-size threshold is short-circuited to False without
+        # being read, even if its contents would otherwise match.
+        with TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "diffusion_pytorch_model.safetensors"
+            file_path.write_bytes(self.LFS_POINTER_TEXT.encode() + b"\x00" * 4096)
+            assert _is_lfs_pointer(file_path) is False
+
+    def test_missing_file_returns_false(self):
+        assert _is_lfs_pointer("/nonexistent/path/foo.safetensors") is False
+
+    def test_unrelated_short_file_not_flagged(self):
+        with TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "config.json"
+            file_path.write_text('{"version": 2}\n')
+            assert _is_lfs_pointer(file_path) is False


### PR DESCRIPTION
# What does this PR do?

Detect Git LFS pointer stubs in `load_state_dict` *before* attempting to deserialize them, and raise a clear error pointing at the actual fix instead of failing with a cryptic safetensors / pickle deserialization error far away from the real cause.

## Why

When a Hugging Face repository is mirrored without LFS-aware copying — for example, `git clone` without a subsequent `git lfs pull`, or `gsutil rsync` / `aws s3 sync` from a bucket that holds the original git checkout — the resulting local directory contains ~130-byte text pointer stubs in place of the real `.safetensors` weights:

```
version https://git-lfs.github.com/spec/v1
oid sha256:<hash>
size <bytes>
```

`from_pretrained(<that-local-dir>)` then fails deep inside safetensors with a confusing tensor-shape / format error, often after several minutes of partial loads, with no hint that the problem is a missing LFS pull. The existing fallback in `load_state_dict` does try to detect this case, but only after the failed load and only for git-style cloning (its message tells users to run `git lfs install` + `git lfs pull`, which is wrong advice for a `gsutil rsync` mirror).

## Changes

1. **New helper** `_is_lfs_pointer(path)` in `src/diffusers/utils/hub_utils.py`.

   Reads at most 64 bytes, after a single `os.path.getsize` short-circuit (real weight files are MB–GB; LFS pointer files are ~130 bytes). Returns `False` for any kind of I/O error so it never gets in the way of a real load.

2. **Preemptive check** at the top of `load_state_dict` in `src/diffusers/models/model_loading_utils.py`. If the resolved checkpoint file is an LFS pointer, raise `OSError` with a message that:
   - names the actual file path,
   - explains the two common causes (`git clone` without `git lfs pull`, and bucket-mirror tools like `gsutil rsync` / `aws s3 sync`),
   - suggests the LFS-aware alternative (`huggingface-cli download <repo_id> --local-dir <dir>`).

   The existing post-failure detection in the `except` block is kept as a safety net for any path that bypasses the new pre-check.

3. **Unit tests** in `tests/others/test_hub_utils.py` covering five cases:
   - LFS pointer is detected (`True`)
   - small synthetic safetensors header is **not** flagged
   - large file with the LFS marker as a prefix is short-circuited to `False` by the size check
   - missing path returns `False` (no exception)
   - unrelated short JSON file is **not** flagged

   The helper is purely byte-oriented so tests run without GPU, network, or any model fixtures.

## Why not extend to all `safetensors.torch.load_file` sites at once

There are a handful of other places (`loaders/lora_base.py`, `loaders/unet.py`, `loaders/textual_inversion.py`, `hooks/group_offloading.py`, `utils/state_dict_utils.py`) that call safetensors directly without going through `load_state_dict`. Happy to extend the pre-check to those sites in a follow-up if maintainers prefer; this PR keeps scope to the central loader path that covers the `from_pretrained` flow most users hit first.

## Behavioral change

- For valid weights: zero impact (one `os.path.getsize` short-circuits the check immediately).
- For LFS pointer files: an immediate, clear `OSError` instead of a delayed, cryptic deserialization error. No previously-loadable file becomes unloadable.

Fixes # (no related issue — surfaced repeatedly when mirroring HF repos to non-LFS-aware buckets)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? (no user-facing docs to update; helper is internal)
- [x] Did you write any new necessary tests? (5 new unit tests in `tests/others/test_hub_utils.py`)


## Who can review?

General functionalities: @sayakpaul @yiyixuxu @DN6
