### PR TITLE
Add `AttentionMixin` to Bria transformers

### DIFF
--- a/src/diffusers/models/transformers/transformer_bria.py
+++ b/src/diffusers/models/transformers/transformer_bria.py
@@ -10,7 +10,7 @@ from ...configuration_utils import ConfigMixin, register_to_config
 from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
 from ...utils import apply_lora_scale, logging
 from ...utils.torch_utils import maybe_adjust_dtype_for_device, maybe_allow_in_graph
-from ..attention import AttentionModuleMixin, FeedForward
+from ..attention import AttentionMixin, AttentionModuleMixin, FeedForward
 from ..attention_dispatch import dispatch_attention_fn
 from ..cache_utils import CacheMixin
 from ..embeddings import TimestepEmbedding, apply_rotary_emb, get_timestep_embedding
@@ -501,7 +501,9 @@ class BriaSingleTransformerBlock(nn.Module):
         return encoder_hidden_states, hidden_states
 
 
-class BriaTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin, CacheMixin):
+class BriaTransformer2DModel(
+    ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin, CacheMixin, AttentionMixin
+):
     """
     The Transformer model introduced in Flux. Based on FluxPipeline with several changes:
     - no pooled embeddings

--- a/src/diffusers/models/transformers/transformer_bria_fibo.py
+++ b/src/diffusers/models/transformers/transformer_bria_fibo.py
@@ -26,7 +26,7 @@ from ...utils import (
     logging,
 )
 from ...utils.torch_utils import maybe_adjust_dtype_for_device, maybe_allow_in_graph
-from ..attention import AttentionModuleMixin, FeedForward
+from ..attention import AttentionMixin, AttentionModuleMixin, FeedForward
 from ..attention_dispatch import dispatch_attention_fn
 from ..normalization import AdaLayerNormContinuous, AdaLayerNormZero, AdaLayerNormZeroSingle
 
@@ -426,7 +426,7 @@ class BriaFiboTimestepProjEmbeddings(nn.Module):
         return timesteps_emb
 
 
-class BriaFiboTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin):
+class BriaFiboTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin, AttentionMixin):
     """
     Parameters:
         patch_size (`int`): Patch size to turn the input data into small patches.

--- a/tests/models/transformers/test_models_transformer_bria.py
+++ b/tests/models/transformers/test_models_transformer_bria.py
@@ -88,6 +88,11 @@ class BriaTransformerTesterConfig(BaseModelTesterConfig):
 
 
 class TestBriaTransformer(BriaTransformerTesterConfig, ModelTesterMixin):
+    def test_attention_processor_api(self):
+        model = self.model_class(**self.get_init_dict())
+        assert len(model.attn_processors) > 0
+        model.set_attn_processor(model.attn_processors)
+
     def test_deprecated_inputs_img_txt_ids_3d(self):
         init_dict = self.get_init_dict()
         inputs_dict = self.get_dummy_inputs()

--- a/tests/models/transformers/test_models_transformer_bria_fibo.py
+++ b/tests/models/transformers/test_models_transformer_bria_fibo.py
@@ -91,7 +91,10 @@ class BriaFiboTransformerTesterConfig(BaseModelTesterConfig):
 
 
 class TestBriaFiboTransformer(BriaFiboTransformerTesterConfig, ModelTesterMixin):
-    pass
+    def test_attention_processor_api(self):
+        model = self.model_class(**self.get_init_dict())
+        assert len(model.attn_processors) > 0
+        model.set_attn_processor(model.attn_processors)
 
 
 class TestBriaFiboTransformerTraining(BriaFiboTransformerTesterConfig, TrainingTesterMixin):


### PR DESCRIPTION
# What does this PR do?

Follow-up to #13941. `BriaTransformer2DModel` and `BriaFiboTransformer2DModel` build their attention with `AttentionModuleMixin` but don't inherit the model-level `AttentionMixin`, so `attn_processors` / `set_attn_processor` / `fuse_qkv_projections` raise `AttributeError` — the same gap fixed for ovis (#13630) and `WanVACETransformer3DModel` (#12186). Adding `AttentionMixin` resolves it.

I also checked `AnyFlowTransformer3DModel`, `AnyFlowFARTransformer3DModel`, and `ErnieImageTransformer2DModel` — they have the same gap, but their model test suites already have unrelated pre-existing failures on `main`, so I left them out here to keep this PR green. Happy to follow up on those separately if the suites get sorted.

Added the same regression test to each model (`attn_processors` is populated and `set_attn_processor` round-trips). `test_models_transformer_bria.py` and `test_models_transformer_bria_fibo.py` are green.

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Pointed it at `.ai/` — read `AGENTS.md` and `review-rules.md`.
  - [x] Self-reviewed the diff against `.ai/review-rules.md`.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed via a GitHub issue? Part of the `AttentionMixin` gaps from #13656 (see #13941).
- [x] Did you write any new tests?

## Who can review?

@hlky — follow-up to #13941, from your model review in #13656.
