### PR TITLE
fix(examples): remove incorrect text_ids concatenation in FLUX DreamBooth LoRA training

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux.py
@@ -1512,7 +1512,7 @@ def main(args):
     # Handle class prompt for prior-preservation.
     if args.with_prior_preservation:
         if not args.train_text_encoder:
-            class_prompt_hidden_states, class_pooled_prompt_embeds, class_text_ids = compute_text_embeddings(
+            class_prompt_hidden_states, class_pooled_prompt_embeds, _ = compute_text_embeddings(
                 args.class_prompt, text_encoders, tokenizers
             )
 
@@ -1533,7 +1533,6 @@ def main(args):
             if args.with_prior_preservation:
                 prompt_embeds = torch.cat([prompt_embeds, class_prompt_hidden_states], dim=0)
                 pooled_prompt_embeds = torch.cat([pooled_prompt_embeds, class_pooled_prompt_embeds], dim=0)
-                text_ids = torch.cat([text_ids, class_text_ids], dim=0)
         # if we're optimizing the text encoder (both if instance prompt is used for all images or custom prompts)
         # we need to tokenize and encode the batch prompts on all training steps
         else:


### PR DESCRIPTION
## Description
This PR fixes a critical `RuntimeError` (dimension mismatch) that occurs during FLUX DreamBooth LoRA training when `--with_prior_preservation` is enabled and the static, pre-computed text embeddings path is triggered.

### Core Bug Mechanism (Why it crashed)
In `examples/dreambooth/train_dreambooth_lora_flux.py` (around line 1536), when `args.with_prior_preservation` was `True`, the script incorrectly performed:
```python
text_ids = torch.cat([text_ids, class_text_ids], dim=0)
```

Closes #10722