### PR TITLE
[mps] Fix NaN in Attention.get_attention_scores when attention_mask is None

### DIFF
--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -676,9 +676,10 @@ class Attention(nn.Module):
             key = key.float()
 
         if attention_mask is None:
-            if query.device.type == "mps":
-                # MPS' baddbmm does not short-circuit on beta=0, so an
-                # uninitialized input from torch.empty() can propagate NaN.
+            if query.device.type == "mps" and is_torch_version("<", "2.14.0"):
+                # Before torch 2.14 (pytorch#187522), MPS' baddbmm did not
+                # short-circuit on beta=0, so an uninitialized input from
+                # torch.empty() could propagate NaN. Fixed upstream from 2.14.
                 baddbmm_input = torch.zeros(
                     query.shape[0], query.shape[1], key.shape[1], dtype=query.dtype, device=query.device
                 )

--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -676,9 +676,16 @@ class Attention(nn.Module):
             key = key.float()
 
         if attention_mask is None:
-            baddbmm_input = torch.empty(
-                query.shape[0], query.shape[1], key.shape[1], dtype=query.dtype, device=query.device
-            )
+            if query.device.type == "mps":
+                # MPS' baddbmm does not short-circuit on beta=0, so an
+                # uninitialized input from torch.empty() can propagate NaN.
+                baddbmm_input = torch.zeros(
+                    query.shape[0], query.shape[1], key.shape[1], dtype=query.dtype, device=query.device
+                )
+            else:
+                baddbmm_input = torch.empty(
+                    query.shape[0], query.shape[1], key.shape[1], dtype=query.dtype, device=query.device
+                )
             beta = 0
         else:
             baddbmm_input = attention_mask

--- a/tests/models/test_attention_processor.py
+++ b/tests/models/test_attention_processor.py
@@ -10,7 +10,7 @@ from packaging import version
 from diffusers import DiffusionPipeline
 from diffusers.models.attention_processor import Attention, AttnAddedKVProcessor
 
-from ..testing_utils import torch_device
+from ..testing_utils import is_torch_version, torch_device
 
 
 class AttnAddedKVProcessorTests(unittest.TestCase):
@@ -135,30 +135,33 @@ class DeprecatedAttentionBlockTests(unittest.TestCase):
         self.assertTrue(np.allclose(conversion, after_conversion, atol=1e-3))
 
 
-class GetAttentionScoresMPSTests(unittest.TestCase):
-    @pytest.mark.skipif(torch_device != "mps", reason="test exercises an MPS-specific code path")
-    def test_no_nan_when_attention_mask_is_none_on_mps(self):
-        # Regression test: torch.empty() on MPS can return non-finite values,
-        # and MPS' baddbmm does not short-circuit on beta=0, so an unmasked
-        # call to get_attention_scores used to propagate NaN into the output.
-        torch.manual_seed(0)
-        heads, dim_head, seq_len = 4, 32, 256
-        attn = Attention(
-            query_dim=heads * dim_head,
-            heads=heads,
-            dim_head=dim_head,
-            bias=False,
-        ).to(torch_device, torch.float16)
+@pytest.mark.skipif(torch_device != "mps", reason="test exercises an MPS-specific code path")
+@pytest.mark.skipif(
+    is_torch_version(">=", "2.14.0"),
+    reason="baddbmm beta=0 NaN fixed upstream in pytorch#187522 (torch>=2.14); MPS workaround no longer applied",
+)
+def test_no_nan_when_attention_mask_is_none_on_mps():
+    # Regression test: torch.empty() on MPS can return non-finite values,
+    # and MPS' baddbmm does not short-circuit on beta=0, so an unmasked
+    # call to get_attention_scores used to propagate NaN into the output.
+    torch.manual_seed(0)
+    heads, dim_head, seq_len = 4, 32, 256
+    attn = Attention(
+        query_dim=heads * dim_head,
+        heads=heads,
+        dim_head=dim_head,
+        bias=False,
+    ).to(torch_device, torch.float16)
 
