### PR TITLE
refactor mochi transformer tests

### DIFF
--- a/tests/models/transformers/test_models_transformer_mochi.py
+++ b/tests/models/transformers/test_models_transformer_mochi.py
@@ -13,58 +13,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
 import torch
 
 from diffusers import MochiTransformer3DModel
+from diffusers.utils.torch_utils import randn_tensor
 
 from ...testing_utils import enable_full_determinism, torch_device
-from ..test_modeling_common import ModelTesterMixin
+from ..testing_utils import (
+    BaseModelTesterConfig,
+    MemoryTesterMixin,
+    ModelTesterMixin,
+    TrainingTesterMixin,
+)
 
 
 enable_full_determinism()
 
 
-class MochiTransformerTests(ModelTesterMixin, unittest.TestCase):
-    model_class = MochiTransformer3DModel
-    main_input_name = "hidden_states"
-    uses_custom_attn_processor = True
-    # Overriding it because of the transformer size.
-    model_split_percents = [0.7, 0.6, 0.6]
+class MochiTransformerTesterConfig(BaseModelTesterConfig):
+    @property
+    def model_class(self):
+        return MochiTransformer3DModel
 
     @property
-    def dummy_input(self):
-        batch_size = 2
-        num_channels = 4
-        num_frames = 2
-        height = 16
-        width = 16
-        embedding_dim = 16
-        sequence_length = 16
+    def main_input_name(self) -> str:
+        return "hidden_states"
 
-        hidden_states = torch.randn((batch_size, num_channels, num_frames, height, width)).to(torch_device)
-        encoder_hidden_states = torch.randn((batch_size, sequence_length, embedding_dim)).to(torch_device)
-        encoder_attention_mask = torch.ones((batch_size, sequence_length)).bool().to(torch_device)
-        timestep = torch.randint(0, 1000, size=(batch_size,)).to(torch_device)
+    @property
+    def uses_custom_attn_processor(self) -> bool:
+        return True
 
+    @property
+    def output_shape(self) -> tuple:
+        return (4, 2, 16, 16)
+
+    @property
+    def input_shape(self) -> tuple:
+        return (4, 2, 16, 16)
+
+    @property
+    def model_split_percents(self) -> list:
+        # Overriding it because of the transformer size.
+        return [0.7, 0.6, 0.6]
+
+    @property
+    def generator(self):
+        return torch.Generator("cpu").manual_seed(0)
+
+    def get_init_dict(self) -> dict:
         return {
-            "hidden_states": hidden_states,
-            "encoder_hidden_states": encoder_hidden_states,
-            "timestep": timestep,
-            "encoder_attention_mask": encoder_attention_mask,
-        }
-
-    @property
-    def input_shape(self):
-        return (4, 2, 16, 16)
-
-    @property
-    def output_shape(self):
-        return (4, 2, 16, 16)
-
-    def prepare_init_args_and_inputs_for_common(self):
-        init_dict = {
             "patch_size": 2,
             "num_attention_heads": 2,
             "attention_head_dim": 8,
@@ -78,9 +75,42 @@ class MochiTransformerTests(ModelTesterMixin, unittest.TestCase):
             "activation_fn": "swiglu",
             "max_sequence_length": 16,
         }
-        inputs_dict = self.dummy_input
-        return init_dict, inputs_dict
 
+    def get_dummy_inputs(self) -> dict:
+        batch_size = 2
+        num_channels = 4
+        num_frames = 2
+        height = 16
+        width = 16
+        embedding_dim = 16
+        sequence_length = 16
+
+        hidden_states = randn_tensor(
+            (batch_size, num_channels, num_frames, height, width), generator=self.generator, device=torch_device
+        )
+        encoder_hidden_states = randn_tensor(
+            (batch_size, sequence_length, embedding_dim), generator=self.generator, device=torch_device
+        )
+        encoder_attention_mask = torch.ones((batch_size, sequence_length)).bool().to(torch_device)
+        timestep = torch.randint(0, 1000, size=(batch_size,), generator=self.generator).to(torch_device)
+
+        return {
+            "hidden_states": hidden_states,
+            "encoder_hidden_states": encoder_hidden_states,
+            "timestep": timestep,
+            "encoder_attention_mask": encoder_attention_mask,
+        }
+
+
+class TestMochiTransformer(MochiTransformerTesterConfig, ModelTesterMixin):
+    pass
+
+
+class TestMochiTransformerMemory(MochiTransformerTesterConfig, MemoryTesterMixin):
+    pass
+
+
+class TestMochiTransformerTraining(MochiTransformerTesterConfig, TrainingTesterMixin):
     def test_gradient_checkpointing_is_applied(self):
         expected_set = {"MochiTransformer3DModel"}
         super().test_gradient_checkpointing_is_applied(expected_set=expected_set)


### PR DESCRIPTION
# What does this PR do?

Part of the ongoing modeling-test migration (following #13369 and #13153). Refactors the Mochi transformer tests into a `MochiTransformerTesterConfig` plus per-component test classes: `ModelTesterMixin`, `MemoryTesterMixin`, and `TrainingTesterMixin`.

`MochiTransformer3DModel` doesn't set `_repeated_blocks` and doesn't expose attention processors, so the compile and attention mixins are not included.

Ran the full test file on a GPU, all pass.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case. (Discussed on Slack with @sayakpaul.)
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@sayakpaul