### PR TITLE
fix: Add missing StableAudioPipeline dummy class to prevent RecursionError (closes #13274)

### DIFF
--- a/src/diffusers/utils/dummy_torch_and_transformers_objects.py
+++ b/src/diffusers/utils/dummy_torch_and_transformers_objects.py
@@ -122,6 +122,36 @@ class Flux2ModularPipeline(metaclass=DummyObject):
         requires_backends(cls, ["torch", "transformers"])
 
 
+class StableAudioPipeline(metaclass=DummyObject):
+    _backends = ["torch", "transformers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch", "transformers"])
+
+    @classmethod
+    def from_config(cls, *args, **kwargs):
+        requires_backends(cls, ["torch", "transformers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch", "transformers"])
+
+
+class FluxAutoBlocks(metaclass=DummyObject):
+    _backends = ["torch", "transformers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torch", "transformers"])
+
+    @classmethod
+    def from_config(cls, *args, **kwargs):
+        requires_backends(cls, ["torch", "transformers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["torch", "transformers"])
+
+
 class FluxAutoBlocks(metaclass=DummyObject):
     _backends = ["torch", "transformers"]
 


### PR DESCRIPTION
## What
The dummy objects file `src/diffusers/utils/dummy_torch_and_transformers_objects.py` is missing the `StableAudioPipeline` class, which causes a `RecursionError: maximum recursion depth exceeded` when importing `StableAudioPipeline` on systems without the required backends (e.g., AMD MI300X with certain configurations). This happens because the import system enters an infinite recursion trying to resolve the missing class.

## Fix
Added the `StableAudioPipeline` dummy class with the same pattern as other dummy classes in the file so that when the required backends are missing, a proper error message is raised instead of a recursion error.

Closes #13274