### PR TITLE
[LTX 2.3] update docs

### DIFF
--- a/docs/source/en/api/pipelines/ltx2.md
+++ b/docs/source/en/api/pipelines/ltx2.md
@@ -377,7 +377,7 @@ height = 512
 random_seed = 42
 frame_rate = 24.0
 generator = torch.Generator(device).manual_seed(random_seed)
-model_path = "dg845/LTX-2.3-Diffusers"
+model_path = "diffusers/LTX-2.3-Diffusers"
 
 pipe = LTX2ImageToVideoPipeline.from_pretrained(model_path, torch_dtype=torch.bfloat16)
 pipe.enable_sequential_cpu_offload(device=device)
@@ -449,7 +449,7 @@ height = 512
 random_seed = 42
 frame_rate = 24.0
 generator = torch.Generator(device).manual_seed(random_seed)
-model_path = "dg845/LTX-2.3-Diffusers"
+model_path = "diffusers/LTX-2.3-Diffusers"
 
 pipe = LTX2Pipeline.from_pretrained(model_path, torch_dtype=torch.bfloat16)
 pipe.enable_model_cpu_offload(device=device)

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_hdr_lora.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_hdr_lora.py
@@ -80,7 +80,7 @@ EXAMPLE_DOC_STRING = """
         >>> from diffusers.pipelines.ltx2.export_utils import encode_hdr_tensor_to_mp4
         >>> from diffusers.utils import load_video
 
-        >>> pipe = LTX2HDRPipeline.from_pretrained("dg845/LTX-2.3-Distilled-Diffusers", torch_dtype=torch.bfloat16)
+        >>> pipe = LTX2HDRPipeline.from_pretrained("diffusers/LTX-2.3-Distilled-Diffusers", torch_dtype=torch.bfloat16)
         >>> pipe.enable_sequential_cpu_offload(device="cuda")
         >>> pipe.load_lora_weights(
         ...     "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_ic_lora.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_ic_lora.py
@@ -79,7 +79,7 @@ EXAMPLE_DOC_STRING = """
         >>> from diffusers.pipelines.ltx2.utils import DEFAULT_NEGATIVE_PROMPT
         >>> from diffusers.utils import load_video
 
-        >>> pipe = LTX2InContextPipeline.from_pretrained("dg845/LTX-2.3-Diffusers", torch_dtype=torch.bfloat16)
+        >>> pipe = LTX2InContextPipeline.from_pretrained("diffusers/LTX-2.3-Diffusers", torch_dtype=torch.bfloat16)
         >>> pipe.enable_sequential_cpu_offload(device="cuda")
         >>> pipe.load_lora_weights(
         ...     "Lightricks/LTX-2-19b-LoRA-Camera-Control-Dolly-In",


### PR DESCRIPTION
mirrored @dg845 LTX2.3 repos under the diffusers org with some diffusers inference examples, this PR updates the docs to refer to those repos:
https://huggingface.co/diffusers/LTX-2.3-Diffusers
https://huggingface.co/diffusers/LTX-2.3-Distilled-Diffusers

@dg845
@sayakpaul 