### PR TITLE
override torch stuff to prevent them from getting updated

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -19,8 +19,11 @@ env:
   PIPELINE_USAGE_CUTOFF: 0
   SLACK_API_TOKEN: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
   CONSOLIDATED_REPORT_PATH: consolidated_test_report.md
-  # Force tokenizers<0.23.0 across every `uv pip install` in this workflow,
-  # even when transformers@main declares a higher lower-bound.
+  # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
+  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
+  #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
+  #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
+  #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
   UV_OVERRIDE: /tmp/uv-overrides.txt
 
 jobs:
@@ -77,7 +80,7 @@ jobs:
         run: nvidia-smi
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
           uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
@@ -131,7 +134,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
         uv pip install peft@git+https://github.com/huggingface/peft.git
@@ -199,7 +202,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
     - name: Environment
@@ -241,7 +244,7 @@ jobs:
         run: nvidia-smi
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
           uv pip install peft@git+https://github.com/huggingface/peft.git
@@ -292,7 +295,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.6.0\ntorchvision==0.21.0\ntorchaudio==2.6.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
           uv pip install peft@git+https://github.com/huggingface/peft.git
@@ -368,7 +371,7 @@ jobs:
         run: nvidia-smi
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip install -U ${{ matrix.config.backend }}
           if [ "${{ join(matrix.config.additional_deps, ' ') }}" != "" ]; then
@@ -421,7 +424,7 @@ jobs:
         run: nvidia-smi
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip install -U bitsandbytes optimum_quanto
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git

--- a/.github/workflows/pr_modular_tests.yml
+++ b/.github/workflows/pr_modular_tests.yml
@@ -34,8 +34,11 @@ env:
   OMP_NUM_THREADS: 4
   MKL_NUM_THREADS: 4
   PYTEST_TIMEOUT: 60
-  # Force tokenizers<0.23.0 across every `uv pip install` in this workflow,
-  # even when transformers@main declares a higher lower-bound.
+  # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
+  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
+  #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
+  #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
+  #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
   UV_OVERRIDE: /tmp/uv-overrides.txt
 
 jobs:
@@ -124,7 +127,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git --no-deps

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -29,8 +29,11 @@ env:
   OMP_NUM_THREADS: 4
   MKL_NUM_THREADS: 4
   PYTEST_TIMEOUT: 60
-  # Force tokenizers<0.23.0 across every `uv pip install` in this workflow,
-  # even when transformers@main declares a higher lower-bound.
+  # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
+  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
+  #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
+  #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
+  #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
   UV_OVERRIDE: /tmp/uv-overrides.txt
 
 jobs:
@@ -120,7 +123,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git --no-deps
@@ -197,7 +200,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
 
@@ -248,7 +251,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         # TODO (sayakpaul, DN6): revisit `--no-deps`
         uv pip install -U peft@git+https://github.com/huggingface/peft.git --no-deps

--- a/.github/workflows/pr_tests_gpu.yml
+++ b/.github/workflows/pr_tests_gpu.yml
@@ -30,8 +30,11 @@ env:
   HF_XET_HIGH_PERFORMANCE: 1
   PYTEST_TIMEOUT: 600
   PIPELINE_USAGE_CUTOFF: 1000000000 # set high cutoff so that only always-test pipelines run
-  # Force tokenizers<0.23.0 across every `uv pip install` in this workflow,
-  # even when transformers@main declares a higher lower-bound.
+  # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
+  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
+  #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
+  #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
+  #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
   UV_OVERRIDE: /tmp/uv-overrides.txt
 
 jobs:
@@ -95,7 +98,7 @@ jobs:
           fetch-depth: 2
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
       - name: Environment
         run: |
@@ -137,7 +140,7 @@ jobs:
           nvidia-smi
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
@@ -207,7 +210,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip install peft@git+https://github.com/huggingface/peft.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
@@ -272,7 +275,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
         uv pip install -e ".[quality,training]"
 

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -20,8 +20,11 @@ env:
   HF_XET_HIGH_PERFORMANCE: 1
   PYTEST_TIMEOUT: 600
   PIPELINE_USAGE_CUTOFF: 50000
-  # Force tokenizers<0.23.0 across every `uv pip install` in this workflow,
-  # even when transformers@main declares a higher lower-bound.
+  # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
+  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
+  #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
+  #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
+  #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
   UV_OVERRIDE: /tmp/uv-overrides.txt
 
 jobs:
@@ -40,7 +43,7 @@ jobs:
           fetch-depth: 2
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
       - name: Environment
         run: |
@@ -81,7 +84,7 @@ jobs:
           nvidia-smi
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
@@ -133,7 +136,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip install peft@git+https://github.com/huggingface/peft.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
@@ -188,7 +191,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
     - name: Environment
@@ -232,7 +235,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
     - name: Environment
       run: |
@@ -273,7 +276,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
 
     - name: Environment

--- a/.github/workflows/release_tests_fast.yml
+++ b/.github/workflows/release_tests_fast.yml
@@ -19,8 +19,11 @@ env:
   MKL_NUM_THREADS: 8
   PYTEST_TIMEOUT: 600
   PIPELINE_USAGE_CUTOFF: 50000
-  # Force tokenizers<0.23.0 across every `uv pip install` in this workflow,
-  # even when transformers@main declares a higher lower-bound.
+  # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
+  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
+  #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
+  #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
+  #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
   UV_OVERRIDE: /tmp/uv-overrides.txt
 
 jobs:
@@ -39,7 +42,7 @@ jobs:
           fetch-depth: 2
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
       - name: Environment
@@ -81,7 +84,7 @@ jobs:
           nvidia-smi
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
@@ -133,7 +136,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip install peft@git+https://github.com/huggingface/peft.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
@@ -185,7 +188,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+          printf 'tokenizers<0.23.0\ntorch==2.6.0\ntorchvision==0.21.0\ntorchaudio==2.6.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip install peft@git+https://github.com/huggingface/peft.git
           uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
@@ -246,7 +249,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
     - name: Environment
@@ -290,7 +293,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
     - name: Environment
@@ -334,7 +337,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
+        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
 


### PR DESCRIPTION
# What does this PR do?

Fix https://github.com/huggingface/diffusers/actions/runs/26616425981/job/78433040396

Tested by replicating the CI workflow. The previous PR didn't fully realize the "install dependencies" step, which is what necessitates this PR.