### PR TITLE
Log VQ remapping configuration through the model logger

### DIFF
--- a/src/diffusers/models/autoencoders/vae.py
+++ b/src/diffusers/models/autoencoders/vae.py
@@ -17,7 +17,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from ...utils import BaseOutput
+from ...utils import BaseOutput, logging
 from ...utils.torch_utils import randn_tensor
 from ..activations import get_activation
 from ..attention_processor import SpatialNorm
@@ -27,6 +27,8 @@ from ..unets.unet_2d_blocks import (
     get_down_block,
     get_up_block,
 )
+
+logger = logging.get_logger(__name__)
 
 
 @dataclass
@@ -599,7 +601,7 @@ class VectorQuantizer(nn.Module):
             if self.unknown_index == "extra":
                 self.unknown_index = self.re_embed
                 self.re_embed = self.re_embed + 1
-            print(
+            logger.info(
                 f"Remapping {self.n_e} indices to {self.re_embed} indices. "
                 f"Using {self.unknown_index} for unknown indices."
             )

--- a/src/diffusers/models/autoencoders/vae.py
+++ b/src/diffusers/models/autoencoders/vae.py
@@ -17,7 +17,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from ...utils import BaseOutput
+from ...utils import BaseOutput, logging
 from ...utils.torch_utils import randn_tensor
 from ..activations import get_activation
 from ..attention_processor import SpatialNorm
@@ -27,6 +27,9 @@ from ..unets.unet_2d_blocks import (
     get_down_block,
     get_up_block,
 )
+
+
+logger = logging.get_logger(__name__)
 
 
 @dataclass
@@ -599,7 +602,7 @@ class VectorQuantizer(nn.Module):
             if self.unknown_index == "extra":
                 self.unknown_index = self.re_embed
                 self.re_embed = self.re_embed + 1
-            print(
+            logger.info(
                 f"Remapping {self.n_e} indices to {self.re_embed} indices. "
                 f"Using {self.unknown_index} for unknown indices."
             )

--- a/tests/models/autoencoders/test_models_vq.py
+++ b/tests/models/autoencoders/test_models_vq.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import pytest
 import torch
 
 from diffusers import VQModel
+from diffusers.models.autoencoders.vae import VectorQuantizer
 from diffusers.utils.torch_utils import randn_tensor
 
 from ...testing_utils import backend_manual_seed, enable_full_determinism, torch_device
@@ -107,6 +109,18 @@ class TestVQModel(VQModelTesterConfig, ModelTesterMixin):
         expected_output = torch.tensor([0.1936])
         # fmt: on
         assert torch.allclose(output, expected_output, atol=1e-3)
+
+    def test_vector_quantizer_logs_remap_configuration(self, tmp_path):
+        remap_path = tmp_path / "used.npy"
+        np.save(remap_path, np.array([0, 2, 4], dtype=np.int64))
+
+        with self.assertLogs("diffusers.models.autoencoders.vae", level="INFO") as captured_logs:
+            VectorQuantizer(n_e=8, vq_embed_dim=4, beta=0.25, remap=str(remap_path), unknown_index="extra")
+
+        assert any(
+            "Remapping 8 indices to 4 indices. Using 3 for unknown indices." in message
+            for message in captured_logs.output
+        )
 
 
 class TestVQModelTraining(VQModelTesterConfig, TrainingTesterMixin):

--- a/tests/models/autoencoders/test_models_vq.py
+++ b/tests/models/autoencoders/test_models_vq.py
@@ -13,10 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
+import numpy as np
 import pytest
 import torch
 
 from diffusers import VQModel
+from diffusers.models.autoencoders.vae import VectorQuantizer
 from diffusers.utils.torch_utils import randn_tensor
 
 from ...testing_utils import backend_manual_seed, enable_full_determinism, torch_device
@@ -118,6 +122,18 @@ class TestVQModel(VQModelTesterConfig, ModelTesterMixin):
         expected_output = torch.tensor([0.1936])
         # fmt: on
         assert torch.allclose(output, expected_output, atol=1e-3)
+
+    def test_vector_quantizer_logs_remap_configuration(self, caplog, tmp_path):
+        remap_path = tmp_path / "used.npy"
+        np.save(remap_path, np.array([0, 2, 4], dtype=np.int64))
+
+        with caplog.at_level(logging.INFO, logger="diffusers.models.autoencoders.vae"):
+            VectorQuantizer(n_e=8, vq_embed_dim=4, beta=0.25, remap=str(remap_path), unknown_index="extra")
+
+        assert any(
+            "Remapping 8 indices to 4 indices. Using 3 for unknown indices." in record.message
+            for record in caplog.records
+        )
 
 
 class TestVQModelTraining(VQModelTesterConfig, TrainingTesterMixin):


### PR DESCRIPTION
## Summary
- route `VectorQuantizer` remap configuration output through the model logger instead of writing directly to stdout
- add a regression test that captures the remap message when remapping is enabled

## Why
This message is emitted from library/model initialization code. Sending it to stdout makes it harder for downstream users to manage output, while the logger keeps the signal available without forcing terminal noise.

## Validation
- `python -m pytest tests/models/autoencoders/test_models_vq.py -k test_vector_quantizer_logs_remap_configuration -q`
- `ruff check src/diffusers/models/autoencoders/vae.py tests/models/autoencoders/test_models_vq.py`
- `ruff format --check src/diffusers/models/autoencoders/vae.py tests/models/autoencoders/test_models_vq.py`
- `python -m py_compile src/diffusers/models/autoencoders/vae.py tests/models/autoencoders/test_models_vq.py`

## Issue Linkage
This is a small logging cleanup and is not tied to an existing tracked issue.