### PR TITLE
schedulers/scheduling_dpmsolver_multistep: round timesteps for exponential and beta sigma schedules

### DIFF
--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -455,10 +455,12 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_exponential(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
+            timesteps = timesteps.round()
         elif self.config.use_beta_sigmas:
             sigmas = np.flip(sigmas).copy()
             sigmas = self._convert_to_beta(in_sigmas=sigmas, num_inference_steps=num_inference_steps)
             timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
+            timesteps = timesteps.round()
         elif self.config.use_flow_sigmas:
             alphas = np.linspace(1, 1 / self.config.num_train_timesteps, num_inference_steps + 1)
             sigmas = 1.0 - alphas


### PR DESCRIPTION
# What does this PR do?

In `DPMSolverMultistepScheduler.set_timesteps`, the `use_karras_sigmas` and
`use_lu_lambdas` branches both call `timesteps.round()` after computing
timesteps via `_sigma_to_t` (which returns floating-point values through
interpolation), before those timesteps are cast to `torch.int64`.

The `use_exponential_sigmas` and `use_beta_sigmas` branches were missing this
`.round()` call, causing raw float values to be **truncated** (not rounded) on
the `torch.int64` cast at the end of `set_timesteps`. This silently introduces
a systematic off-by-one error in the noise schedule index lookup whenever
either of these two sigma modes is used with this scheduler.

This PR adds `timesteps = timesteps.round()` to both branches, consistent with
the existing pattern already established by `use_karras_sigmas` and
`use_lu_lambdas`.

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@DN6