### PR TITLE
[pipelines] fix SD3 crash with pre-computed prompt_embeds and num_images_per_prompt

### DIFF
--- a/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet.py
+++ b/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet.py
@@ -447,6 +447,13 @@ class StableDiffusion3ControlNetPipeline(
         else:
             batch_size = prompt_embeds.shape[0]
 
+        # The internal `_get_*_prompt_embeds` helpers expand the encoded embeddings
+        # by `num_images_per_prompt`, but user-supplied embeddings bypass that path.
+        # Track that here so we can apply the same expansion at the end and keep the
+        # batch dimension consistent with `prepare_latents` (see #10712).
+        prompt_embeds_was_provided = prompt_embeds is not None
+        negative_prompt_embeds_was_provided = negative_prompt_embeds is not None
+
         if prompt_embeds is None:
             prompt_2 = prompt_2 or prompt
             prompt_2 = [prompt_2] if isinstance(prompt_2, str) else prompt_2
@@ -541,6 +548,28 @@ class StableDiffusion3ControlNetPipeline(
             negative_prompt_embeds = torch.cat([negative_clip_prompt_embeds, t5_negative_prompt_embed], dim=-2)
             negative_pooled_prompt_embeds = torch.cat(
                 [negative_pooled_prompt_embed, negative_pooled_prompt_2_embed], dim=-1
+            )
+
+        # Apply `num_images_per_prompt` expansion to user-supplied embeddings to match
+        # what `_get_*_prompt_embeds` already does for freshly-encoded ones (#10712).
+        if prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = prompt_embeds.shape[-2], prompt_embeds.shape[-1]
+            prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, hidden_dim)
+            pooled_dim = pooled_prompt_embeds.shape[-1]
+            pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            pooled_prompt_embeds = pooled_prompt_embeds.view(batch_size * num_images_per_prompt, pooled_dim)
+
+        if do_classifier_free_guidance and negative_prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = negative_prompt_embeds.shape[-2], negative_prompt_embeds.shape[-1]
+            negative_prompt_embeds = negative_prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            negative_prompt_embeds = negative_prompt_embeds.view(
+                batch_size * num_images_per_prompt, seq_len, hidden_dim
+            )
+            pooled_dim = negative_pooled_prompt_embeds.shape[-1]
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.view(
+                batch_size * num_images_per_prompt, pooled_dim
             )
 
         if self.text_encoder is not None:

--- a/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet_inpainting.py
+++ b/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet_inpainting.py
@@ -469,6 +469,13 @@ class StableDiffusion3ControlNetInpaintingPipeline(
         else:
             batch_size = prompt_embeds.shape[0]
 
+        # The internal `_get_*_prompt_embeds` helpers expand the encoded embeddings
+        # by `num_images_per_prompt`, but user-supplied embeddings bypass that path.
+        # Track that here so we can apply the same expansion at the end and keep the
+        # batch dimension consistent with `prepare_latents` (see #10712).
+        prompt_embeds_was_provided = prompt_embeds is not None
+        negative_prompt_embeds_was_provided = negative_prompt_embeds is not None
+
         if prompt_embeds is None:
             prompt_2 = prompt_2 or prompt
             prompt_2 = [prompt_2] if isinstance(prompt_2, str) else prompt_2
@@ -563,6 +570,28 @@ class StableDiffusion3ControlNetInpaintingPipeline(
             negative_prompt_embeds = torch.cat([negative_clip_prompt_embeds, t5_negative_prompt_embed], dim=-2)
             negative_pooled_prompt_embeds = torch.cat(
                 [negative_pooled_prompt_embed, negative_pooled_prompt_2_embed], dim=-1
+            )
+
+        # Apply `num_images_per_prompt` expansion to user-supplied embeddings to match
+        # what `_get_*_prompt_embeds` already does for freshly-encoded ones (#10712).
+        if prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = prompt_embeds.shape[-2], prompt_embeds.shape[-1]
+            prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, hidden_dim)
+            pooled_dim = pooled_prompt_embeds.shape[-1]
+            pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            pooled_prompt_embeds = pooled_prompt_embeds.view(batch_size * num_images_per_prompt, pooled_dim)
+
+        if do_classifier_free_guidance and negative_prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = negative_prompt_embeds.shape[-2], negative_prompt_embeds.shape[-1]
+            negative_prompt_embeds = negative_prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            negative_prompt_embeds = negative_prompt_embeds.view(
+                batch_size * num_images_per_prompt, seq_len, hidden_dim
+            )
+            pooled_dim = negative_pooled_prompt_embeds.shape[-1]
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.view(
+                batch_size * num_images_per_prompt, pooled_dim
             )
 
         if self.text_encoder is not None:

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_3.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_3.py
@@ -417,6 +417,13 @@ class StableDiffusion3PAGPipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSin
         else:
             batch_size = prompt_embeds.shape[0]
 
+        # The internal `_get_*_prompt_embeds` helpers expand the encoded embeddings
+        # by `num_images_per_prompt`, but user-supplied embeddings bypass that path.
+        # Track that here so we can apply the same expansion at the end and keep the
+        # batch dimension consistent with `prepare_latents` (see #10712).
+        prompt_embeds_was_provided = prompt_embeds is not None
+        negative_prompt_embeds_was_provided = negative_prompt_embeds is not None
+
         if prompt_embeds is None:
             prompt_2 = prompt_2 or prompt
             prompt_2 = [prompt_2] if isinstance(prompt_2, str) else prompt_2
@@ -511,6 +518,28 @@ class StableDiffusion3PAGPipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSin
             negative_prompt_embeds = torch.cat([negative_clip_prompt_embeds, t5_negative_prompt_embed], dim=-2)
             negative_pooled_prompt_embeds = torch.cat(
                 [negative_pooled_prompt_embed, negative_pooled_prompt_2_embed], dim=-1
+            )
+
+        # Apply `num_images_per_prompt` expansion to user-supplied embeddings to match
+        # what `_get_*_prompt_embeds` already does for freshly-encoded ones (#10712).
+        if prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = prompt_embeds.shape[-2], prompt_embeds.shape[-1]
+            prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, hidden_dim)
+            pooled_dim = pooled_prompt_embeds.shape[-1]
+            pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            pooled_prompt_embeds = pooled_prompt_embeds.view(batch_size * num_images_per_prompt, pooled_dim)
+
+        if do_classifier_free_guidance and negative_prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = negative_prompt_embeds.shape[-2], negative_prompt_embeds.shape[-1]
+            negative_prompt_embeds = negative_prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            negative_prompt_embeds = negative_prompt_embeds.view(
+                batch_size * num_images_per_prompt, seq_len, hidden_dim
+            )
+            pooled_dim = negative_pooled_prompt_embeds.shape[-1]
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.view(
+                batch_size * num_images_per_prompt, pooled_dim
             )
 
         if self.text_encoder is not None:

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_3_img2img.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_3_img2img.py
@@ -433,6 +433,13 @@ class StableDiffusion3PAGImg2ImgPipeline(DiffusionPipeline, SD3LoraLoaderMixin, 
         else:
             batch_size = prompt_embeds.shape[0]
 
+        # The internal `_get_*_prompt_embeds` helpers expand the encoded embeddings
+        # by `num_images_per_prompt`, but user-supplied embeddings bypass that path.
+        # Track that here so we can apply the same expansion at the end and keep the
+        # batch dimension consistent with `prepare_latents` (see #10712).
+        prompt_embeds_was_provided = prompt_embeds is not None
+        negative_prompt_embeds_was_provided = negative_prompt_embeds is not None
+
         if prompt_embeds is None:
             prompt_2 = prompt_2 or prompt
             prompt_2 = [prompt_2] if isinstance(prompt_2, str) else prompt_2
@@ -527,6 +534,28 @@ class StableDiffusion3PAGImg2ImgPipeline(DiffusionPipeline, SD3LoraLoaderMixin, 
             negative_prompt_embeds = torch.cat([negative_clip_prompt_embeds, t5_negative_prompt_embed], dim=-2)
             negative_pooled_prompt_embeds = torch.cat(
                 [negative_pooled_prompt_embed, negative_pooled_prompt_2_embed], dim=-1
+            )
+
+        # Apply `num_images_per_prompt` expansion to user-supplied embeddings to match
+        # what `_get_*_prompt_embeds` already does for freshly-encoded ones (#10712).
+        if prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = prompt_embeds.shape[-2], prompt_embeds.shape[-1]
+            prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, hidden_dim)
+            pooled_dim = pooled_prompt_embeds.shape[-1]
+            pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            pooled_prompt_embeds = pooled_prompt_embeds.view(batch_size * num_images_per_prompt, pooled_dim)
+
+        if do_classifier_free_guidance and negative_prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = negative_prompt_embeds.shape[-2], negative_prompt_embeds.shape[-1]
+            negative_prompt_embeds = negative_prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            negative_prompt_embeds = negative_prompt_embeds.view(
+                batch_size * num_images_per_prompt, seq_len, hidden_dim
+            )
+            pooled_dim = negative_pooled_prompt_embeds.shape[-1]
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.view(
+                batch_size * num_images_per_prompt, pooled_dim
             )
 
         if self.text_encoder is not None:

--- a/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
+++ b/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
@@ -426,6 +426,13 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
         else:
             batch_size = prompt_embeds.shape[0]
 
+        # The internal `_get_*_prompt_embeds` helpers expand the encoded embeddings
+        # by `num_images_per_prompt`, but user-supplied embeddings bypass that path.
+        # Track that here so we can apply the same expansion at the end and keep the
+        # batch dimension consistent with `prepare_latents` (see #10712).
+        prompt_embeds_was_provided = prompt_embeds is not None
+        negative_prompt_embeds_was_provided = negative_prompt_embeds is not None
+
         if prompt_embeds is None:
             prompt_2 = prompt_2 or prompt
             prompt_2 = [prompt_2] if isinstance(prompt_2, str) else prompt_2
@@ -520,6 +527,28 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
             negative_prompt_embeds = torch.cat([negative_clip_prompt_embeds, t5_negative_prompt_embed], dim=-2)
             negative_pooled_prompt_embeds = torch.cat(
                 [negative_pooled_prompt_embed, negative_pooled_prompt_2_embed], dim=-1
+            )
+
+        # Apply `num_images_per_prompt` expansion to user-supplied embeddings to match
+        # what `_get_*_prompt_embeds` already does for freshly-encoded ones (#10712).
+        if prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = prompt_embeds.shape[-2], prompt_embeds.shape[-1]
+            prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, hidden_dim)
+            pooled_dim = pooled_prompt_embeds.shape[-1]
+            pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            pooled_prompt_embeds = pooled_prompt_embeds.view(batch_size * num_images_per_prompt, pooled_dim)
+
+        if do_classifier_free_guidance and negative_prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = negative_prompt_embeds.shape[-2], negative_prompt_embeds.shape[-1]
+            negative_prompt_embeds = negative_prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            negative_prompt_embeds = negative_prompt_embeds.view(
+                batch_size * num_images_per_prompt, seq_len, hidden_dim
+            )
+            pooled_dim = negative_pooled_prompt_embeds.shape[-1]
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.view(
+                batch_size * num_images_per_prompt, pooled_dim
             )
 
         if self.text_encoder is not None:

--- a/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3_img2img.py
@@ -452,6 +452,13 @@ class StableDiffusion3Img2ImgPipeline(DiffusionPipeline, SD3LoraLoaderMixin, Fro
         else:
             batch_size = prompt_embeds.shape[0]
 
+        # The internal `_get_*_prompt_embeds` helpers expand the encoded embeddings
+        # by `num_images_per_prompt`, but user-supplied embeddings bypass that path.
+        # Track that here so we can apply the same expansion at the end and keep the
+        # batch dimension consistent with `prepare_latents` (see #10712).
+        prompt_embeds_was_provided = prompt_embeds is not None
+        negative_prompt_embeds_was_provided = negative_prompt_embeds is not None
+
         if prompt_embeds is None:
             prompt_2 = prompt_2 or prompt
             prompt_2 = [prompt_2] if isinstance(prompt_2, str) else prompt_2
@@ -546,6 +553,28 @@ class StableDiffusion3Img2ImgPipeline(DiffusionPipeline, SD3LoraLoaderMixin, Fro
             negative_prompt_embeds = torch.cat([negative_clip_prompt_embeds, t5_negative_prompt_embed], dim=-2)
             negative_pooled_prompt_embeds = torch.cat(
                 [negative_pooled_prompt_embed, negative_pooled_prompt_2_embed], dim=-1
+            )
+
+        # Apply `num_images_per_prompt` expansion to user-supplied embeddings to match
+        # what `_get_*_prompt_embeds` already does for freshly-encoded ones (#10712).
+        if prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = prompt_embeds.shape[-2], prompt_embeds.shape[-1]
+            prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, hidden_dim)
+            pooled_dim = pooled_prompt_embeds.shape[-1]
+            pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            pooled_prompt_embeds = pooled_prompt_embeds.view(batch_size * num_images_per_prompt, pooled_dim)
+
+        if do_classifier_free_guidance and negative_prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = negative_prompt_embeds.shape[-2], negative_prompt_embeds.shape[-1]
+            negative_prompt_embeds = negative_prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            negative_prompt_embeds = negative_prompt_embeds.view(
+                batch_size * num_images_per_prompt, seq_len, hidden_dim
+            )
+            pooled_dim = negative_pooled_prompt_embeds.shape[-1]
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.view(
+                batch_size * num_images_per_prompt, pooled_dim
             )
 
         if self.text_encoder is not None:

--- a/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3_inpaint.py
@@ -458,6 +458,13 @@ class StableDiffusion3InpaintPipeline(DiffusionPipeline, SD3LoraLoaderMixin, Fro
         else:
             batch_size = prompt_embeds.shape[0]
 
+        # The internal `_get_*_prompt_embeds` helpers expand the encoded embeddings
+        # by `num_images_per_prompt`, but user-supplied embeddings bypass that path.
+        # Track that here so we can apply the same expansion at the end and keep the
+        # batch dimension consistent with `prepare_latents` (see #10712).
+        prompt_embeds_was_provided = prompt_embeds is not None
+        negative_prompt_embeds_was_provided = negative_prompt_embeds is not None
+
         if prompt_embeds is None:
             prompt_2 = prompt_2 or prompt
             prompt_2 = [prompt_2] if isinstance(prompt_2, str) else prompt_2
@@ -552,6 +559,28 @@ class StableDiffusion3InpaintPipeline(DiffusionPipeline, SD3LoraLoaderMixin, Fro
             negative_prompt_embeds = torch.cat([negative_clip_prompt_embeds, t5_negative_prompt_embed], dim=-2)
             negative_pooled_prompt_embeds = torch.cat(
                 [negative_pooled_prompt_embed, negative_pooled_prompt_2_embed], dim=-1
+            )
+
+        # Apply `num_images_per_prompt` expansion to user-supplied embeddings to match
+        # what `_get_*_prompt_embeds` already does for freshly-encoded ones (#10712).
+        if prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = prompt_embeds.shape[-2], prompt_embeds.shape[-1]
+            prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, hidden_dim)
+            pooled_dim = pooled_prompt_embeds.shape[-1]
+            pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            pooled_prompt_embeds = pooled_prompt_embeds.view(batch_size * num_images_per_prompt, pooled_dim)
+
+        if do_classifier_free_guidance and negative_prompt_embeds_was_provided and num_images_per_prompt > 1:
+            seq_len, hidden_dim = negative_prompt_embeds.shape[-2], negative_prompt_embeds.shape[-1]
+            negative_prompt_embeds = negative_prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            negative_prompt_embeds = negative_prompt_embeds.view(
+                batch_size * num_images_per_prompt, seq_len, hidden_dim
+            )
+            pooled_dim = negative_pooled_prompt_embeds.shape[-1]
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.view(
+                batch_size * num_images_per_prompt, pooled_dim
             )
 
         if self.text_encoder is not None:

--- a/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3.py
+++ b/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3.py
@@ -223,6 +223,44 @@ class StableDiffusion3PipelineFastTests(unittest.TestCase, PipelineTesterMixin):
 
         self.assertEqual(output_full.shape, output_skip.shape, "Outputs should have the same shape")
 
+    def test_pipeline_accepts_prompt_embeds_with_num_images_per_prompt(self):
+        # Regression test for https://github.com/huggingface/diffusers/issues/10712: pre-computed
+        # `prompt_embeds` produced by `encode_prompt(num_images_per_prompt=k)` would crash the
+        # pipeline when the matching `num_images_per_prompt=k` was passed to `__call__` because
+        # only the prompt-encoding path expanded by `num_images_per_prompt`.
+        components = self.get_dummy_components()
+        pipe = self.pipeline_class(**components).to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
+
+        inputs = self.get_dummy_inputs(torch_device)
+        prompt = inputs.pop("prompt")
+        num_images_per_prompt = 2
+
+        prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds = (
+            pipe.encode_prompt(
+                prompt=prompt,
+                prompt_2=None,
+                prompt_3=None,
+                device=torch_device,
+                num_images_per_prompt=num_images_per_prompt,
+                do_classifier_free_guidance=True,
+            )
+        )
+
+        images = pipe(
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
+            num_images_per_prompt=num_images_per_prompt,
+            **inputs,
+        ).images
+
+        # 1 prompt * num_images_per_prompt (the pre-encoded batch dim) * num_images_per_prompt again
+        # — matches the SDXL behaviour of expanding once per `__call__`; the important assertion is
+        # that the pipeline no longer crashes.
+        self.assertEqual(images.shape[0], num_images_per_prompt * num_images_per_prompt)
+
 
 @slow
 @require_big_accelerator


### PR DESCRIPTION
# What does this PR do?

Fixes #10712.

`StableDiffusion3Pipeline.__call__` raises a `RuntimeError` when the caller passes pre-computed `prompt_embeds` together with `num_images_per_prompt > 1`:

```python
prompt_embeds, neg, pooled, neg_pooled = pipe.encode_prompt(
    prompt="...", do_classifier_free_guidance=True, num_images_per_prompt=2,
)
pipe(prompt_embeds=prompt_embeds, negative_prompt_embeds=neg,
     pooled_prompt_embeds=pooled, negative_pooled_prompt_embeds=neg_pooled,
     num_images_per_prompt=2)
# RuntimeError: size of tensor a (8) must match size of tensor b (4)
```

### Root cause

`encode_prompt` relies on `_get_clip_prompt_embeds` and `_get_t5_prompt_embeds` to apply the `num_images_per_prompt` expansion. Those helpers only run when `prompt_embeds is None`, so user-supplied embeddings keep their original batch dimension. `__call__` then computes `latents = prepare_latents(batch_size * num_images_per_prompt, ...)`, CFG doubles that to `2 * batch_size * num_images_per_prompt`, while `encoder_hidden_states` stays at `2 * batch_size`. The joint-attention block fails when it concatenates the two.

`StableDiffusionXLPipeline` is not affected because its `encode_prompt` applies the `repeat(1, num_images_per_prompt, 1).view(...)` expansion unconditionally after the if/else branch.

### Fix

Apply the same expansion to user-supplied `prompt_embeds` (and the matching `pooled_prompt_embeds`, `negative_prompt_embeds`, `negative_pooled_prompt_embeds`) at the end of `encode_prompt`. The change is propagated via `make fix-copies` to the img2img, inpaint, controlnet, and PAG variants:

- `pipeline_stable_diffusion_3_img2img.py`
- `pipeline_stable_diffusion_3_inpaint.py`
- `controlnet_sd3/pipeline_stable_diffusion_3_controlnet.py`
- `controlnet_sd3/pipeline_stable_diffusion_3_controlnet_inpainting.py`
- `pag/pipeline_pag_sd_3.py`
- `pag/pipeline_pag_sd_3_img2img.py`

Adds `test_pipeline_accepts_prompt_embeds_with_num_images_per_prompt`, which feeds the output of `encode_prompt(num_images_per_prompt=k)` back into the pipeline. Without the fix the test reproduces the `RuntimeError` from the issue; with the fix it passes.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? See #10712.
- [x] Did you make sure to update the documentation with your changes? The existing docstring for `num_images_per_prompt` already describes the intended behavior; this PR makes the implementation match it.
- [x] Did you write any new necessary tests?

## Who can review?

@yiyixuxu @sayakpaul