### PR TITLE
fix(cosmos2_5_predict): guard text safety check with isinstance like the video path

### DIFF
--- a/src/diffusers/pipelines/cosmos/pipeline_cosmos2_5_predict.py
+++ b/src/diffusers/pipelines/cosmos/pipeline_cosmos2_5_predict.py
@@ -664,7 +664,7 @@ class Cosmos2_5_PredictBasePipeline(DiffusionPipeline):
 
         device = self._execution_device
 
-        if self.safety_checker is not None:
+        if isinstance(self.safety_checker, CosmosSafetyChecker):
             self.safety_checker.to(device)
             if prompt is not None:
                 prompt_list = [prompt] if isinstance(prompt, str) else prompt


### PR DESCRIPTION
## What does this PR do?

Fixes #13864.

In `Cosmos2_5_PredictBasePipeline.__call__`, the **text** safety check and the **video** safety check guard `self.safety_checker` inconsistently:

- Video path: `if isinstance(self.safety_checker, CosmosSafetyChecker):`
- Text path: `if self.safety_checker is not None:`

When `safety_checker` is a non-`None` object that is not a `CosmosSafetyChecker` (e.g. a user passes the wrong object via `safety_checker=`), the text path calls `self.safety_checker.check_text_safety(...)` and raises:

```
AttributeError: 'Cosmos2_5_PredictBasePipeline' object has no attribute 'check_text_safety'
```

while the video path silently skips. This PR aligns the text guard with the existing `isinstance` guard used by the video path, so both branches degrade gracefully on an unexpected `safety_checker` type. `None` is still rejected earlier in `__call__` with the explicit license `ValueError`, so this does not weaken the default safety behavior.

## Before submitting
- [x] This change is consistent with the existing `isinstance(self.safety_checker, CosmosSafetyChecker)` guard already used for the video safety check in the same method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
