### PR TITLE
Create `TestHooks` generator on `torch_device`

### DIFF
--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -159,7 +159,7 @@ class TestHooks:
         }
 
     def get_generator(self):
-        return torch.manual_seed(0)
+        return torch.Generator(device=torch_device).manual_seed(0)
 
     def test_hook_registry(self):
         registry = HookRegistry.check_if_exists_or_initialize(self.model)


### PR DESCRIPTION
# What does this PR do?

This PR implements a suggested fix to #13242 which creates the test generator in `TestHooks.get_generator` on `torch_device` rather than on CPU. This fixes a device mismatch error for the following tests (locally, when a GPU is present):

- `test_inference`
- `test_stateful_hook`
- `test_invocation_order_stateful_first`
- `test_invocation_order_stateful_middle`
- `test_invocation_order_stateful_last`


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul
