### PR TITLE
refactor cogview4 transformer tests

### DIFF
--- a/tests/models/transformers/test_models_transformer_cogview4.py
+++ b/tests/models/transformers/test_models_transformer_cogview4.py
@@ -12,59 +12,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
 import torch
 
 from diffusers import CogView4Transformer2DModel
+from diffusers.utils.torch_utils import randn_tensor
 
 from ...testing_utils import enable_full_determinism, torch_device
-from ..test_modeling_common import ModelTesterMixin
+from ..testing_utils import (
+    BaseModelTesterConfig,
+    MemoryTesterMixin,
+    ModelTesterMixin,
+    TrainingTesterMixin,
+)
 
 
 enable_full_determinism()
 
 
-class CogView3PlusTransformerTests(ModelTesterMixin, unittest.TestCase):
-    model_class = CogView4Transformer2DModel
-    main_input_name = "hidden_states"
-    uses_custom_attn_processor = True
+class CogView4TransformerTesterConfig(BaseModelTesterConfig):
+    @property
+    def model_class(self):
+        return CogView4Transformer2DModel
 
     @property
-    def dummy_input(self):
-        batch_size = 2
-        num_channels = 4
-        height = 8
-        width = 8
-        embedding_dim = 8
-        sequence_length = 8
+    def main_input_name(self) -> str:
+        return "hidden_states"
 
-        hidden_states = torch.randn((batch_size, num_channels, height, width)).to(torch_device)
-        encoder_hidden_states = torch.randn((batch_size, sequence_length, embedding_dim)).to(torch_device)
-        original_size = torch.tensor([height * 8, width * 8]).unsqueeze(0).repeat(batch_size, 1).to(torch_device)
-        target_size = torch.tensor([height * 8, width * 8]).unsqueeze(0).repeat(batch_size, 1).to(torch_device)
-        crop_coords = torch.tensor([0, 0]).unsqueeze(0).repeat(batch_size, 1).to(torch_device)
-        timestep = torch.randint(0, 1000, size=(batch_size,)).to(torch_device)
+    @property
+    def uses_custom_attn_processor(self) -> bool:
+        return True
 
+    @property
+    def output_shape(self) -> tuple:
+        return (4, 8, 8)
+
+    @property
+    def input_shape(self) -> tuple:
+        return (4, 8, 8)
+
+    @property
+    def generator(self):
+        return torch.Generator("cpu").manual_seed(0)
+
+    def get_init_dict(self) -> dict:
         return {
-            "hidden_states": hidden_states,
-            "encoder_hidden_states": encoder_hidden_states,
-            "timestep": timestep,
-            "original_size": original_size,
-            "target_size": target_size,
-            "crop_coords": crop_coords,
-        }
-
-    @property
-    def input_shape(self):
-        return (4, 8, 8)
-
-    @property
-    def output_shape(self):
-        return (4, 8, 8)
-
-    def prepare_init_args_and_inputs_for_common(self):
-        init_dict = {
             "patch_size": 2,
             "in_channels": 4,
             "num_layers": 2,
@@ -75,9 +66,45 @@ class CogView3PlusTransformerTests(ModelTesterMixin, unittest.TestCase):
             "time_embed_dim": 8,
             "condition_dim": 4,
         }
-        inputs_dict = self.dummy_input
-        return init_dict, inputs_dict
 
+    def get_dummy_inputs(self) -> dict:
+        batch_size = 2
+        num_channels = 4
+        height = 8
+        width = 8
+        embedding_dim = 8
+        sequence_length = 8
+
+        hidden_states = randn_tensor(
+            (batch_size, num_channels, height, width), generator=self.generator, device=torch_device
+        )
+        encoder_hidden_states = randn_tensor(
+            (batch_size, sequence_length, embedding_dim), generator=self.generator, device=torch_device
+        )
+        original_size = torch.tensor([height * 8, width * 8]).unsqueeze(0).repeat(batch_size, 1).to(torch_device)
+        target_size = torch.tensor([height * 8, width * 8]).unsqueeze(0).repeat(batch_size, 1).to(torch_device)
+        crop_coords = torch.tensor([0, 0]).unsqueeze(0).repeat(batch_size, 1).to(torch_device)
+        timestep = torch.randint(0, 1000, size=(batch_size,), generator=self.generator).to(torch_device)
+
+        return {
+            "hidden_states": hidden_states,
+            "encoder_hidden_states": encoder_hidden_states,
+            "timestep": timestep,
+            "original_size": original_size,
+            "target_size": target_size,
+            "crop_coords": crop_coords,
+        }
+
+
+class TestCogView4Transformer(CogView4TransformerTesterConfig, ModelTesterMixin):
+    pass
+
+
+class TestCogView4TransformerMemory(CogView4TransformerTesterConfig, MemoryTesterMixin):
+    pass
+
+
+class TestCogView4TransformerTraining(CogView4TransformerTesterConfig, TrainingTesterMixin):
     def test_gradient_checkpointing_is_applied(self):
         expected_set = {"CogView4Transformer2DModel"}
         super().test_gradient_checkpointing_is_applied(expected_set=expected_set)


### PR DESCRIPTION
# What does this PR do?

Part of the ongoing modeling-test migration (following #13369 and #13153). Refactors the CogView4 transformer tests into a `CogView4TransformerTesterConfig` plus per-component test classes: `ModelTesterMixin`, `MemoryTesterMixin`, and `TrainingTesterMixin`.

`CogView4Transformer2DModel` doesn't set `_repeated_blocks` and doesn't expose attention processors, so the compile and attention mixins are not included.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case. (Discussed on Slack with @sayakpaul)
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@sayakpaul