### PR TITLE
z-image support npu

### DIFF
--- a/src/diffusers/models/controlnets/controlnet_z_image.py
+++ b/src/diffusers/models/controlnets/controlnet_z_image.py
@@ -329,7 +329,7 @@ class RopeEmbedder:
         result = []
         for i in range(len(self.axes_dims)):
             index = ids[:, i]
-            result.append(self.freqs_cis[i][index])
+            result.append(torch.complex(self.freqs_cis[i].real[index], self.freqs_cis[i].imag[index]))
         return torch.cat(result, dim=-1)
 
 

--- a/src/diffusers/models/transformers/transformer_z_image.py
+++ b/src/diffusers/models/transformers/transformer_z_image.py
@@ -24,6 +24,7 @@ from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
 from ...models.attention_processor import Attention
 from ...models.modeling_utils import ModelMixin
 from ...models.normalization import RMSNorm
+from ...utils import is_torch_npu_available
 from ...utils.torch_utils import maybe_allow_in_graph
 from ..attention_dispatch import dispatch_attention_fn
 from ..modeling_outputs import Transformer2DModelOutput
@@ -322,37 +323,72 @@ class RopeEmbedder:
         self.axes_lens = axes_lens
         assert len(axes_dims) == len(axes_lens), "axes_dims and axes_lens must have the same length"
         self.freqs_cis = None
+        self.freqs_real = None
+        self.freqs_imag = None
 
     @staticmethod
     def precompute_freqs_cis(dim: list[int], end: list[int], theta: float = 256.0):
         with torch.device("cpu"):
-            freqs_cis = []
-            for i, (d, e) in enumerate(zip(dim, end)):
-                freqs = 1.0 / (theta ** (torch.arange(0, d, 2, dtype=torch.float64, device="cpu") / d))
-                timestep = torch.arange(e, device=freqs.device, dtype=torch.float64)
-                freqs = torch.outer(timestep, freqs).float()
-                freqs_cis_i = torch.polar(torch.ones_like(freqs), freqs).to(torch.complex64)  # complex64
-                freqs_cis.append(freqs_cis_i)
+            if is_torch_npu_available:
+                freqs_real_list = []
+                freqs_imag_list = []
+                for i, (d, e) in enumerate(zip(dim, end)):
+                    freqs = 1.0 / (theta ** (torch.arange(0, d, 2, dtype=torch.float64, device="cpu") / d))
+                    timestep = torch.arange(e, device=freqs.device, dtype=torch.float64)
+                    freqs = torch.outer(timestep, freqs).float()
+                    freqs_real = torch.cos(freqs)
+                    freqs_imag = torch.sin(freqs)
+                    freqs_real_list.append(freqs_real.to(torch.float32))
+                    freqs_imag_list.append(freqs_imag.to(torch.float32))
 
-            return freqs_cis
+                return freqs_real_list, freqs_imag_list
+            else:
+                freqs_cis = []
+                for i, (d, e) in enumerate(zip(dim, end)):
+                    freqs = 1.0 / (theta ** (torch.arange(0, d, 2, dtype=torch.float64, device="cpu") / d))
+                    timestep = torch.arange(e, device=freqs.device, dtype=torch.float64)
+                    freqs = torch.outer(timestep, freqs).float()
+                    freqs_cis_i = torch.polar(torch.ones_like(freqs), freqs).to(torch.complex64)  # complex64
+                    freqs_cis.append(freqs_cis_i)
+                return freqs_cis
 
     def __call__(self, ids: torch.Tensor):
         assert ids.ndim == 2
         assert ids.shape[-1] == len(self.axes_dims)
         device = ids.device
 