-        for _ in range(20):
-            # Pollute the MPS allocator pool with non-finite values so that a
-            # subsequent torch.empty() is likely to return NaN-filled memory.
-            polluter = torch.full((heads, seq_len, seq_len), float("nan"), device=torch_device, dtype=torch.float16)
-            del polluter
+    for _ in range(20):
+        # Pollute the MPS allocator pool with non-finite values so that a
+        # subsequent torch.empty() is likely to return NaN-filled memory.
+        polluter = torch.full((heads, seq_len, seq_len), float("nan"), device=torch_device, dtype=torch.float16)
+        del polluter
 
-            query = torch.randn(1, seq_len, heads * dim_head, device=torch_device, dtype=torch.float16)
-            key = torch.randn(1, seq_len, heads * dim_head, device=torch_device, dtype=torch.float16)
-            scores = attn.get_attention_scores(
-                attn.head_to_batch_dim(query), attn.head_to_batch_dim(key), attention_mask=None
-            )
-            self.assertFalse(torch.isnan(scores).any().item(), "attention scores contain NaN on MPS")
+        query = torch.randn(1, seq_len, heads * dim_head, device=torch_device, dtype=torch.float16)
+        key = torch.randn(1, seq_len, heads * dim_head, device=torch_device, dtype=torch.float16)
+        scores = attn.get_attention_scores(
+            attn.head_to_batch_dim(query), attn.head_to_batch_dim(key), attention_mask=None
+        )
+        assert not torch.isnan(scores).any().item(), "attention scores contain NaN on MPS"

--- a/tests/models/test_attention_processor.py
+++ b/tests/models/test_attention_processor.py
@@ -133,3 +133,32 @@ class DeprecatedAttentionBlockTests(unittest.TestCase):
 
         self.assertTrue(np.allclose(pre_conversion, conversion, atol=1e-3))
         self.assertTrue(np.allclose(conversion, after_conversion, atol=1e-3))
+
+
+class GetAttentionScoresMPSTests(unittest.TestCase):
+    @pytest.mark.skipif(torch_device != "mps", reason="test exercises an MPS-specific code path")
+    def test_no_nan_when_attention_mask_is_none_on_mps(self):
+        # Regression test: torch.empty() on MPS can return non-finite values,
+        # and MPS' baddbmm does not short-circuit on beta=0, so an unmasked
+        # call to get_attention_scores used to propagate NaN into the output.
+        torch.manual_seed(0)
+        heads, dim_head, seq_len = 4, 32, 256
+        attn = Attention(
+            query_dim=heads * dim_head,
+            heads=heads,
+            dim_head=dim_head,
+            bias=False,
+        ).to(torch_device, torch.float16)
+
+        for _ in range(20):
+            # Pollute the MPS allocator pool with non-finite values so that a
+            # subsequent torch.empty() is likely to return NaN-filled memory.
+            polluter = torch.full((heads, seq_len, seq_len), float("nan"), device=torch_device, dtype=torch.float16)
+            del polluter
+
+            query = torch.randn(1, seq_len, heads * dim_head, device=torch_device, dtype=torch.float16)
+            key = torch.randn(1, seq_len, heads * dim_head, device=torch_device, dtype=torch.float16)
+            scores = attn.get_attention_scores(
+                attn.head_to_batch_dim(query), attn.head_to_batch_dim(key), attention_mask=None
+            )
+            self.assertFalse(torch.isnan(scores).any().item(), "attention scores contain NaN on MPS")

--- a/tests/models/test_attention_processor.py
+++ b/tests/models/test_attention_processor.py
@@ -9,7 +9,7 @@ from packaging import version
 from diffusers import DiffusionPipeline
 from diffusers.models.attention_processor import Attention, AttnAddedKVProcessor
 
-from ..testing_utils import torch_device
+from ..testing_utils import is_torch_version, torch_device
 
 
 class TestAttnAddedKVProcessor:
