### PR TITLE
Fix typo: maxmium -> maximum in memory optimization docs

### DIFF
--- a/docs/source/en/optimization/memory.md
+++ b/docs/source/en/optimization/memory.md
@@ -156,7 +156,7 @@ pipeline = StableDiffusionXLPipeline.from_pretrained(
 )
 ```
 
-Diffusers uses the maxmium memory of all devices by default, but if they don't fit on the GPUs, then you'll need to use a single GPU and offload to the CPU with the methods below.
+Diffusers uses the maximum memory of all devices by default, but if they don't fit on the GPUs, then you'll need to use a single GPU and offload to the CPU with the methods below.
 
 - [`~DiffusionPipeline.enable_model_cpu_offload`] only works on a single GPU but a very large model may not fit on it
 - [`~DiffusionPipeline.enable_sequential_cpu_offload`] may work but it is extremely slow and also limited to a single GPU

--- a/src/diffusers/schedulers/deprecated/scheduling_karras_ve.py
+++ b/src/diffusers/schedulers/deprecated/scheduling_karras_ve.py
@@ -218,10 +218,12 @@ class KarrasVeScheduler(SchedulerMixin, ConfigMixin):
             sample_prev (`torch.Tensor`): TODO
             derivative (`torch.Tensor`): TODO
             return_dict (`bool`, *optional*, defaults to `True`):
-                Whether or not to return a [`~schedulers.scheduling_ddpm.DDPMSchedulerOutput`] or `tuple`.
+                Whether or not to return a [`~schedulers.scheduling_karras_ve.KarrasVESchedulerOutput`] or `tuple`.
 
         Returns:
-            prev_sample (TODO): updated sample in the diffusion chain. derivative (TODO): TODO
+            [`~schedulers.scheduling_karras_ve.KarrasVESchedulerOutput`] or `tuple`:
+                If return_dict is `True`, [`~schedulers.scheduling_karras_ve.KarrasVESchedulerOutput`] is returned,
+                otherwise a tuple is returned where the first element is the sample tensor.
 
         """
         pred_original_sample = sample_prev + sigma_prev * model_output

--- a/src/diffusers/schedulers/scheduling_karras_ve_flax.py
+++ b/src/diffusers/schedulers/scheduling_karras_ve_flax.py
@@ -227,7 +227,9 @@ class FlaxKarrasVeScheduler(FlaxSchedulerMixin, ConfigMixin):
             return_dict (`bool`): option for returning tuple rather than FlaxKarrasVeOutput class
 
         Returns:
-            prev_sample (TODO): updated sample in the diffusion chain. derivative (TODO): TODO
+            [`~schedulers.scheduling_karras_ve_flax.FlaxKarrasVeOutput`] or `tuple`:
+                If return_dict is `True`, [`~schedulers.scheduling_karras_ve_flax.FlaxKarrasVeOutput`] is returned,
+                otherwise a tuple is returned where the first element is the sample tensor.
 
         """
         pred_original_sample = sample_prev + sigma_prev * model_output


### PR DESCRIPTION
Fixes a typo in `docs/source/en/optimization/memory.md`: `maxmium` → `maximum`.