### PR TITLE
[utils] preserve method metadata in apply_forward_hook

### DIFF
--- a/src/diffusers/utils/accelerate_utils.py
+++ b/src/diffusers/utils/accelerate_utils.py
@@ -15,6 +15,8 @@
 Accelerate utilities: Utilities related to accelerate
 """
 
+import functools
+
 from packaging import version
 
 from .import_utils import is_accelerate_available
@@ -40,6 +42,7 @@ def apply_forward_hook(method):
     if version.parse(accelerate_version) < version.parse("0.17.0"):
         return method
 
+    @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
         if hasattr(self, "_hf_hook") and hasattr(self._hf_hook, "pre_forward"):
             self._hf_hook.pre_forward(self)

--- a/tests/others/test_utils.py
+++ b/tests/others/test_utils.py
@@ -284,6 +284,27 @@ class RandnTensorTester(unittest.TestCase):
         )
 
 
+class ApplyForwardHookTester(unittest.TestCase):
+    """Tests for :func:`diffusers.utils.accelerate_utils.apply_forward_hook`."""
+
+    def test_preserves_wrapped_function_metadata(self):
+        import inspect
+
+        from diffusers.utils.accelerate_utils import apply_forward_hook
+
+        @apply_forward_hook
+        def example(self, x: int, y: int = 0) -> int:
+            """Example method docstring."""
+            return x + y
+
+        assert example.__name__ == "example"
+        assert example.__doc__ == "Example method docstring."
+        assert hasattr(example, "__wrapped__")
+        signature = inspect.signature(example)
+        assert list(signature.parameters) == ["self", "x", "y"]
+        assert signature.parameters["y"].default == 0
+
+
 # Copied from https://github.com/huggingface/transformers/blob/main/tests/utils/test_expectations.py
 class ExpectationsTester(unittest.TestCase):
     def test_expectations(self):


### PR DESCRIPTION
## What does this PR do?

Fixes #6575

`@apply_forward_hook` wraps methods like `AutoencoderKL.encode` and `AutoencoderKL.decode`, but the inner `wrapper` did not use `functools.wraps`. As a result the wrapped methods lost their `__name__`, `__doc__`, `__module__` and signature, so `huggingface/doc-builder` could not render them through the `[[autodoc]]` directive and they show up as `wrapper` with a generic `(*args, **kwargs)` signature on the live API docs:

- https://huggingface.co/docs/diffusers/main/en/api/models/autoencoderkl
- https://huggingface.co/docs/diffusers/main/en/api/models/consistency_decoder_vae
- https://huggingface.co/docs/diffusers/main/en/api/models/vq

The same affects every autoencoder that uses the decorator (~29 files under `src/diffusers/models/autoencoders/`). Adding `@functools.wraps(method)` to the inner wrapper restores the original metadata so doc-builder's `inspect.unwrap` + `inspect.signature` flow picks up the real method. Call-time behaviour is unchanged.

### Before

```
AutoencoderKL.decode.__name__   == "wrapper"
AutoencoderKL.decode.__doc__    is None
inspect.signature(AutoencoderKL.decode) == (self, *args, **kwargs)
```

### After

```
AutoencoderKL.decode.__name__   == "decode"
AutoencoderKL.decode.__doc__    == "Decode a batch of images. ..."
inspect.signature(AutoencoderKL.decode) == (self, z: torch.FloatTensor, return_dict: bool = True, generator=None) -> ...
```

Regression tests in `tests/others/test_utils.py::ApplyForwardHookTester` assert that the wrapped method exposes the right metadata (name, docstring, signature including default values, `__wrapped__`) and that the underlying offload hook still fires through the wrapper.

The HF doc-builder CI preview will show the corrected rendering on the autoencoder pages once this PR is open.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? #6575
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@stevhliu @sayakpaul