### PR TITLE
Add `AttentionMixin` to transformers that are missing it

### DIFF
--- a/src/diffusers/models/transformers/transformer_anyflow.py
+++ b/src/diffusers/models/transformers/transformer_anyflow.py
@@ -29,7 +29,7 @@ from ...configuration_utils import ConfigMixin, register_to_config
 from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
 from ...utils import apply_lora_scale, logging
 from ...utils.torch_utils import maybe_adjust_dtype_for_device
-from ..attention import AttentionModuleMixin, FeedForward
+from ..attention import AttentionMixin, AttentionModuleMixin, FeedForward
 from ..attention_dispatch import dispatch_attention_fn
 from ..embeddings import PixArtAlphaTextProjection, TimestepEmbedding, Timesteps, get_1d_rotary_pos_embed
 from ..modeling_outputs import Transformer2DModelOutput
@@ -504,7 +504,7 @@ class AnyFlowTransformerBlock(nn.Module):
         return hidden_states
 
 
-class AnyFlowTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin):
+class AnyFlowTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin, AttentionMixin):
     r"""
     Bidirectional 3D Transformer for AnyFlow flow-map sampling.
 

--- a/src/diffusers/models/transformers/transformer_anyflow_far.py
+++ b/src/diffusers/models/transformers/transformer_anyflow_far.py
@@ -31,7 +31,7 @@ from ...configuration_utils import ConfigMixin, register_to_config
 from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
 from ...utils import BaseOutput, apply_lora_scale, logging
 from ...utils.torch_utils import maybe_adjust_dtype_for_device
-from ..attention import AttentionModuleMixin, FeedForward
+from ..attention import AttentionMixin, AttentionModuleMixin, FeedForward
 from ..attention_dispatch import dispatch_attention_fn
 from ..embeddings import PixArtAlphaTextProjection, TimestepEmbedding, Timesteps, get_1d_rotary_pos_embed
 from ..modeling_outputs import Transformer2DModelOutput
@@ -958,7 +958,7 @@ def _build_far_block_mask_from_far_cfg(far_cfg, has_clean, device):
     )
 
 
-class AnyFlowFARTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin):
+class AnyFlowFARTransformer3DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin, AttentionMixin):
     r"""
     Causal (FAR) 3D Transformer for AnyFlow flow-map sampling with chunk-wise autoregressive generation.
 

--- a/src/diffusers/models/transformers/transformer_bria.py
+++ b/src/diffusers/models/transformers/transformer_bria.py
@@ -10,7 +10,7 @@ from ...configuration_utils import ConfigMixin, register_to_config
 from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
 from ...utils import apply_lora_scale, logging
 from ...utils.torch_utils import maybe_adjust_dtype_for_device, maybe_allow_in_graph
-from ..attention import AttentionModuleMixin, FeedForward
+from ..attention import AttentionMixin, AttentionModuleMixin, FeedForward
 from ..attention_dispatch import dispatch_attention_fn
 from ..cache_utils import CacheMixin
 from ..embeddings import TimestepEmbedding, apply_rotary_emb, get_timestep_embedding
@@ -501,7 +501,9 @@ class BriaSingleTransformerBlock(nn.Module):
         return encoder_hidden_states, hidden_states
 
 
-class BriaTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin, CacheMixin):
+class BriaTransformer2DModel(
+    ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin, CacheMixin, AttentionMixin
+):
     """
     The Transformer model introduced in Flux. Based on FluxPipeline with several changes:
     - no pooled embeddings

--- a/src/diffusers/models/transformers/transformer_bria_fibo.py
+++ b/src/diffusers/models/transformers/transformer_bria_fibo.py
@@ -26,7 +26,7 @@ from ...utils import (
     logging,
 )
 from ...utils.torch_utils import maybe_adjust_dtype_for_device, maybe_allow_in_graph
-from ..attention import AttentionModuleMixin, FeedForward
+from ..attention import AttentionMixin, AttentionModuleMixin, FeedForward
 from ..attention_dispatch import dispatch_attention_fn
 from ..normalization import AdaLayerNormContinuous, AdaLayerNormZero, AdaLayerNormZeroSingle
 
@@ -426,7 +426,7 @@ class BriaFiboTimestepProjEmbeddings(nn.Module):
         return timesteps_emb
 
 
-class BriaFiboTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin):
+class BriaFiboTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin, AttentionMixin):
     """
     Parameters:
         patch_size (`int`): Patch size to turn the input data into small patches.

