### PR TITLE
fix(controlnet_hunyuan): wire num_layers, pooled_projection_dim, use_style_cond into from_transformer (#13641)

### DIFF
--- a/src/diffusers/models/controlnets/controlnet_hunyuan.py
+++ b/src/diffusers/models/controlnets/controlnet_hunyuan.py
@@ -189,7 +189,9 @@ class HunyuanDiT2DControlNetModel(ModelMixin, ConfigMixin):
         text_len_t5 = config.text_len_t5
 
         conditioning_channels = conditioning_channels
-        transformer_num_layers = transformer_num_layers or config.transformer_num_layers
+        transformer_num_layers = transformer_num_layers or config.num_layers
+        pooled_projection_dim = config.pooled_projection_dim
+        use_style_cond_and_image_meta_size = config.use_style_cond_and_image_meta_size
 
         controlnet = cls(
             conditioning_channels=conditioning_channels,
@@ -203,9 +205,11 @@ class HunyuanDiT2DControlNetModel(ModelMixin, ConfigMixin):
             mlp_ratio=mlp_ratio,
             num_attention_heads=num_attention_heads,
             patch_size=patch_size,
+            pooled_projection_dim=pooled_projection_dim,
             sample_size=sample_size,
             text_len=text_len,
             text_len_t5=text_len_t5,
+            use_style_cond_and_image_meta_size=use_style_cond_and_image_meta_size,
         )
         if load_weights_from_transformer:
             key = controlnet.load_state_dict(transformer.state_dict(), strict=False)


### PR DESCRIPTION
## Summary

Fixes Issue 1 in #13641.

`HunyuanDiT2DControlNetModel.from_transformer()` was reading `config.transformer_num_layers`, but `HunyuanDiT2DModel` stores the layer count under `config.num_layers`. The default call path therefore raised `AttributeError`. Even when `transformer_num_layers` was passed manually, the method also dropped `pooled_projection_dim` and `use_style_cond_and_image_meta_size`, so a ControlNet built from a non-default transformer silently fell back to defaults (`pooled_projection_dim=1024`, `use_style_cond_and_image_meta_size=True`) and could fail weight loading with size mismatches.

## Fix

- Read `config.num_layers` (the actual `HunyuanDiT2DModel` config attribute) rather than the non-existent `transformer_num_layers`.
- Forward `pooled_projection_dim` and `use_style_cond_and_image_meta_size` from the source transformer config, so the ControlNet is constructed with the same conditioning embedding shapes and style-cond setting as the transformer it derives from.

## Verification

The reproduction snippet from #13641 now works:

```python
from diffusers import HunyuanDiT2DControlNetModel, HunyuanDiT2DModel

transformer = HunyuanDiT2DModel(
    sample_size=8, num_layers=4, patch_size=2,
    attention_head_dim=4, num_attention_heads=2, in_channels=4,
    cross_attention_dim=8, cross_attention_dim_t5=8,
    pooled_projection_dim=4, hidden_size=8, text_len=4, text_len_t5=4,
    use_style_cond_and_image_meta_size=False,
)

cn = HunyuanDiT2DControlNetModel.from_transformer(transformer)  # no AttributeError
assert cn.config.transformer_num_layers == 4
assert cn.config.pooled_projection_dim == 4
assert cn.config.use_style_cond_and_image_meta_size is False
```

Existing default-config call sites (e.g. with the public `Tencent-Hunyuan/HunyuanDiT-Diffusers` checkpoint) are unchanged: the default `pooled_projection_dim=1024` and `use_style_cond_and_image_meta_size=True` match the public config exactly, so they round-trip to the same values that were previously hardcoded by omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
