### PR TITLE
Fix ZImageControlNetModel.from_transformer sharing weights with the base transformer

### DIFF
--- a/src/diffusers/models/controlnets/controlnet_z_image.py
+++ b/src/diffusers/models/controlnets/controlnet_z_image.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import math
 from typing import Literal
 
@@ -517,15 +518,18 @@ class ZImageControlNetModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOrigi
 
     @classmethod
     def from_transformer(cls, controlnet, transformer):
+        # Deep-copy the reused transformer modules/params so the control net owns independent weights;
+        # a shallow assignment registers them on the control net and leaks later ``.to()``/optimizer
+        # updates back into the transformer.
         controlnet.t_scale = transformer.t_scale
-        controlnet.t_embedder = transformer.t_embedder
-        controlnet.all_x_embedder = transformer.all_x_embedder
-        controlnet.cap_embedder = transformer.cap_embedder
-        controlnet.rope_embedder = transformer.rope_embedder
-        controlnet.noise_refiner = transformer.noise_refiner
-        controlnet.context_refiner = transformer.context_refiner
-        controlnet.x_pad_token = transformer.x_pad_token
-        controlnet.cap_pad_token = transformer.cap_pad_token
+        controlnet.t_embedder = copy.deepcopy(transformer.t_embedder)
+        controlnet.all_x_embedder = copy.deepcopy(transformer.all_x_embedder)
+        controlnet.cap_embedder = copy.deepcopy(transformer.cap_embedder)
+        controlnet.rope_embedder = copy.deepcopy(transformer.rope_embedder)
+        controlnet.noise_refiner = copy.deepcopy(transformer.noise_refiner)
+        controlnet.context_refiner = copy.deepcopy(transformer.context_refiner)
+        controlnet.x_pad_token = copy.deepcopy(transformer.x_pad_token)
+        controlnet.cap_pad_token = copy.deepcopy(transformer.cap_pad_token)
         return controlnet
 
     @staticmethod

--- a/tests/models/controlnets/test_models_controlnet_z_image.py
+++ b/tests/models/controlnets/test_models_controlnet_z_image.py
@@ -1,0 +1,96 @@
+# coding=utf-8
+# Copyright 2025 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+
+from diffusers import ZImageControlNetModel, ZImageTransformer2DModel
+
+
+def _get_tiny_transformer():
+    return ZImageTransformer2DModel(
+        all_patch_size=(2,),
+        all_f_patch_size=(1,),
+        in_channels=16,
+        dim=16,
+        n_layers=1,
+        n_refiner_layers=1,
+        n_heads=1,
+        n_kv_heads=2,
+        qk_norm=True,
+        cap_feat_dim=16,
+        rope_theta=256.0,
+        t_scale=1000.0,
+        axes_dims=[8, 4, 4],
+        axes_lens=[256, 32, 32],
+    )
+
+
+def _get_tiny_controlnet():
+    return ZImageControlNetModel(
+        control_layers_places=[0],
+        control_refiner_layers_places=[0],
+        control_in_dim=16,
+        all_patch_size=(2,),
+        all_f_patch_size=(1,),
+        dim=16,
+        n_refiner_layers=1,
+        n_heads=1,
+        n_kv_heads=2,
+        qk_norm=True,
+    )
+
+
+class ZImageControlNetModelTests(unittest.TestCase):
+    def test_from_transformer_copies_weights_without_sharing(self):
+        torch.manual_seed(0)
+        transformer = _get_tiny_transformer()
+        # Z-Image initializes a few tensors with ``torch.empty``; fill them with finite values
+        # so the mutation checks below are not thrown off by uninitialized memory.
+        with torch.no_grad():
+            for p in transformer.parameters():
+                p.normal_()
+
+        controlnet = ZImageControlNetModel.from_transformer(_get_tiny_controlnet(), transformer)
+
+        # The components carried over from the transformer must be independent objects, not shared
+        # references -- otherwise casting or optimizing the control net silently mutates the
+        # transformer too.
+        self.assertIsNot(controlnet.t_embedder, transformer.t_embedder)
+        self.assertIsNot(controlnet.all_x_embedder, transformer.all_x_embedder)
+        self.assertIsNot(controlnet.cap_embedder, transformer.cap_embedder)
+        self.assertIsNot(controlnet.noise_refiner, transformer.noise_refiner)
+        self.assertIsNot(controlnet.context_refiner, transformer.context_refiner)
+        self.assertIsNot(controlnet.x_pad_token, transformer.x_pad_token)
+        self.assertIsNot(controlnet.cap_pad_token, transformer.cap_pad_token)
+
+        # The carried-over weights must start out identical to the transformer's (a copy, not a re-init).
+        for (_, copied), (_, original) in zip(
+            controlnet.noise_refiner.named_parameters(), transformer.noise_refiner.named_parameters()
+        ):
+            self.assertTrue(torch.equal(copied, original))
+
+        # Concretely: mutating every control-net parameter must leave the transformer untouched.
+        reference = {name: param.detach().clone() for name, param in transformer.named_parameters()}
+        with torch.no_grad():
+            for param in controlnet.parameters():
+                param.add_(1.0)
+        for name, param in transformer.named_parameters():
+            self.assertTrue(torch.equal(reference[name], param), f"transformer parameter '{name}' was mutated")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# What does this PR do?

`ZImageControlNetModel.from_transformer` assigns the transformer's `t_embedder`, `all_x_embedder`, `cap_embedder`, `rope_embedder`, `noise_refiner`, `context_refiner` and the `x_pad_token` / `cap_pad_token` parameters straight onto the control net. They get registered as the control net's own submodules, so anything done to the control net later also touches the transformer: `controlnet.to(dtype/device)` or an optimizer over `controlnet.parameters()` mutates the base transformer's weights in place.

This deep-copies the reused components so the control net owns independent weights, the same way `FluxControlNetModel` holds its own copies. `t_scale` is a float and stays a plain assignment.

There was no test under `tests/models/controlnets/` for this model, so I added one for `from_transformer`: it checks the carried-over modules are independent objects, start out as exact copies, and that mutating the control net leaves the transformer untouched. Fails on `main`, passes here.

A larger `__init__` refactor is also possible (build these submodules and load them via `state_dict`, like Flux); happy to do that instead if you'd prefer. I kept this one minimal.

Fixes #13077

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Pointed it at `.ai/` — read `AGENTS.md` and `review-rules.md`.
  - [x] Self-reviewed the diff against `.ai/review-rules.md`.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed via a GitHub issue? Fixing reported issue #13077.
- [x] Did you write any new necessary tests?

## Who can review?

@hlky — you added the Z-Image ControlNet in #12792, so this is your area.
