### PR TITLE
[tests] fix anyflow tests layerwise casting

### DIFF
--- a/src/diffusers/models/transformers/transformer_anyflow_far.py
+++ b/src/diffusers/models/transformers/transformer_anyflow_far.py
@@ -111,6 +111,7 @@ class AnyFlowCausalAttnProcessor:
 
         if encoder_hidden_states is None:
             encoder_hidden_states = hidden_states
+        target_dtype = hidden_states.dtype  # Effective compute dtype
 
         query = attn.to_q(hidden_states)
         key = attn.to_k(encoder_hidden_states)
@@ -121,8 +122,10 @@ class AnyFlowCausalAttnProcessor:
         if attn.norm_k is not None:
             key = attn.norm_k(key)
 
-        # Make layerwise upcasting work.
-        value = value.to(query.dtype)
+        # norm_q and norm_k upcast query and key to FP32 due to the use of RMSNorm, so cast them back to the effective
+        # compute dtype.
+        query = query.to(target_dtype)
+        key = key.to(target_dtype)
 
         # Layout (B, H, L, D) is required by KV-cache slicing and rotary application.
         query = query.unflatten(2, (attn.heads, -1)).transpose(1, 2)

--- a/tests/models/transformers/test_models_transformer_anyflow_far.py
+++ b/tests/models/transformers/test_models_transformer_anyflow_far.py
@@ -135,17 +135,11 @@ class TestAnyFlowFARTransformer3DTraining(AnyFlowFARTransformer3DTesterConfig, T
     # GPU-only (`torch.nn.attention.flex_attention` raises NotImplementedError on CPU). The
     # bidi transformer test file covers training on the SDPA path; FAR training correctness
     # is exercised end-to-end on H200 via the pipeline replay (L2=0 against NVlabs/AnyFlow).
-    pytest.mark.skipif(torch_device == "cpu", "FlexAttention has no CPU backward kernel.")
-
     def test_training(self):
         super().test_training()
 
-    pytest.mark.skipif(torch_device == "cpu", "FlexAttention has no CPU backward kernel.")
-
     def test_training_with_ema(self):
         super().test_training_with_ema()
-
-    pytest.mark.skipif(torch_device == "cpu", "FlexAttention has no CPU backward kernel.")
 
     def test_gradient_checkpointing_equivalence(self, loss_tolerance=1e-5, param_grad_tol=5e-5, skip=None):
         super().test_gradient_checkpointing_equivalence(loss_tolerance, param_grad_tol, skip)


### PR DESCRIPTION
# What does this PR do?

This PR is a follow up to #13855 which tries to fix the AnyFlow FAR causal transformer layerwise casting tests completely. See https://github.com/huggingface/diffusers/pull/13855#discussion_r3354224353 for an explanation of the main fix. This PR also includes removing the Flex Attention training CPU skips following https://github.com/huggingface/diffusers/pull/13855#discussion_r3354246526.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul

