### PR TITLE
Add from_single_file support to ErnieImageTransformer2DModel

### DIFF
--- a/src/diffusers/loaders/single_file_model.py
+++ b/src/diffusers/loaders/single_file_model.py
@@ -33,6 +33,7 @@ from .single_file_utils import (
     convert_chroma_transformer_checkpoint_to_diffusers,
     convert_controlnet_checkpoint,
     convert_cosmos_transformer_checkpoint_to_diffusers,
+    convert_ernie_image_transformer_checkpoint_to_diffusers,
     convert_flux2_transformer_checkpoint_to_diffusers,
     convert_flux_transformer_checkpoint_to_diffusers,
     convert_hidream_transformer_to_diffusers,
@@ -112,6 +113,10 @@ SINGLE_FILE_LOADABLE_CLASSES = {
     },
     "ChromaTransformer2DModel": {
         "checkpoint_mapping_fn": convert_chroma_transformer_checkpoint_to_diffusers,
+        "default_subfolder": "transformer",
+    },
+    "ErnieImageTransformer2DModel": {
+        "checkpoint_mapping_fn": convert_ernie_image_transformer_checkpoint_to_diffusers,
         "default_subfolder": "transformer",
     },
     "LTXVideoTransformer3DModel": {

--- a/src/diffusers/loaders/single_file_utils.py
+++ b/src/diffusers/loaders/single_file_utils.py
@@ -4165,14 +4165,10 @@ def convert_ltx2_audio_vae_to_diffusers(checkpoint, **kwargs):
 
 
 def convert_ernie_image_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
-    converted_state_dict = {}
     keys = list(checkpoint.keys())
 
     for k in keys:
         if "model.diffusion_model." in k:
             checkpoint[k.replace("model.diffusion_model.", "")] = checkpoint.pop(k)
 
-    for k in list(checkpoint.keys()):
-        converted_state_dict[k] = checkpoint.pop(k)
-
-    return converted_state_dict
+    return checkpoint

--- a/src/diffusers/loaders/single_file_utils.py
+++ b/src/diffusers/loaders/single_file_utils.py
@@ -4162,3 +4162,17 @@ def convert_ltx2_audio_vae_to_diffusers(checkpoint, **kwargs):
         update_state_dict_inplace(converted_state_dict, key, new_key)
 
     return converted_state_dict
+
+
+def convert_ernie_image_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
+    converted_state_dict = {}
+    keys = list(checkpoint.keys())
+
+    for k in keys:
+        if "model.diffusion_model." in k:
+            checkpoint[k.replace("model.diffusion_model.", "")] = checkpoint.pop(k)
+
+    for k in list(checkpoint.keys()):
+        converted_state_dict[k] = checkpoint.pop(k)
+
+    return converted_state_dict

--- a/src/diffusers/models/transformers/transformer_ernie_image.py
+++ b/src/diffusers/models/transformers/transformer_ernie_image.py
@@ -25,7 +25,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from ...configuration_utils import ConfigMixin, register_to_config
-from ...loaders import PeftAdapterMixin
+from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
 from ...utils import BaseOutput, logging
 from ..attention import AttentionModuleMixin
 from ..attention_dispatch import dispatch_attention_fn
@@ -289,7 +289,7 @@ class ErnieImageAdaLNContinuous(nn.Module):
         return x
 
 
-class ErnieImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
+class ErnieImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin):
     _supports_gradient_checkpointing = True
     _repeated_blocks = ["ErnieImageSharedAdaLNBlock"]
 


### PR DESCRIPTION
# What does this PR do?

Fixes #13722. `ErnieImageTransformer2DModel` does not implement `from_single_file`, unlike other models (Flux, Chroma, Z-Image, etc.), so loading a single-file checkpoint (e.g. a OneTrainer finetune) errors with `AttributeError`.

Adding standard `FromOriginalModelMixin` to the class and register a minimal checkpoint converter that strips the common `model.diffusion_model.` prefix(same shape as the Flux/Chroma converters)
Fixes #13722

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue? https://github.com/huggingface/diffusers/issues/13722
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@DN6 @sayakpaul