### PR TITLE
Fix incorrect batch temporal IDs for `cond_model_input` in Flux2 Klein img2img training

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux2_klein_img2img.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_klein_img2img.py
@@ -1663,13 +1663,13 @@ def main(args):
                 cond_model_input = (cond_model_input - latents_bn_mean) / latents_bn_std
 
                 model_input_ids = Flux2KleinPipeline._prepare_latent_ids(model_input).to(device=model_input.device)
-                cond_model_input_list = [cond_model_input[i].unsqueeze(0) for i in range(cond_model_input.shape[0])]
-                cond_model_input_ids = Flux2KleinPipeline._prepare_image_ids(cond_model_input_list).to(
+                # Each batch element is an independent training sample with a single
+                # conditional image. Generate temporal IDs for one sample and expand
+                # across the batch, avoiding incorrect cross-sample temporal offsets.
+                cond_model_input_ids = Flux2KleinPipeline._prepare_image_ids([cond_model_input[0:1]]).to(
                     device=cond_model_input.device
                 )
-                cond_model_input_ids = cond_model_input_ids.view(
-                    cond_model_input.shape[0], -1, model_input_ids.shape[-1]
-                )
+                cond_model_input_ids = cond_model_input_ids.expand(cond_model_input.shape[0], -1, -1)
 
                 # Sample noise that we'll add to the latents
                 noise = torch.randn_like(model_input)


### PR DESCRIPTION
# What does this PR do?

Fixes #13866

`train_dreambooth_lora_flux2_klein_img2img.py` builds the conditional-image position ids wrong for a batch:

```python
cond_model_input_list = [cond_model_input[i].unsqueeze(0) for i in range(cond_model_input.shape[0])]
cond_model_input_ids = Flux2KleinPipeline._prepare_image_ids(cond_model_input_list)...
```

`_prepare_image_ids` is meant for **multiple reference images of one instance** — it assigns each list element a different temporal coordinate (`T = scale + scale*i` → 10, 20, 30, …). But here each batch element is an **independent training sample with a single conditional image**, so they all get spurious cross-sample temporal offsets instead of the same `T`.

Fix: generate ids for one sample and `expand` across the batch, so every sample shares `T = 10`. This is the Flux2 Klein counterpart of the same bug/fix in `train_dreambooth_lora_flux2_img2img.py` (#13811).

## Verification

`Flux2KleinPipeline._prepare_image_ids` on a `(3, 4, 4, 4)` input (CPU, no weights):

```
OLD T per-batch (unique): [10, 20, 30]   # cross-sample offsets = the bug
NEW T per-batch (unique): [10, 10, 10]   # independent samples share one temporal id
shapes: (3, 16, 4) (3, 16, 4)            # output shape unchanged
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue? #13866
- [x] Did you write any new necessary tests? (n/a — one-line correctness fix in an example training script, mirroring the approved #13811 fix)

## Who can review?

@sayakpaul @linoytsaban
