### PR TITLE
fix(attention): correct XLA flash attention availability check and in…

### DIFF
--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -324,12 +324,12 @@ class Attention(nn.Module):
                 Specify the partition specification if using SPMD. Otherwise None.
         """
         if use_xla_flash_attention:
-            if not is_torch_xla_available:
-                raise "torch_xla is not available"
+            if not is_torch_xla_available():
+                raise ImportError("torch_xla is not available")
             elif is_torch_xla_version("<", "2.3"):
-                raise "flash attention pallas kernel is supported from torch_xla version 2.3"
+                raise ImportError("flash attention pallas kernel is supported from torch_xla version 2.3")
             elif is_spmd() and is_torch_xla_version("<", "2.4"):
-                raise "flash attention pallas kernel using SPMD is supported from torch_xla version 2.4"
+                raise ImportError("flash attention pallas kernel using SPMD is supported from torch_xla version 2.4")
             else:
                 if is_flux:
                     processor = XLAFluxFlashAttnProcessor2_0(partition_spec)


### PR DESCRIPTION
# Fix broken XLA Flash Attention version guard

## Problem

`Attention.set_use_xla_flash_attention(True)` contains a broken version guard in `attention_processor.py` (lines 327–332) due to two compounding issues:

1. `is_torch_xla_available` is referenced without `()`, so the function object itself is evaluated instead of its return value. Since function objects are always truthy, the availability check never executes as intended.

2. All three `raise "string"` statements are invalid Python. `raise` requires an exception deriving from `BaseException`; otherwise it results in:

   ```
   TypeError: exceptions must derive from BaseException
   ```

## Impact

When `set_use_xla_flash_attention(True)` is called on a system without XLA installed, the availability guard is bypassed and execution proceeds to instantiate `XLAFlashAttnProcessor2_0`.

However, `XLAFlashAttnProcessor2_0` is only defined inside the module-level `if is_torch_xla_available():` block, resulting in:

```python
NameError: name 'XLAFlashAttnProcessor2_0' is not defined
```

This produces an obscure failure far from the actual root cause and provides no actionable guidance to users. The same issue affects the XLA version checks for `>= 2.3` and `>= 2.4`.

## Fix

* Call `is_torch_xla_available()` instead of referencing the function object.
* Replace all `raise "string"` statements with `raise ImportError(...)`.
* Align error handling with the existing missing-dependency checks used elsewhere in the file.

## Result

Users now receive clear and actionable `ImportError` messages when XLA is unavailable or does not meet the required version, instead of encountering unrelated runtime failures.