-        if self.freqs_cis is None:
-            self.freqs_cis = self.precompute_freqs_cis(self.axes_dims, self.axes_lens, theta=self.theta)
-            self.freqs_cis = [freqs_cis.to(device) for freqs_cis in self.freqs_cis]
-        else:
-            # Ensure freqs_cis are on the same device as ids
-            if self.freqs_cis[0].device != device:
-                self.freqs_cis = [freqs_cis.to(device) for freqs_cis in self.freqs_cis]
+        if is_torch_npu_available:
+            if self.freqs_real is None or self.freqs_imag is None:
+                freqs_real, freqs_imag = self.precompute_freqs_cis(self.axes_dims, self.axes_lens, theta=self.theta)
+                self.freqs_real = [fr.to(device) for fr in freqs_real]
+                self.freqs_imag = [fi.to(device) for fi in freqs_imag]
+            else:
+                # Ensure freqs_cis are on the same device as ids
+                if self.freqs_real[0].device != device:
+                    self.freqs_real = [fr.to(device) for fr in freqs_real]
+                    self.freqs_imag = [fi.to(device) for fi in freqs_imag]
 
-        result = []
-        for i in range(len(self.axes_dims)):
-            index = ids[:, i]
-            result.append(self.freqs_cis[i][index])
+            result = []
+            for i in range(len(self.axes_dims)):
+                index = ids[:, i]
+                real_part = self.freqs_real[i][index]
+                imag_part = self.freqs_imag[i][index]
+                complex_part = torch.complex(real_part, imag_part)
+                result.append(complex_part)
+        else:
+            if self.freqs_cis is None:
+                self.freqs_cis = self.precompute_freqs_cis(self.axes_dims, self.axes_lens, theta=self.theta)
+                self.freqs_cis = [freqs_cis.to(device) for freqs_cis in self.freqs_cis]
+            else:
+                # Ensure freqs_cis are on the same device as ids
+                if self.freqs_cis[0].device != device:
+                    self.freqs_cis = [freqs_cis.to(device) for freqs_cis in self.freqs_cis]
+
+            result = []
+            for i in range(len(self.axes_dims)):
+                index = ids[:, i]
+                result.append(self.freqs_cis[i][index])
+
         return torch.cat(result, dim=-1)
 
 

--- a/src/diffusers/models/transformers/transformer_z_image.py
+++ b/src/diffusers/models/transformers/transformer_z_image.py
@@ -24,7 +24,6 @@ from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
 from ...models.attention_processor import Attention
 from ...models.modeling_utils import ModelMixin
 from ...models.normalization import RMSNorm
-from ...utils import is_torch_npu_available
 from ...utils.torch_utils import maybe_allow_in_graph
 from ..attention_dispatch import dispatch_attention_fn
 from ..modeling_outputs import Transformer2DModelOutput
@@ -323,72 +322,37 @@ class RopeEmbedder:
         self.axes_lens = axes_lens
         assert len(axes_dims) == len(axes_lens), "axes_dims and axes_lens must have the same length"
         self.freqs_cis = None
-        self.freqs_real = None
-        self.freqs_imag = None
 
     @staticmethod
     def precompute_freqs_cis(dim: list[int], end: list[int], theta: float = 256.0):
         with torch.device("cpu"):
-            if is_torch_npu_available:
-                freqs_real_list = []
-                freqs_imag_list = []
-                for i, (d, e) in enumerate(zip(dim, end)):
-                    freqs = 1.0 / (theta ** (torch.arange(0, d, 2, dtype=torch.float64, device="cpu") / d))
-                    timestep = torch.arange(e, device=freqs.device, dtype=torch.float64)
-                    freqs = torch.outer(timestep, freqs).float()
-                    freqs_real = torch.cos(freqs)
-                    freqs_imag = torch.sin(freqs)
-                    freqs_real_list.append(freqs_real.to(torch.float32))
-                    freqs_imag_list.append(freqs_imag.to(torch.float32))
+            freqs_cis = []
+            for i, (d, e) in enumerate(zip(dim, end)):
+                freqs = 1.0 / (theta ** (torch.arange(0, d, 2, dtype=torch.float64, device="cpu") / d))
+                timestep = torch.arange(e, device=freqs.device, dtype=torch.float64)
+                freqs = torch.outer(timestep, freqs).float()
+                freqs_cis_i = torch.polar(torch.ones_like(freqs), freqs).to(torch.complex64)  # complex64
+                freqs_cis.append(freqs_cis_i)
 
