### PR TITLE
Clarify LTX2 pipeline docs and examples

### DIFF
--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
@@ -195,17 +195,16 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
             A scheduler to be used in combination with `transformer` to denoise the encoded image latents.
         vae ([`AutoencoderKLLTXVideo`]):
             Variational Auto-Encoder (VAE) Model to encode and decode images to and from latent representations.
-        text_encoder ([`T5EncoderModel`]):
-            [T5](https://huggingface.co/docs/transformers/en/model_doc/t5#transformers.T5EncoderModel), specifically
-            the [google/t5-v1_1-xxl](https://huggingface.co/google/t5-v1_1-xxl) variant.
-        tokenizer (`CLIPTokenizer`):
-            Tokenizer of class
-            [CLIPTokenizer](https://huggingface.co/docs/transformers/en/model_doc/clip#transformers.CLIPTokenizer).
-        tokenizer (`T5TokenizerFast`):
-            Second Tokenizer of class
-            [T5TokenizerFast](https://huggingface.co/docs/transformers/en/model_doc/t5#transformers.T5TokenizerFast).
+        audio_vae ([`AutoencoderKLLTX2Audio`]):
+            Variational Auto-Encoder (VAE) model used to encode and decode the generated audio latents.
+        text_encoder ([`Gemma3ForConditionalGeneration`]):
+            Gemma 3 text encoder used to produce prompt embeddings for the video and audio branches.
+        tokenizer (`GemmaTokenizer` or `GemmaTokenizerFast`):
+            Tokenizer paired with the Gemma 3 text encoder.
         connectors ([`LTX2TextConnectors`]):
             Text connector stack used to adapt text encoder hidden states for the video and audio branches.
+        vocoder ([`LTX2Vocoder`] or [`LTX2VocoderWithBWE`]):
+            Vocoder used to decode generated audio latents into waveforms.
     """
 
     model_cpu_offload_seq = "text_encoder->connectors->transformer->vae->audio_vae->vocoder"
@@ -244,7 +243,7 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
         self.vae_temporal_compression_ratio = (
             self.vae.temporal_compression_ratio if getattr(self, "vae", None) is not None else 8
         )
-        # TODO: check whether the MEL compression ratio logic here is corrct
+        # TODO: check whether the MEL compression ratio logic here is correct
         self.audio_vae_mel_compression_ratio = (
             self.audio_vae.mel_compression_ratio if getattr(self, "audio_vae", None) is not None else 4
         )

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
@@ -71,7 +71,7 @@ EXAMPLE_DOC_STRING = """
         >>> negative_prompt = "worst quality, inconsistent motion, blurry, jittery, distorted, static"
 
         >>> frame_rate = 24.0
-        >>> video = pipe(
+        >>> video, audio = pipe(
         ...     conditions=conditions,
         ...     prompt=prompt,
         ...     negative_prompt=negative_prompt,
@@ -235,11 +235,9 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
 
 class LTX2ConditionPipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
     r"""
-    Pipeline for video generation which allows image conditions to be inserted at arbitary parts of the video.
+    Pipeline for video generation that applies image or video conditions at specific frame indices.
 
     Reference: https://github.com/Lightricks/LTX-Video
-
-    TODO
     """
 
     model_cpu_offload_seq = "text_encoder->connectors->transformer->vae->audio_vae->vocoder"

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_image2video.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_image2video.py
@@ -204,11 +204,9 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
 
 class LTX2ImageToVideoPipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
     r"""
-    Pipeline for image-to-video generation.
+    Pipeline for image-to-video generation with an optional multimodal processor for image-conditioned prompting.
 
     Reference: https://github.com/Lightricks/LTX-Video
-
-    TODO
     """
 
     model_cpu_offload_seq = "text_encoder->connectors->transformer->vae->audio_vae->vocoder"
@@ -247,7 +245,7 @@ class LTX2ImageToVideoPipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraL
         self.vae_temporal_compression_ratio = (
             self.vae.temporal_compression_ratio if getattr(self, "vae", None) is not None else 8
         )
-        # TODO: check whether the MEL compression ratio logic here is corrct
+        # TODO: check whether the MEL compression ratio logic here is correct
         self.audio_vae_mel_compression_ratio = (
             self.audio_vae.mel_compression_ratio if getattr(self, "audio_vae", None) is not None else 4
         )

--- a/src/diffusers/pipelines/ltx2/pipeline_output.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_output.py
@@ -16,7 +16,8 @@ class LTX2PipelineOutput(BaseOutput):
             denoised PIL image sequences of length `num_frames.` It can also be a NumPy array or Torch tensor of shape
             `(batch_size, num_frames, channels, height, width)`.
         audio (`torch.Tensor`, `np.ndarray`):
-            TODO
+            Generated audio aligned with the returned video. When returned as a tensor or NumPy array, the shape is
+            `(batch_size, channels, samples)`.
     """
 
     frames: torch.Tensor


### PR DESCRIPTION
## Summary
- fix the `LTX2ConditionPipeline` example to unpack both video and audio when `return_dict=False`
- replace remaining LTX2 docstring TODOs with concrete descriptions
- correct outdated Gemma/T5 argument docs and a couple of LTX2 typos

## Why
These LTX2 pipeline docs still contain placeholder text and one broken example snippet, which makes the new pipelines harder to follow.

## Validation
- `python -m py_compile` on the touched LTX2 pipeline modules
- `git diff --check`