### PR TITLE
[CI] Bump style-bot SHA + switch to GitHub App

### DIFF
--- a/.github/workflows/pr_style_bot.yml
+++ b/.github/workflows/pr_style_bot.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   style:
-    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@42642d4a896bd43a8360b29f5f32934232f4db32
+    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@e2867e92c07d15e1bf18994d0a945ef5ad6b8d65
     with:
       python_quality_dependencies: "[quality]"
     secrets:

--- a/.github/workflows/pr_style_bot.yml
+++ b/.github/workflows/pr_style_bot.yml
@@ -5,13 +5,14 @@ on:
     types: [created]
 
 permissions:
-  contents: write
   pull-requests: write
+  contents: read
 
 jobs:
   style:
-    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@e000c1c89c65aee188041723456ac3a479416d4c  # main
+    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@42642d4a896bd43a8360b29f5f32934232f4db32
     with:
       python_quality_dependencies: "[quality]"
     secrets:
-      bot_token: ${{ secrets.HF_STYLE_BOT_ACTION }}
+      app_id: ${{ secrets.HF_BOT_STYLE_APP_ID }}
+      app_private_key: ${{ secrets.HF_BOT_STYLE_SECRET_PEM }}


### PR DESCRIPTION
## Summary

- Bumps the pinned SHA of the reusable `style-bot-action.yml` workflow to the hardened version ([huggingface/huggingface_hub#4183](https://github.com/huggingface/huggingface_hub/pull/4183))
- Switches from static PAT (`HF_STYLE_BOT_ACTION`) to GitHub App short-lived tokens (`HF_BOT_STYLE_APP_ID` + `HF_BOT_STYLE_SECRET_PEM`)
- Drops `contents: write` (push is now handled inside the reusable workflow via the app token)

⚠️ Requires `HF_BOT_STYLE_APP_ID` and `HF_BOT_STYLE_SECRET_PEM` secrets to be set in this repo's settings.