### PR TITLE
schedulers/dpmsolver_multistep: add missing `sde-dpmsolver` branch in third-order update

### DIFF
--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -1133,6 +1133,15 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
                 + (alpha_t * ((1.0 - torch.exp(-2.0 * h) - 2.0 * h) / (2.0 * h) ** 2 - 0.5)) * D2
                 + sigma_t * torch.sqrt(1.0 - torch.exp(-2 * h)) * noise
             )
+        elif self.config.algorithm_type == "sde-dpmsolver":
+            assert noise is not None
+            x_t = (
+                (alpha_t / alpha_s0) * sample
+                - 2.0 * (sigma_t * (torch.exp(h) - 1.0)) * D0
+                - 2.0 * (sigma_t * ((torch.exp(h) - 1.0) / h - 1.0)) * D1
+                - 2.0 * (sigma_t * ((torch.exp(h) - 1.0 - h) / h**2 - 0.5)) * D2
+                + sigma_t * torch.sqrt(torch.exp(2 * h) - 1.0) * noise
+            )
         return x_t
 
     def index_for_timestep(


### PR DESCRIPTION
This happens silently after the two lower-order warm-up steps complete (i.e. on step 3+),
making it a hard runtime crash for any user who configures `sde-dpmsolver` with
`solver_order=3`.

The fix adds the missing `elif self.config.algorithm_type == "sde-dpmsolver"` branch,
derived from the same factor-of-2 doubling pattern that governs the `sde-dpmsolver`
formulation relative to `dpmsolver` at every other order (per Appendix A of the
[DPMSolver paper](https://huggingface.co/papers/2206.00927)), and using the identical
noise term `sigma_t * sqrt(exp(2h) - 1) * noise` already present in the 1st- and
2nd-order `sde-dpmsolver` branches.

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?
@yiyixuxu