### PR TITLE
fix marigold depth failure in xpu and A100

### DIFF
--- a/tests/pipelines/marigold/test_marigold_depth.py
+++ b/tests/pipelines/marigold/test_marigold_depth.py
@@ -341,15 +341,24 @@ class MarigoldDepthPipelineIntegrationTests(unittest.TestCase):
                 pipe_kwargs.get("processing_resolution", 768),
                 "Unexpected output resolution",
             )
-
         self.assertTrue(np.allclose(prediction_slice, expected_slice, atol=atol))
 
     def test_marigold_depth_einstein_f32_cpu_G0_S1_P32_E1_B1_M1(self):
+        # fmt: off
+        expected_slices = Expectations(
+            {
+                ("cuda", 7): np.array([0.4328, 0.4328, 0.4328, 0.4328, 0.4328, 0.4328, 0.4328, 0.4328, 0.4328]),
+                ("xpu", None): np.array([0.4323, 0.4323, 0.4323, 0.4323, 0.4323, 0.4323, 0.4323, 0.4323, 0.4323]),
+            }
+        )
+        expected_slice = expected_slices.get_expectation()
+        # fmt: on
+
         self._test_marigold_depth(
             is_fp16=False,
             device="cpu",
             generator_seed=0,
-            expected_slice=np.array([0.4323, 0.4323, 0.4323, 0.4323, 0.4323, 0.4323, 0.4323, 0.4323, 0.4323]),
+            expected_slice=expected_slice,
             num_inference_steps=1,
             processing_resolution=32,
             ensemble_size=1,
@@ -358,11 +367,20 @@ class MarigoldDepthPipelineIntegrationTests(unittest.TestCase):
         )
 
     def test_marigold_depth_einstein_f32_accelerator_G0_S1_P768_E1_B1_M1(self):
+        # fmt: off
+        expected_slices = Expectations(
+            {
+                ("cuda", 7): np.array([0.1243, 0.1265, 0.1291, 0.1239, 0.1252, 0.1266, 0.1245, 0.1225, 0.1179]),
+                ("xpu", None): np.array([0.1244, 0.1265, 0.1292, 0.1240, 0.1252, 0.1266, 0.1246, 0.1226, 0.1180]),
+            }
+        )
+        expected_slice = expected_slices.get_expectation()
+        # fmt: on
         self._test_marigold_depth(
             is_fp16=False,
             device=torch_device,
             generator_seed=0,
-            expected_slice=np.array([0.1244, 0.1265, 0.1292, 0.1240, 0.1252, 0.1266, 0.1246, 0.1226, 0.1180]),
+            expected_slice=expected_slice,
             num_inference_steps=1,
             processing_resolution=768,
             ensemble_size=1,
@@ -371,11 +389,21 @@ class MarigoldDepthPipelineIntegrationTests(unittest.TestCase):
         )
 
     def test_marigold_depth_einstein_f16_accelerator_G0_S1_P768_E1_B1_M1(self):
+        # fmt: off
+        expected_slices = Expectations(
+            {
+                ("cuda", 7): np.array([0.1242, 0.1263, 0.1290, 0.1237, 0.1249, 0.1263, 0.1243, 0.1223, 0.1177]),
+                ("xpu", 3): np.array([0.1241, 0.1262,  0.1290, 0.1237, 0.125, 0.1265, 0.1243, 0.1223, 0.1179]),
+                ("xpu", 5): np.array([0.1244, 0.1265, 0.1292, 0.1240, 0.1252, 0.1266, 0.1245, 0.1225, 0.1179]),
+            }
+        )
+        expected_slice = expected_slices.get_expectation()
+        # fmt: on
         self._test_marigold_depth(
             is_fp16=True,
             device=torch_device,
             generator_seed=0,
-            expected_slice=np.array([0.1241, 0.1262, 0.1290, 0.1238, 0.1250, 0.1265, 0.1244, 0.1225, 0.1179]),
+            expected_slice=expected_slice,
             num_inference_steps=1,
             processing_resolution=768,
             ensemble_size=1,
@@ -384,11 +412,21 @@ class MarigoldDepthPipelineIntegrationTests(unittest.TestCase):
         )
 
     def test_marigold_depth_einstein_f16_accelerator_G2024_S1_P768_E1_B1_M1(self):
