### PR TITLE
Initialize ZImage pad tokens deterministically

### DIFF
--- a/src/diffusers/models/transformers/transformer_z_image.py
+++ b/src/diffusers/models/transformers/transformer_z_image.py
@@ -457,14 +457,14 @@ class ZImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOr
                     for layer_id in range(n_refiner_layers)
                 ]
             )
-            self.siglip_pad_token = nn.Parameter(torch.empty((1, dim)))
+            self.siglip_pad_token = nn.Parameter(torch.zeros((1, dim)))
         else:
             self.siglip_embedder = None
             self.siglip_refiner = None
             self.siglip_pad_token = None
 
-        self.x_pad_token = nn.Parameter(torch.empty((1, dim)))
-        self.cap_pad_token = nn.Parameter(torch.empty((1, dim)))
+        self.x_pad_token = nn.Parameter(torch.zeros((1, dim)))
+        self.cap_pad_token = nn.Parameter(torch.zeros((1, dim)))
 
         self.layers = nn.ModuleList(
             [


### PR DESCRIPTION
This PR fixes a determinism issue in ZImageTransformer2DModel by initializing its pad tokens with zeros instead of torch.empty().

The model's pad tokens participate in the forward path when padded caption or image tokens are present. Because they were previously created with torch.empty(), direct model instantiation from config could pick up uninitialized values, which made outputs unstable across runs and could surface NaNs in layerwise casting tests.

pytest tests/models/transformers/test_models_transformer_z_image.py::ZImageTransformerTests::test_layerwise_casting_inference
this case sometimes pass, sometimes fail