@@ -135,6 +135,10 @@ class TestDeprecatedAttentionBlock:
 
 
 @pytest.mark.skipif(torch_device != "mps", reason="test exercises an MPS-specific code path")
+@pytest.mark.skipif(
+    is_torch_version(">=", "2.14.0"),
+    reason="baddbmm beta=0 NaN fixed upstream in pytorch#187522 (torch>=2.14); MPS workaround no longer applied",
+)
 def test_no_nan_when_attention_mask_is_none_on_mps():
     # Regression test: torch.empty() on MPS can return non-finite values,
     # and MPS' baddbmm does not short-circuit on beta=0, so an unmasked

--- a/tests/models/test_attention_processor.py
+++ b/tests/models/test_attention_processor.py
@@ -132,3 +132,31 @@ class TestDeprecatedAttentionBlock:
 
         assert np.allclose(pre_conversion, conversion, atol=1e-3)
         assert np.allclose(conversion, after_conversion, atol=1e-3)
+
+
+@pytest.mark.skipif(torch_device != "mps", reason="test exercises an MPS-specific code path")
+def test_no_nan_when_attention_mask_is_none_on_mps():
+    # Regression test: torch.empty() on MPS can return non-finite values,
+    # and MPS' baddbmm does not short-circuit on beta=0, so an unmasked
+    # call to get_attention_scores used to propagate NaN into the output.
+    torch.manual_seed(0)
+    heads, dim_head, seq_len = 4, 32, 256
+    attn = Attention(
+        query_dim=heads * dim_head,
+        heads=heads,
+        dim_head=dim_head,
+        bias=False,
+    ).to(torch_device, torch.float16)
+
+    for _ in range(20):
+        # Pollute the MPS allocator pool with non-finite values so that a
+        # subsequent torch.empty() is likely to return NaN-filled memory.
+        polluter = torch.full((heads, seq_len, seq_len), float("nan"), device=torch_device, dtype=torch.float16)
+        del polluter
+
+        query = torch.randn(1, seq_len, heads * dim_head, device=torch_device, dtype=torch.float16)
+        key = torch.randn(1, seq_len, heads * dim_head, device=torch_device, dtype=torch.float16)
+        scores = attn.get_attention_scores(
+            attn.head_to_batch_dim(query), attn.head_to_batch_dim(key), attention_mask=None
+        )
+        assert not torch.isnan(scores).any().item(), "attention scores contain NaN on MPS"


### PR DESCRIPTION
# What does this PR do?

Fixes #11229

`Attention.get_attention_scores` allocates `baddbmm_input` with `torch.empty()` and uses `beta=0`, relying on `baddbmm` to ignore the uninitialized input. The MPS `baddbmm` kernel does not short-circuit on `beta=0`, so any NaN/Inf in the uninitialized memory propagates through `0 * NaN = NaN` and poisons the attention output. CUDA happens to mask this because its allocator typically returns zero-initialized memory.

This change uses `torch.zeros` instead of `torch.empty` **only on MPS**, leaving the CUDA / CPU / XPU paths unchanged so they don't pay the extra fill cost.

In real workloads this surfaces as black/NaN images from `StableDiffusionXLPipeline` with `enable_attention_slicing()` on Apple Silicon + fp16, which is the standard memory-saving path on Macs with limited unified memory.

## Reproduction

Minimal repro on M-series MPS (without the fix): 30/30 trials produce NaN. With the fix: 0/30. CPU baseline: 0/5. Verified on M4 MacBook Pro, torch 2.11.0, fp16 and fp32.

The added test `GetAttentionScoresMPSTests.test_no_nan_when_attention_mask_is_none_on_mps` reproduces the bug deterministically (fails 20/20 without the fix, passes 20/20 with it) by polluting the MPS allocator pool with NaN-filled tensors before each call.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Was this discussed/approved via a GitHub issue or the forum?  --> Fixes existing issue #11229.

## Who can review?

@pcuenca (MPS / Apple Silicon maintainer per the PR template)
