### PR TITLE
Fix Cosmos2 safety checker grad mode leak

### DIFF
--- a/src/diffusers/pipelines/cosmos/pipeline_cosmos2_video2world.py
+++ b/src/diffusers/pipelines/cosmos/pipeline_cosmos2_video2world.py
@@ -199,7 +199,11 @@ class Cosmos2VideoToWorldPipeline(DiffusionPipeline):
         super().__init__()
 
         if safety_checker is None:
-            safety_checker = CosmosSafetyChecker()
+            grad_enabled = torch.is_grad_enabled()
+            try:
+                safety_checker = CosmosSafetyChecker()
+            finally:
+                torch.set_grad_enabled(grad_enabled)
 
         self.register_modules(
             vae=vae,

--- a/tests/pipelines/cosmos/test_cosmos2_video2world.py
+++ b/tests/pipelines/cosmos/test_cosmos2_video2world.py
@@ -17,6 +17,7 @@ import json
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 import numpy as np
 import PIL.Image
@@ -157,6 +158,27 @@ class Cosmos2VideoToWorldPipelineFastTests(PipelineTesterMixin, unittest.TestCas
         generated_slice = generated_video.flatten()
         generated_slice = torch.cat([generated_slice[:8], generated_slice[-8:]])
         self.assertTrue(torch.allclose(generated_slice, expected_slice, atol=1e-3))
+
+    def test_default_safety_checker_preserves_grad_mode(self):
+        components = self.get_dummy_components()
+        components.pop("safety_checker")
+
+        class GradDisablingCosmosSafetyChecker:
+            def __init__(self):
+                torch.set_grad_enabled(False)
+
+        original_grad_mode = torch.is_grad_enabled()
+        torch.set_grad_enabled(True)
+        try:
+            with mock.patch(
+                "diffusers.pipelines.cosmos.pipeline_cosmos2_video2world.CosmosSafetyChecker",
+                GradDisablingCosmosSafetyChecker,
+            ):
+                self.pipeline_class(**components)
+
+            self.assertTrue(torch.is_grad_enabled())
+        finally:
+            torch.set_grad_enabled(original_grad_mode)
 
     def test_components_function(self):
         init_components = self.get_dummy_components()


### PR DESCRIPTION
## What does this PR do?

Fixes #13790.

`Cosmos2VideoToWorldPipeline` creates a default `CosmosSafetyChecker` when `safety_checker=None`. If the guardrail dependency changes PyTorch's global grad mode during construction, that state leaks out of `from_pretrained()` and leaves `torch.is_grad_enabled()` disabled globally.

This preserves and restores the caller's grad mode around default safety checker construction.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the documentation guidelines, and here are tips on formatting docstrings.
- [x] Did you write any new necessary tests?

## Who can review?

@DN6

## Tests

- Added `test_default_safety_checker_preserves_grad_mode` to cover default safety checker construction that disables grad mode.
- Verified RED locally by running the new test before the fix and observing it fail with `AssertionError: False is not true`.
- `python -m pytest tests/pipelines/cosmos/test_cosmos2_video2world.py::Cosmos2VideoToWorldPipelineFastTests::test_default_safety_checker_preserves_grad_mode -q`
- `python -m pytest tests/pipelines/cosmos/test_cosmos2_video2world.py -q`
- `make style`
- `make quality`
