### PR TITLE
Fix ignored generator in FlowMatchEulerDiscreteScheduler

### DIFF
--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -21,6 +21,7 @@ import torch
 
 from ..configuration_utils import ConfigMixin, register_to_config
 from ..utils import BaseOutput, is_scipy_available, logging
+from ..utils.torch_utils import randn_tensor
 from .scheduling_utils import SchedulerMixin
 
 
@@ -507,7 +508,7 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
 
         if self.config.stochastic_sampling:
             x0 = sample - current_sigma * model_output
-            noise = torch.randn_like(sample)
+            noise = randn_tensor(sample.shape, generator=generator, device=sample.device, dtype=sample.dtype)
             prev_sample = (1.0 - next_sigma) * x0 + next_sigma * noise
         else:
             prev_sample = sample + dt * model_output


### PR DESCRIPTION
# What does this PR do?

`FlowMatchEulerDiscreteScheduler.step()` accepts a generator argument, but when `stochastic_sampling=True` it calls plain `torch.randn_like(sample)` instead of using the generator. This makes results non-deterministic even with a fixed seed.

This PR replaces `torch.randn_like` call with the existing `randn_tensor(..., generator=generator, device=sample.device, dtype=sample.dtype)` so the scheduler respects the passed generator in the stochastic sampling path, consistent with how other schedulers in diffusers handle randomness.

I'm using z-image with `euler_ancestral` which gave me inconsistent results, which led me to to fixing it.

## Simple reproduce script
```python
import torch
from diffusers import FlowMatchEulerDiscreteScheduler
scheduler = FlowMatchEulerDiscreteScheduler(stochastic_sampling=True)
scheduler.set_timesteps(10, device="cpu")
sample = torch.zeros(1, 4, 64, 64)
model_output = torch.ones(1, 4, 64, 64) * 0.5

# First run
generator = torch.Generator().manual_seed(42)
out1 = scheduler.step(model_output, scheduler.timesteps[0], sample, generator=generator).prev_sample

# Second run with same seed — must reset scheduler to reset step_index
scheduler.set_timesteps(10, device="cpu")
generator = torch.Generator().manual_seed(42)
out2 = scheduler.step(model_output, scheduler.timesteps[0], sample, generator=generator).prev_sample

# Before this fix: out1 != out2  (torch.randn_like ignores generator)
# After this fix:  out1 == out2
print("Same seed produces identical results:", torch.allclose(out1, out2))
```

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] I did not include any new tests, let me know if I should add some.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. 

Core library:

- Schedulers: @yiyixuxu

(Sorry for the spam ping re-do, it looks like github overwrote main with a previous repository I had hosted under the same name.. This time it's from a branch in my fork)