### PR TITLE
Fix the `disable_free_noise` function in `AnimateDiffFreeNoiseMixin`

### DIFF
--- a/src/diffusers/pipelines/free_noise_utils.py
+++ b/src/diffusers/pipelines/free_noise_utils.py
@@ -525,7 +525,6 @@ class AnimateDiffFreeNoiseMixin:
         else:
             blocks = [*self.unet.down_blocks, *self.unet.up_blocks]
 
-        blocks = [*self.unet.down_blocks, self.unet.mid_block, *self.unet.up_blocks]
         for block in blocks:
             self._disable_free_noise_in_block(block)
 


### PR DESCRIPTION
# What does this PR do?
Fixes the `disable_free_noise` function in `AnimateDiffFreeNoiseMixin`

The `self.unet.mid_block` was being unconditionally included as a result of the new `if/else` branch introduced in #9288.
This means that `self._disable_free_noise_in_block(block)` could be called for the `mid_block`, which would attempt to access the `motion_modules` property of the `mid_block` even though it does not exist:

https://github.com/huggingface/diffusers/blob/f7fd76adcd288494a1a13c82d06e37579170aaf3/src/diffusers/pipelines/free_noise_utils.py#L192

The fix simply removes the leftover blocks assignment line.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@a-r-r-o-w 
@dhruvrnaik 
