### PR TITLE
fix(dreambooth): correct batch handling in _prepare_image_ids for flux2 img2img

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
@@ -1717,12 +1717,15 @@ def main(args):
                 cond_model_input = (cond_model_input - latents_bn_mean) / latents_bn_std
 
                 model_input_ids = Flux2Pipeline._prepare_latent_ids(model_input).to(device=model_input.device)
-                cond_model_input_list = [cond_model_input[i].unsqueeze(0) for i in range(cond_model_input.shape[0])]
-                cond_model_input_ids = Flux2Pipeline._prepare_image_ids(cond_model_input_list).to(
-                    device=cond_model_input.device
-                )
-                cond_model_input_ids = cond_model_input_ids.view(
-                    cond_model_input.shape[0], -1, model_input_ids.shape[-1]
+                # Generate image IDs for a single sample, then expand across batch.
+                # Using _prepare_image_ids on individual batch elements assigns different
+                # temporal IDs per sample (T=10, T=20, ...) which is incorrect — batch
+                # elements are independent samples and should share the same temporal id.
+                cond_model_input_ids = Flux2Pipeline._prepare_image_ids(
+                    [cond_model_input[0:1]]
+                ).to(device=cond_model_input.device)
+                cond_model_input_ids = cond_model_input_ids.expand(
+                    cond_model_input.shape[0], -1, -1
                 )
 
                 # Sample noise that we'll add to the latents


### PR DESCRIPTION
## Summary

Fixes #13811.

In `train_dreambooth_lora_flux2_img2img.py`, `_prepare_image_ids` is called on individual batch elements, which assigns different temporal IDs per sample (T=10, T=20, T=30...). This is incorrect because batch elements are independent training samples with only one conditional image each — they should not have inter-sample temporal relationships.

## Fix

Generate image IDs for a single sample using `_prepare_image_ids([cond_model_input[0:1]])`, then expand across the batch dimension with `.expand(batch_size, -1, -1)`. This ensures all samples share the same temporal id.

## Why this is correct

`_prepare_image_ids` is designed for **multiple reference images within a single sample**, where different temporal embeddings distinguish multiple reference images of the same instance. In the training script, each batch element is an independent sample with one conditional image, so there should be no cross-sample temporal offset.