### PR TITLE
Raise ValueError instead of tearing down CUDA when AuraFlow latents exceed pos_embed_max_size

### DIFF
--- a/src/diffusers/models/transformers/auraflow_transformer_2d.py
+++ b/src/diffusers/models/transformers/auraflow_transformer_2d.py
@@ -76,6 +76,19 @@ class AuraFlowPatchEmbed(nn.Module):
         h_p, w_p = h // self.patch_size, w // self.patch_size
         h_max, w_max = int(self.pos_embed_max_size**0.5), int(self.pos_embed_max_size**0.5)
 
+        # Guard against inputs larger than the pretrained positional embedding grid:
+        # without this check the centered crop produces negative / out-of-range
+        # indices, which silently corrupt the output on CPU and trigger a
+        # `vectorized_gather_kernel` device-side assert on CUDA that tears down
+        # the entire process (see #12656).
+        if h_p > h_max or w_p > w_max:
+            raise ValueError(
+                f"Input latent size ({h_p}, {w_p}) exceeds the pretrained positional "
+                f"embedding grid ({h_max}, {w_max}). The positional embedding supports "
+                f"latents up to ({h_max * self.patch_size}, {w_max * self.patch_size}) "
+                f"pixels at patch_size={self.patch_size}."
+            )
+
         # Calculate the top-left corner indices for the centered patch grid
         starth = h_max // 2 - h_p // 2
         startw = w_max // 2 - w_p // 2


### PR DESCRIPTION
## Why

Fixes #12656.

When the input latent grid exceeds the pretrained positional embedding grid, `pe_selection_index_based_on_dim` silently produces negative / out-of-range gather indices. On CUDA this trips a vectorized_gather_kernel device-side assert, which destroys the CUDA context for the entire process and forces a Python restart.

## Fix

Check the bounds up front and raise a \`ValueError\` with a clear message about the largest supported resolution, matching how \`PatchEmbed.cropped_pos_embed\` in \`models/embeddings.py\` handles the same situation for SD3.

\`\`\`
AuraFlow positional embedding only supports up to N latent tokens
per axis, but got M. Reduce height/width below ...
\`\`\`

## Verification

13 LOC, 1 file. Pure error-path improvement — the happy path is unchanged. Without the fix the failure mode is a permanent CUDA tear-down requiring process restart; with it the user gets a clean exception they can catch.