### PR TITLE
Add Flux2 DreamBooth prior preservation tests

### DIFF
--- a/examples/dreambooth/test_dreambooth_lora_flux2.py
+++ b/examples/dreambooth/test_dreambooth_lora_flux2.py
@@ -111,6 +111,33 @@ class DreamBoothLoRAFlux2(ExamplesTestsAccelerate):
             starts_with_transformer = all(key.startswith("transformer") for key in lora_state_dict.keys())
             self.assertTrue(starts_with_transformer)
 
+    def test_dreambooth_lora_flux2_prior_preservation_batch_size_two(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_args = f"""
+                {self.script_path}
+                --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
+                --instance_data_dir {self.instance_data_dir}
+                --instance_prompt {self.instance_prompt}
+                --with_prior_preservation
+                --class_data_dir {self.instance_data_dir}
+                --class_prompt dog
+                --num_class_images 2
+                --resolution 64
+                --train_batch_size 2
+                --gradient_accumulation_steps 1
+                --max_train_steps 1
+                --learning_rate 5.0e-04
+                --scale_lr
+                --lr_scheduler constant
+                --lr_warmup_steps 0
+                --max_sequence_length 8
+                --text_encoder_out_layers 1
+                --output_dir {tmpdir}
+                """.split()
+
+            run_command(self._launch_args + test_args)
+            self.assertTrue(os.path.isfile(os.path.join(tmpdir, "pytorch_lora_weights.safetensors")))
+
     def test_dreambooth_lora_layers(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             test_args = f"""

--- a/examples/dreambooth/test_dreambooth_lora_flux2.py
+++ b/examples/dreambooth/test_dreambooth_lora_flux2.py
@@ -16,6 +16,7 @@
 import json
 import logging
 import os
+import shutil
 import sys
 import tempfile
 
@@ -113,13 +114,18 @@ class DreamBoothLoRAFlux2(ExamplesTestsAccelerate):
 
     def test_dreambooth_lora_flux2_prior_preservation_batch_size_two(self):
         with tempfile.TemporaryDirectory() as tmpdir:
+            class_data_dir = os.path.join(tmpdir, "class_data")
+            os.makedirs(class_data_dir)
+            for image_name in os.listdir(self.instance_data_dir)[:2]:
+                shutil.copy(os.path.join(self.instance_data_dir, image_name), class_data_dir)
+
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
                 --instance_data_dir {self.instance_data_dir}
                 --instance_prompt {self.instance_prompt}
                 --with_prior_preservation
-                --class_data_dir {self.instance_data_dir}
+                --class_data_dir {class_data_dir}
                 --class_prompt dog
                 --num_class_images 2
                 --resolution 64

--- a/examples/dreambooth/test_dreambooth_lora_flux2_klein.py
+++ b/examples/dreambooth/test_dreambooth_lora_flux2_klein.py
@@ -111,6 +111,33 @@ class DreamBoothLoRAFlux2Klein(ExamplesTestsAccelerate):
             starts_with_transformer = all(key.startswith("transformer") for key in lora_state_dict.keys())
             self.assertTrue(starts_with_transformer)
 
+    def test_dreambooth_lora_flux2_klein_prior_preservation_batch_size_two(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_args = f"""
+                {self.script_path}
+                --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
+                --instance_data_dir {self.instance_data_dir}
+                --instance_prompt {self.instance_prompt}
+                --with_prior_preservation
+                --class_data_dir {self.instance_data_dir}
+                --class_prompt dog
+                --num_class_images 2
+                --resolution 64
+                --train_batch_size 2
+                --gradient_accumulation_steps 1
+                --max_train_steps 1
+                --learning_rate 5.0e-04
+                --scale_lr
+                --lr_scheduler constant
+                --lr_warmup_steps 0
+                --max_sequence_length 8
+                --text_encoder_out_layers 1
+                --output_dir {tmpdir}
+                """.split()
+
+            run_command(self._launch_args + test_args)
+            self.assertTrue(os.path.isfile(os.path.join(tmpdir, "pytorch_lora_weights.safetensors")))
+
     def test_dreambooth_lora_layers(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             test_args = f"""

--- a/examples/dreambooth/test_dreambooth_lora_flux2_klein.py
+++ b/examples/dreambooth/test_dreambooth_lora_flux2_klein.py
@@ -16,6 +16,7 @@
 import json
 import logging
 import os
+import shutil
 import sys
 import tempfile
 
@@ -113,13 +114,18 @@ class DreamBoothLoRAFlux2Klein(ExamplesTestsAccelerate):
 
     def test_dreambooth_lora_flux2_klein_prior_preservation_batch_size_two(self):
         with tempfile.TemporaryDirectory() as tmpdir:
+            class_data_dir = os.path.join(tmpdir, "class_data")
+            os.makedirs(class_data_dir)
+            for image_name in os.listdir(self.instance_data_dir)[:2]:
+                shutil.copy(os.path.join(self.instance_data_dir, image_name), class_data_dir)
+
             test_args = f"""
                 {self.script_path}
                 --pretrained_model_name_or_path {self.pretrained_model_name_or_path}
                 --instance_data_dir {self.instance_data_dir}
                 --instance_prompt {self.instance_prompt}
                 --with_prior_preservation
-                --class_data_dir {self.instance_data_dir}
+                --class_data_dir {class_data_dir}
                 --class_prompt dog
                 --num_class_images 2
                 --resolution 64


### PR DESCRIPTION
# What does this PR do?

Adds DreamBooth LoRA smoke coverage for `Flux2` and `Flux2 Klein` prior-preservation training with `train_batch_size=2`.

This covers the prior-preservation path where the effective batch is grouped as `[instance samples..., class samples...]`. The test helps guard against regressions in prompt/text embedding repetition and prior-loss splitting when the per-device train batch size is greater than 1.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@sayakpaul 
