### PR TITLE
Fix black image output in QwenImageEdit docstring

### DIFF
--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit.py
@@ -58,6 +58,7 @@ EXAMPLE_DOC_STRING = """
         ... )
         >>> # Depending on the variant being used, the pipeline call will slightly vary.
         >>> # Refer to the pipeline documentation for more details.
+        >>> pipe.vae.to(torch.float32)
         >>> image = pipe(image, prompt, num_inference_steps=50).images[0]
         >>> image.save("qwenimage_edit.png")
         ```


### PR DESCRIPTION
**Fixes #13819**

## What does this PR do?
This fixes a bug in the `QwenImageEditPipeline` documentation snippet where users were getting a black image output. 

Because the pipeline was initialized in `torch.bfloat16`, the `AutoencoderKL` (VAE) mathematically overflows during the `decode` step, resulting in `NaN` values that the image processor converts to black pixels. 

This PR adds `pipe.vae.to(torch.float32)` to the docstring example to prevent the overflow and ensure proper image generation.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue?
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?
@yiyixuxu @patrickvonplaten