### PR TITLE
Add `from_single_file` support for `Ideogram4Transformer2DModel`

### DIFF
--- a/src/diffusers/loaders/single_file_model.py
+++ b/src/diffusers/loaders/single_file_model.py
@@ -42,6 +42,7 @@ from .single_file_utils import (
     convert_flux_transformer_checkpoint_to_diffusers,
     convert_hidream_transformer_to_diffusers,
     convert_hunyuan_video_transformer_to_diffusers,
+    convert_ideogram4_transformer_checkpoint_to_diffusers,
     convert_ldm_unet_checkpoint,
     convert_ldm_vae_checkpoint,
     convert_ltx2_audio_vae_to_diffusers,
@@ -174,6 +175,10 @@ SINGLE_FILE_LOADABLE_CLASSES = {
     },
     "CosmosTransformer3DModel": {
         "checkpoint_mapping_fn": convert_cosmos_transformer_checkpoint_to_diffusers,
+        "default_subfolder": "transformer",
+    },
+    "Ideogram4Transformer2DModel": {
+        "checkpoint_mapping_fn": convert_ideogram4_transformer_checkpoint_to_diffusers,
         "default_subfolder": "transformer",
     },
     "QwenImageTransformer2DModel": {

--- a/src/diffusers/loaders/single_file_utils.py
+++ b/src/diffusers/loaders/single_file_utils.py
@@ -4180,3 +4180,23 @@ def convert_ernie_image_transformer_checkpoint_to_diffusers(checkpoint, **kwargs
             checkpoint[k.replace("model.diffusion_model.", "")] = checkpoint.pop(k)
 
     return checkpoint
+
+
+def convert_ideogram4_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
+    # Original/GGUF Ideogram 4 checkpoints fuse the attention projection as `attention.qkv` and name
+    # the output projection `attention.o`; diffusers uses split to_q/to_k/to_v and to_out.0. Every
+    # other key already matches the diffusers layout.
+    if not any(k.endswith("attention.qkv.weight") for k in checkpoint):
+        return checkpoint
+    converted_state_dict = {}
+    num_layers = max(int(k.split(".")[1]) for k in checkpoint if k.startswith("layers.")) + 1
+    for i in range(num_layers):
+        q, k, v = torch.chunk(checkpoint.pop(f"layers.{i}.attention.qkv.weight"), 3, dim=0)
+        converted_state_dict[f"layers.{i}.attention.to_q.weight"] = q
+        converted_state_dict[f"layers.{i}.attention.to_k.weight"] = k
+        converted_state_dict[f"layers.{i}.attention.to_v.weight"] = v
+        converted_state_dict[f"layers.{i}.attention.to_out.0.weight"] = checkpoint.pop(
+            f"layers.{i}.attention.o.weight"
+        )
+    converted_state_dict.update(checkpoint)
+    return converted_state_dict


### PR DESCRIPTION
# What does this PR do?

Adds `from_single_file` support for `Ideogram4Transformer2DModel`, so the community Ideogram 4 single-file / GGUF checkpoints load directly — e.g. [leejet/ideogram-4-GGUF](https://huggingface.co/leejet/ideogram-4-GGUF) and [stduhpf/ideogram-4-gguf](https://huggingface.co/stduhpf/ideogram-4-gguf), which are popular but currently can't be loaded in diffusers.

The single-file layout already matches diffusers except attention, which fuses the projection as `attention.qkv` and names the output projection `attention.o`. The conversion splits `qkv` into `to_q`/`to_k`/`to_v` and renames `o` → `to_out.0`; every other key passes through unchanged.

```python
import torch
from diffusers import Ideogram4Transformer2DModel, GGUFQuantizationConfig

transformer = Ideogram4Transformer2DModel.from_single_file(
    "https://huggingface.co/leejet/ideogram-4-GGUF/blob/main/ideogram4-Q4_0.gguf",
    config="ideogram-ai/ideogram-4-fp8",
    subfolder="transformer",
    quantization_config=GGUFQuantizationConfig(compute_dtype=torch.bfloat16),
)
```

Checked on the `Q4_0` GGUF: the converted state dict matches the model 1:1 (all keys and shapes), it loads through `from_single_file` and runs on a 16 GB GPU (~5.7 GB), and the split `to_q`/`to_k`/`to_v` line up with the official bf16 weights — cross-checked against the swapped splits to confirm the `[q, k, v]` order.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md)?
- [ ] Was this discussed/approved via a GitHub issue or the forum? It's a small additive `from_single_file` registration, mirroring the existing converters (flux/chroma/cosmos/…).
- [x] Did you make sure to update the documentation with your changes? No doc change needed.
- [ ] Did you write any new necessary tests? The Ideogram weights are gated, so a standard single-file integration test needs gated access in CI — happy to add one in whatever form you prefer; verification is in the description above.

## Who can review?

@DN6 @sayakpaul
