### PR TITLE
Fix CogView3 lazy export to match the actual output class name

### DIFF
--- a/src/diffusers/pipelines/cogview3/__init__.py
+++ b/src/diffusers/pipelines/cogview3/__init__.py
@@ -12,7 +12,7 @@ from ...utils import (
 
 _dummy_objects = {}
 _additional_imports = {}
-_import_structure = {"pipeline_output": ["CogView3PlusPipelineOutput"]}
+_import_structure = {"pipeline_output": ["CogView3PipelineOutput"]}
 
 try:
     if not (is_transformers_available() and is_torch_available()):


### PR DESCRIPTION
The `cogview3` package advertises `CogView3PlusPipelineOutput` in its lazy `_import_structure`, but the output class is defined as `CogView3PipelineOutput` (no "Plus") in `pipeline_output.py`. Because of the mismatch, `from diffusers.pipelines.cogview3 import CogView3PlusPipelineOutput` raises an ImportError.

This points the lazy export at the real class name. The pipeline module already imports `CogView3PipelineOutput`, and the API docs autodoc that same name, so this just brings the lazy export in line with both.

```python
# before: raises ImportError
from diffusers.pipelines.cogview3 import CogView3PlusPipelineOutput
# after: resolves to the class defined in pipeline_output.py
from diffusers.pipelines.cogview3 import CogView3PipelineOutput
```

The neighbouring `CogView3PlusPipeline` export is the actual pipeline class name and is intentionally left as-is — only the output-class export had the stray "Plus".

Addresses Issue 1 of #13648.