### PR TITLE
Fix FlowMatchEulerDiscreteScheduler double-shift in set_timesteps

### DIFF
--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -128,6 +128,10 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         timesteps = torch.from_numpy(timesteps).to(dtype=torch.float32)
 
         sigmas = timesteps / num_train_timesteps
+        # Record the pre-shift sigma range so `set_timesteps` rebuilds the same linear range and
+        # applies the static shift exactly once. Storing the post-shift values here would cause
+        # `set_timesteps` to shift an already-shifted sigma range a second time (see #13243).
+        sigmas_unshifted = sigmas
         if not use_dynamic_shifting:
             # when use_dynamic_shifting is True, we apply the timestep shifting on the fly based on the image resolution
             sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)
@@ -140,8 +144,8 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         self._shift = shift
 
         self.sigmas = sigmas.to("cpu")  # to avoid too much CPU/GPU communication
-        self.sigma_min = self.sigmas[-1].item()
-        self.sigma_max = self.sigmas[0].item()
+        self.sigma_min = sigmas_unshifted[-1].item()
+        self.sigma_max = sigmas_unshifted[0].item()
 
     @property
     def shift(self):

--- a/tests/schedulers/test_scheduler_flow_match_euler_discrete.py
+++ b/tests/schedulers/test_scheduler_flow_match_euler_discrete.py
@@ -1,0 +1,44 @@
+import torch
+
+from diffusers import FlowMatchEulerDiscreteScheduler
+
+
+def test_set_timesteps_matches_init_with_static_shift():
+    """Regression for #13243: with `use_dynamic_shifting=False` and matching
+    `num_inference_steps`, `set_timesteps` must reproduce the same sigmas as
+    `__init__`. Previously `sigma_min`/`sigma_max` stored the post-shift values,
+    so `set_timesteps` rebuilt sigmas in shifted space and then applied the
+    shift again, producing a different schedule for the same arguments.
+    """
+    num_train_timesteps = 1000
+    shift = 3.0
+
+    scheduler = FlowMatchEulerDiscreteScheduler(
+        num_train_timesteps=num_train_timesteps,
+        shift=shift,
+        use_dynamic_shifting=False,
+    )
+    init_sigmas = scheduler.sigmas.clone()
+
+    scheduler.set_timesteps(num_inference_steps=num_train_timesteps)
+
+    # set_timesteps appends a trailing 0.0 sentinel; compare the leading entries.
+    assert torch.allclose(init_sigmas, scheduler.sigmas[:-1], atol=1e-5), (
+        f"set_timesteps produced a different schedule than __init__ for the same "
+        f"args. init[-3:]={init_sigmas[-3:].tolist()} "
+        f"post[-3:]={scheduler.sigmas[-4:-1].tolist()}"
+    )
+
+
+def test_dynamic_shifting_is_unaffected():
+    """With `use_dynamic_shifting=True` no static shift runs in `__init__`,
+    so the pre-existing behavior must be preserved by the fix."""
+    scheduler = FlowMatchEulerDiscreteScheduler(
+        num_train_timesteps=1000,
+        shift=3.0,
+        use_dynamic_shifting=True,
+    )
+    # Without dynamic shift inputs (mu) we just check sigma_min/max are the
+    # untouched linear endpoints (1.0 at top, 1/N at bottom).
+    assert scheduler.sigma_max == 1.0
+    assert abs(scheduler.sigma_min - 1.0 / 1000) < 1e-6


### PR DESCRIPTION
## What does this PR do?

Fixes #13243 — `FlowMatchEulerDiscreteScheduler.set_timesteps` applies the static timestep shift a second time when `use_dynamic_shifting=False`, so calling `set_timesteps(num_train_timesteps)` on a scheduler produces a different sigma schedule than the one `__init__` cached.

### Root cause

`__init__` records `sigma_min`/`sigma_max` from the **post-shift** sigma range:

```python
sigmas = timesteps / num_train_timesteps
if not use_dynamic_shifting:
    sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)  # ← shift applied
...
self.sigma_min = self.sigmas[-1].item()  # ← post-shift value
self.sigma_max = self.sigmas[0].item()   # ← post-shift value
```

`set_timesteps` then rebuilds sigmas via `linspace(_sigma_to_t(sigma_max), _sigma_to_t(sigma_min), N)` — already in shifted space — and applies the same shift again:

```python
sigmas = self.shift * sigmas / (1 + (self.shift - 1) * sigmas)
```

### Reproduction

```python
from diffusers import FlowMatchEulerDiscreteScheduler
import torch

s = FlowMatchEulerDiscreteScheduler(num_train_timesteps=1000, shift=3.0, use_dynamic_shifting=False)
init_sigmas = s.sigmas.clone()
s.set_timesteps(num_inference_steps=1000)

print(init_sigmas[-3:])       # tensor([0.0089, 0.0060, 0.0030])
print(s.sigmas[-4:-1])        # tensor([0.0148, 0.0119, 0.0089])  ← different
torch.allclose(init_sigmas, s.sigmas[:-1])  # False
```

The same args produce two different schedules.

### Fix

Record the pre-shift sigmas in `__init__` and derive `sigma_min`/`sigma_max` from them. `set_timesteps` then regenerates the linear sigma range correctly and the static shift is applied exactly once. `self.sigmas` is unchanged (still post-shift); only the cached endpoints change.

### Test

Added `tests/schedulers/test_scheduler_flow_match_euler_discrete.py`:

- `test_set_timesteps_matches_init_with_static_shift` — fails on `main`, passes with the fix.
- `test_dynamic_shifting_is_unaffected` — pins that the `use_dynamic_shifting=True` path is untouched (no static shift in `__init__`, so this code path never had the bug).

## Before submitting
- [x] This PR fixes a bug — links #13243 with a clear repro.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests? — Yes, regression test added.

## Who can review?

@yiyixuxu @DN6
