### PR TITLE
fix(stable_audio): align batched initial audio with prompts (#13629)

### DIFF
--- a/src/diffusers/pipelines/stable_audio/pipeline_stable_audio.py
+++ b/src/diffusers/pipelines/stable_audio/pipeline_stable_audio.py
@@ -483,7 +483,7 @@ class StableAudioPipeline(DiffusionPipeline):
             audio[:, :, : min(audio_length, audio_vae_length)] = initial_audio_waveforms[:, :, :audio_vae_length]
 
             encoded_audio = self.vae.encode(audio).latent_dist.sample(generator)
-            encoded_audio = encoded_audio.repeat((num_waveforms_per_prompt, 1, 1))
+            encoded_audio = encoded_audio.repeat_interleave(num_waveforms_per_prompt, dim=0)
             latents = encoded_audio + latents
         return latents
 


### PR DESCRIPTION
## Summary

Fixes Issue 1 in #13629.

`StableAudioPipeline.prepare_latents()` was expanding batched initial audio with `encoded_audio.repeat((num_waveforms_per_prompt, 1, 1))`, which produces an interleaved layout `[audio0, audio1, audio0, audio1]`. The corresponding text+duration embeds are expanded per prompt by `encode_prompt()` to `[prompt0, prompt0, prompt1, prompt1]`. For batched audio-to-audio with `num_waveforms_per_prompt > 1`, prompts and initial audio became misaligned, so each generation could be conditioned on another prompt’s initial audio. Existing tests only assert output shape and missed it.

## Fix

Switch `repeat` to `repeat_interleave(..., dim=0)` so batched initial audio expands as `[audio0, audio0, audio1, audio1]`, matching the prompt expansion.

## Verification

The reproduction snippet from #13629 now prints the expected order:

```python
import torch
from diffusers import StableAudioPipeline
# (same DummyVAE / SimpleNamespace scaffolding as in the issue)
print(latents[:, 0, 0].tolist())  # [10.0, 10.0, 20.0, 20.0]
```

`num_waveforms_per_prompt == 1` is unchanged because `repeat_interleave` and `repeat` are equivalent in that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
