### PR TITLE
Validate `num_inference_steps > 0` in `DDPMScheduler.set_timesteps` (#13394)

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddpm.py
+++ b/src/diffusers/schedulers/scheduling_ddpm.py
@@ -308,6 +308,11 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
             timesteps = np.array(timesteps, dtype=np.int64)
             self.custom_timesteps = True
         else:
+            if num_inference_steps is None or num_inference_steps <= 0:
+                # Without this guard, `num_inference_steps == 0` produces an empty
+                # timestep schedule and downstream `step()` calls operate on stale
+                # state — silent rather than failing fast (#13394).
+                raise ValueError(f"`num_inference_steps` must be a positive integer, got {num_inference_steps}.")
             if num_inference_steps > self.config.num_train_timesteps:
                 raise ValueError(
                     f"`num_inference_steps`: {num_inference_steps} cannot be larger than `self.config.train_timesteps`:"

--- a/src/diffusers/schedulers/scheduling_ddpm_parallel.py
+++ b/src/diffusers/schedulers/scheduling_ddpm_parallel.py
@@ -323,6 +323,11 @@ class DDPMParallelScheduler(SchedulerMixin, ConfigMixin):
             timesteps = np.array(timesteps, dtype=np.int64)
             self.custom_timesteps = True
         else:
+            if num_inference_steps is None or num_inference_steps <= 0:
+                # Without this guard, `num_inference_steps == 0` produces an empty
+                # timestep schedule and downstream `step()` calls operate on stale
+                # state — silent rather than failing fast (#13394).
+                raise ValueError(f"`num_inference_steps` must be a positive integer, got {num_inference_steps}.")
             if num_inference_steps > self.config.num_train_timesteps:
                 raise ValueError(
                     f"`num_inference_steps`: {num_inference_steps} cannot be larger than `self.config.train_timesteps`:"

--- a/tests/schedulers/test_scheduler_ddpm.py
+++ b/tests/schedulers/test_scheduler_ddpm.py
@@ -190,6 +190,22 @@ class DDPMSchedulerTest(SchedulerCommonTest):
         ):
             scheduler.set_timesteps(timesteps=timesteps)
 
+    def test_set_timesteps_rejects_non_positive_num_inference_steps(self):
+        # Regression for https://github.com/huggingface/diffusers/issues/13394:
+        # `num_inference_steps=0` previously left the scheduler in an unusable
+        # state silently. Both 0 and negative values should fail fast.
+        scheduler_class = self.scheduler_classes[0]
+        scheduler_config = self.get_scheduler_config()
+        scheduler = scheduler_class(**scheduler_config)
+
+        with self.assertRaisesRegex(ValueError, r"`num_inference_steps` must be a positive integer"):
+            scheduler.set_timesteps(num_inference_steps=0)
+        with self.assertRaisesRegex(ValueError, r"`num_inference_steps` must be a positive integer"):
+            scheduler.set_timesteps(num_inference_steps=-1)
+        # Sanity check: a positive value still works after the rejected calls.
+        scheduler.set_timesteps(num_inference_steps=10)
+        self.assertEqual(scheduler.num_inference_steps, 10)
+
     def test_full_loop_with_noise(self):
         scheduler_class = self.scheduler_classes[0]
         scheduler_config = self.get_scheduler_config()


### PR DESCRIPTION
Fixes #13394.

## Summary

`DDPMScheduler.set_timesteps(num_inference_steps=0)` (or negative) silently accepted the input, ran `np.linspace(0, num_train_timesteps - 1, 0)` to produce an empty schedule, and left the scheduler in a broken state. The bug only surfaced later when `step()` operated on stale state — instead of failing fast.

\`scheduling_block_refinement.py\` already validates `num_inference_steps > 0`. This PR brings DDPM in line.

## Fix

Add the same guard in `DDPMScheduler.set_timesteps` (and propagate to its `# Copied from` sibling \`DDPMSchedulerParallel\` via `python utils/check_copies.py --fix_and_overwrite`):

```python
if num_inference_steps is None or num_inference_steps <= 0:
    raise ValueError(
        f"`num_inference_steps` must be a positive integer, got {num_inference_steps}."
    )
```

(The pre-existing too-large check is preserved.)

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- BEFORE: origin/main, no error raised ---
git fetch origin main && git checkout origin/main
python - <<'PY'
from diffusers import DDPMScheduler
sched = DDPMScheduler()
sched.set_timesteps(num_inference_steps=0)
print(\"NO ERROR. timesteps:\", sched.timesteps)  # Expected: NO ERROR / empty
PY

# --- AFTER: this branch ---
git fetch origin pull/<PR>/head:fix && git checkout fix
python - <<'PY'
from diffusers import DDPMScheduler
sched = DDPMScheduler()
try:
    sched.set_timesteps(num_inference_steps=0)
except ValueError as e:
    print(f\"OK: {e}\")  # Expected: \`num_inference_steps\` must be a positive integer, got 0.
PY
```

## What I ran locally

```
pytest tests/schedulers/test_scheduler_ddpm.py -k \"custom_timesteps or rejects_non_positive\"
# 5 passed
```

The new \`test_set_timesteps_rejects_non_positive_num_inference_steps\` covers both `0` and `-1`, and verifies the scheduler still works for a positive value afterwards. It fails on `origin/main` (no exception raised) and passes on this branch.

## Notes

- 2 source files updated (DDPM + parallel sibling), 1 test file. Verified no other `# Copied from` consumers exist for `DDPMScheduler.set_timesteps` via `python utils/check_copies.py`.

---

🤖 Disclosure: Authored with assistance from Claude (Anthropic), reviewed and tested by me.