### PR TITLE
Enable LoRA loading on `ErnieImageModularPipeline`

### DIFF
--- a/src/diffusers/modular_pipelines/ernie_image/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/ernie_image/modular_pipeline.py
@@ -15,6 +15,7 @@
 import torch
 
 from ...configuration_utils import ConfigMixin, register_to_config
+from ...loaders import ErnieImageLoraLoaderMixin
 from ...utils import logging
 from ..modular_pipeline import ModularPipeline
 
@@ -63,7 +64,7 @@ class ErnieImagePachifier(ConfigMixin):
         )
 
 
-class ErnieImageModularPipeline(ModularPipeline):
+class ErnieImageModularPipeline(ModularPipeline, ErnieImageLoraLoaderMixin):
     """
     A ModularPipeline for ErnieImage.
 


### PR DESCRIPTION
# What does this PR do?

This tiny PR fixes #13967.

I applied same mechanism (LoRA mixin) used in other modular pipelines (Z-Image, FLUX.2, etc).

## Before submitting
- [X] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [ ] Did you point it at the project conventions in [`.ai/`](https://github.com/huggingface/diffusers/tree/main/.ai) (e.g. via `make claude` / `make codex`)? See [Coding with AI agents](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md#coding-with-ai-agents).
  - [X] Did you self-review the diff against [`.ai/review-rules.md`](https://github.com/huggingface/diffusers/blob/main/.ai/review-rules.md)?
- [X] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md)? (important for complex PRs)
- [X] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
Yes, see #13967
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@asomoza @sayakpaul