### PR TITLE
schedulers/flow_match_euler_discrete: fix double-shift bug by storing sigma_min/sigma_max before shift is applied

### DIFF
--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -128,6 +128,11 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         timesteps = torch.from_numpy(timesteps).to(dtype=torch.float32)
 
         sigmas = timesteps / num_train_timesteps
+        # Store sigma_min/sigma_max from the unshifted linear sigmas so that set_timesteps
+        # can reconstruct the correct input range and apply the shift exactly once.
+        self.sigma_min = sigmas[-1].item()
+        self.sigma_max = sigmas[0].item()
+
         if not use_dynamic_shifting:
             # when use_dynamic_shifting is True, we apply the timestep shifting on the fly based on the image resolution
             sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)
@@ -140,8 +145,6 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         self._shift = shift
 
         self.sigmas = sigmas.to("cpu")  # to avoid too much CPU/GPU communication
-        self.sigma_min = self.sigmas[-1].item()
-        self.sigma_max = self.sigmas[0].item()
 
     @property
     def shift(self):


### PR DESCRIPTION
# What does this PR do?

Fixes #13243

`FlowMatchEulerDiscreteScheduler.__init__` was storing `sigma_min` and `sigma_max` **after** the shift formula had already been applied to `sigmas`:

```python
sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)  # shift applied here
...
self.sigma_min = self.sigmas[-1].item()  # already-shifted value stored
self.sigma_max = self.sigmas[0].item()  # already-shifted value stored
```

Then in `set_timesteps`, when no custom sigmas/timesteps are provided, the scheduler reconstructs a linspace from `sigma_max` → `sigma_min` (the shifted values), divides back by `num_train_timesteps`, and **applies the shift formula a second time** — resulting in a doubly-shifted sigma schedule that diverges from what the model was trained with.

This PR moves the `sigma_min`/`sigma_max` assignment to **before** the shift is applied, so `set_timesteps` always starts from the correct unshifted linear range and applies the shift exactly once.

The fix is surgical: `self.sigmas` and `self.timesteps` stored in `__init__` are unchanged. Only the two boundary reference scalars are corrected. Users passing custom `sigmas` or `timesteps` directly to `set_timesteps` are entirely unaffected.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?
@yiyixuxu