### PR TITLE
[SDXL] Fix clip_skip not applied to negative prompt embeddings in encode_prompt

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -470,7 +470,11 @@ class StableDiffusionXLPipeline(
                 # We are only ALWAYS interested in the pooled output of the final text encoder
                 if negative_pooled_prompt_embeds is None and negative_prompt_embeds[0].ndim == 2:
                     negative_pooled_prompt_embeds = negative_prompt_embeds[0]
-                negative_prompt_embeds = negative_prompt_embeds.hidden_states[-2]
+                if clip_skip is None:
+                    negative_prompt_embeds = negative_prompt_embeds.hidden_states[-2]
+                else:
+                    # "2" because SDXL always indexes from the penultimate layer.
+                    negative_prompt_embeds = negative_prompt_embeds.hidden_states[-(clip_skip + 2)]
 
                 negative_prompt_embeds_list.append(negative_prompt_embeds)
 

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -974,3 +974,42 @@ class StableDiffusionXLPipelineIntegrationTests(unittest.TestCase):
         max_diff = numpy_cosine_similarity_distance(image.flatten(), expected_image.flatten())
 
         assert max_diff < 1e-2
+
+    def test_encode_prompt_clip_skip_applied_to_negative(self):
+        # Regression test: clip_skip must be applied symmetrically to both
+        # positive and negative prompt embeddings. Previously the negative path
+        # always used hidden_states[-2] regardless of clip_skip, causing a layer
+        # mismatch that corrupts classifier-free guidance.
+        device = "cpu"
+        components = self.get_dummy_components()
+        sd_pipe = StableDiffusionXLPipeline(**components)
+        sd_pipe = sd_pipe.to(device)
+
+        # Embeddings without clip_skip — both sides use hidden_states[-2]
+        pos_no_skip, neg_no_skip, _, _ = sd_pipe.encode_prompt(
+            prompt="a cat",
+            negative_prompt="blurry",
+            device=device,
+            num_images_per_prompt=1,
+            do_classifier_free_guidance=True,
+            clip_skip=None,
+        )
+
+        # Embeddings with clip_skip=1 — both sides must use hidden_states[-3]
+        pos_skip, neg_skip, _, _ = sd_pipe.encode_prompt(
+            prompt="a cat",
+            negative_prompt="blurry",
+            device=device,
+            num_images_per_prompt=1,
+            do_classifier_free_guidance=True,
+            clip_skip=1,
+        )
+
+        # clip_skip must change the negative embeddings, not leave them identical
+        self.assertFalse(
+            torch.allclose(neg_no_skip, neg_skip),
+            "Negative prompt embeddings must differ when clip_skip changes the hidden layer",
+        )
+
+        # Positive and negative must shift by the same amount — shapes must match
+        self.assertEqual(pos_skip.shape, neg_skip.shape)


### PR DESCRIPTION
# What does this PR do?

In `StableDiffusionXLPipeline.encode_prompt`, the positive prompt correctly
respects `clip_skip` when selecting the hidden layer:

```python
if clip_skip is None:
    prompt_embeds = prompt_embeds.hidden_states[-2]
else:
    prompt_embeds = prompt_embeds.hidden_states[-(clip_skip + 2)]
```

But the negative prompt path (line 473) always hardcodes `hidden_states[-2]`
regardless of `clip_skip`:

```python
negative_prompt_embeds = negative_prompt_embeds.hidden_states[-2]  # clip_skip ignored
```

This means when a user passes `clip_skip=1` (or any non-None value), the
positive and negative embeddings are extracted from **different CLIP layers**,
which corrupts classifier-free guidance since CFG subtracts the two vectors.

This PR fixes the negative prompt path to mirror the positive prompt logic
exactly, and adds a test that calls `encode_prompt` with `clip_skip=1` and
asserts the negative embeddings change accordingly.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?
@yiyixuxu @asomoza