--- a/src/diffusers/models/transformers/transformer_ernie_image.py
+++ b/src/diffusers/models/transformers/transformer_ernie_image.py
@@ -27,7 +27,7 @@ import torch.nn.functional as F
 from ...configuration_utils import ConfigMixin, register_to_config
 from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
 from ...utils import BaseOutput, logging
-from ..attention import AttentionModuleMixin
+from ..attention import AttentionMixin, AttentionModuleMixin
 from ..attention_dispatch import dispatch_attention_fn
 from ..attention_processor import Attention
 from ..embeddings import TimestepEmbedding, Timesteps
@@ -289,7 +289,7 @@ class ErnieImageAdaLNContinuous(nn.Module):
         return x
 
 
-class ErnieImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin):
+class ErnieImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin, AttentionMixin):
     _supports_gradient_checkpointing = True
     _repeated_blocks = ["ErnieImageSharedAdaLNBlock"]
 

--- a/src/diffusers/models/transformers/transformer_longcat_audio_dit.py
+++ b/src/diffusers/models/transformers/transformer_longcat_audio_dit.py
@@ -25,7 +25,7 @@ import torch.nn.functional as F
 from ...configuration_utils import ConfigMixin, register_to_config
 from ...utils import BaseOutput
 from ...utils.torch_utils import lru_cache_unless_export, maybe_allow_in_graph
-from ..attention import AttentionModuleMixin
+from ..attention import AttentionMixin, AttentionModuleMixin
 from ..attention_dispatch import dispatch_attention_fn
 from ..modeling_utils import ModelMixin
 from ..normalization import RMSNorm
@@ -452,7 +452,7 @@ class AudioDiTBlock(nn.Module):
         return hidden_states
 
 
-class LongCatAudioDiTTransformer(ModelMixin, ConfigMixin):
+class LongCatAudioDiTTransformer(ModelMixin, ConfigMixin, AttentionMixin):
     _supports_gradient_checkpointing = False
     _repeated_blocks = ["AudioDiTBlock"]
 

--- a/src/diffusers/models/transformers/transformer_ovis_image.py
+++ b/src/diffusers/models/transformers/transformer_ovis_image.py
@@ -23,7 +23,7 @@ from ...configuration_utils import ConfigMixin, register_to_config
 from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
 from ...utils import logging
 from ...utils.torch_utils import maybe_adjust_dtype_for_device, maybe_allow_in_graph
-from ..attention import AttentionModuleMixin, FeedForward
+from ..attention import AttentionMixin, AttentionModuleMixin, FeedForward
 from ..attention_dispatch import dispatch_attention_fn
 from ..cache_utils import CacheMixin
 from ..embeddings import TimestepEmbedding, Timesteps, apply_rotary_emb, get_1d_rotary_pos_embed
