### PR TITLE
fix(tests): dtype-aware reference cast in test_from_save_pretrained_dtype_inference

### DIFF
--- a/tests/models/testing_utils/common.py
+++ b/tests/models/testing_utils/common.py
@@ -481,7 +481,30 @@ class ModelTesterMixin:
         model.to(torch_device)
         fp32_modules = model._keep_in_fp32_modules or []
 
-        model.to(dtype).save_pretrained(tmp_path)
+        # Cast the in-memory reference the same way `from_pretrained(torch_dtype=dtype)`
+        # does, so the two never diverge: parameters and persistent buffers are cast to
+        # `dtype` (except `_keep_in_fp32_modules`, which stay fp32), while non-persistent
+        # buffers such as RoPE `inv_freq` are not stored in the checkpoint and keep the
+        # dtype assigned in `__init__`. A blanket `model.to(dtype)` casts both of these
+        # cases unconditionally and produces spurious output mismatches.
+        non_persistent_buffers = set()
+        for module_name, module in model.named_modules():
+            for buffer_name in module._non_persistent_buffers_set:
+                non_persistent_buffers.add(f"{module_name}.{buffer_name}" if module_name else buffer_name)
+
+        def _keep_in_fp32(name):
+            return bool(fp32_modules) and any(m in name.split(".") for m in fp32_modules)
+
+        for name, param in model.named_parameters():
+            if param.is_floating_point() and not _keep_in_fp32(name):
+                param.data = param.data.to(dtype)
+        for name, buffer in model.named_buffers():
+            if name in non_persistent_buffers:
+                continue
+            if buffer.is_floating_point() and not _keep_in_fp32(name):
+                buffer.data = buffer.data.to(dtype)
+
+        model.save_pretrained(tmp_path)
         model_loaded = self.model_class.from_pretrained(tmp_path, torch_dtype=dtype).to(torch_device)
 
         for name, param in model_loaded.named_parameters():


### PR DESCRIPTION
## What does this PR do?

Fixes #13869.

`test_from_save_pretrained_dtype_inference` builds its reference output with a blanket `model.to(dtype)`, then compares it against `from_pretrained(tmp_path, torch_dtype=dtype)`. These two casts are not equivalent, so the comparison can diverge spuriously:

- **`_keep_in_fp32_modules`**: `from_pretrained` keeps these modules in fp32 (see `load_model_dict_into_meta` in `model_loading_utils.py`), but `model.to(dtype)` casts them to `dtype`.
- **Non-persistent buffers** (e.g. RoPE `inv_freq` created with an explicit dtype): these are not saved to the checkpoint, so `from_pretrained` never casts them and they keep the dtype assigned in `__init__`. `model.to(dtype)` casts them unconditionally.

Either case makes the in-memory reference differ from the loaded model and the output assertion fails even though save/load is correct.

This PR replaces the blanket cast with one that mirrors the loader's dtype-aware semantics: parameters and persistent buffers are cast to `dtype` (except `_keep_in_fp32_modules`, which stay fp32), while non-persistent buffers are left at their `__init__` dtype.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the documentation with your changes? (test-only change)
- [ ] Did you write any new necessary tests? (this fixes an existing test)

## Who can review?

@dg845 @DN6 (diagnosis from #13869 / #13862 review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)