### PR TITLE
docs(autoencoder_oobleck): remove duplicate OobleckDecoderOutput section

### DIFF
--- a/docs/source/en/api/models/autoencoder_oobleck.md
+++ b/docs/source/en/api/models/autoencoder_oobleck.md
@@ -29,10 +29,6 @@ The abstract from the paper is:
 
 [[autodoc]] models.autoencoders.autoencoder_oobleck.OobleckDecoderOutput
 
-## OobleckDecoderOutput
-
-[[autodoc]] models.autoencoders.autoencoder_oobleck.OobleckDecoderOutput
-
 ## AutoencoderOobleckOutput
 
 [[autodoc]] models.autoencoders.autoencoder_oobleck.AutoencoderOobleckOutput


### PR DESCRIPTION
## Summary

Fixes #13642.

The [`AutoencoderOobleck` reference docs](https://huggingface.co/docs/diffusers/api/models/autoencoder_oobleck) render the `OobleckDecoderOutput` section twice because [`docs/source/en/api/models/autoencoder_oobleck.md`](https://github.com/huggingface/diffusers/blob/0f1abc4ae8b0eb2a3b40e82a310507281144c423/docs/source/en/api/models/autoencoder_oobleck.md) contains the same `[[autodoc]]` block twice. This drops the duplicate so the page documents `AutoencoderOobleck`, `OobleckDecoderOutput`, and `AutoencoderOobleckOutput` once each.

The two output classes that actually exist in `src/diffusers/models/autoencoders/autoencoder_oobleck.py` are `OobleckDecoderOutput` and `AutoencoderOobleckOutput` — both still rendered after this change.

## Changes

- `docs/source/en/api/models/autoencoder_oobleck.md`: delete the duplicate `## OobleckDecoderOutput` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)