### PR TITLE
fix(free_noise): resolve None default, repeat_context/shuffle_context, list gen, mid-block disable (#13653)

### DIFF
--- a/src/diffusers/pipelines/free_noise_utils.py
+++ b/src/diffusers/pipelines/free_noise_utils.py
@@ -372,7 +372,7 @@ class AnimateDiffFreeNoiseMixin:
             )
 
         context_num_frames = (
-            self._free_noise_context_length if self._free_noise_context_length == "repeat_context" else num_frames
+            num_frames if self._free_noise_noise_type == "random" else self._free_noise_context_length
         )
 
         shape = (
@@ -407,7 +407,8 @@ class AnimateDiffFreeNoiseMixin:
                     break
 
                 indices = torch.LongTensor(list(range(window_start, window_end)))
-                shuffled_indices = indices[torch.randperm(window_length, generator=generator)]
+                perm_generator = generator[0] if isinstance(generator, list) else generator
+                shuffled_indices = indices[torch.randperm(window_length, generator=perm_generator)]
 
                 current_start = i
                 current_end = min(num_frames, current_start + window_length)
@@ -491,6 +492,8 @@ class AnimateDiffFreeNoiseMixin:
         allowed_weighting_scheme = ["flat", "pyramid", "delayed_reverse_sawtooth"]
         allowed_noise_type = ["shuffle_context", "repeat_context", "random"]
 
+        context_length = context_length or self.motion_adapter.config.motion_max_seq_length
+
         if context_length > self.motion_adapter.config.motion_max_seq_length:
             logger.warning(
                 f"You have set {context_length=} which is greater than {self.motion_adapter.config.motion_max_seq_length=}. This can lead to bad generation results."
@@ -502,7 +505,7 @@ class AnimateDiffFreeNoiseMixin:
         if noise_type not in allowed_noise_type:
             raise ValueError(f"The parameter `noise_type` must be one of {allowed_noise_type}, but got {noise_type=}")
 
-        self._free_noise_context_length = context_length or self.motion_adapter.config.motion_max_seq_length
+        self._free_noise_context_length = context_length
         self._free_noise_context_stride = context_stride
         self._free_noise_weighting_scheme = weighting_scheme
         self._free_noise_noise_type = noise_type
@@ -525,7 +528,6 @@ class AnimateDiffFreeNoiseMixin:
         else:
             blocks = [*self.unet.down_blocks, *self.unet.up_blocks]
 
-        blocks = [*self.unet.down_blocks, self.unet.mid_block, *self.unet.up_blocks]
         for block in blocks:
             self._disable_free_noise_in_block(block)
 


### PR DESCRIPTION
## Problem

Fixes Issues 2, 3, 4, and 5 of #13653 — four surgical bugs in `free_noise_utils.py`. They are independent but cluster in one file, so I bundled them.

### Issue 2 — `enable_free_noise(context_length=None)` crashes before applying the documented default

The docstring says `context_length=None` falls back to `motion_adapter.config.motion_max_seq_length`, but the warning check at L494 compares `None > int` before the default is resolved at L505.

```python
pipe.enable_free_noise(context_length=None)
# TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

**Fix:** resolve the default once, up front, then drop the now-redundant `or` from the assignment.

### Issue 3 — `repeat_context` / `shuffle_context` ignore `context_length`

`context_num_frames` compares the int `self._free_noise_context_length` to the literal string `"repeat_context"` (looks like the author meant `self._free_noise_noise_type`). It is always falsy, so `context_num_frames` always falls through to `num_frames`. As a result, `repeat_context` starts from `num_frames` random frames and the trailing `[:num_frames]` slice makes the repeat a no-op, and `shuffle_context` shuffles a window the same size as the output instead of a smaller context window.

**Fix (matches the suggestion in the meta-issue):** pick `num_frames` only for `noise_type == "random"`, otherwise use `context_length`.

### Issue 4 — list generators fail in `shuffle_context`

`_prepare_latents_free_noise()` accepts a list of generators (one per batch item, the standard diffusers convention) and `randn_tensor` handles that, but `torch.randperm(window_length, generator=generator)` is then called with the full list and crashes.

**Fix:** use the first generator from the list for the permutation. The shuffle is one window-level operation shared across the batch, so a single deterministic generator is the right semantics. `randn_tensor` keeps using the per-sample list for the actual noise.

### Issue 5 — `disable_free_noise()` always reaches into `mid_block`

Lines 523-528 first compute `blocks` with the correct guard for adapters whose mid-block has no motion modules, then unconditionally re-assign the same list including `mid_block` on the next line. Pipelines whose mid-block lacks `motion_modules` therefore raise `AttributeError` while disabling FreeNoise.

**Fix:** delete the unconditional reassignment.

## Reproductions

(All four come straight from #13653. Verified the logical fixes pass; the pipeline-level repros are end-to-end and need a real motion adapter to drive, which I cannot run locally.)

## Notes

- All four fixes follow the patches the maintainer outlined in the meta-issue. I did not invent new behaviour.
- Issues 1, 6, 7 of #13653 are not included here — Issue 1 is in `onnx_utils.py` (separate PR #13667) and Issues 6/7 each touch a different file. Happy to follow up with those if helpful.
- No new tests added — the meta-issue already calls out the missing slow-test coverage for these paths as a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)