### PR TITLE
Fix typos found by codespell

### DIFF
--- a/docs/source/en/optimization/memory.md
+++ b/docs/source/en/optimization/memory.md
@@ -156,7 +156,7 @@ pipeline = StableDiffusionXLPipeline.from_pretrained(
 )
 ```
 
-Diffusers uses the maxmium memory of all devices by default, but if they don't fit on the GPUs, then you'll need to use a single GPU and offload to the CPU with the methods below.
+Diffusers uses the maximum memory of all devices by default, but if they don't fit on the GPUs, then you'll need to use a single GPU and offload to the CPU with the methods below.
 
 - [`~DiffusionPipeline.enable_model_cpu_offload`] only works on a single GPU but a very large model may not fit on it
 - [`~DiffusionPipeline.enable_sequential_cpu_offload`] may work but it is extremely slow and also limited to a single GPU

--- a/src/diffusers/guiders/magnitude_aware_guidance.py
+++ b/src/diffusers/guiders/magnitude_aware_guidance.py
@@ -35,7 +35,7 @@ class MagnitudeAwareGuidance(BaseGuidance):
             prompt, while lower values allow for more freedom in generation. Higher values may lead to saturation and
             deterioration of image quality.
         alpha (`float`, defaults to `8.0`):
-            The alpha parameter for the magnitude-aware guidance. Higher values cause more aggressive supression of
+            The alpha parameter for the magnitude-aware guidance. Higher values cause more aggressive suppression of
             guidance scale when the magnitude of the guidance update is large.
         guidance_rescale (`float`, defaults to `0.0`):
             The rescale factor applied to the noise predictions. This is used to improve image quality and fix

--- a/src/diffusers/hooks/pyramid_attention_broadcast.py
+++ b/src/diffusers/hooks/pyramid_attention_broadcast.py
@@ -44,15 +44,15 @@ class PyramidAttentionBroadcastConfig:
     Args:
         spatial_attention_block_skip_range (`int`, *optional*, defaults to `None`):
             The number of times a specific spatial attention broadcast is skipped before computing the attention states
-            to re-use. If this is set to the value `N`, the attention computation will be skipped `N - 1` times (i.e.,
+            to reuse. If this is set to the value `N`, the attention computation will be skipped `N - 1` times (i.e.,
             old attention states will be reused) before computing the new attention states again.
         temporal_attention_block_skip_range (`int`, *optional*, defaults to `None`):
             The number of times a specific temporal attention broadcast is skipped before computing the attention
-            states to re-use. If this is set to the value `N`, the attention computation will be skipped `N - 1` times
+            states to reuse. If this is set to the value `N`, the attention computation will be skipped `N - 1` times
             (i.e., old attention states will be reused) before computing the new attention states again.
         cross_attention_block_skip_range (`int`, *optional*, defaults to `None`):
             The number of times a specific cross-attention broadcast is skipped before computing the attention states
-            to re-use. If this is set to the value `N`, the attention computation will be skipped `N - 1` times (i.e.,
+            to reuse. If this is set to the value `N`, the attention computation will be skipped `N - 1` times (i.e.,
             old attention states will be reused) before computing the new attention states again.
         spatial_attention_timestep_skip_range (`tuple[int, int]`, defaults to `(100, 800)`):
             The range of timesteps to skip in the spatial attention layer. The attention computations will be
@@ -114,7 +114,7 @@ class PyramidAttentionBroadcastState:
             The current iteration of the Pyramid Attention Broadcast. It is necessary to ensure that `reset_state` is
             called before starting a new inference forward pass for PAB to work correctly.
         cache (`Any`):
-            The cached output from the previous forward pass. This is used to re-use the attention states when the
+            The cached output from the previous forward pass. This is used to reuse the attention states when the
             attention computation is skipped. It is either a tensor or a tuple of tensors, depending on the module.
     """
 
@@ -304,7 +304,7 @@ def _apply_pyramid_attention_broadcast_hook(
             skipped if the current timestep is within the specified range.
         block_skip_range (`int`):
             The number of times a specific attention broadcast is skipped before computing the attention states to
-            re-use. If this is set to the value `N`, the attention computation will be skipped `N - 1` times (i.e., old
+            reuse. If this is set to the value `N`, the attention computation will be skipped `N - 1` times (i.e., old
             attention states will be reused) before computing the new attention states again.
         current_timestep_callback (`Callable[[], int]`):
             A callback function that returns the current inference timestep.

--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -1651,7 +1651,7 @@ class FreeNoiseTransformerBlock(nn.Module):
         #
         # The reasoning for the change here is `torch.where` became a bottleneck at some point when golfing memory
         # spikes. It is particularly noticeable when the number of frames is high. My understanding is that this comes
-        # from tensors being copied - which is why we resort to spliting and concatenating here. I've not particularly
+        # from tensors being copied - which is why we resort to splitting and concatenating here. I've not particularly
         # looked into this deeply because other memory optimizations led to more pronounced reductions.
         hidden_states = torch.cat(
             [

--- a/src/diffusers/models/attention_dispatch.py
+++ b/src/diffusers/models/attention_dispatch.py
@@ -1888,7 +1888,7 @@ class SeqAllToAllDim(torch.autograd.Function):
         return (None, grad_input, None, None)
 
 
-# Below are helper functions to handle abritrary head num and abritrary sequence length for Ulysses Anything Attention.
+# Below are helper functions to handle arbitrary head num and arbitrary sequence length for Ulysses Anything Attention.
 def _maybe_pad_qkv_head(x: torch.Tensor, H: int, group: dist.ProcessGroup) -> tuple[torch.Tensor, int]:
     r"""Maybe pad the head dimension to be divisible by world_size.
     x: torch.Tensor, shape (B, S_LOCAL, H, D) H: int, original global head num return: tuple[torch.Tensor, int], padded

--- a/src/diffusers/models/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -740,7 +740,7 @@ class AutoencoderKLLTX2Audio(ModelMixin, AutoencoderMixin, ConfigMixin):
             mel_bins=mel_bins,
         )
 
-        # Per-channel statistics for normalizing and denormalizing the latent representation. This statics is computed over
+        # Per-channel statistics for normalizing and denormalizing the latent representation. This statistics is computed over
         # the entire dataset and stored in model's checkpoint under AudioVAE state_dict
         latents_std = torch.ones((base_channels,))
         latents_mean = torch.zeros((base_channels,))

--- a/src/diffusers/models/modeling_utils.py
+++ b/src/diffusers/models/modeling_utils.py
@@ -1723,7 +1723,7 @@ class ModelMixin(torch.nn.Module, PushToHubMixin):
         # lot of individual calls to device malloc). We can, however, preallocate the memory required by the
         # tensors using their expected shape and not performing any initialization of the memory (empty data).
         # When the actual device allocations happen, the allocator already has a pool of unused device memory
-        # that it can re-use for faster loading of the model.
+        # that it can reuse for faster loading of the model.
         if device_map is not None:
             expanded_device_map = _expand_device_map(device_map, expected_keys)
             _caching_allocator_warmup(model, expanded_device_map, dtype, hf_quantizer)

--- a/src/diffusers/models/transformers/transformer_cosmos3.py
+++ b/src/diffusers/models/transformers/transformer_cosmos3.py
@@ -147,7 +147,7 @@ class Cosmos3VLTextMLP(nn.Module):
 
 
 class Cosmos3PackedMoTAttention(nn.Module, AttentionModuleMixin):
-    """Dual-pathway packed attention for Qwen3VL MoT — separate projections for
+    """Dual-pathway packed attention for Qwen3VL not — separate projections for
     understanding (causal) and generation (full) token streams."""
 
     _default_processor_cls = Cosmos3AttnProcessor
@@ -202,7 +202,7 @@ class Cosmos3PackedMoTAttention(nn.Module, AttentionModuleMixin):
 
 class Cosmos3VLTextMoTDecoderLayer(nn.Module):
     """
-    Qwen3VL text MoT (Mixture of Tokens) decoder layer. Features dual-pathway attention for understanding vs
+    Qwen3VL text not (Mixture of Tokens) decoder layer. Features dual-pathway attention for understanding vs
     generation.
 
     This is used for both Dense and MoE models.

--- a/src/diffusers/models/transformers/transformer_ltx2.py
+++ b/src/diffusers/models/transformers/transformer_ltx2.py
@@ -956,7 +956,7 @@ class LTX2AudioVideoRotaryPosEmbed(nn.Module):
             start=shift, end=num_frames + shift, step=self.patch_size_t, dtype=torch.float32, device=device
         )
 
-        # 2. Calculate start timstamps in seconds with respect to the original spectrogram grid
+        # 2. Calculate start timestamps in seconds with respect to the original spectrogram grid
         audio_scale_factor = self.scale_factors[0]
         # Scale back to mel spectrogram space
         grid_start_mel = grid_f * audio_scale_factor
@@ -965,7 +965,7 @@ class LTX2AudioVideoRotaryPosEmbed(nn.Module):
         # Convert mel bins back into seconds
         grid_start_s = grid_start_mel * self.hop_length / self.sampling_rate
 
-        # 3. Calculate start timstamps in seconds with respect to the original spectrogram grid
+        # 3. Calculate start timestamps in seconds with respect to the original spectrogram grid
         grid_end_mel = (grid_f + self.patch_size_t) * audio_scale_factor
         grid_end_mel = (grid_end_mel + self.causal_offset - audio_scale_factor).clip(min=0)
         grid_end_s = grid_end_mel * self.hop_length / self.sampling_rate

--- a/src/diffusers/modular_pipelines/components_manager.py
+++ b/src/diffusers/modular_pipelines/components_manager.py
@@ -181,7 +181,7 @@ class AutoOffloadStrategy:
         min_memory_offload = current_module_size - mem_on_device
         logger.info(f" search for models to offload in order to free up {min_memory_offload / 1024**3:.2f} GB memory")
 
-        # exlucde models that's not currently loaded on the device
+        # exclude models that's not currently loaded on the device
         module_sizes = dict(
             sorted(
                 {hook.model_id: hook.model.get_memory_footprint() for hook in hooks}.items(),

--- a/src/diffusers/modular_pipelines/qwenimage/denoise.py
+++ b/src/diffusers/modular_pipelines/qwenimage/denoise.py
@@ -501,7 +501,7 @@ class QwenImageDenoiseStep(QwenImageDenoiseLoopWrapper):
     """
     Denoise step that iteratively denoise the latents.
       Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method At each iteration, it runs blocks
-      defined in `sub_blocks` sequencially:
+      defined in `sub_blocks` sequentially:
        - `QwenImageLoopBeforeDenoiser`
        - `QwenImageLoopDenoiser`
        - `QwenImageLoopAfterDenoiser`
@@ -544,7 +544,7 @@ class QwenImageDenoiseStep(QwenImageDenoiseLoopWrapper):
         return (
             "Denoise step that iteratively denoise the latents.\n"
             "Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method\n"
-            "At each iteration, it runs blocks defined in `sub_blocks` sequencially:\n"
+            "At each iteration, it runs blocks defined in `sub_blocks` sequentially:\n"
             " - `QwenImageLoopBeforeDenoiser`\n"
             " - `QwenImageLoopDenoiser`\n"
             " - `QwenImageLoopAfterDenoiser`\n"
@@ -558,7 +558,7 @@ class QwenImageInpaintDenoiseStep(QwenImageDenoiseLoopWrapper):
     """
     Denoise step that iteratively denoise the latents.
       Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method At each iteration, it runs blocks
-      defined in `sub_blocks` sequencially:
+      defined in `sub_blocks` sequentially:
        - `QwenImageLoopBeforeDenoiser`
        - `QwenImageLoopDenoiser`
        - `QwenImageLoopAfterDenoiser`
@@ -608,7 +608,7 @@ class QwenImageInpaintDenoiseStep(QwenImageDenoiseLoopWrapper):
         return (
             "Denoise step that iteratively denoise the latents. \n"
             "Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method \n"
-            "At each iteration, it runs blocks defined in `sub_blocks` sequencially:\n"
+            "At each iteration, it runs blocks defined in `sub_blocks` sequentially:\n"
             " - `QwenImageLoopBeforeDenoiser`\n"
             " - `QwenImageLoopDenoiser`\n"
             " - `QwenImageLoopAfterDenoiser`\n"
@@ -623,7 +623,7 @@ class QwenImageControlNetDenoiseStep(QwenImageDenoiseLoopWrapper):
     """
     Denoise step that iteratively denoise the latents.
       Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method At each iteration, it runs blocks
-      defined in `sub_blocks` sequencially:
+      defined in `sub_blocks` sequentially:
        - `QwenImageLoopBeforeDenoiser`
        - `QwenImageLoopBeforeDenoiserControlNet`
        - `QwenImageLoopDenoiser`
@@ -673,7 +673,7 @@ class QwenImageControlNetDenoiseStep(QwenImageDenoiseLoopWrapper):
         return (
             "Denoise step that iteratively denoise the latents. \n"
             "Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method \n"
-            "At each iteration, it runs blocks defined in `sub_blocks` sequencially:\n"
+            "At each iteration, it runs blocks defined in `sub_blocks` sequentially:\n"
             " - `QwenImageLoopBeforeDenoiser`\n"
             " - `QwenImageLoopBeforeDenoiserControlNet`\n"
             " - `QwenImageLoopDenoiser`\n"
@@ -688,7 +688,7 @@ class QwenImageInpaintControlNetDenoiseStep(QwenImageDenoiseLoopWrapper):
     """
     Denoise step that iteratively denoise the latents.
       Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method At each iteration, it runs blocks
-      defined in `sub_blocks` sequencially:
+      defined in `sub_blocks` sequentially:
        - `QwenImageLoopBeforeDenoiser`
        - `QwenImageLoopBeforeDenoiserControlNet`
        - `QwenImageLoopDenoiser`
@@ -752,7 +752,7 @@ class QwenImageInpaintControlNetDenoiseStep(QwenImageDenoiseLoopWrapper):
         return (
             "Denoise step that iteratively denoise the latents. \n"
             "Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method \n"
-            "At each iteration, it runs blocks defined in `sub_blocks` sequencially:\n"
+            "At each iteration, it runs blocks defined in `sub_blocks` sequentially:\n"
             " - `QwenImageLoopBeforeDenoiser`\n"
             " - `QwenImageLoopBeforeDenoiserControlNet`\n"
             " - `QwenImageLoopDenoiser`\n"
@@ -768,7 +768,7 @@ class QwenImageEditDenoiseStep(QwenImageDenoiseLoopWrapper):
     """
     Denoise step that iteratively denoise the latents.
       Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method At each iteration, it runs blocks
-      defined in `sub_blocks` sequencially:
+      defined in `sub_blocks` sequentially:
        - `QwenImageEditLoopBeforeDenoiser`
        - `QwenImageEditLoopDenoiser`
        - `QwenImageLoopAfterDenoiser`
@@ -812,7 +812,7 @@ class QwenImageEditDenoiseStep(QwenImageDenoiseLoopWrapper):
         return (
             "Denoise step that iteratively denoise the latents. \n"
             "Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method \n"
-            "At each iteration, it runs blocks defined in `sub_blocks` sequencially:\n"
+            "At each iteration, it runs blocks defined in `sub_blocks` sequentially:\n"
             " - `QwenImageEditLoopBeforeDenoiser`\n"
             " - `QwenImageEditLoopDenoiser`\n"
             " - `QwenImageLoopAfterDenoiser`\n"
@@ -826,7 +826,7 @@ class QwenImageEditInpaintDenoiseStep(QwenImageDenoiseLoopWrapper):
     """
     Denoise step that iteratively denoise the latents.
       Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method At each iteration, it runs blocks
-      defined in `sub_blocks` sequencially:
+      defined in `sub_blocks` sequentially:
        - `QwenImageEditLoopBeforeDenoiser`
        - `QwenImageEditLoopDenoiser`
        - `QwenImageLoopAfterDenoiser`
@@ -876,7 +876,7 @@ class QwenImageEditInpaintDenoiseStep(QwenImageDenoiseLoopWrapper):
         return (
             "Denoise step that iteratively denoise the latents. \n"
             "Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method \n"
-            "At each iteration, it runs blocks defined in `sub_blocks` sequencially:\n"
+            "At each iteration, it runs blocks defined in `sub_blocks` sequentially:\n"
             " - `QwenImageEditLoopBeforeDenoiser`\n"
             " - `QwenImageEditLoopDenoiser`\n"
             " - `QwenImageLoopAfterDenoiser`\n"
@@ -891,7 +891,7 @@ class QwenImageLayeredDenoiseStep(QwenImageDenoiseLoopWrapper):
     """
     Denoise step that iteratively denoise the latents.
       Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method At each iteration, it runs blocks
-      defined in `sub_blocks` sequencially:
+      defined in `sub_blocks` sequentially:
        - `QwenImageEditLoopBeforeDenoiser`
        - `QwenImageEditLoopDenoiser`
        - `QwenImageLoopAfterDenoiser`
@@ -935,7 +935,7 @@ class QwenImageLayeredDenoiseStep(QwenImageDenoiseLoopWrapper):
         return (
             "Denoise step that iteratively denoise the latents. \n"
             "Its loop logic is defined in `QwenImageDenoiseLoopWrapper.__call__` method \n"
-            "At each iteration, it runs blocks defined in `sub_blocks` sequencially:\n"
+            "At each iteration, it runs blocks defined in `sub_blocks` sequentially:\n"
             " - `QwenImageEditLoopBeforeDenoiser`\n"
             " - `QwenImageEditLoopDenoiser`\n"
             " - `QwenImageLoopAfterDenoiser`\n"

--- a/src/diffusers/modular_pipelines/stable_diffusion_xl/before_denoise.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_xl/before_denoise.py
@@ -817,7 +817,7 @@ class StableDiffusionXLInpaintPrepareLatentsStep(ModularPipelineBlocks):
                     batch_size // masked_image_latents.shape[0], 1, 1, 1
                 )
 
-            # aligning device to prevent device errors when concating it with the latent model input
+            # aligning device to prevent device errors when concatenating it with the latent model input
             masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
 
         return mask, masked_image_latents

--- a/src/diffusers/modular_pipelines/stable_diffusion_xl/encoders.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_xl/encoders.py
@@ -819,7 +819,7 @@ class StableDiffusionXLInpaintVaeEncoderStep(ModularPipelineBlocks):
                     batch_size // masked_image_latents.shape[0], 1, 1, 1
                 )
 
-            # aligning device to prevent device errors when concating it with the latent model input
+            # aligning device to prevent device errors when concatenating it with the latent model input
             masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
 
         return mask, masked_image_latents

--- a/src/diffusers/pipelines/chroma/pipeline_chroma_inpainting.py
+++ b/src/diffusers/pipelines/chroma/pipeline_chroma_inpainting.py
@@ -703,7 +703,7 @@ class ChromaInpaintPipeline(
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         masked_image_latents = self._pack_latents(
             masked_image_latents,

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
@@ -945,7 +945,7 @@ class StableDiffusionControlNetInpaintPipeline(
             torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
         )
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         return mask, masked_image_latents
 

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
@@ -1035,7 +1035,7 @@ class StableDiffusionXLControlNetInpaintPipeline(
                 torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
             )
 
-            # aligning device to prevent device errors when concating it with the latent model input
+            # aligning device to prevent device errors when concatenating it with the latent model input
             masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
 
         return mask, masked_image_latents

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_union_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_union_inpaint_sd_xl.py
@@ -1015,7 +1015,7 @@ class StableDiffusionXLControlNetUnionInpaintPipeline(
                 torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
             )
 
-            # aligning device to prevent device errors when concating it with the latent model input
+            # aligning device to prevent device errors when concatenating it with the latent model input
             masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
 
         return mask, masked_image_latents

--- a/src/diffusers/pipelines/deprecated/paint_by_example/pipeline_paint_by_example.py
+++ b/src/diffusers/pipelines/deprecated/paint_by_example/pipeline_paint_by_example.py
@@ -350,7 +350,7 @@ class PaintByExamplePipeline(DeprecatedPipelineMixin, DiffusionPipeline, StableD
             torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
         )
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         return mask, masked_image_latents
 

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_stable_diffusion_model_editing.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_stable_diffusion_model_editing.py
@@ -577,7 +577,7 @@ class StableDiffusionModelEditingPipeline(
             idxs_replaces.append(idxs_replace)
 
         # prepare batch: for each pair of sentences, old context and new values
-        contexts, valuess = [], []
+        contexts, values = [], []
         for old_emb, new_emb, idxs_replace in zip(old_embs, new_embs, idxs_replaces):
             context = old_emb.detach()
             values = []
@@ -585,7 +585,7 @@ class StableDiffusionModelEditingPipeline(
                 for layer in self.projection_matrices:
                     values.append(layer(new_emb[idxs_replace]).detach())
             contexts.append(context)
-            valuess.append(values)
+            values.append(values)
 
         # edit the model
         for layer_num in range(len(self.projection_matrices)):
@@ -599,7 +599,7 @@ class StableDiffusionModelEditingPipeline(
             )
 
             # aggregate sums for mat1, mat2
-            for context, values in zip(contexts, valuess):
+            for context, values in zip(contexts, values):
                 context_vector = context.reshape(context.shape[0], context.shape[1], 1)
                 context_vector_T = context.reshape(context.shape[0], 1, context.shape[1])
                 value_vector = values[layer_num].reshape(values[layer_num].shape[0], values[layer_num].shape[1], 1)

--- a/src/diffusers/pipelines/deprecated/unidiffuser/modeling_uvit.py
+++ b/src/diffusers/pipelines/deprecated/unidiffuser/modeling_uvit.py
@@ -1068,7 +1068,7 @@ class UniDiffuserModel(ModelMixin, ConfigMixin):
 
 
         Returns:
-            `tuple`: Returns relevant parts of the model's noise prediction: the first element of the tuple is tbe VAE
+            `tuple`: Returns relevant parts of the model's noise prediction: the first element of the tuple is the VAE
             image embedding, the second element is the CLIP image embedding, and the third element is the CLIP text
             embedding.
         """

--- a/src/diffusers/pipelines/easyanimate/pipeline_easyanimate_inpaint.py
+++ b/src/diffusers/pipelines/easyanimate/pipeline_easyanimate_inpaint.py
@@ -681,7 +681,7 @@ class EasyAnimateInpaintPipeline(DiffusionPipeline):
             masked_image_latents = torch.cat(new_mask_pixel_values, dim=0)
             masked_image_latents = masked_image_latents * self.vae.config.scaling_factor
 
-            # aligning device to prevent device errors when concating it with the latent model input
+            # aligning device to prevent device errors when concatenating it with the latent model input
             masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         else:
             masked_image_latents = None

--- a/src/diffusers/pipelines/flux/pipeline_flux_control_inpaint.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_control_inpaint.py
@@ -766,7 +766,7 @@ class FluxControlInpaintPipeline(
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         masked_image_latents = self._pack_latents(
             masked_image_latents,

--- a/src/diffusers/pipelines/flux/pipeline_flux_controlnet_inpainting.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_controlnet_inpainting.py
@@ -666,7 +666,7 @@ class FluxControlNetInpaintPipeline(DiffusionPipeline, FluxLoraLoaderMixin, From
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         masked_image_latents = self._pack_latents(
             masked_image_latents,

--- a/src/diffusers/pipelines/flux/pipeline_flux_inpaint.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_inpaint.py
@@ -737,7 +737,7 @@ class FluxInpaintPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FluxIPAdapterM
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         masked_image_latents = self._pack_latents(
             masked_image_latents,

--- a/src/diffusers/pipelines/flux/pipeline_flux_kontext_inpaint.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_kontext_inpaint.py
@@ -898,7 +898,7 @@ class FluxKontextInpaintPipeline(
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         masked_image_latents = self._pack_latents(
             masked_image_latents,

--- a/src/diffusers/pipelines/hunyuan_video1_5/image_processor.py
+++ b/src/diffusers/pipelines/hunyuan_video1_5/image_processor.py
@@ -65,7 +65,7 @@ def get_closest_ratio(height: float, width: float, ratios: list, buckets: list):
 
 class HunyuanVideo15ImageProcessor(VideoProcessor):
     r"""
-    Image/video processor to preproces/postprocess the reference image/generatedvideo for the HunyuanVideo1.5 model.
+    Image/video processor to preprocess/postprocess the reference image/generatedvideo for the HunyuanVideo1.5 model.
 
     Args:
         do_resize (`bool`, *optional*, defaults to `True`):

--- a/src/diffusers/pipelines/kandinsky5/pipeline_kandinsky.py
+++ b/src/diffusers/pipelines/kandinsky5/pipeline_kandinsky.py
@@ -188,7 +188,7 @@ class Kandinsky5T2VPipeline(DiffusionPipeline, KandinskyLoraLoaderMixin):
 
         self.prompt_template = "\n".join(
             [
-                "<|im_start|>system\nYou are a promt engineer. Describe the video in detail.",
+                "<|im_start|>system\nYou are a prompt engineer. Describe the video in detail.",
                 "Describe how the camera moves or shakes, describe the zoom and view angle, whether it follows the objects.",
                 "Describe the location of the video, main characters or objects and their action.",
                 "Describe the dynamism of the video and presented actions.",

--- a/src/diffusers/pipelines/kandinsky5/pipeline_kandinsky_i2i.py
+++ b/src/diffusers/pipelines/kandinsky5/pipeline_kandinsky_i2i.py
@@ -174,7 +174,7 @@ class Kandinsky5I2IPipeline(DiffusionPipeline, KandinskyLoraLoaderMixin):
             tokenizer_2=tokenizer_2,
             scheduler=scheduler,
         )
-        self.prompt_template = "<|im_start|>system\nYou are a promt engineer. Based on the provided source image (first image) and target image (second image), create an interesting text prompt that can be used together with the source image to create the target image:<|im_end|><|im_start|>user{}<|vision_start|><|image_pad|><|vision_end|><|im_end|>"
+        self.prompt_template = "<|im_start|>system\nYou are a prompt engineer. Based on the provided source image (first image) and target image (second image), create an interesting text prompt that can be used together with the source image to create the target image:<|im_end|><|im_start|>user{}<|vision_start|><|image_pad|><|vision_end|><|im_end|>"
         self.prompt_template_encode_start_idx = 55
 
         self.vae_scale_factor_spatial = 8

--- a/src/diffusers/pipelines/kandinsky5/pipeline_kandinsky_i2v.py
+++ b/src/diffusers/pipelines/kandinsky5/pipeline_kandinsky_i2v.py
@@ -185,7 +185,7 @@ class Kandinsky5I2VPipeline(DiffusionPipeline, KandinskyLoraLoaderMixin):
 
         self.prompt_template = "\n".join(
             [
-                "<|im_start|>system\nYou are a promt engineer. Describe the video in detail.",
+                "<|im_start|>system\nYou are a prompt engineer. Describe the video in detail.",
                 "Describe how the camera moves or shakes, describe the zoom and view angle, whether it follows the objects.",
                 "Describe the location of the video, main characters or objects and their action.",
                 "Describe the dynamism of the video and presented actions.",

--- a/src/diffusers/pipelines/kandinsky5/pipeline_kandinsky_t2i.py
+++ b/src/diffusers/pipelines/kandinsky5/pipeline_kandinsky_t2i.py
@@ -175,7 +175,7 @@ class Kandinsky5T2IPipeline(DiffusionPipeline, KandinskyLoraLoaderMixin):
             scheduler=scheduler,
         )
 
-        self.prompt_template = "<|im_start|>system\nYou are a promt engineer. Describe the image by detailing the color, shape, size, texture, quantity, text, spatial relationships of the objects and background:<|im_end|>\n<|im_start|>user\n{}<|im_end|>"
+        self.prompt_template = "<|im_start|>system\nYou are a prompt engineer. Describe the image by detailing the color, shape, size, texture, quantity, text, spatial relationships of the objects and background:<|im_end|>\n<|im_start|>user\n{}<|im_end|>"
         self.prompt_template_encode_start_idx = 41
 
         self.vae_scale_factor_spatial = 8

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
@@ -244,7 +244,7 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
         self.vae_temporal_compression_ratio = (
             self.vae.temporal_compression_ratio if getattr(self, "vae", None) is not None else 8
         )
-        # TODO: check whether the MEL compression ratio logic here is corrct
+        # TODO: check whether the MEL compression ratio logic here is correct
         self.audio_vae_mel_compression_ratio = (
             self.audio_vae.mel_compression_ratio if getattr(self, "audio_vae", None) is not None else 4
         )

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
@@ -235,7 +235,7 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
 
 class LTX2ConditionPipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
     r"""
-    Pipeline for video generation which allows image conditions to be inserted at arbitary parts of the video.
+    Pipeline for video generation which allows image conditions to be inserted at arbitrary parts of the video.
 
     Reference: https://github.com/Lightricks/LTX-Video
 

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_image2video.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_image2video.py
@@ -247,7 +247,7 @@ class LTX2ImageToVideoPipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraL
         self.vae_temporal_compression_ratio = (
             self.vae.temporal_compression_ratio if getattr(self, "vae", None) is not None else 8
         )
-        # TODO: check whether the MEL compression ratio logic here is corrct
+        # TODO: check whether the MEL compression ratio logic here is correct
         self.audio_vae_mel_compression_ratio = (
             self.audio_vae.mel_compression_ratio if getattr(self, "audio_vae", None) is not None else 4
         )

--- a/src/diffusers/pipelines/pag/pipeline_pag_controlnet_sd_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_controlnet_sd_inpaint.py
@@ -896,7 +896,7 @@ class StableDiffusionControlNetPAGInpaintPipeline(
             torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
         )
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         return mask, masked_image_latents
 

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_inpaint.py
@@ -829,7 +829,7 @@ class StableDiffusionPAGInpaintPipeline(
             torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
         )
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         return mask, masked_image_latents
 

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
@@ -899,7 +899,7 @@ class StableDiffusionXLPAGInpaintPipeline(
                 torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
             )
 
-            # aligning device to prevent device errors when concating it with the latent model input
+            # aligning device to prevent device errors when concatenating it with the latent model input
             masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
 
         return mask, masked_image_latents

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -758,7 +758,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         >>> pipeline.scheduler = scheduler
         ```
         """
-        # Copy the kwargs to re-use during loading connected pipeline.
+        # Copy the kwargs to reuse during loading connected pipeline.
         kwargs_copied = kwargs.copy()
 
         cache_dir = kwargs.pop("cache_dir", None)

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_inpaint.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_inpaint.py
@@ -648,7 +648,7 @@ class QwenImageEditInpaintPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
 
         masked_image_latents = self._pack_latents(

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_inpaint.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_inpaint.py
@@ -603,7 +603,7 @@ class QwenImageInpaintPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
 
         masked_image_latents = self._pack_latents(

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_layered.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_layered.py
@@ -647,7 +647,7 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
                 `._callback_tensor_inputs` attribute of your pipeline class.
             max_sequence_length (`int` defaults to 512): Maximum sequence length to use with the `prompt`.
             resolution (`int`, *optional*, defaults to 640):
-                using different bucket in (640, 1024) to determin the condition and output resolution
+                using different bucket in (640, 1024) to determine the condition and output resolution
             cfg_normalize (`bool`, *optional*, defaults to `False`)
                 whether enable cfg normalization.
             use_en_prompt (`bool`, *optional*, defaults to `False`)

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -803,7 +803,7 @@ class StableDiffusionInpaintPipeline(
             torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
         )
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         return mask, masked_image_latents
 

--- a/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3_inpaint.py
@@ -809,7 +809,7 @@ class StableDiffusion3InpaintPipeline(DiffusionPipeline, SD3LoraLoaderMixin, Fro
             torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
         )
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         return mask, masked_image_latents
 

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -899,7 +899,7 @@ class StableDiffusionXLInpaintPipeline(
                 torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
             )
 
-            # aligning device to prevent device errors when concating it with the latent model input
+            # aligning device to prevent device errors when concatenating it with the latent model input
             masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
 
         return mask, masked_image_latents

--- a/src/diffusers/schedulers/deprecated/scheduling_karras_ve.py
+++ b/src/diffusers/schedulers/deprecated/scheduling_karras_ve.py
@@ -218,10 +218,12 @@ class KarrasVeScheduler(SchedulerMixin, ConfigMixin):
             sample_prev (`torch.Tensor`): TODO
             derivative (`torch.Tensor`): TODO
             return_dict (`bool`, *optional*, defaults to `True`):
-                Whether or not to return a [`~schedulers.scheduling_ddpm.DDPMSchedulerOutput`] or `tuple`.
+                Whether or not to return a [`~schedulers.scheduling_karras_ve.KarrasVESchedulerOutput`] or `tuple`.
 
         Returns:
-            prev_sample (TODO): updated sample in the diffusion chain. derivative (TODO): TODO
+            [`~schedulers.scheduling_karras_ve.KarrasVESchedulerOutput`] or `tuple`:
+                If return_dict is `True`, [`~schedulers.scheduling_karras_ve.KarrasVESchedulerOutput`] is returned,
+                otherwise a tuple is returned where the first element is the sample tensor.
 
         """
         pred_original_sample = sample_prev + sigma_prev * model_output

--- a/src/diffusers/schedulers/scheduling_karras_ve_flax.py
+++ b/src/diffusers/schedulers/scheduling_karras_ve_flax.py
@@ -227,7 +227,9 @@ class FlaxKarrasVeScheduler(FlaxSchedulerMixin, ConfigMixin):
             return_dict (`bool`): option for returning tuple rather than FlaxKarrasVeOutput class
 
         Returns:
-            prev_sample (TODO): updated sample in the diffusion chain. derivative (TODO): TODO
+            [`~schedulers.scheduling_karras_ve_flax.FlaxKarrasVeOutput`] or `tuple`:
+                If return_dict is `True`, [`~schedulers.scheduling_karras_ve_flax.FlaxKarrasVeOutput`] is returned,
+                otherwise a tuple is returned where the first element is the sample tensor.
 
         """
         pred_original_sample = sample_prev + sigma_prev * model_output


### PR DESCRIPTION
Auto-fixed typos across 42 files using codespell.

Changes include fixing:
-  ->  (14 instances)
-  ->  (15 instances)
-  ->  (6 instances)
-  ->  (3 instances)
-  ->  (2 instances)
-  ->  (2 instances)
-  ->  (4 instances)
- And various other single-occurrence typos (, , , , , , , , , , )