### PR TITLE
[docs] fix typo in AutoencoderOobleck docs (#13642)

### DIFF
--- a/docs/source/en/api/models/autoencoder_oobleck.md
+++ b/docs/source/en/api/models/autoencoder_oobleck.md
@@ -29,10 +29,6 @@ The abstract from the paper is:
 
 [[autodoc]] models.autoencoders.autoencoder_oobleck.OobleckDecoderOutput
 
-## OobleckDecoderOutput
-
-[[autodoc]] models.autoencoders.autoencoder_oobleck.OobleckDecoderOutput
-
 ## AutoencoderOobleckOutput
 
 [[autodoc]] models.autoencoders.autoencoder_oobleck.AutoencoderOobleckOutput


### PR DESCRIPTION
# What does this PR do?

Fixes #13642
Typo in `AutoencoderOobleck` docs: duplicated `OobleckDecoderOutput` descriptions


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@stevhliu or @sayakpaul please check guys! Thank you!