-                return freqs_real_list, freqs_imag_list
-            else:
-                freqs_cis = []
-                for i, (d, e) in enumerate(zip(dim, end)):
-                    freqs = 1.0 / (theta ** (torch.arange(0, d, 2, dtype=torch.float64, device="cpu") / d))
-                    timestep = torch.arange(e, device=freqs.device, dtype=torch.float64)
-                    freqs = torch.outer(timestep, freqs).float()
-                    freqs_cis_i = torch.polar(torch.ones_like(freqs), freqs).to(torch.complex64)  # complex64
-                    freqs_cis.append(freqs_cis_i)
-                return freqs_cis
+            return freqs_cis
 
     def __call__(self, ids: torch.Tensor):
         assert ids.ndim == 2
         assert ids.shape[-1] == len(self.axes_dims)
         device = ids.device
 
-        if is_torch_npu_available:
-            if self.freqs_real is None or self.freqs_imag is None:
-                freqs_real, freqs_imag = self.precompute_freqs_cis(self.axes_dims, self.axes_lens, theta=self.theta)
-                self.freqs_real = [fr.to(device) for fr in freqs_real]
-                self.freqs_imag = [fi.to(device) for fi in freqs_imag]
-            else:
-                # Ensure freqs_cis are on the same device as ids
-                if self.freqs_real[0].device != device:
-                    self.freqs_real = [fr.to(device) for fr in freqs_real]
-                    self.freqs_imag = [fi.to(device) for fi in freqs_imag]
-
-            result = []
-            for i in range(len(self.axes_dims)):
-                index = ids[:, i]
-                real_part = self.freqs_real[i][index]
-                imag_part = self.freqs_imag[i][index]
-                complex_part = torch.complex(real_part, imag_part)
-                result.append(complex_part)
+        if self.freqs_cis is None:
+            self.freqs_cis = self.precompute_freqs_cis(self.axes_dims, self.axes_lens, theta=self.theta)
+            self.freqs_cis = [freqs_cis.to(device) for freqs_cis in self.freqs_cis]
         else:
-            if self.freqs_cis is None:
-                self.freqs_cis = self.precompute_freqs_cis(self.axes_dims, self.axes_lens, theta=self.theta)
+            # Ensure freqs_cis are on the same device as ids
+            if self.freqs_cis[0].device != device:
                 self.freqs_cis = [freqs_cis.to(device) for freqs_cis in self.freqs_cis]
-            else:
-                # Ensure freqs_cis are on the same device as ids
-                if self.freqs_cis[0].device != device:
-                    self.freqs_cis = [freqs_cis.to(device) for freqs_cis in self.freqs_cis]
 
-            result = []
-            for i in range(len(self.axes_dims)):
-                index = ids[:, i]
-                result.append(self.freqs_cis[i][index])
-
+        result = []
+        for i in range(len(self.axes_dims)):
+            index = ids[:, i]
+            result.append(torch.complex(self.freqs_cis[i].real[index], self.freqs_cis[i].imag[index]))
         return torch.cat(result, dim=-1)
 
 


### PR DESCRIPTION
# What does this PR do?
Notice: Here is a PR extraction from https://github.com/huggingface/diffusers/pull/12979 to support z-image runs on NPU.

Issue: The Diffusers Z-Image pipeline fails on Ascend NPU because aclnnIndex lacks support for complex64. When freqs_cis is stored as a complex tensor on the NPU and then indexed, the call crashes.

Fix: Rework the RoPE frequency handling so that the NPU never needs to index complex64 tensors.

Running Environment:
I run this model base on cache-dit(https://github.com/vipshop/cache-dit/) which depends on diffusers to inference.

Command:
python3 generate.py zimage --model-path /home/weights/Z-Image-Turbo --attn _native_npu

Error before fixed:
<img width="2305" height="566" alt="image" src="https://github.com/user-attachments/assets/931eecfd-39b6-41f5-b3e8-6ba33bae00ea" />


Result after fixed:
<img width="859" height="858" alt="image" src="https://github.com/user-attachments/assets/2aa9d7bf-6879-4668-ae8a-3643b8126bb7" />



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu
- Pipelines and pipeline callbacks: @yiyixuxu and @asomoza
- Training examples: @sayakpaul
- Docs: @stevhliu and @sayakpaul
- JAX and MPS: @pcuenca
- Audio: @sanchit-gandhi
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
