### PR TITLE
Guard against zero `std_cfg` in `rescale_noise_cfg` (#13425)

### DIFF
--- a/src/diffusers/pipelines/animatediff/pipeline_animatediff_sdxl.py
+++ b/src/diffusers/pipelines/animatediff/pipeline_animatediff_sdxl.py
@@ -141,6 +141,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
@@ -161,6 +161,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_union_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_union_inpaint_sd_xl.py
@@ -151,6 +151,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/controlnet_hunyuandit/pipeline_hunyuandit_controlnet.py
+++ b/src/diffusers/pipelines/controlnet_hunyuandit/pipeline_hunyuandit_controlnet.py
@@ -156,6 +156,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/deprecated/alt_diffusion/pipeline_alt_diffusion.py
+++ b/src/diffusers/pipelines/deprecated/alt_diffusion/pipeline_alt_diffusion.py
@@ -84,6 +84,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_ldm3d/pipeline_stable_diffusion_ldm3d.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_ldm3d/pipeline_stable_diffusion_ldm3d.py
@@ -94,6 +94,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_panorama/pipeline_stable_diffusion_panorama.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_panorama/pipeline_stable_diffusion_panorama.py
@@ -89,6 +89,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/deprecated/text_to_video_synthesis/pipeline_text_to_video_zero_sdxl.py
+++ b/src/diffusers/pipelines/deprecated/text_to_video_synthesis/pipeline_text_to_video_zero_sdxl.py
@@ -335,6 +335,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/easyanimate/pipeline_easyanimate.py
+++ b/src/diffusers/pipelines/easyanimate/pipeline_easyanimate.py
@@ -117,6 +117,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/easyanimate/pipeline_easyanimate_control.py
+++ b/src/diffusers/pipelines/easyanimate/pipeline_easyanimate_control.py
@@ -193,6 +193,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/easyanimate/pipeline_easyanimate_inpaint.py
+++ b/src/diffusers/pipelines/easyanimate/pipeline_easyanimate_inpaint.py
@@ -215,6 +215,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/hunyuandit/pipeline_hunyuandit.py
+++ b/src/diffusers/pipelines/hunyuandit/pipeline_hunyuandit.py
@@ -140,6 +140,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/ledits_pp/pipeline_leditspp_stable_diffusion.py
+++ b/src/diffusers/pipelines/ledits_pp/pipeline_leditspp_stable_diffusion.py
@@ -260,6 +260,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/ledits_pp/pipeline_leditspp_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/ledits_pp/pipeline_leditspp_stable_diffusion_xl.py
@@ -1722,6 +1722,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/ltx/pipeline_ltx.py
+++ b/src/diffusers/pipelines/ltx/pipeline_ltx.py
@@ -161,6 +161,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/ltx/pipeline_ltx_condition.py
+++ b/src/diffusers/pipelines/ltx/pipeline_ltx_condition.py
@@ -243,6 +243,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/ltx/pipeline_ltx_i2v_long_multi_prompt.py
+++ b/src/diffusers/pipelines/ltx/pipeline_ltx_i2v_long_multi_prompt.py
@@ -136,6 +136,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/ltx/pipeline_ltx_image2video.py
+++ b/src/diffusers/pipelines/ltx/pipeline_ltx_image2video.py
@@ -180,6 +180,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
@@ -176,6 +176,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
@@ -226,6 +226,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_image2video.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_image2video.py
@@ -196,6 +196,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/pag/pipeline_pag_hunyuandit.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_hunyuandit.py
@@ -143,6 +143,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd.py
@@ -88,6 +88,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_inpaint.py
@@ -115,6 +115,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl.py
@@ -103,6 +103,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_img2img.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_img2img.py
@@ -108,6 +108,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
@@ -121,6 +121,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -86,6 +86,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -101,6 +101,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -105,6 +105,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -116,6 +116,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg

--- a/src/diffusers/pipelines/t2i_adapter/pipeline_stable_diffusion_xl_adapter.py
+++ b/src/diffusers/pipelines/t2i_adapter/pipeline_stable_diffusion_xl_adapter.py
@@ -144,6 +144,11 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
     std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
     std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
     # rescale the results from guidance (fixes overexposure)
+    # Guard against `std_cfg == 0` (constant/zero `noise_cfg`, which can happen at the
+    # beginning of a schedule or in numerical edge cases): a raw division would produce
+    # `nan`/`inf` and silently corrupt the diffusion output (issue #13425). When the
+    # standard deviation of the guided prediction is zero, the rescaling is a no-op.
+    std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
     noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
     # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
     noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg


### PR DESCRIPTION
Fixes #13425.

## Summary

`rescale_noise_cfg` divides `std_text` by `std_cfg` without any numerical guard:

```python
std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
noise_pred_rescaled = noise_cfg * (std_text / std_cfg)   # ← nan / inf when std_cfg == 0
```

If `noise_cfg` has zero variance (e.g. a constant or zero-valued guided prediction at the start of a schedule, or numerical edge cases), `std_cfg == 0`, the division produces `nan`/`inf`, and the silent corruption propagates through the rest of the diffusion process — no exception is raised.

## Fix

Clamp `std_cfg` to `torch.finfo(noise_cfg.dtype).eps` before the divide. In the degenerate case the rescaling becomes a no-op (`0 * <finite> == 0`) instead of `nan`. In the non-degenerate case the clamp is below numerical noise, so the rescaling result is unchanged in practice.

```python
std_cfg = std_cfg.clamp(min=torch.finfo(noise_cfg.dtype).eps)
noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
```

The fix was applied to the canonical copy in `pipelines/stable_diffusion/pipeline_stable_diffusion.py` and propagated to all 31 \"# Copied from\" duplicates via `python utils/check_copies.py --fix_and_overwrite`. `python utils/check_copies.py` (no flags) is green.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- BEFORE: origin/main, expect NaN ---
git fetch origin main && git checkout origin/main
python - <<'PY'
import torch
from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import rescale_noise_cfg
noise_cfg = torch.zeros(1, 4, 8, 8)            # std == 0
noise_pred_text = torch.randn_like(noise_cfg)
result = rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=1.0)
print('any nan:', torch.isnan(result).any().item())  # Expected: True
PY

# --- AFTER: this branch ---
git fetch origin pull/<PR>/head:fix && git checkout fix
python - <<'PY'
import torch
from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import rescale_noise_cfg
noise_cfg = torch.zeros(1, 4, 8, 8)
noise_pred_text = torch.randn_like(noise_cfg)
result = rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=1.0)
print('any nan:', torch.isnan(result).any().item())  # Expected: False
print('any inf:', torch.isinf(result).any().item())  # Expected: False
print('max abs:', result.abs().max().item())          # Expected: 0.0
PY
```

I confirmed both runs locally:
- `origin/main` → `any nan: True`
- this branch → `any nan: False, any inf: False, max abs: 0.0`

A second sanity check with a non-degenerate `noise_cfg = torch.randn(...)` produces an unchanged result on this branch (the clamp is below numerical noise).

## Notes

- 32 files touched, all the change is the same 4-line guard before the divide.
- No public API change; pure numerical hardening.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic). Reproducer was run against both `origin/main` and this branch end-to-end.