### PR TITLE
Fix `EMAModel.restore()` foreach path crashing with device mismatch when model is on GPU

### DIFF
--- a/src/diffusers/training_utils.py
+++ b/src/diffusers/training_utils.py
@@ -856,11 +856,6 @@ class EMAModel:
         else:
             for c_param, param in zip(self.temp_stored_params, parameters):
                 param.data.copy_(c_param.data)
-                [c_param.to(param.device).data for c_param, param in zip(self.temp_stored_params, parameters)],
-            )
-        else:
-            for c_param, param in zip(self.temp_stored_params, parameters):
-                param.data.copy_(c_param.data)
         # Better memory-wise.
         self.temp_stored_params = None
 

--- a/src/diffusers/training_utils.py
+++ b/src/diffusers/training_utils.py
@@ -850,12 +850,12 @@ class EMAModel:
             raise RuntimeError("This ExponentialMovingAverage has no `store()`ed weights to `restore()`")
         if self.foreach:
             torch._foreach_copy_(
-                [param.data for param in parameters], [c_param.data for c_param in self.temp_stored_params]
+                [param.data for param in parameters],
+                [c_param.to(param.device).data for c_param, param in zip(self.temp_stored_params, parameters)],
             )
         else:
             for c_param, param in zip(self.temp_stored_params, parameters):
                 param.data.copy_(c_param.data)
-
         # Better memory-wise.
         self.temp_stored_params = None
 

--- a/src/diffusers/training_utils.py
+++ b/src/diffusers/training_utils.py
@@ -856,6 +856,11 @@ class EMAModel:
         else:
             for c_param, param in zip(self.temp_stored_params, parameters):
                 param.data.copy_(c_param.data)
+                [c_param.to(param.device).data for c_param, param in zip(self.temp_stored_params, parameters)],
+            )
+        else:
+            for c_param, param in zip(self.temp_stored_params, parameters):
+                param.data.copy_(c_param.data)
         # Better memory-wise.
         self.temp_stored_params = None
 

--- a/tests/others/test_ema.py
+++ b/tests/others/test_ema.py
@@ -180,28 +180,6 @@ class EMAModelTests(unittest.TestCase):
         assert torch.allclose(output, output_loaded, atol=1e-4)
 
     def test_store_restore(self):
-        # The foreach restore() path passed raw CPU tensors from store() to
-        # torch._foreach_copy_(), which requires same-device tensors and therefore
-        # crashes on GPU.  Fix: mirror copy_to()'s pattern of moving each stored
-        # tensor to param.device before the foreach copy.
-        unet, ema_unet = self.get_models()
-        original_params = [p.data.clone() for p in unet.parameters()]
-
-        # Simulate one EMA step so shadow params differ from model params.
-        unet = self.simulate_backprop(unet)
-        ema_unet.step(unet.parameters())
-
-        # Standard EMA validation pattern: store → copy_to → restore.
-        ema_unet.store(unet.parameters())
-        ema_unet.copy_to(unet.parameters())
-        ema_unet.restore(unet.parameters())
-
-        # After restore(), model weights must equal the pre-copy_to values.
-        for restored, original in zip(unet.parameters(), original_params):
-            assert torch.allclose(restored.data, original.to(restored.device), atol=1e-6), (
-                "restore() foreach path did not correctly recover the stored parameters"
-            )
-    def test_store_restore(self):
         # store() saves params to CPU; restore() must move them back to the model's
         # device before copying.  The non-foreach path uses copy_() which is
         # cross-device safe; this test guards that restore() actually round-trips

--- a/tests/others/test_ema.py
+++ b/tests/others/test_ema.py
@@ -378,3 +378,20 @@ class EMAModelTestsForeach(unittest.TestCase):
         output_loaded = loaded_unet(noisy_latents, timesteps, encoder_hidden_states).sample
 
         assert torch.allclose(output, output_loaded, atol=1e-4)
