### PR TITLE
[qwenimage] add image_area kwarg to QwenImageEditPlusPipeline

### DIFF
--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_plus.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_plus.py
@@ -64,7 +64,6 @@ EXAMPLE_DOC_STRING = """
 """
 
 CONDITION_IMAGE_SIZE = 384 * 384
-VAE_IMAGE_SIZE = 1024 * 1024
 
 
 # Copied from diffusers.pipelines.qwenimage.pipeline_qwenimage.calculate_shift
@@ -534,6 +533,7 @@ class QwenImageEditPlusPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
         true_cfg_scale: float = 4.0,
         height: int | None = None,
         width: int | None = None,
+        image_area: int = 1024 * 1024,
         num_inference_steps: int = 50,
         sigmas: list[float] | None = None,
         guidance_scale: float | None = None,
@@ -579,6 +579,12 @@ class QwenImageEditPlusPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
                 The height in pixels of the generated image. This is set to 1024 by default for the best results.
             width (`int`, *optional*, defaults to self.unet.config.sample_size * self.vae_scale_factor):
                 The width in pixels of the generated image. This is set to 1024 by default for the best results.
+            image_area (`int`, *optional*, defaults to `1024 * 1024`):
+                Target pixel area used to derive (a) the default output `height`/`width` from the input image's
+                aspect ratio when those are not explicitly provided, and (b) the resolution at which the input
+                image(s) are encoded by the VAE. When `height` and `width` are both passed explicitly they
+                override the default-derivation, but `image_area` still controls the VAE-encoding size of the
+                input image(s).
             num_inference_steps (`int`, *optional*, defaults to 50):
                 The number of denoising steps. More denoising steps usually lead to a higher quality image at the
                 expense of slower inference.
@@ -640,7 +646,7 @@ class QwenImageEditPlusPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
             returning a tuple, the first element is a list with the generated images.
         """
         image_size = image[-1].size if isinstance(image, list) else image.size
-        calculated_width, calculated_height = calculate_dimensions(1024 * 1024, image_size[0] / image_size[1])
+        calculated_width, calculated_height = calculate_dimensions(image_area, image_size[0] / image_size[1])
         height = height or calculated_height
         width = width or calculated_width
 
@@ -696,7 +702,7 @@ class QwenImageEditPlusPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
                 condition_width, condition_height = calculate_dimensions(
                     CONDITION_IMAGE_SIZE, image_width / image_height
                 )
-                vae_width, vae_height = calculate_dimensions(VAE_IMAGE_SIZE, image_width / image_height)
+                vae_width, vae_height = calculate_dimensions(image_area, image_width / image_height)
                 condition_image_sizes.append((condition_width, condition_height))
                 vae_image_sizes.append((vae_width, vae_height))
                 condition_images.append(self.image_processor.resize(img, condition_height, condition_width))


### PR DESCRIPTION
# What does this PR do?

Adds an `image_area` keyword argument to `QwenImageEditPlusPipeline.__call__`, letting callers control the target pixel area used for generation. Previously this was hardcoded to `1024 * 1024` in two places, with no way to override it short of computing and passing both `height` and `width` manually — and even then the input images were still re-encoded by the VAE at ~1MP regardless.

With this PR a user can now do:

```python
pipe(image, prompt, image_area=768 * 768)   # smaller, faster
pipe(image, prompt, image_area=1280 * 1280) # larger
```

`image_area` controls two things consistently:
1. The default `height`/`width` derived from the input image's aspect ratio when those are not explicitly passed.
2. The resolution at which the input image(s) are encoded by the VAE.

When `height` and `width` are both passed explicitly they continue to override (1); `image_area` still drives (2).

### Motivation

The pipeline previously offered no way to dial generation/encoding resolution up or down from the ~1MP default. That's restrictive for users who want to trade fidelity for speed (lower) or push for higher fidelity (higher). This PR exposes the existing internal sizing knob as a public kwarg, with no behavior change at the default.

### Changes

All changes are confined to `src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_plus.py`:

- New `image_area: int = 1024 * 1024` kwarg on `__call__`, placed between `width` and `num_inference_steps` to keep resolution-related kwargs grouped.
- New docstring entry documenting the kwarg's dual effect (default-derivation + VAE-encoding size).
- `calculate_dimensions(1024 * 1024, ...)` → `calculate_dimensions(image_area, ...)` at the default-dimension call site.
- `calculate_dimensions(VAE_IMAGE_SIZE, ...)` → `calculate_dimensions(image_area, ...)` at the VAE-encode call site.
- Removed the now-unused module-level constant `VAE_IMAGE_SIZE = 1024 * 1024`. The companion constant `CONDITION_IMAGE_SIZE = 384 * 384` is kept (it controls VLM token budget for the conditioning branch — a different concern, out of scope here).

### Backward compatibility

Fully backward-compatible. The default value is exactly the previously-hardcoded `1024 * 1024`, so existing call sites get identical behavior.

Fixes # N/A — small standalone enhancement, no associated issue.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? (docstring entry added for the new kwarg)
- [ ] Did you write any new necessary tests? — N/A: no behavior change at default; this is a passthrough kwarg whose default exactly preserves prior behavior.

Local checks: `make fix-copies` clean, `ruff format` / `ruff check` clean.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza 
- Update: @naykun apparently you're the right person to contact for this review!