+        # fmt: off
+        expected_slices = Expectations(
+            {
+                ("cuda", 7): np.array([0.1709, 0.1722, 0.1736, 0.1699, 0.1699, 0.1693, 0.1697, 0.1661, 0.1589]),
+                ("xpu", 3): np.array([0.1709, 0.1722, 0.1736, 0.1699, 0.1698, 0.1693, 0.1696, 0.1660, 0.1589]),
+                ("xpu", 5): np.array([0.1709, 0.1722, 0.1738, 0.1699, 0.1699, 0.1694, 0.1697, 0.1661, 0.1589]),
+            }
+        )
+        expected_slice = expected_slices.get_expectation()
+        # fmt: on
         self._test_marigold_depth(
             is_fp16=True,
             device=torch_device,
             generator_seed=2024,
-            expected_slice=np.array([0.1710, 0.1725, 0.1738, 0.1700, 0.1700, 0.1696, 0.1698, 0.1663, 0.1592]),
+            expected_slice=expected_slice,
             num_inference_steps=1,
             processing_resolution=768,
             ensemble_size=1,
@@ -400,9 +438,9 @@ class MarigoldDepthPipelineIntegrationTests(unittest.TestCase):
         # fmt: off
         expected_slices = Expectations(
             {
-                ("cuda", 7): np.array([0.1085, 0.1098, 0.1110, 0.1081, 0.1085, 0.1082, 0.1085, 0.1057, 0.0996]),
-                ("xpu", 3): np.array([0.1084, 0.1096, 0.1108, 0.1080, 0.1083, 0.1080,
- 0.1085, 0.1057, 0.0996]),
+                ("cuda", 7): np.array([0.1083, 0.1096, 0.1107, 0.1078, 0.1082, 0.1079, 0.1084, 0.1055, 0.0994]),
+                ("xpu", 3): np.array([0.1083, 0.1096, 0.1107, 0.1079, 0.1082, 0.1079, 0.1083, 0.1055, 0.0994]),
+                ("xpu", 5): np.array([0.1086, 0.1098, 0.1111, 0.1082, 0.1085, 0.1081, 0.1086, 0.1057, 0.0996]),
             }
         )
         expected_slice = expected_slices.get_expectation()
@@ -421,11 +459,21 @@ class MarigoldDepthPipelineIntegrationTests(unittest.TestCase):
         )
 
     def test_marigold_depth_einstein_f16_accelerator_G0_S1_P512_E1_B1_M1(self):
+        # fmt: off
+        expected_slices = Expectations(
+            {
+                ("cuda", 7): np.array([0.2683, 0.2693, 0.2698, 0.2666, 0.2632, 0.2615, 0.2656, 0.2603, 0.2573]),
+                ("xpu", 3): np.array([0.2678, 0.2688, 0.2695, 0.2661, 0.2629, 0.2612, 0.2654, 0.2600, 0.2573]),
+                ("xpu", 5): np.array([0.2683, 0.2693, 0.2698, 0.2666, 0.2634, 0.2617,0.2659, 0.2603, 0.2576]),
+            }
+        )
+        expected_slice = expected_slices.get_expectation()
+        # fmt: on
         self._test_marigold_depth(
             is_fp16=True,
             device=torch_device,
             generator_seed=0,
-            expected_slice=np.array([0.2683, 0.2693, 0.2698, 0.2666, 0.2632, 0.2615, 0.2656, 0.2603, 0.2573]),
+            expected_slice=expected_slice,
             num_inference_steps=1,
             processing_resolution=512,
             ensemble_size=1,
@@ -434,11 +482,22 @@ class MarigoldDepthPipelineIntegrationTests(unittest.TestCase):
         )
 
     def test_marigold_depth_einstein_f16_accelerator_G0_S1_P768_E3_B1_M1(self):
+        # fmt: off
+        expected_slices = Expectations(
+            {
+                ("cuda", 7): np.array([0.1075, 0.1099, 0.1121, 0.1069, 0.1070, 0.1066, 0.1063, 0.1011, 0.0931]),
+                ("xpu", 3): np.array([0.1074, 0.1097, 0.1120, 0.1068, 0.1069, 0.1064, 0.1061, 0.1010, 0.0930]),
+                ("xpu", 5): np.array([0.1196, 0.1212, 0.1234, 0.1189, 0.1193, 0.1199, 0.1192, 0.1162, 0.1105]),
+            }
+        )
+        expected_slice = expected_slices.get_expectation()
+        # fmt: on
+
         self._test_marigold_depth(
             is_fp16=True,
             device=torch_device,
             generator_seed=0,
-            expected_slice=np.array([0.1200, 0.1215, 0.1237, 0.1193, 0.1197, 0.1202, 0.1196, 0.1166, 0.1109]),
+            expected_slice=expected_slice,
             num_inference_steps=1,
             processing_resolution=768,
             ensemble_size=3,
@@ -448,11 +507,22 @@ class MarigoldDepthPipelineIntegrationTests(unittest.TestCase):
         )
 
     def test_marigold_depth_einstein_f16_accelerator_G0_S1_P768_E4_B2_M1(self):
+        # fmt: off
+        expected_slices = Expectations(
+            {
+                ("cuda", 7): np.array([0.0933, 0.0952, 0.0969, 0.0927, 0.0927, 0.0918, 0.0922, 0.0872, 0.0792]),
+                ("xpu", 3): np.array([0.1010, 0.1031, 0.1052, 0.1006, 0.1010, 0.1007, 0.1005, 0.0961, 0.0890]),
+                ("xpu", 5): np.array([0.1118, 0.1132, 0.1153, 0.1110, 0.1112, 0.1115, 0.1108, 0.1076, 0.1016]),
+            }
+        )
+        expected_slice = expected_slices.get_expectation()
+        # fmt: on
+
         self._test_marigold_depth(
             is_fp16=True,
             device=torch_device,
             generator_seed=0,
-            expected_slice=np.array([0.1121, 0.1135, 0.1155, 0.1111, 0.1115, 0.1118, 0.1111, 0.1079, 0.1019]),
+            expected_slice=expected_slice,
             num_inference_steps=1,
             processing_resolution=768,
             ensemble_size=4,
@@ -462,11 +532,21 @@ class MarigoldDepthPipelineIntegrationTests(unittest.TestCase):
         )
 
     def test_marigold_depth_einstein_f16_accelerator_G0_S1_P512_E1_B1_M0(self):
+        # fmt: off
+        expected_slices = Expectations(
+            {
+                ("cuda", 7): np.array([0.2671, 0.2690, 0.2720, 0.2659, 0.2676, 0.2739, 0.2664, 0.2686, 0.2573]),
+                ("xpu", 3): np.array([0.2671, 0.2686, 0.2715, 0.2656, 0.2671, 0.2734, 0.2661, 0.2681, 0.2573]),
+                ("xpu", 5): np.array([0.2671, 0.2690, 0.2720, 0.2659, 0.2676, 0.2739, 0.2664, 0.2686, 0.2576]),
+            }
+        )
+        expected_slice = expected_slices.get_expectation()
+        # fmt: on
         self._test_marigold_depth(
             is_fp16=True,
             device=torch_device,
             generator_seed=0,
-            expected_slice=np.array([0.2671, 0.2690, 0.2720, 0.2659, 0.2676, 0.2739, 0.2664, 0.2686, 0.2573]),
+            expected_slice=expected_slice,
             num_inference_steps=1,
             processing_resolution=512,
             ensemble_size=1,


### PR DESCRIPTION
fix tests/pipelines/marigold/test_marigold_depth.py::MarigoldDepthPipelineIntegrationTests failure in xpu and A100

@sayakpaul please help review and merge