### PR TITLE
fix: log ignored longcat positional id arguments

### DIFF
--- a/src/diffusers/pipelines/longcat_image/pipeline_longcat_image.py
+++ b/src/diffusers/pipelines/longcat_image/pipeline_longcat_image.py
@@ -110,7 +110,7 @@ def prepare_pos_ids(modality_id=0, type="text", start=(0, 0), num_token=None, he
     if type == "text":
         assert num_token
         if height or width:
-            print('Warning: The parameters of height and width will be ignored in "text" type.')
+            logger.warning('The parameters `height` and `width` are ignored when `type="text"`.')
         pos_ids = torch.zeros(num_token, 3)
         pos_ids[..., 0] = modality_id
         pos_ids[..., 1] = torch.arange(num_token) + start[0]
@@ -118,14 +118,14 @@ def prepare_pos_ids(modality_id=0, type="text", start=(0, 0), num_token=None, he
     elif type == "image":
         assert height and width
         if num_token:
-            print('Warning: The parameter of num_token will be ignored in "image" type.')
+            logger.warning('The parameter `num_token` is ignored when `type="image"`.')
         pos_ids = torch.zeros(height, width, 3)
         pos_ids[..., 0] = modality_id
         pos_ids[..., 1] = pos_ids[..., 1] + torch.arange(height)[:, None] + start[0]
         pos_ids[..., 2] = pos_ids[..., 2] + torch.arange(width)[None, :] + start[1]
         pos_ids = pos_ids.reshape(height * width, 3)
     else:
-        raise KeyError(f'Unknow type {type}, only support "text" or "image".')
+        raise KeyError(f'Unknown type {type}, only support "text" or "image".')
     return pos_ids
 
 

--- a/src/diffusers/pipelines/longcat_image/pipeline_longcat_image_edit.py
+++ b/src/diffusers/pipelines/longcat_image/pipeline_longcat_image_edit.py
@@ -108,7 +108,7 @@ def prepare_pos_ids(modality_id=0, type="text", start=(0, 0), num_token=None, he
     if type == "text":
         assert num_token
         if height or width:
-            print('Warning: The parameters of height and width will be ignored in "text" type.')
+            logger.warning('The parameters `height` and `width` are ignored when `type="text"`.')
         pos_ids = torch.zeros(num_token, 3)
         pos_ids[..., 0] = modality_id
         pos_ids[..., 1] = torch.arange(num_token) + start[0]
@@ -116,14 +116,14 @@ def prepare_pos_ids(modality_id=0, type="text", start=(0, 0), num_token=None, he
     elif type == "image":
         assert height and width
         if num_token:
-            print('Warning: The parameter of num_token will be ignored in "image" type.')
+            logger.warning('The parameter `num_token` is ignored when `type="image"`.')
         pos_ids = torch.zeros(height, width, 3)
         pos_ids[..., 0] = modality_id
         pos_ids[..., 1] = pos_ids[..., 1] + torch.arange(height)[:, None] + start[0]
         pos_ids[..., 2] = pos_ids[..., 2] + torch.arange(width)[None, :] + start[1]
         pos_ids = pos_ids.reshape(height * width, 3)
     else:
-        raise KeyError(f'Unknow type {type}, only support "text" or "image".')
+        raise KeyError(f'Unknown type {type}, only support "text" or "image".')
     return pos_ids
 
 

--- a/tests/pipelines/longcat_image/test_prepare_pos_ids.py
+++ b/tests/pipelines/longcat_image/test_prepare_pos_ids.py
@@ -1,0 +1,45 @@
+import pytest
+
+from diffusers.pipelines.longcat_image.pipeline_longcat_image import (
+    logger as base_logger,
+    prepare_pos_ids as prepare_pos_ids_base,
+)
+from diffusers.pipelines.longcat_image.pipeline_longcat_image_edit import (
+    logger as edit_logger,
+    prepare_pos_ids as prepare_pos_ids_edit,
+)
+from ...testing_utils import CaptureLogger
+
+
+@pytest.mark.parametrize(
+    ("prepare_pos_ids", "logger"),
+    (
+        (prepare_pos_ids_base, base_logger),
+        (prepare_pos_ids_edit, edit_logger),
+    ),
+)
+def test_prepare_pos_ids_logs_ignored_text_dimensions(prepare_pos_ids, logger):
+    with CaptureLogger(logger) as captured:
+        prepare_pos_ids(type="text", num_token=4, height=8, width=8)
+
+    assert 'ignored when `type="text"`' in captured.out
+
+
+@pytest.mark.parametrize(
+    ("prepare_pos_ids", "logger"),
+    (
+        (prepare_pos_ids_base, base_logger),
+        (prepare_pos_ids_edit, edit_logger),
+    ),
+)
+def test_prepare_pos_ids_logs_ignored_image_num_token(prepare_pos_ids, logger):
+    with CaptureLogger(logger) as captured:
+        prepare_pos_ids(type="image", num_token=4, height=2, width=3)
+
+    assert 'ignored when `type="image"`' in captured.out
+
+
+@pytest.mark.parametrize("prepare_pos_ids", (prepare_pos_ids_base, prepare_pos_ids_edit))
+def test_prepare_pos_ids_unknown_type_message(prepare_pos_ids):
+    with pytest.raises(KeyError, match='Unknown type audio'):
+        prepare_pos_ids(type="audio", num_token=4)


### PR DESCRIPTION
## Summary

This PR replaces direct `print()` warnings in the LongCat positional-id helpers with standard logger warnings and fixes the `Unknown type` error message.

## Problem

`prepare_pos_ids()` in both LongCat image pipelines currently prints warnings directly to stdout when callers pass ignored arguments. That is noisy for library consumers and harder to capture in tests. The helper also raises a `KeyError` with a small typo in the message.

## Changes

- replace direct `print()` calls with `logger.warning()` in both LongCat image helpers
- fix `Unknow type` to `Unknown type`
- add a small regression test covering both helpers

## Verification

- `python -m py_compile src/diffusers/pipelines/longcat_image/pipeline_longcat_image.py src/diffusers/pipelines/longcat_image/pipeline_longcat_image_edit.py tests/pipelines/longcat_image/test_prepare_pos_ids.py`
- Not run: `pytest` is not available in this environment, so I could not execute the new test locally.
