### PR TITLE
Fix duplicate safetensors.load_file call in _onload_from_disk when st…

### DIFF
--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -259,17 +259,16 @@ class ModuleGroup:
         current_stream = self._torch_accelerator_module.current_stream() if self.record_stream else None
 
         with context:
-            # Load to CPU (if using streams) or directly to target device, pin, and async copy to device
-            device = str(self.onload_device) if self.stream is None else "cpu"
-            loaded_tensors = safetensors.torch.load_file(self.safetensors_file_path, device=device)
-
             if self.stream is not None:
+                # Load to CPU first, pin memory, then async copy to the target device
+                loaded_tensors = safetensors.torch.load_file(self.safetensors_file_path, device="cpu")
                 for key, tensor_obj in self.key_to_tensor.items():
                     pinned_tensor = loaded_tensors[key].pin_memory()
                     tensor_obj.data = pinned_tensor.to(self.onload_device, non_blocking=self.non_blocking)
                     if self.record_stream:
                         tensor_obj.data.record_stream(current_stream)
             else:
+                # Load directly to the target device
                 onload_device = (
                     self.onload_device.type if isinstance(self.onload_device, torch.device) else self.onload_device
                 )


### PR DESCRIPTION
# Fix: Duplicate `safetensors.load_file` Call in `_onload_from_disk`

## Problem

In `src/diffusers/hooks/group_offloading.py`, `ModuleGroup._onload_from_disk` called `safetensors.torch.load_file()` twice when `stream is None` (the default, non-streaming path):

```python
# Called unconditionally — result discarded when stream is None
device = str(self.onload_device) if self.stream is None else "cpu"
loaded_tensors = safetensors.torch.load_file(
    self.safetensors_file_path,
    device=device,
)

if self.stream is not None:
    ...
else:
    onload_device = (
        self.onload_device.type
        if isinstance(self.onload_device, torch.device)
        else self.onload_device
    )

    # Second load — overwrites the first, which is silently discarded
    loaded_tensors = safetensors.torch.load_file(
        self.safetensors_file_path,
        device=onload_device,
    )
```

The first load result was immediately overwritten and garbage collected. As a result, every `_onload_from_disk` invocation in the default (`use_stream=False`) path performed two full tensor loads from disk while only using the second result.

Since `offload_to_disk_path` is typically used without streaming, this affected the documented and most common usage pattern.

## Impact

* **2× disk I/O** on every group load, slowing inference when disk offloading is enabled.
* **Transient 2× memory usage during loading** (CPU memory and potentially VRAM depending on the target device), increasing the risk of OOM on memory-constrained systems.
* Triggered on **every `_onload_from_disk` call**, which can occur hundreds or thousands of times during an inference run depending on model size and denoising steps.

## Solution

Move the `load_file()` call into the corresponding execution branch so that tensors are loaded exactly once using the correct device argument for that path.

This removes the redundant disk read and avoids allocating an unused copy of the loaded tensors while preserving existing behavior.
