### PR TITLE
Fix model infrastructure edge cases

### DIFF
--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -324,12 +324,12 @@ class Attention(nn.Module):
                 Specify the partition specification if using SPMD. Otherwise None.
         """
         if use_xla_flash_attention:
-            if not is_torch_xla_available:
-                raise "torch_xla is not available"
+            if not is_torch_xla_available():
+                raise ImportError("torch_xla is not available")
             elif is_torch_xla_version("<", "2.3"):
-                raise "flash attention pallas kernel is supported from torch_xla version 2.3"
+                raise ImportError("flash attention pallas kernel is supported from torch_xla version 2.3")
             elif is_spmd() and is_torch_xla_version("<", "2.4"):
-                raise "flash attention pallas kernel using SPMD is supported from torch_xla version 2.4"
+                raise ImportError("flash attention pallas kernel using SPMD is supported from torch_xla version 2.4")
             else:
                 if is_flux:
                     processor = XLAFluxFlashAttnProcessor2_0(partition_spec)

--- a/src/diffusers/models/auto_model.py
+++ b/src/diffusers/models/auto_model.py
@@ -275,10 +275,17 @@ class AutoModel(ConfigMixin):
         library = None
         orig_class_name = None
 
+        def load_config_with_name(config_name, *args, **kwargs):
+            original_config_name = cls.config_name
+            try:
+                cls.config_name = config_name
+                return cls.load_config(*args, **kwargs)
+            finally:
+                cls.config_name = original_config_name
+
         # Always attempt to fetch model_index.json first
         try:
-            cls.config_name = "model_index.json"
-            config = cls.load_config(pretrained_model_or_path, **load_config_kwargs)
+            config = load_config_with_name("model_index.json", pretrained_model_or_path, **load_config_kwargs)
 
             if subfolder is not None and subfolder in config:
                 library, orig_class_name = config[subfolder]
@@ -289,8 +296,9 @@ class AutoModel(ConfigMixin):
 
         # Unable to load from model_index.json so fallback to loading from config
         if library is None and orig_class_name is None:
-            cls.config_name = "config.json"
-            config = cls.load_config(pretrained_model_or_path, subfolder=subfolder, **load_config_kwargs)
+            config = load_config_with_name(
+                "config.json", pretrained_model_or_path, subfolder=subfolder, **load_config_kwargs
+            )
 
             if "_class_name" in config:
                 # If we find a class name in the config, we can try to load the model as a diffusers model
@@ -342,7 +350,7 @@ class AutoModel(ConfigMixin):
 
         load_id_kwargs = {"pretrained_model_name_or_path": pretrained_model_or_path, **kwargs}
         parts = [load_id_kwargs.get(field, "null") for field in DIFFUSERS_LOAD_ID_FIELDS]
-        load_id = "|".join("null" if p is None else p for p in parts)
+        load_id = "|".join("null" if p is None else str(p) for p in parts)
         model._diffusers_load_id = load_id
 
         return model

--- a/src/diffusers/models/cache_utils.py
+++ b/src/diffusers/models/cache_utils.py
@@ -159,6 +159,7 @@ class CacheMixin:
         registry = HookRegistry.check_if_exists_or_initialize(self)
         registry._set_context(name)
 
-        yield
-
-        registry._set_context(None)
+        try:
+            yield
+        finally:
+            registry._set_context(None)

--- a/src/diffusers/models/downsampling.py
+++ b/src/diffusers/models/downsampling.py
@@ -18,7 +18,7 @@ import torch.nn.functional as F
 
 from ..utils import deprecate
 from .normalization import RMSNorm
-from .upsampling import upfirdn2d_native
+from .upsampling import _prepare_fir_kernel, upfirdn2d_native
 
 
 class Downsample1D(nn.Module):
@@ -210,16 +210,13 @@ class FirDownsample2D(nn.Module):
         """
 
         assert isinstance(factor, int) and factor >= 1
