### PR TITLE
[DreamBooth SDXL LoRA] Apply SNR min-weighting to prior preservation loss when snr_gamma is set

### DIFF
--- a/examples/dreambooth/test_dreambooth_lora.py
+++ b/examples/dreambooth/test_dreambooth_lora.py
@@ -377,3 +377,29 @@ class DreamBoothLoRASDXL(ExamplesTestsAccelerate):
                 # checkpoint-2 should have been deleted
                 {"checkpoint-4", "checkpoint-6"},
             )
+
+    def test_dreambooth_lora_sdxl_snr_gamma_with_prior_preservation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_args = f"""
+                examples/dreambooth/train_dreambooth_lora_sdxl.py
+                --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
+                --instance_data_dir docs/source/en/imgs
+                --instance_prompt photo
+                --resolution 64
+                --train_batch_size 2
+                --gradient_accumulation_steps 1
+                --max_train_steps 2
+                --learning_rate 5.0e-04
+                --scale_lr
+                --lr_scheduler constant
+                --lr_warmup_steps 0
+                --snr_gamma 5.0
+                --with_prior_preservation
+                --class_data_dir docs/source/en/imgs
+                --class_prompt photo
+                --output_dir {tmpdir}
+                """.split()
+
+            run_command(self._launch_args + test_args)
+            # Verify training completed and produced a valid LoRA weights file.
+            self.assertTrue(os.path.isfile(os.path.join(tmpdir, "pytorch_lora_weights.safetensors")))

--- a/examples/dreambooth/train_dreambooth_lora_sdxl.py
+++ b/examples/dreambooth/train_dreambooth_lora_sdxl.py
@@ -1853,6 +1853,12 @@ def main(args):
                     loss = loss.mean(dim=list(range(1, len(loss.shape)))) * mse_loss_weights
                     loss = loss.mean()
 
+                    if args.with_prior_preservation:
+                        # Apply the same SNR weighting to the prior loss for consistency.
+                        prior_loss = F.mse_loss(model_pred_prior.float(), target_prior.float(), reduction="none")
+                        prior_loss = prior_loss.mean(dim=list(range(1, len(prior_loss.shape)))) * mse_loss_weights
+                        prior_loss = prior_loss.mean()
+
                 if args.with_prior_preservation:
                     # Add the prior loss to the instance loss.
                     loss = loss + args.prior_loss_weight * prior_loss


### PR DESCRIPTION
# What does this PR do?

In `examples/dreambooth/train_dreambooth_lora_sdxl.py`, when training with
both `--snr_gamma` and `--with_prior_preservation`, the Min-SNR loss
weighting (Section 3.4 of https://huggingface.co/papers/2303.09556) is
applied to the instance loss but silently skipped for the prior preservation
loss. The prior loss is computed before the `snr_gamma` branch runs, so
`mse_loss_weights` is never multiplied into it — the prior loss always
falls back to plain MSE regardless of `--snr_gamma`.

This PR fixes the `snr_gamma` branch to also apply `mse_loss_weights` to
`prior_loss`, mirroring the same pattern already used for the instance loss.
A new test covering the `--snr_gamma` + `--with_prior_preservation` combination
is also added to `test_dreambooth_lora.py`.

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?
@sayakpaul