### PR TITLE
Fix from_pretrain typo in StableCascade and Wuerstchen docstrings

### DIFF
--- a/src/diffusers/pipelines/deprecated/wuerstchen/pipeline_wuerstchen.py
+++ b/src/diffusers/pipelines/deprecated/wuerstchen/pipeline_wuerstchen.py
@@ -45,7 +45,7 @@ EXAMPLE_DOC_STRING = """
         >>> prior_pipe = WuerstchenPriorPipeline.from_pretrained(
         ...     "warp-ai/wuerstchen-prior", torch_dtype=torch.float16
         ... ).to("cuda")
-        >>> gen_pipe = WuerstchenDecoderPipeline.from_pretrain("warp-ai/wuerstchen", torch_dtype=torch.float16).to(
+        >>> gen_pipe = WuerstchenDecoderPipeline.from_pretrained("warp-ai/wuerstchen", torch_dtype=torch.float16).to(
         ...     "cuda"
         ... )
 

--- a/src/diffusers/pipelines/stable_cascade/pipeline_stable_cascade.py
+++ b/src/diffusers/pipelines/stable_cascade/pipeline_stable_cascade.py
@@ -44,7 +44,7 @@ EXAMPLE_DOC_STRING = """
         >>> prior_pipe = StableCascadePriorPipeline.from_pretrained(
         ...     "stabilityai/stable-cascade-prior", torch_dtype=torch.bfloat16
         ... ).to("cuda")
-        >>> gen_pipe = StableCascadeDecoderPipeline.from_pretrain(
+        >>> gen_pipe = StableCascadeDecoderPipeline.from_pretrained(
         ...     "stabilityai/stable-cascade", torch_dtype=torch.float16
         ... ).to("cuda")
 


### PR DESCRIPTION
## Bug

Two pipeline docstrings call `.from_pretrain(...)` instead of `.from_pretrained(...)`:

- `src/diffusers/pipelines/stable_cascade/pipeline_stable_cascade.py:47` — `StableCascadeDecoderPipeline.from_pretrain(`
- `src/diffusers/pipelines/deprecated/wuerstchen/pipeline_wuerstchen.py:48` — `WuerstchenDecoderPipeline.from_pretrain(`

Users copy-pasting the rendered example hit `AttributeError: type object '...Pipeline' has no attribute 'from_pretrain'`.

The sibling prior-pipeline call on the line directly above each typo already uses the correct `from_pretrained`, confirming this is a typo, not an intentional alias.

## Fix

Rename `from_pretrain` → `from_pretrained` in both docstrings.