### PR TITLE
fix(ddpm): use _execution_device, validate inputs, free hooks (#13649)

### DIFF
--- a/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
+++ b/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
@@ -73,7 +73,8 @@ class DDPMPipeline(DiffusionPipeline):
                 The number of denoising steps. More denoising steps usually lead to a higher quality image at the
                 expense of slower inference.
             output_type (`str`, *optional*, defaults to `"pil"`):
-                The output format of the generated image. Choose between `PIL.Image` or `np.array`.
+                The output format of the generated image. Choose between `PIL.Image`, `np.array` or
+                `torch.Tensor`.
             return_dict (`bool`, *optional*, defaults to `True`):
                 Whether or not to return a [`~pipelines.ImagePipelineOutput`] instead of a plain tuple.
 
@@ -97,6 +98,17 @@ class DDPMPipeline(DiffusionPipeline):
                 If `return_dict` is `True`, [`~pipelines.ImagePipelineOutput`] is returned, otherwise a `tuple` is
                 returned where the first element is a list with the generated images
         """
+        if output_type not in ["pt", "np", "pil"]:
+            raise ValueError(f"output_type must be one of ['pt', 'np', 'pil'], got '{output_type}'.")
+
+        if isinstance(generator, list) and len(generator) != batch_size:
+            raise ValueError(
+                f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
+                f" size of {batch_size}. Make sure the batch size matches the length of the generators."
+            )
+
+        device = self._execution_device
+
         # Sample gaussian noise to begin loop
         if isinstance(self.unet.config.sample_size, int):
             image_shape = (
@@ -108,12 +120,12 @@ class DDPMPipeline(DiffusionPipeline):
         else:
             image_shape = (batch_size, self.unet.config.in_channels, *self.unet.config.sample_size)
 
-        if self.device.type == "mps":
+        if device.type == "mps":
             # randn does not work reproducibly on mps
             image = randn_tensor(image_shape, generator=generator, dtype=self.unet.dtype)
-            image = image.to(self.device)
+            image = image.to(device)
         else:
-            image = randn_tensor(image_shape, generator=generator, device=self.device, dtype=self.unet.dtype)
+            image = randn_tensor(image_shape, generator=generator, device=device, dtype=self.unet.dtype)
 
         # set step values
         self.scheduler.set_timesteps(num_inference_steps)
@@ -129,9 +141,12 @@ class DDPMPipeline(DiffusionPipeline):
                 xm.mark_step()
 
         image = (image / 2 + 0.5).clamp(0, 1)
-        image = image.cpu().permute(0, 2, 3, 1).numpy()
-        if output_type == "pil":
-            image = self.numpy_to_pil(image)
+        if output_type != "pt":
+            image = image.cpu().permute(0, 2, 3, 1).numpy()
+            if output_type == "pil":
+                image = self.numpy_to_pil(image)
+
+        self.maybe_free_model_hooks()
 
         if not return_dict:
             return (image,)


### PR DESCRIPTION
## What does this PR do?

Fixes the three issues called out in the [`ddpm` model/pipeline review](https://github.com/huggingface/diffusers/issues/13649) (cc @hlky). All three changes live in `pipelines/ddpm/pipeline_ddpm.py` and follow the suggested fixes from the issue, with precedents from `DDIMPipeline` and `ConsistencyModelPipeline`.

### Issue 1 — `DDPMPipeline` does not run latents on the offload execution device

`DDPMPipeline` declares `model_cpu_offload_seq = "unet"` but initializes the latent on `self.device` (which stays CPU under `enable_model_cpu_offload()`) and never calls `self.maybe_free_model_hooks()` before returning. Switched to `self._execution_device`, threaded that into the `randn_tensor` call (and the `mps` branch), and added the `maybe_free_model_hooks()` call before the return so the offload contract is honored and the UNet doesn't stay resident on the accelerator.

### Issue 2 — Generator lists are not validated against `batch_size`

A short generator list either gets silently treated like a single generator or raises a raw `IndexError`. Added the same `ValueError` guard `DDIMPipeline` and `ConsistencyModelPipeline` use, so users get a clear message when `len(generator) != batch_size`.

### Issue 3 — Invalid `output_type` values silently return NumPy

Any `output_type` other than `"pil"` previously fell through to NumPy, including typos and `"pt"`. Added an explicit `output_type in {"pt", "np", "pil"}` check at the top of `__call__`, made `"pt"` actually return the tensor (skipping the `.cpu().numpy()` round-trip), and updated the docstring to mention `torch.Tensor`. Behavior for the documented values (`"pil"`, default; `"np"`) is unchanged.

## Reproductions

The repros from #13649 are short and self-contained — see the issue body for runnable scripts that demonstrate each failure mode.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case. Yes — #13649.
- [ ] Did you make sure to update the documentation with your changes? Doc string updated in this file; no separate docs page touched.
- [ ] Did you write any new necessary tests?

## Who can review?

@hlky — this addresses all three issues from the `ddpm` review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)