@@ -387,6 +387,7 @@ class OvisImageTransformer2DModel(
     PeftAdapterMixin,
     FromOriginalModelMixin,
     CacheMixin,
+    AttentionMixin,
 ):
     """
     The Transformer model introduced in Ovis-Image.

--- a/tests/models/transformers/test_models_transformer_anyflow.py
+++ b/tests/models/transformers/test_models_transformer_anyflow.py
@@ -98,6 +98,11 @@ class AnyFlowTransformer3DTesterConfig(BaseModelTesterConfig):
 
 
 class TestAnyFlowTransformer3D(AnyFlowTransformer3DTesterConfig, ModelTesterMixin):
+    def test_attention_processor_api(self):
+        model = self.model_class(**self.get_init_dict())
+        assert len(model.attn_processors) > 0
+        model.set_attn_processor(model.attn_processors)
+
     """Core model tests for AnyFlow Transformer 3D (bidirectional variant)."""
 
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])

--- a/tests/models/transformers/test_models_transformer_anyflow.py
+++ b/tests/models/transformers/test_models_transformer_anyflow.py
@@ -98,12 +98,12 @@ class AnyFlowTransformer3DTesterConfig(BaseModelTesterConfig):
 
 
 class TestAnyFlowTransformer3D(AnyFlowTransformer3DTesterConfig, ModelTesterMixin):
+    """Core model tests for AnyFlow Transformer 3D (bidirectional variant)."""
+
     def test_attention_processor_api(self):
         model = self.model_class(**self.get_init_dict())
         assert len(model.attn_processors) > 0
         model.set_attn_processor(model.attn_processors)
-
-    """Core model tests for AnyFlow Transformer 3D (bidirectional variant)."""
 
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
     def test_from_save_pretrained_dtype_inference(self, tmp_path, dtype):

--- a/tests/models/transformers/test_models_transformer_anyflow_far.py
+++ b/tests/models/transformers/test_models_transformer_anyflow_far.py
@@ -111,12 +111,12 @@ class AnyFlowFARTransformer3DTesterConfig(BaseModelTesterConfig):
 
 
 class TestAnyFlowFARTransformer3D(AnyFlowFARTransformer3DTesterConfig, ModelTesterMixin):
+    """Core model tests for AnyFlow FAR causal Transformer 3D."""
+
     def test_attention_processor_api(self):
         model = self.model_class(**self.get_init_dict())
         assert len(model.attn_processors) > 0
         model.set_attn_processor(model.attn_processors)
-
-    """Core model tests for AnyFlow FAR causal Transformer 3D."""
 
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
     def test_from_save_pretrained_dtype_inference(self, tmp_path, dtype):

--- a/tests/models/transformers/test_models_transformer_anyflow_far.py
+++ b/tests/models/transformers/test_models_transformer_anyflow_far.py
@@ -111,6 +111,11 @@ class AnyFlowFARTransformer3DTesterConfig(BaseModelTesterConfig):
 
 
 class TestAnyFlowFARTransformer3D(AnyFlowFARTransformer3DTesterConfig, ModelTesterMixin):
+    def test_attention_processor_api(self):
+        model = self.model_class(**self.get_init_dict())
+        assert len(model.attn_processors) > 0
+        model.set_attn_processor(model.attn_processors)
+
     """Core model tests for AnyFlow FAR causal Transformer 3D."""
 
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])

--- a/tests/models/transformers/test_models_transformer_bria.py
+++ b/tests/models/transformers/test_models_transformer_bria.py
@@ -88,6 +88,11 @@ class BriaTransformerTesterConfig(BaseModelTesterConfig):
 
 
 class TestBriaTransformer(BriaTransformerTesterConfig, ModelTesterMixin):
+    def test_attention_processor_api(self):
+        model = self.model_class(**self.get_init_dict())
+        assert len(model.attn_processors) > 0
+        model.set_attn_processor(model.attn_processors)
+
     def test_deprecated_inputs_img_txt_ids_3d(self):
         init_dict = self.get_init_dict()
         inputs_dict = self.get_dummy_inputs()

--- a/tests/models/transformers/test_models_transformer_bria_fibo.py
+++ b/tests/models/transformers/test_models_transformer_bria_fibo.py
@@ -91,7 +91,10 @@ class BriaFiboTransformerTesterConfig(BaseModelTesterConfig):
 
 
 class TestBriaFiboTransformer(BriaFiboTransformerTesterConfig, ModelTesterMixin):
-    pass
+    def test_attention_processor_api(self):
+        model = self.model_class(**self.get_init_dict())
+        assert len(model.attn_processors) > 0
+        model.set_attn_processor(model.attn_processors)
 
 
 class TestBriaFiboTransformerTraining(BriaFiboTransformerTesterConfig, TrainingTesterMixin):

--- a/tests/models/transformers/test_models_transformer_ernie_image.py
+++ b/tests/models/transformers/test_models_transformer_ernie_image.py
@@ -101,7 +101,10 @@ class ErnieImageTransformerTesterConfig(BaseModelTesterConfig):
 
 
 class TestErnieImageTransformer(ErnieImageTransformerTesterConfig, ModelTesterMixin):
-    pass
+    def test_attention_processor_api(self):
+        model = self.model_class(**self.get_init_dict())
+        assert len(model.attn_processors) > 0
+        model.set_attn_processor(model.attn_processors)
 
 
 class TestErnieImageTransformerTraining(ErnieImageTransformerTesterConfig, TrainingTesterMixin):

--- a/tests/models/transformers/test_models_transformer_longcat_audio_dit.py
+++ b/tests/models/transformers/test_models_transformer_longcat_audio_dit.py
@@ -82,7 +82,10 @@ class LongCatAudioDiTTransformerTesterConfig(BaseModelTesterConfig):
 
 
 class TestLongCatAudioDiTTransformer(LongCatAudioDiTTransformerTesterConfig, ModelTesterMixin):
-    pass
+    def test_attention_processor_api(self):
+        model = self.model_class(**self.get_init_dict())
+        assert len(model.attn_processors) > 0
+        model.set_attn_processor(model.attn_processors)
 
 
 class TestLongCatAudioDiTTransformerMemory(LongCatAudioDiTTransformerTesterConfig, MemoryTesterMixin):

--- a/tests/models/transformers/test_models_transformer_ovis_image.py
+++ b/tests/models/transformers/test_models_transformer_ovis_image.py
@@ -88,7 +88,13 @@ class OvisImageTransformerTesterConfig(BaseModelTesterConfig):
 
 
 class TestOvisImageTransformer(OvisImageTransformerTesterConfig, ModelTesterMixin):
-    pass
+    def test_attention_processor_api(self):
+        # OvisImageTransformer2DModel should expose the standard AttentionMixin APIs.
+        model = self.model_class(**self.get_init_dict())
+        assert len(model.attn_processors) > 0
+        model.set_attn_processor(model.attn_processors)
+        model.fuse_qkv_projections()
+        model.unfuse_qkv_projections()
 
 
 class TestOvisImageTransformerTraining(OvisImageTransformerTesterConfig, TrainingTesterMixin):


### PR DESCRIPTION
# What does this PR do?

Several transformers build their attention with `AttentionModuleMixin` but don't inherit the model-level `AttentionMixin`, so `attn_processors` / `set_attn_processor` / `fuse_qkv_projections` / `unfuse_qkv_projections` raise `AttributeError`. This adds `AttentionMixin` to all of them, the same way `WanVACETransformer3DModel` was handled (#12186):

- `OvisImageTransformer2DModel` (the original #13630 finding)
- `BriaTransformer2DModel`, `BriaFiboTransformer2DModel`
- `AnyFlowTransformer3DModel`, `AnyFlowFARTransformer3DModel`
- `ErnieImageTransformer2DModel`
- `LongCatAudioDiTTransformer`

The attention modules already use `AttentionModuleMixin`, so the four APIs work without further changes and resolve to each model's own processor. Each model gets a regression test that `attn_processors` is populated and `set_attn_processor` round-trips.

Note: `AnyFlowTransformer3DModel`, `AnyFlowFARTransformer3DModel`, and `ErnieImageTransformer2DModel` have some unrelated pre-existing failures in their model test suites on `main` (not touched here); the new `test_attention_processor_api` passes for all seven.

Addresses the `AttentionMixin` pattern from #13656.

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Pointed it at `.ai/` — read `AGENTS.md` and `review-rules.md`.
  - [x] Self-reviewed the diff against `.ai/review-rules.md`.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed via a GitHub issue? Yes — #13656 / #13630.
- [x] Did you write any new tests?

## Who can review?

@hlky — batched per your suggestion, from your model reviews in #13656.