+
+    def test_store_restore(self):
+        # The foreach restore() path passed raw CPU tensors from store() to
+        # torch._foreach_copy_(), which requires same-device tensors and therefore
+        # crashes on GPU. Fix: mirror copy_to()'s pattern of moving each stored
+        # tensor to param.device before the foreach copy.
+        unet, ema_unet = self.get_models()
+        original_params = [p.data.clone() for p in unet.parameters()]
+        unet = self.simulate_backprop(unet)
+        ema_unet.step(unet.parameters())
+        ema_unet.store(unet.parameters())
+        ema_unet.copy_to(unet.parameters())
+        ema_unet.restore(unet.parameters())
+        for restored, original in zip(unet.parameters(), original_params):
+            assert torch.allclose(restored.data, original.to(restored.device), atol=1e-6), (
+                "restore() foreach path did not correctly recover the stored parameters"
+            )

--- a/tests/others/test_ema.py
+++ b/tests/others/test_ema.py
@@ -179,6 +179,51 @@ class EMAModelTests(unittest.TestCase):
 
         assert torch.allclose(output, output_loaded, atol=1e-4)
 
+    def test_store_restore(self):
+        # The foreach restore() path passed raw CPU tensors from store() to
+        # torch._foreach_copy_(), which requires same-device tensors and therefore
+        # crashes on GPU.  Fix: mirror copy_to()'s pattern of moving each stored
+        # tensor to param.device before the foreach copy.
+        unet, ema_unet = self.get_models()
+        original_params = [p.data.clone() for p in unet.parameters()]
+
+        # Simulate one EMA step so shadow params differ from model params.
+        unet = self.simulate_backprop(unet)
+        ema_unet.step(unet.parameters())
+
+        # Standard EMA validation pattern: store → copy_to → restore.
+        ema_unet.store(unet.parameters())
+        ema_unet.copy_to(unet.parameters())
+        ema_unet.restore(unet.parameters())
+
+        # After restore(), model weights must equal the pre-copy_to values.
+        for restored, original in zip(unet.parameters(), original_params):
+            assert torch.allclose(restored.data, original.to(restored.device), atol=1e-6), (
+                "restore() foreach path did not correctly recover the stored parameters"
+            )
+    def test_store_restore(self):
+        # store() saves params to CPU; restore() must move them back to the model's
+        # device before copying.  The non-foreach path uses copy_() which is
+        # cross-device safe; this test guards that restore() actually round-trips
+        # the original weights regardless of device.
+        unet, ema_unet = self.get_models()
+        original_params = [p.data.clone() for p in unet.parameters()]
+
+        # Simulate one EMA step so shadow params differ from model params.
+        unet = self.simulate_backprop(unet)
+        ema_unet.step(unet.parameters())
+
+        # Standard EMA validation pattern: store → copy_to → restore.
+        ema_unet.store(unet.parameters())
+        ema_unet.copy_to(unet.parameters())
+        ema_unet.restore(unet.parameters())
+
+        # After restore(), model weights must equal the pre-copy_to values.
+        for restored, original in zip(unet.parameters(), original_params):
+            assert torch.allclose(restored.data, original.to(restored.device), atol=1e-6), (
+                "restore() did not correctly recover the stored parameters"
+            )
+
 
 class EMAModelTestsForeach(unittest.TestCase):
     model_id = "hf-internal-testing/tiny-stable-diffusion-pipe"


### PR DESCRIPTION
# What does this PR do?

Fixes a runtime crash in `EMAModel.restore()` when `foreach=True` and the model lives on a non-CPU device (e.g. CUDA).

`store()` always saves parameters to CPU (`param.detach().cpu().clone()`). The `foreach` path in `restore()` then passed those raw CPU tensors directly to `torch._foreach_copy_()`, which requires all tensors to be on the same device:

```python
# before (broken on GPU)
torch._foreach_copy_(
    [param.data for param in parameters],
    [c_param.data for c_param in self.temp_stored_params],  # always CPU
)
```

This raises `RuntimeError: Expected all tensors to be on same device` for any user who calls the standard EMA validation pattern (`store → copy_to → restore`) with `foreach=True` on a GPU machine.

The fix mirrors the pattern already used correctly in `copy_to()`'s foreach path (line 780), which moves each shadow param to the target device before the copy:

```python
# after (matches copy_to() pattern)
torch._foreach_copy_(
    [param.data for param in parameters],
    [c_param.to(param.device).data for c_param, param in zip(self.temp_stored_params, parameters)],
)
```

Also adds `test_store_restore` to both `EMAModelTests` and `EMAModelTestsForeach` — the store/restore round-trip was completely untested prior to this PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@sayakpaul