### PR TITLE
refactor skyreels_v2 transformer tests

### DIFF
--- a/tests/models/transformers/test_models_transformer_skyreels_v2.py
+++ b/tests/models/transformers/test_models_transformer_skyreels_v2.py
@@ -12,57 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
 import torch
 
 from diffusers import SkyReelsV2Transformer3DModel
+from diffusers.utils.torch_utils import randn_tensor
 
-from ...testing_utils import (
-    enable_full_determinism,
-    torch_device,
+from ...testing_utils import enable_full_determinism, torch_device
+from ..testing_utils import (
+    AttentionTesterMixin,
+    BaseModelTesterConfig,
+    MemoryTesterMixin,
+    ModelTesterMixin,
+    TorchCompileTesterMixin,
+    TrainingTesterMixin,
 )
-from ..test_modeling_common import ModelTesterMixin, TorchCompileTesterMixin
 
 
 enable_full_determinism()
 
 
-class SkyReelsV2Transformer3DTests(ModelTesterMixin, TorchCompileTesterMixin, unittest.TestCase):
-    model_class = SkyReelsV2Transformer3DModel
-    main_input_name = "hidden_states"
-    uses_custom_attn_processor = True
+class SkyReelsV2Transformer3DTesterConfig(BaseModelTesterConfig):
+    @property
+    def model_class(self):
+        return SkyReelsV2Transformer3DModel
 
     @property
-    def dummy_input(self):
-        batch_size = 1
-        num_channels = 4
-        num_frames = 2
-        height = 16
-        width = 16
-        text_encoder_embedding_dim = 16
-        sequence_length = 12
+    def main_input_name(self) -> str:
+        return "hidden_states"
 
-        hidden_states = torch.randn((batch_size, num_channels, num_frames, height, width)).to(torch_device)
-        timestep = torch.randint(0, 1000, size=(batch_size,)).to(torch_device)
-        encoder_hidden_states = torch.randn((batch_size, sequence_length, text_encoder_embedding_dim)).to(torch_device)
+    @property
+    def uses_custom_attn_processor(self) -> bool:
+        return True
 
+    @property
+    def output_shape(self) -> tuple:
+        return (4, 1, 16, 16)
+
+    @property
+    def input_shape(self) -> tuple:
+        return (4, 1, 16, 16)
+
+    @property
+    def generator(self):
+        return torch.Generator("cpu").manual_seed(0)
+
+    def get_init_dict(self) -> dict:
         return {
-            "hidden_states": hidden_states,
-            "encoder_hidden_states": encoder_hidden_states,
-            "timestep": timestep,
-        }
-
-    @property
-    def input_shape(self):
-        return (4, 1, 16, 16)
-
-    @property
-    def output_shape(self):
-        return (4, 1, 16, 16)
-
-    def prepare_init_args_and_inputs_for_common(self):
-        init_dict = {
             "patch_size": (1, 2, 2),
             "num_attention_heads": 2,
             "attention_head_dim": 12,
@@ -76,9 +71,48 @@ class SkyReelsV2Transformer3DTests(ModelTesterMixin, TorchCompileTesterMixin, un
             "qk_norm": "rms_norm_across_heads",
             "rope_max_seq_len": 32,
         }
-        inputs_dict = self.dummy_input
-        return init_dict, inputs_dict
 
+    def get_dummy_inputs(self) -> dict:
+        batch_size = 1
+        num_channels = 4
+        num_frames = 2
+        height = 16
+        width = 16
+        text_encoder_embedding_dim = 16
+        sequence_length = 12
+
+        hidden_states = randn_tensor(
+            (batch_size, num_channels, num_frames, height, width), generator=self.generator, device=torch_device
+        )
+        timestep = torch.randint(0, 1000, size=(batch_size,), generator=self.generator).to(torch_device)
+        encoder_hidden_states = randn_tensor(
+            (batch_size, sequence_length, text_encoder_embedding_dim), generator=self.generator, device=torch_device
+        )
+
+        return {
+            "hidden_states": hidden_states,
+            "encoder_hidden_states": encoder_hidden_states,
+            "timestep": timestep,
+        }
+
+
+class TestSkyReelsV2Transformer3D(SkyReelsV2Transformer3DTesterConfig, ModelTesterMixin):
+    pass
+
+
+class TestSkyReelsV2Transformer3DMemory(SkyReelsV2Transformer3DTesterConfig, MemoryTesterMixin):
+    pass
+
+
+class TestSkyReelsV2Transformer3DTraining(SkyReelsV2Transformer3DTesterConfig, TrainingTesterMixin):
     def test_gradient_checkpointing_is_applied(self):
         expected_set = {"SkyReelsV2Transformer3DModel"}
         super().test_gradient_checkpointing_is_applied(expected_set=expected_set)
+
+
+class TestSkyReelsV2Transformer3DAttention(SkyReelsV2Transformer3DTesterConfig, AttentionTesterMixin):
+    pass
+
+
+class TestSkyReelsV2Transformer3DCompile(SkyReelsV2Transformer3DTesterConfig, TorchCompileTesterMixin):
+    pass


### PR DESCRIPTION
# What does this PR do?

Part of the ongoing modeling-test migration (following #13369 and #13153). Refactors the SkyReels-V2 transformer tests into a `SkyReelsV2Transformer3DTesterConfig` plus per-component test classes: `ModelTesterMixin`, `MemoryTesterMixin`, `TrainingTesterMixin`, `AttentionTesterMixin`, and `TorchCompileTesterMixin`.

`SkyReelsV2Transformer3DModel` sets `_repeated_blocks` and exposes attention processors, so the compile and attention mixins are included.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case. (Discussed on Slack with @sayakpaul.)
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@sayakpaul