### PR TITLE
Point users at AOBaseConfig replacement when passing string quant_type to TorchAoConfig

### DIFF
--- a/src/diffusers/quantizers/quantization_config.py
+++ b/src/diffusers/quantizers/quantization_config.py
@@ -476,7 +476,55 @@ class TorchAoConfig(QuantizationConfigMixin):
         from torchao.quantization.quant_api import AOBaseConfig
 
         if not isinstance(self.quant_type, AOBaseConfig):
+            if isinstance(self.quant_type, str):
+                raise TypeError(self._build_string_quant_type_error(self.quant_type))
             raise TypeError(f"quant_type must be an AOBaseConfig instance, got {type(self.quant_type).__name__}")
+
+    @staticmethod
+    def _build_string_quant_type_error(quant_type: str) -> str:
+        """Build a migration-guidance error for legacy string ``quant_type`` values.
+
+        Older diffusers releases accepted lowercase strings such as ``"int8_weight_only"`` or ``"float8dq_e4m3_row"``.
+        That path was removed (see PR #13291) in favour of passing an ``AOBaseConfig`` subclass instance from
+        ``torchao.quantization`` directly. Users on torchao >= 0.16 also hit this because the legacy lowercase
+        factories were removed upstream. This helper surfaces the rename so users can self-migrate.
+        """
+        # Map common legacy strings to their torchao Config-class replacements. We deliberately
+        # do not auto-instantiate the Config; the new API exposes options (granularity, dtype,
+        # version, ...) the legacy strings hard-coded, and silent defaults would be surprising.
+        legacy_to_config = {
+            "int4wo": "Int4WeightOnlyConfig",
+            "int4_weight_only": "Int4WeightOnlyConfig",
+            "int8wo": "Int8WeightOnlyConfig",
+            "int8_weight_only": "Int8WeightOnlyConfig",
+            "int8dq": "Int8DynamicActivationInt8WeightConfig",
+            "int8_dynamic_activation_int8_weight": "Int8DynamicActivationInt8WeightConfig",
+            "float8wo": "Float8WeightOnlyConfig",
+            "float8wo_e4m3": "Float8WeightOnlyConfig",
+            "float8wo_e5m2": "Float8WeightOnlyConfig",
+            "float8_weight_only": "Float8WeightOnlyConfig",
+            "float8dq": "Float8DynamicActivationFloat8WeightConfig",
+            "float8dq_e4m3": "Float8DynamicActivationFloat8WeightConfig",
+            "float8dq_e4m3_row": "Float8DynamicActivationFloat8WeightConfig",
+            "float8dq_e4m3_tensor": "Float8DynamicActivationFloat8WeightConfig",
+            "float8_dynamic_activation_float8_weight": "Float8DynamicActivationFloat8WeightConfig",
+            "float8_static_activation_float8_weight": "Float8StaticActivationFloat8WeightConfig",
+        }
+        suggestion = legacy_to_config.get(quant_type)
+        message = (
+            f"TorchAoConfig no longer accepts string quant_type values (got {quant_type!r}); "
+            "pass an AOBaseConfig instance from torchao.quantization instead."
+        )
+        if suggestion is not None:
+            message += (
+                f" For {quant_type!r}, use "
+                f"`from torchao.quantization import {suggestion}; TorchAoConfig({suggestion}())`."
+            )
+        message += (
+            " See https://huggingface.co/docs/diffusers/main/en/quantization/torchao for "
+            "the full list of supported AOBaseConfig classes."
+        )
+        return message
 
     def to_dict(self):
         """Convert configuration to a dictionary."""

--- a/tests/quantization/torchao/test_torchao.py
+++ b/tests/quantization/torchao/test_torchao.py
@@ -112,6 +112,31 @@ class TorchAoConfigTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             _ = TorchAoConfig(42)
 