-        if kernel is None:
-            kernel = [1] * factor
-
-        # setup kernel
-        kernel = torch.tensor(kernel, dtype=torch.float32)
-        if kernel.ndim == 1:
-            kernel = torch.outer(kernel, kernel)
-        kernel /= torch.sum(kernel)
-
-        kernel = kernel * gain
+        kernel = _prepare_fir_kernel(
+            kernel,
+            factor=factor,
+            gain=gain,
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        )
 
         if self.use_conv:
             _, _, convH, convW = weight.shape
@@ -227,7 +224,7 @@ class FirDownsample2D(nn.Module):
             stride_value = [factor, factor]
             upfirdn_input = upfirdn2d_native(
                 hidden_states,
-                torch.tensor(kernel, device=hidden_states.device),
+                kernel,
                 pad=((pad_value + 1) // 2, pad_value // 2),
             )
             output = F.conv2d(upfirdn_input, weight, stride=stride_value, padding=0)
@@ -235,7 +232,7 @@ class FirDownsample2D(nn.Module):
             pad_value = kernel.shape[0] - factor
             output = upfirdn2d_native(
                 hidden_states,
-                torch.tensor(kernel, device=hidden_states.device),
+                kernel,
                 down=factor,
                 pad=((pad_value + 1) // 2, pad_value // 2),
             )
@@ -380,19 +377,17 @@ def downsample_2d(
     """
 
     assert isinstance(factor, int) and factor >= 1
-    if kernel is None:
-        kernel = [1] * factor
-
-    kernel = torch.tensor(kernel, dtype=torch.float32)
-    if kernel.ndim == 1:
-        kernel = torch.outer(kernel, kernel)
-    kernel /= torch.sum(kernel)
-
-    kernel = kernel * gain
+    kernel = _prepare_fir_kernel(
+        kernel,
+        factor=factor,
+        gain=gain,
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
     pad_value = kernel.shape[0] - factor
     output = upfirdn2d_native(
         hidden_states,
-        kernel.to(device=hidden_states.device),
+        kernel,
         down=factor,
         pad=((pad_value + 1) // 2, pad_value // 2),
     )

--- a/src/diffusers/models/embeddings.py
+++ b/src/diffusers/models/embeddings.py
@@ -328,7 +328,7 @@ def get_1d_sincos_pos_embed_from_grid(embed_dim, pos, output_type="np", flip_sin
         output_type (`str`, *optional*, defaults to `"np"`): Output type. Use `"pt"` for PyTorch tensors.
         flip_sin_to_cos (`bool`, *optional*, defaults to `False`): Whether to flip sine and cosine embeddings.
         dtype (`torch.dtype`, *optional*): Data type for frequency calculations. If `None`, defaults to
-            `torch.float32` on MPS devices (which don't support `torch.float64`) and `torch.float64` on other devices.
+            `torch.float32`.
 
     Returns:
         `torch.Tensor`: Sinusoidal positional embeddings of shape `(M, D)`.
@@ -346,7 +346,7 @@ def get_1d_sincos_pos_embed_from_grid(embed_dim, pos, output_type="np", flip_sin
 
     # Auto-detect appropriate dtype if not specified
     if dtype is None:
-        dtype = torch.float32 if pos.device.type == "mps" else torch.float64
+        dtype = torch.float32
 
     omega = torch.arange(embed_dim // 2, device=pos.device, dtype=dtype)
     omega /= embed_dim / 2.0

--- a/src/diffusers/models/modeling_flax_utils.py
+++ b/src/diffusers/models/modeling_flax_utils.py
@@ -318,6 +318,8 @@ class FlaxModelMixin(PushToHubMixin):
                 subfolder=subfolder,
                 **kwargs,
             )
+        else:
+            unused_kwargs = kwargs
 
         model, model_kwargs = cls.from_config(config, dtype=dtype, return_unused_kwargs=True, **unused_kwargs)
 

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -1592,7 +1592,7 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
             "`enable_parallelism` is an experimental feature. The API may change in the future and breaking changes may be introduced at any time without warning."
         )
 
-        if not torch.distributed.is_available() and not torch.distributed.is_initialized():
+        if not torch.distributed.is_available() or not torch.distributed.is_initialized():
             raise RuntimeError(
                 "torch.distributed must be available and initialized before calling `enable_parallelism`."
             )

--- a/src/diffusers/models/upsampling.py
+++ b/src/diffusers/models/upsampling.py
@@ -21,6 +21,27 @@ from ..utils.import_utils import is_torch_version
 from .normalization import RMSNorm
 
 
+def _prepare_fir_kernel(
+    kernel: torch.Tensor | None,
+    *,
+    factor: int,
+    gain: float,
+    device: torch.device,
+    dtype: torch.dtype,
+    upsample: bool = False,
+) -> torch.Tensor:
+    if kernel is None:
+        kernel = [1] * factor
+
+    kernel = torch.as_tensor(kernel, device=device, dtype=torch.float32)
+    if kernel.ndim == 1:
+        kernel = torch.outer(kernel, kernel)
+    kernel = kernel / torch.sum(kernel)
+
+    scale = gain * (factor**2) if upsample else gain
+    return (kernel * scale).to(device=device, dtype=dtype)
+
+
 class Upsample1D(nn.Module):
     """A 1D upsampling layer with an optional convolution.
 
@@ -253,17 +274,14 @@ class FirUpsample2D(nn.Module):
 
         assert isinstance(factor, int) and factor >= 1
 
-        # Setup filter kernel.
-        if kernel is None:
-            kernel = [1] * factor
-
-        # setup kernel
-        kernel = torch.tensor(kernel, dtype=torch.float32)
-        if kernel.ndim == 1:
-            kernel = torch.outer(kernel, kernel)
-        kernel /= torch.sum(kernel)
-
-        kernel = kernel * (gain * (factor**2))
+        kernel = _prepare_fir_kernel(
+            kernel,
+            factor=factor,
+            gain=gain,
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+            upsample=True,
+        )
 
         if self.use_conv:
             convH = weight.shape[2]
@@ -300,14 +318,14 @@ class FirUpsample2D(nn.Module):
 
             output = upfirdn2d_native(
                 inverse_conv,
-                torch.tensor(kernel, device=inverse_conv.device),
+                kernel.to(device=inverse_conv.device, dtype=inverse_conv.dtype),
                 pad=((pad_value + 1) // 2 + factor - 1, pad_value // 2 + 1),
             )
         else:
             pad_value = kernel.shape[0] - factor
             output = upfirdn2d_native(
                 hidden_states,
-                torch.tensor(kernel, device=hidden_states.device),
+                kernel,
                 up=factor,
                 pad=((pad_value + 1) // 2 + factor - 1, pad_value // 2),
             )
@@ -496,19 +514,18 @@ def upsample_2d(
             Tensor of the shape `[N, C, H * factor, W * factor]`
     """
     assert isinstance(factor, int) and factor >= 1
-    if kernel is None:
-        kernel = [1] * factor
-
-    kernel = torch.tensor(kernel, dtype=torch.float32)
-    if kernel.ndim == 1:
-        kernel = torch.outer(kernel, kernel)
-    kernel /= torch.sum(kernel)
-
-    kernel = kernel * (gain * (factor**2))
+    kernel = _prepare_fir_kernel(
+        kernel,
+        factor=factor,
+        gain=gain,
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+        upsample=True,
+    )
     pad_value = kernel.shape[0] - factor
     output = upfirdn2d_native(
         hidden_states,
-        kernel.to(device=hidden_states.device),
+        kernel,
         up=factor,
         pad=((pad_value + 1) // 2 + factor - 1, pad_value // 2),
     )

--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -708,7 +708,7 @@ def is_torch_xla_version(operation: str, version: str):
         version (`str`):
             A string version of torch_xla
     """
-    if not is_torch_xla_available:
+    if not is_torch_xla_available():
         return False
     return compare_versions(parse(_torch_xla_version), operation, version)
 

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -18,6 +18,8 @@ import unittest
 import torch
 
 from diffusers.hooks import HookRegistry, ModelHook
+from diffusers.hooks.hooks import BaseState, StateManager
+from diffusers.models.cache_utils import CacheMixin
 from diffusers.training_utils import free_memory
 from diffusers.utils.logging import get_logger
 
@@ -112,6 +114,27 @@ class StatefulAddHook(ModelHook):
 
     def reset_state(self, module):
         self.increment = 0
+
+
+class CacheTestState(BaseState):
+    def reset(self):
+        pass
+
+
+class CacheTestHook(ModelHook):
+    _is_stateful = True
+
+    def __init__(self):
+        super().__init__()
+        self.state_manager = StateManager(CacheTestState)
+
+    def reset_state(self, module):
+        self.state_manager.reset()
+
+
+class CacheContextModel(torch.nn.Module, CacheMixin):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
 
 
 class SkipLayerHook(ModelHook):
@@ -337,6 +360,20 @@ class HookTests(unittest.TestCase):
             ("MultiplyHook pre_forward\nMultiplyHook post_forward\n").replace(" ", "").replace("\n", "")
         )
         self.assertEqual(output, expected_invocation_order_log)
+
+    def test_cache_context_clears_stateful_hook_context_after_exception(self):
+        model = CacheContextModel()
+        hook = CacheTestHook()
+        HookRegistry.check_if_exists_or_initialize(model).register_hook(hook, "cache_test")
+
+        with self.assertRaisesRegex(RuntimeError, "interrupted"):
+            with model.cache_context("failed-call"):
+                hook.state_manager.get_state()
+                raise RuntimeError("interrupted")
+
+        self.assertIsNone(hook.state_manager._current_context)
+        with self.assertRaisesRegex(ValueError, "No context is set"):
+            hook.state_manager.get_state()
 
     def test_invocation_order_stateful_last(self):
         registry = HookRegistry.check_if_exists_or_initialize(self.model)

--- a/tests/models/test_attention_processor.py
+++ b/tests/models/test_attention_processor.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -9,6 +10,7 @@ from packaging import version
 
 from diffusers import DiffusionPipeline
 from diffusers.models.attention_processor import Attention, AttnAddedKVProcessor
+from diffusers.utils import import_utils
 
 from ..testing_utils import torch_device
 
@@ -81,6 +83,23 @@ class AttnAddedKVProcessorTests(unittest.TestCase):
         only_cross_attn_out = attn(**forward_args)
 
         self.assertTrue((only_cross_attn_out != self_and_cross_attn_out).all())
+
+
+class AttentionXLAFlashAttentionTests(unittest.TestCase):
+    def test_set_use_xla_flash_attention_raises_import_error_without_torch_xla(self):
+        attn = Attention(query_dim=4, heads=1, dim_head=4)
+
+        with patch("diffusers.models.attention_processor.is_torch_xla_available", return_value=False):
+            with self.assertRaisesRegex(ImportError, "torch_xla is not available"):
+                attn.set_use_xla_flash_attention(True)
+
+    def test_is_torch_xla_version_returns_false_without_torch_xla(self):
+        import_utils.is_torch_xla_version.cache_clear()
+        try:
+            with patch("diffusers.utils.import_utils.is_torch_xla_available", return_value=False):
+                self.assertFalse(import_utils.is_torch_xla_version("<", "2.3"))
+        finally:
+            import_utils.is_torch_xla_version.cache_clear()
 
 
 class DeprecatedAttentionBlockTests(unittest.TestCase):

--- a/tests/models/test_layers_utils.py
+++ b/tests/models/test_layers_utils.py
@@ -21,9 +21,11 @@ import torch
 from torch import nn
 
 from diffusers.models.attention import GEGLU, AdaLayerNorm, ApproximateGELU
-from diffusers.models.embeddings import get_timestep_embedding
+from diffusers.models.downsampling import FirDownsample2D, downsample_2d
+from diffusers.models.embeddings import get_1d_sincos_pos_embed_from_grid, get_timestep_embedding
 from diffusers.models.resnet import Downsample2D, ResnetBlock2D, Upsample2D
 from diffusers.models.transformers.transformer_2d import Transformer2DModel
+from diffusers.models.upsampling import FirUpsample2D, upsample_2d
 
 from ..testing_utils import (
     backend_manual_seed,
@@ -67,6 +69,20 @@ class EmbeddingsTests(unittest.TestCase):
         t2 = get_timestep_embedding(timesteps, embedding_dim, flip_sin_to_cos=False)
 
         assert torch.allclose(t1.cpu(), t2.cpu(), 1e-3)
+
+    def test_1d_sincos_pos_embed_default_dtype_is_float32(self):
+        pos = torch.arange(4, dtype=torch.float32)
+
+        emb = get_1d_sincos_pos_embed_from_grid(8, pos, output_type="pt")
+
+        assert emb.dtype == torch.float32
+
+    def test_1d_sincos_pos_embed_honors_explicit_dtype(self):
+        pos = torch.arange(4, dtype=torch.float32)
+
+        emb = get_1d_sincos_pos_embed_from_grid(8, pos, output_type="pt", dtype=torch.float64)
+
+        assert emb.dtype == torch.float64
 
     def test_timestep_downscale_freq_shift(self):
         embedding_dim = 16
@@ -136,6 +152,28 @@ class Upsample2DBlockTests(unittest.TestCase):
             [-0.2173, -1.2079, -1.2079, 0.2952, 1.1254, 1.1254, 0.2952, 1.1254, 1.1254], dtype=torch.bfloat16
         )
         assert torch.allclose(output_slice.flatten(), expected_slice, atol=1e-3)
+
+    @require_torch_version_greater_equal("2.1")
+    def test_upsample_2d_fir_bfloat16(self):
+        torch.manual_seed(0)
+        sample = torch.randn(1, 1, 4, 4).to(torch.bfloat16)
+
+        upsampled = upsample_2d(sample)
+
+        assert upsampled.dtype == torch.bfloat16
+        assert upsampled.shape == (1, 1, 8, 8)
+
+    @require_torch_version_greater_equal("2.1")
+    def test_fir_upsample_with_conv_bfloat16(self):
+        torch.manual_seed(0)
+        sample = torch.randn(1, 1, 4, 4).to(torch.bfloat16)
+        upsample = FirUpsample2D(channels=1, out_channels=1, use_conv=True).to(torch.bfloat16)
+
+        with torch.no_grad():
+            upsampled = upsample(sample)
+
+        assert upsampled.dtype == torch.bfloat16
+        assert upsampled.shape == (1, 1, 8, 8)
 
     def test_upsample_with_conv(self):
         torch.manual_seed(0)
@@ -227,6 +265,28 @@ class Downsample2DBlockTests(unittest.TestCase):
         output_slice = downsampled[0, -1, -3:, -3:]
         expected_slice = torch.tensor([-0.6586, 0.5985, 0.0721, 0.1256, -0.1492, 0.4436, -0.2544, 0.5021, 1.1522])
         assert torch.allclose(output_slice.flatten(), expected_slice, atol=1e-3)
+
+    @require_torch_version_greater_equal("2.1")
+    def test_downsample_2d_fir_bfloat16(self):
+        torch.manual_seed(0)
+        sample = torch.randn(1, 1, 8, 8).to(torch.bfloat16)
+
+        downsampled = downsample_2d(sample)
+
+        assert downsampled.dtype == torch.bfloat16
+        assert downsampled.shape == (1, 1, 4, 4)
+
+    @require_torch_version_greater_equal("2.1")
+    def test_fir_downsample_with_conv_bfloat16(self):
+        torch.manual_seed(0)
+        sample = torch.randn(1, 1, 8, 8).to(torch.bfloat16)
+        downsample = FirDownsample2D(channels=1, out_channels=1, use_conv=True).to(torch.bfloat16)
+
+        with torch.no_grad():
+            downsampled = downsample(sample)
+
+        assert downsampled.dtype == torch.bfloat16
+        assert downsampled.shape == (1, 1, 4, 4)
 
 
 class ResnetBlock2DTests(unittest.TestCase):

--- a/tests/models/test_modeling_flax_utils.py
+++ b/tests/models/test_modeling_flax_utils.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+def test_flax_from_pretrained_with_supplied_config_preserves_unused_kwargs():
+    pytest.importorskip("jax")
+    pytest.importorskip("flax")
+
+    from diffusers.models.modeling_flax_utils import FlaxModelMixin
+
+    class ReachedFromConfig(Exception):
+        pass
+
+    class DummyFlaxModel(FlaxModelMixin):
+        @classmethod
+        def from_config(cls, config, dtype=None, return_unused_kwargs=False, **kwargs):
+            assert config == {"hidden_size": 4}
+            assert kwargs == {"extra_kwarg": "value"}
+            raise ReachedFromConfig()
+
+    with pytest.raises(ReachedFromConfig):
+        DummyFlaxModel.from_pretrained(
+            "unused",
+            config={"hidden_size": 4},
+            local_files_only=True,
+            extra_kwarg="value",
+        )

--- a/tests/models/test_modeling_utils.py
+++ b/tests/models/test_modeling_utils.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch
+
+from diffusers import ContextParallelConfig
+from diffusers.models.modeling_utils import ModelMixin
+
+
+class DummyParallelModel(ModelMixin):
+    pass
+
+
+class ModelMixinParallelismTests(unittest.TestCase):
+    def test_enable_parallelism_short_circuits_when_distributed_unavailable(self):
+        model = DummyParallelModel()
+
+        with (
+            patch("torch.distributed.is_available", return_value=False),
+            patch("torch.distributed.is_initialized", side_effect=AssertionError("should not be called")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "torch.distributed must be available and initialized"):
+                model.enable_parallelism(config=ContextParallelConfig(ring_degree=2))
+
+    def test_enable_parallelism_raises_when_distributed_uninitialized(self):
+        model = DummyParallelModel()
+
+        with (
+            patch("torch.distributed.is_available", return_value=True),
+            patch("torch.distributed.is_initialized", return_value=False),
+            patch("torch.distributed.get_rank", side_effect=AssertionError("should not be called")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "torch.distributed must be available and initialized"):
+                model.enable_parallelism(config=ContextParallelConfig(ring_degree=2))

--- a/tests/models/test_models_auto.py
+++ b/tests/models/test_models_auto.py
@@ -2,17 +2,30 @@ import json
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import torch
 from transformers import CLIPTextModel, LongformerModel
 
 from diffusers import ConfigMixin
-from diffusers.models import AutoModel, UNet2DConditionModel
+from diffusers.models import AutoModel, UNet2DConditionModel, UNet2DModel
 from diffusers.models.modeling_utils import ModelMixin
 
 
 class TestAutoModel(unittest.TestCase):
+    def _create_tiny_unet(self):
+        return UNet2DModel(
+            sample_size=4,
+            in_channels=1,
+            out_channels=1,
+            layers_per_block=1,
+            block_out_channels=(4,),
+            down_block_types=("DownBlock2D",),
+            up_block_types=("UpBlock2D",),
+            norm_num_groups=1,
+        )
+
     @patch(
         "diffusers.models.AutoModel.load_config",
         side_effect=[EnvironmentError("File not found"), {"_class_name": "UNet2DConditionModel"}],
@@ -79,6 +92,43 @@ class TestAutoModel(unittest.TestCase):
             model = AutoModel.from_pretrained(tmpdir, subfolder=subfolder, trust_remote_code=True)
             assert model.__class__.__name__ == "CustomModel"
             assert model.config["hidden_size"] == 8
+
+    def test_load_from_local_model_index_pathlike_restores_config_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            unet_dir = root / "unet"
+
+            self._create_tiny_unet().save_pretrained(unet_dir, safe_serialization=False)
+            (root / "model_index.json").write_text(
+                json.dumps({"_class_name": "DummyPipeline", "unet": ["diffusers", "UNet2DModel"]})
+            )
+
+            model = AutoModel.from_pretrained(root, subfolder="unet", use_safetensors=False)
+
+            self.assertIsInstance(model, UNet2DModel)
+            self.assertEqual(AutoModel.config_name, "config.json")
+            self.assertIsInstance(model._diffusers_load_id, str)
+            self.assertIn(str(root), model._diffusers_load_id)
+
+            model_from_config = AutoModel.from_config(unet_dir)
+            self.assertIsInstance(model_from_config, UNet2DModel)
+
+    def test_load_from_local_config_fallback_restores_config_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model_dir = Path(tmpdir)
+            self._create_tiny_unet().save_pretrained(model_dir, safe_serialization=False)
+
+            model = AutoModel.from_pretrained(model_dir, use_safetensors=False)
+
+            self.assertIsInstance(model, UNet2DModel)
+            self.assertEqual(AutoModel.config_name, "config.json")
+
+    @patch("diffusers.models.AutoModel.load_config", side_effect=RuntimeError("boom"))
+    def test_load_config_exception_restores_config_name(self, mock_load_config):
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            AutoModel.from_pretrained("does-not-matter")
+
+        self.assertEqual(AutoModel.config_name, "config.json")
 
 
 class TestAutoModelFromConfig(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes #13655.

This PR addresses several small model-infrastructure edge cases that can surface as runtime failures or state leaks:

- restores `AutoModel.config_name` after model-index probing, config fallback, and exceptions
- supports local `PathLike` model paths when building `_diffusers_load_id`
- clears `CacheMixin.cache_context()` hook state even when the wrapped block raises
- keeps FIR up/downsampling kernels on the input device and dtype for low-precision tensors
- fixes XLA availability checks to call the helper and raise real `ImportError`s
- fixes `enable_parallelism()` to reject unavailable or uninitialized distributed setups
- preserves unused kwargs when `FlaxModelMixin.from_pretrained()` receives an explicit config
- defaults 1D sin/cos positional embedding calculations to `torch.float32`

## Root Cause

The failures come from a few independent guard/state issues:

- `AutoModel.from_pretrained()` temporarily mutated the class-level `config_name` without guaranteed restoration and joined load-id parts without stringifying path objects.
- `cache_context()` reset hook context only on normal exit, so exceptions could leave stateful hooks bound to a stale context.
- FIR helpers rebuilt kernels as `float32` tensors after receiving low-precision inputs, which could mismatch `bfloat16` or other low-precision activations/weights.
- A few availability checks tested function objects instead of calling them, raised strings instead of exceptions, or used `and` where `or` was required for guard logic.
- The Flax explicit-config path skipped initialization of `unused_kwargs`.

## Validation

Ran focused and broader checks locally:

- `pytest tests/models/test_modeling_utils.py -q`
- `pytest tests/models/test_modeling_flax_utils.py -q`
- `pytest tests/hooks/test_hooks.py -q -k cache_context_clears_stateful_hook_context_after_exception`
- `pytest tests/models/test_attention_processor.py -q -k 'xla_flash_attention or is_torch_xla_version'`
- `pytest tests/models/test_layers_utils.py -q -k 'sincos_pos_embed or fir_bfloat16 or fir_upsample_with_conv_bfloat16 or fir_downsample_with_conv_bfloat16'`
- `pytest tests/models/test_models_auto.py -q -k 'local_model_index_pathlike or local_config_fallback or load_config_exception'`
- `pytest tests/hooks/test_hooks.py -q`
- `pytest tests/models/test_layers_utils.py -q`
- `uvx ruff check ...`
- `uvx ruff format --check ...`
- `git diff --check`
