### PR TITLE
Fix #13094: fix: correct Z-Image guidance scale threshold from > 1 to > 0

### DIFF
--- a/examples/community/pipeline_z_image_differential_img2img.py
+++ b/examples/community/pipeline_z_image_differential_img2img.py
@@ -432,7 +432,7 @@ class ZImageDifferentialImg2ImgPipeline(DiffusionPipeline, ZImageLoraLoaderMixin
 
     @property
     def do_classifier_free_guidance(self):
-        return self._guidance_scale > 1
+        return self._guidance_scale > 0
 
     @property
     def joint_attention_kwargs(self):


### PR DESCRIPTION
Fixes #13094

Minimal fix for the linked issue.

Local test infra unavailable in CI sandbox.

---
This change was prepared with AI assistance under human direction and review.