### PR TITLE
Fix AttentionModuleMixin.set_attention_backend skipping hub kernel download

### DIFF
--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -159,13 +159,19 @@ class AttentionModuleMixin:
             return self.processor
 
     def set_attention_backend(self, backend: str):
-        from .attention_dispatch import AttentionBackendName
+        from .attention_dispatch import (
+            AttentionBackendName,
+            _check_attention_backend_requirements,
+            _maybe_download_kernel_for_backend,
+        )
 
         available_backends = {x.value for x in AttentionBackendName.__members__.values()}
         if backend not in available_backends:
             raise ValueError(f"`{backend=}` must be one of the following: " + ", ".join(available_backends))
 
         backend = AttentionBackendName(backend.lower())
+        _check_attention_backend_requirements(backend)
+        _maybe_download_kernel_for_backend(backend)
         self.processor._attention_backend = backend
 
     def set_use_npu_flash_attention(self, use_npu_flash_attention: bool) -> None:

--- a/tests/models/test_attention_processor.py
+++ b/tests/models/test_attention_processor.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 import tempfile
 import unittest
+import unittest.mock as mock
 
 import numpy as np
 import pytest
@@ -8,6 +9,7 @@ import torch
 from packaging import version
 
 from diffusers import DiffusionPipeline
+from diffusers.models.attention import AttentionModuleMixin
 from diffusers.models.attention_processor import Attention, AttnAddedKVProcessor
 
 from ..testing_utils import torch_device
@@ -133,3 +135,42 @@ class DeprecatedAttentionBlockTests(unittest.TestCase):
 
         self.assertTrue(np.allclose(pre_conversion, conversion, atol=1e-3))
         self.assertTrue(np.allclose(conversion, after_conversion, atol=1e-3))
+
+
+class AttentionModuleMixinSetBackendTests(unittest.TestCase):
+    """Regression tests for `AttentionModuleMixin.set_attention_backend` (issue #13284).
+
+    When called on an individual submodule, the per-module setter must trigger the
+    same hub kernel download path that the model-level setter on `ModelMixin` does.
+    Otherwise hub-only backends (e.g. `sage_hub`) are silently configured without
+    their kernel ever being loaded and inference fails later inside
+    `dispatch_attention_fn`.
+    """
+
+    class _DummyProcessor:
+        _attention_backend = None
+
+    class _DummyAttention(AttentionModuleMixin):
+        def __init__(self):
+            self.processor = AttentionModuleMixinSetBackendTests._DummyProcessor()
+
+    def test_set_attention_backend_invokes_kernel_download_for_hub_backend(self):
+        module = self._DummyAttention()
+
+        with (
+            mock.patch("diffusers.models.attention_dispatch._check_attention_backend_requirements") as mocked_check,
+            mock.patch("diffusers.models.attention_dispatch._maybe_download_kernel_for_backend") as mocked_download,
+        ):
+            module.set_attention_backend("sage_hub")
+
+        from diffusers.models.attention_dispatch import AttentionBackendName
+
+        mocked_check.assert_called_once_with(AttentionBackendName.SAGE_HUB)
+        mocked_download.assert_called_once_with(AttentionBackendName.SAGE_HUB)
+        self.assertEqual(module.processor._attention_backend, AttentionBackendName.SAGE_HUB)
+
+    def test_set_attention_backend_rejects_unknown_backend(self):
+        module = self._DummyAttention()
+
+        with self.assertRaises(ValueError):
+            module.set_attention_backend("not_a_real_backend")


### PR DESCRIPTION
## What does this PR do?

Fixes #13284.

`AttentionModuleMixin.set_attention_backend` (`src/diffusers/models/attention.py`) validated the backend name and set `self.processor._attention_backend`, but skipped the `_check_attention_backend_requirements(...)` and `_maybe_download_kernel_for_backend(...)` calls that `ModelMixin.set_attention_backend` (`src/diffusers/models/modeling_utils.py`) performs. As a result, applying a hub backend like `sage_hub` only to individual attention submodules silently left the kernel registry uninitialized and inference crashed later with `TypeError: 'NoneType' object is not callable` inside `dispatch_attention_fn`.

The fix mirrors the requirement-check and kernel-download steps into the submodule setter so per-block backend overrides work for hub kernels too.

## Reproduction

The repro from the issue (`Wan-AI/Wan2.1-T2V-1.3B-Diffusers` + per-submodule `sage_hub`) now runs through inference without the `NoneType` crash, and the underlying `_HUB_KERNELS_REGISTRY` entry for `sage_hub` is populated as expected.

## Tests

Added a regression test in `tests/models/test_attention_processor.py::AttentionModuleMixinSetBackendTests` that:

- calls `set_attention_backend("sage_hub")` on a minimal `AttentionModuleMixin` instance and asserts both `_check_attention_backend_requirements` and `_maybe_download_kernel_for_backend` are invoked with the resolved backend (using `unittest.mock.patch` so no kernel download or GPU is required), and that `processor._attention_backend` is updated;
- asserts that passing an unknown backend name still raises `ValueError`.

Both tests pass on the fix and fail on `main` (verified by temporarily reverting the source change).

## Before submitting
- [x] This PR fixes a typo or improves the docs (no quality tests required)? No, bug fix.
- [x] Did you read the contributor guideline?
- [x] Did you write any new necessary tests? Yes.

## Who can review?

@yiyixuxu @DN6 @sayakpaul