### PR TITLE
fix(onnx): make provider_options optional in OnnxRuntimeModel._from_pretrained (#13653)

### DIFF
--- a/src/diffusers/pipelines/onnx_utils.py
+++ b/src/diffusers/pipelines/onnx_utils.py
@@ -182,7 +182,7 @@ class OnnxRuntimeModel:
                 Path(model_id, model_file_name).as_posix(),
                 provider=provider,
                 sess_options=sess_options,
-                provider_options=kwargs.pop("provider_options"),
+                provider_options=kwargs.pop("provider_options", None),
             )
             kwargs["model_save_dir"] = Path(model_id)
         # load model from hub
@@ -202,7 +202,7 @@ class OnnxRuntimeModel:
                 model_cache_path,
                 provider=provider,
                 sess_options=sess_options,
-                provider_options=kwargs.pop("provider_options"),
+                provider_options=kwargs.pop("provider_options", None),
             )
         return cls(model=model, **kwargs)
 


### PR DESCRIPTION
## Problem

Fixes Issue 1 of #13653.

`OnnxRuntimeModel._from_pretrained()` calls `kwargs.pop("provider_options")` without a default in both the local-directory and Hub branches. Pipeline loading happens to pass `provider_options=None`, so the failure is hidden in that path. Direct use of the public helper, however, raises `KeyError` before any loading happens.

## Reproduction

```python
import tempfile
from diffusers.pipelines.onnx_utils import OnnxRuntimeModel

with tempfile.TemporaryDirectory() as d:
    OnnxRuntimeModel.from_pretrained(d)
# KeyError: 'provider_options'
```

## Fix

Pass a `None` default to both `kwargs.pop("provider_options", None)` calls. The downstream `OnnxRuntimeModel.load_model()` already normalises `None → []` (lines 86-89), so the new default keeps existing pipeline-loading behaviour identical and unblocks direct `from_pretrained()` calls.

## Notes

- Two-line change, scoped strictly to lines 185 and 205 of `onnx_utils.py`.
- No new tests added — the maintainer's review note already flags missing test coverage for direct `OnnxRuntimeModel.from_pretrained()` and lists this in the meta-issue test-coverage section, which felt like an explicit follow-up rather than something to slip into this surgical fix. Happy to add a fast unit test if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)