+    def test_string_quant_type_error_includes_migration_hint(self):
+        """
+        Passing a legacy string quant_type should raise TypeError and the message should name the
+        replacement AOBaseConfig class so users on torchao >= 0.16 (where the legacy lowercase
+        factories were removed) can self-migrate. See issues #13286 and #13266.
+        """
+        legacy_to_config = {
+            "int8_weight_only": "Int8WeightOnlyConfig",
+            "int8wo": "Int8WeightOnlyConfig",
+            "float8_weight_only": "Float8WeightOnlyConfig",
+            "float8dq_e4m3_row": "Float8DynamicActivationFloat8WeightConfig",
+            "float8_dynamic_activation_float8_weight": "Float8DynamicActivationFloat8WeightConfig",
+        }
+        for legacy, config_name in legacy_to_config.items():
+            with self.assertRaises(TypeError) as cm:
+                TorchAoConfig(legacy)
+            message = str(cm.exception)
+            self.assertIn(repr(legacy), message)
+            self.assertIn(config_name, message)
+
+        # Strings without a known mapping should still raise TypeError and point at the docs.
+        with self.assertRaises(TypeError) as cm:
+            TorchAoConfig("not_a_real_quant_type")
+        self.assertIn("AOBaseConfig", str(cm.exception))
+
     def test_repr(self):
         """
         Check that there is no error in the repr


### PR DESCRIPTION
## What does this PR do?

Fixes #13286. Also covers the diffusers-side root cause behind #13266.

PR #13291 removed the string-based `quant_type` path from `TorchAoConfig` in favour of an `AOBaseConfig` subclass instance from `torchao.quantization` (e.g. `Int8WeightOnlyConfig()`). That cleanup is good, but the remaining error for a string input,

```
TypeError: quant_type must be an AOBaseConfig instance, got str
```

doesn't name a replacement. Users running existing code, especially against `torchao >= 0.16` where the legacy lowercase factories (`float8_weight_only`, `int8_weight_only`, `float8_dynamic_activation_float8_weight`, ...) were removed upstream, hit the rename without a concrete migration path.

This PR maps the common legacy strings to their `Config` class replacements and surfaces that mapping in the `TypeError`, so the error itself tells the user which import to add and how to instantiate it. Unknown strings still raise but point at the torchao quantization docs. The non-string branch is unchanged, and the public surface (`TorchAoConfig(AOBaseConfig)`) is untouched.

## Before this PR

```python
>>> from diffusers import TorchAoConfig
>>> TorchAoConfig("float8dq_e4m3_row")
TypeError: quant_type must be an AOBaseConfig instance, got str
```

## After this PR

```python
>>> from diffusers import TorchAoConfig
>>> TorchAoConfig("float8dq_e4m3_row")
TypeError: TorchAoConfig no longer accepts string quant_type values (got 'float8dq_e4m3_row');
pass an AOBaseConfig instance from torchao.quantization instead. For 'float8dq_e4m3_row', use
`from torchao.quantization import Float8DynamicActivationFloat8WeightConfig;
 TorchAoConfig(Float8DynamicActivationFloat8WeightConfig())`. See
https://huggingface.co/docs/diffusers/main/en/quantization/torchao for the full list of
supported AOBaseConfig classes.
```

The suggestion does not auto-instantiate the Config for the user: the new API exposes options (granularity, dtype, version, ...) that the legacy strings hard-coded (e.g. `float8dq_e4m3_row` set `granularity=(PerRow(), PerRow())`), and silently picking a default would be surprising. Naming the class is enough to unblock migration.

## Tests

Added `test_string_quant_type_error_includes_migration_hint` to `tests/quantization/torchao/test_torchao.py` covering both reproductions from the linked issues (`float8dq_e4m3_row`, `int8wo`, `float8_weight_only`, ...) and an unknown-string fallback. The pre-existing `test_post_init_check` still passes unchanged.

```
$ pytest tests/quantization/torchao/test_torchao.py::TorchAoConfigTest -v
tests/quantization/torchao/test_torchao.py::TorchAoConfigTest::test_post_init_check PASSED
tests/quantization/torchao/test_torchao.py::TorchAoConfigTest::test_repr PASSED
tests/quantization/torchao/test_torchao.py::TorchAoConfigTest::test_string_quant_type_error_includes_migration_hint PASSED
tests/quantization/torchao/test_torchao.py::TorchAoConfigTest::test_to_dict PASSED
4 passed
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case). Improves an error message.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our philosophy doc (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Issues #13286 and #13266.
- [x] Did you make sure to update the documentation with your changes? Error message links to the existing torchao quantization doc page.
- [x] Did you write any new necessary tests?

## Who can review?

@sayakpaul @DN6 - tagging the reviewers from PR #13291 (the original string-removal PR) since this is a follow-up on the same surface.