### PR TITLE
fix(ernie-image): pass attn_mask=None when text is unpadded

### DIFF
--- a/src/diffusers/models/transformers/transformer_ernie_image.py
+++ b/src/diffusers/models/transformers/transformer_ernie_image.py
@@ -408,15 +408,15 @@ class ErnieImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin):
         )
         rotary_pos_emb = self.pos_embed(torch.cat([image_ids, text_ids], dim=1))
 
-        # Attention mask: True = valid (attend), False = padding (mask out), matches sdpa bool convention
-        valid_text = (
-            torch.arange(Tmax, device=device).view(1, Tmax) < text_lens.view(B, 1)
-            if Tmax > 0
-            else torch.zeros((B, 0), device=device, dtype=torch.bool)
-        )
-        attention_mask = torch.cat([torch.ones((B, N_img), device=device, dtype=torch.bool), valid_text], dim=1)[
-            :, None, None, :
-        ]
+        # Attention mask: True = valid (attend), False = padding (mask out), matches sdpa bool convention.
+        # Skip building it when there's no padding so flash-attn (which rejects non-None masks) can run.
+        if Tmax > 0 and not bool((text_lens == Tmax).all()):
+            valid_text = torch.arange(Tmax, device=device).view(1, Tmax) < text_lens.view(B, 1)
+            attention_mask = torch.cat([torch.ones((B, N_img), device=device, dtype=torch.bool), valid_text], dim=1)[
+                :, None, None, :
+            ]
+        else:
+            attention_mask = None
 
         # AdaLN
         sample = self.time_proj(timestep)

--- a/tests/models/transformers/test_models_transformer_ernie_image.py
+++ b/tests/models/transformers/test_models_transformer_ernie_image.py
@@ -23,6 +23,7 @@ from diffusers.utils.torch_utils import randn_tensor
 
 from ...testing_utils import torch_device
 from ..testing_utils import (
+    AttentionBackendTesterMixin,
     BaseModelTesterConfig,
     ModelTesterMixin,
     TorchCompileTesterMixin,
@@ -130,3 +131,7 @@ class TestErnieImageTransformerCompile(ErnieImageTransformerTesterConfig, TorchC
     @pytest.mark.skip(reason="Fullgraph is broken.")
     def test_compile_on_different_shapes(self):
         super().test_compile_on_different_shapes()
+
+
+class TestErnieImageTransformerAttentionBackend(ErnieImageTransformerTesterConfig, AttentionBackendTesterMixin):
+    """Attention backend tests for ErnieImage Transformer."""


### PR DESCRIPTION
## What does this PR do?

Fixes #13801.

If you call `pipeline.transformer.set_attention_backend("flash")` on an `ErnieImagePipeline`, it crashes:

```
ValueError: attn_mask is not supported for flash-attn 2.
```

The same code works fine on `ZImagePipeline` and `Flux2KleinPipeline`.

## Root cause

`ErnieImageTransformer2DModel.forward` always builds a boolean attention mask from `text_lens`, even when every sample already has the full text length. In the common single-prompt case (where `Tmax = lens.max()` in `_pad_text`), every position is valid and the mask is just all True. flash-attn 2 rejects any non-`None` `attn_mask`, so the call fails before any attention runs.

Z-Image already handles this. In `_prepare_for_attention` (transformer_z_image.py:792-797) it does:

```python
if all(seq == max_seqlen for seq in item_seqlens):
    attn_mask = None
else:
    attn_mask = ...  # build it
```

## Fix

Do the same thing in Ernie's forward. If at least one sample is padded, build the mask. Otherwise pass `None`.

The previous all-True bool mask was a no-op on sdpa, cudnn and native paths (no positions get masked, no `-inf` rows), so behavior on those backends doesn't change. I verified that numerically: with the same seed and inputs, baseline and fix produce bit-identical output in both the uniform (`text_lens=[16,16]`) and padded (`text_lens=[16,12]`) cases. Norm, mean, std, and per-element samples match to 7 decimal places.

flash-attn and its variants are now usable when the batch is uniform.

## Test

Wires the existing `AttentionBackendTesterMixin` into the Ernie test class (mirrors the Flux pattern). Native_cudnn backend tests pass; flash variants skip cleanly when `kernels` isn't installed, and will catch the regression when it is.

## Before submitting

- [ ] This PR fixes a typo or improves the docs.
- [x] Read the contributor guideline.
- [x] Read the philosophy doc.
- [x] Discussed via GitHub issue (#13801).
- [x] Documentation: mask construction is internal to the forward and not referenced in `docs/source/en/`.
- [x] New tests: wired in `AttentionBackendTesterMixin` for Ernie.

## Who can review?

@yiyixuxu @sayakpaul