### PR TITLE
update safetensors.torch._tobytes to safetensors.torch._to_ndarray

### DIFF
--- a/src/diffusers/utils/remote_utils.py
+++ b/src/diffusers/utils/remote_utils.py
@@ -183,7 +183,7 @@ def prepare_decode(
         headers["Accept"] = "image/png"
     elif output_type == "mp4":
         headers["Accept"] = "text/plain"
-    tensor_data = safetensors.torch._tobytes(tensor, "tensor")
+    tensor_data = safetensors.torch._to_ndarray(tensor)[0].tobytes()
     return {"data": tensor_data, "params": parameters, "headers": headers}
 
 
@@ -369,7 +369,7 @@ def prepare_encode(
     if shift_factor is not None:
         parameters["shift_factor"] = shift_factor
     if isinstance(image, torch.Tensor):
-        data = safetensors.torch._tobytes(image.contiguous(), "tensor")
+        data = safetensors.torch._to_ndarray(image.contiguous())[0].tobytes()
         parameters["shape"] = list(image.shape)
         parameters["dtype"] = str(image.dtype).split(".")[-1]
     else:


### PR DESCRIPTION
since the api is changed in safetensors 0.8.0rc0

@sayakpaul 

the crash like
```
=
______________________________ RemoteAutoencoderKLHunyuanVideoTests.test_output_type_pil_image_format ______________________________

self = <tests.remote.test_remote_decode.RemoteAutoencoderKLHunyuanVideoTests testMethod=test_output_type_pil_image_format>

    def test_output_type_pil_image_format(self):
        inputs = self.get_dummy_inputs()
        processor = self.processor_cls()
>       output = remote_decode(output_type="pil", processor=processor, image_format="png", **inputs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/remote/test_remote_decode.py:284:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/diffusers/utils/remote_utils.py:314: in remote_decode
    kwargs = prepare_decode(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

tensor = tensor([[[[[ 1.0605e+00,  3.8159e-01,  3.9355e-01,  ...,  1.5784e-01,
            -5.4102e-01, -1.0566e+00],
         ...76e-01, -7.9102e-01,  ...,  5.4834e-01,
             7.3584e-01,  1.6416e+00]]]]], device='xpu:0', dtype=torch.float16)
processor = VideoProcessor {
  "_class_name": "VideoProcessor",
  "_diffusers_version": "0.39.0.dev0",
  "do_binarize": false,
  "..._resize": true,
  "reducing_gap": null,
  "resample": "lanczos",
  "vae_latent_channels": 4,
  "vae_scale_factor": 8
}

do_scaling = True, scaling_factor = 0.476986, shift_factor = None, output_type = 'pil', image_format = 'png'
partial_postprocess = False, height = None, width = None

    def prepare_decode(
        tensor: "torch.Tensor",
        processor: "VaeImageProcessor" | "VideoProcessor" | None = None,
        do_scaling: bool = True,
        scaling_factor: float | None = None,
        shift_factor: float | None = None,
        output_type: Literal["mp4", "pil", "pt"] = "pil",
        image_format: Literal["png", "jpg"] = "jpg",
        partial_postprocess: bool = False,
        height: int | None = None,
        width: int | None = None,
    ):
        headers = {}
        parameters = {
            "image_format": image_format,
            "output_type": output_type,
            "partial_postprocess": partial_postprocess,
            "shape": list(tensor.shape),
            "dtype": str(tensor.dtype).split(".")[-1],
        }
        if do_scaling and scaling_factor is not None:
            parameters["scaling_factor"] = scaling_factor
        if do_scaling and shift_factor is not None:
            parameters["shift_factor"] = shift_factor
        if do_scaling and scaling_factor is None:
            parameters["do_scaling"] = do_scaling
        elif do_scaling and scaling_factor is None and shift_factor is None:
            parameters["do_scaling"] = do_scaling
        if height is not None and width is not None:
            parameters["height"] = height
            parameters["width"] = width
        headers["Content-Type"] = "tensor/binary"
        headers["Accept"] = "tensor/binary"
        if output_type == "pil" and image_format == "jpg" and processor is None:
            headers["Accept"] = "image/jpeg"
        elif output_type == "pil" and image_format == "png" and processor is None:
            headers["Accept"] = "image/png"
        elif output_type == "mp4":
            headers["Accept"] = "text/plain"
>       tensor_data = safetensors.torch._tobytes(tensor, "tensor")
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
E       AttributeError: module 'safetensors.torch' has no attribute '_tobytes'

src/diffusers/utils/remote_utils.py:186: AttributeError
```