### PR TITLE
Fix stale docstring in KarrasVeScheduler.step_correct

### DIFF
--- a/src/diffusers/schedulers/deprecated/scheduling_karras_ve.py
+++ b/src/diffusers/schedulers/deprecated/scheduling_karras_ve.py
@@ -218,10 +218,12 @@ class KarrasVeScheduler(SchedulerMixin, ConfigMixin):
             sample_prev (`torch.Tensor`): TODO
             derivative (`torch.Tensor`): TODO
             return_dict (`bool`, *optional*, defaults to `True`):
-                Whether or not to return a [`~schedulers.scheduling_ddpm.DDPMSchedulerOutput`] or `tuple`.
+                Whether or not to return a [`~schedulers.scheduling_karras_ve.KarrasVESchedulerOutput`] or `tuple`.
 
         Returns:
-            prev_sample (TODO): updated sample in the diffusion chain. derivative (TODO): TODO
+            [`~schedulers.scheduling_karras_ve.KarrasVESchedulerOutput`] or `tuple`:
+                If return_dict is `True`, [`~schedulers.scheduling_karras_ve.KarrasVESchedulerOutput`] is returned,
+                otherwise a tuple is returned where the first element is the sample tensor.
 
         """
         pred_original_sample = sample_prev + sigma_prev * model_output

--- a/src/diffusers/schedulers/scheduling_karras_ve_flax.py
+++ b/src/diffusers/schedulers/scheduling_karras_ve_flax.py
@@ -227,7 +227,9 @@ class FlaxKarrasVeScheduler(FlaxSchedulerMixin, ConfigMixin):
             return_dict (`bool`): option for returning tuple rather than FlaxKarrasVeOutput class
 
         Returns:
-            prev_sample (TODO): updated sample in the diffusion chain. derivative (TODO): TODO
+            [`~schedulers.scheduling_karras_ve_flax.FlaxKarrasVeOutput`] or `tuple`:
+                If return_dict is `True`, [`~schedulers.scheduling_karras_ve_flax.FlaxKarrasVeOutput`] is returned,
+                otherwise a tuple is returned where the first element is the sample tensor.
 
         """
         pred_original_sample = sample_prev + sigma_prev * model_output


### PR DESCRIPTION
## Description

Fixes stale docstring in :

1. **Stale reference**: The  parameter docstring incorrectly referenced `~schedulers.scheduling_ddpm.DDPMSchedulerOutput` instead of the correct `~schedulers.scheduling_karras_ve.KarrasVESchedulerOutput`. The `step()` method (same file) already had the correct reference.

2. **TODO placeholders**: The Returns section contained `prev_sample (TODO)` and `derivative (TODO): TODO` placeholder text. Replaced with proper documentation matching the pattern used in `step()`.

Applied the same Returns fix to the Flax version (`scheduling_karras_ve_flax.py`) which had the same placeholder TODOs.

## Related issues
- Cleans up two TODO docstring placeholders