### PR TITLE
fix(flux): warn on unsupported ip_adapter_masks

### DIFF
--- a/src/diffusers/models/transformers/transformer_flux.py
+++ b/src/diffusers/models/transformers/transformer_flux.py
@@ -190,6 +190,10 @@ class FluxIPAdapterAttnProcessor(torch.nn.Module):
         ip_hidden_states: list[torch.Tensor] | None = None,
         ip_adapter_masks: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        if ip_adapter_masks is not None:
+            logger.warning_once(
+                "`ip_adapter_masks` is not supported by the Flux IP-Adapter and will be ignored."
+            )
         batch_size = hidden_states.shape[0]
 
         query, key, value, encoder_query, encoder_key, encoder_value = _get_qkv_projections(


### PR DESCRIPTION
# What does this PR do?

Addresses the flux review (#13584), Issue 1: `FluxIPAdapterAttnProcessor` accepts `ip_adapter_masks` but never applies them, so region-specific IP-Adapter conditioning silently has no effect (the repro in the issue prints `0.0` between masked and unmasked runs).

I looked at implementing the masks properly (the SD `IPAdapterAttnProcessor2_0` pattern), but:
- no Flux pipeline plumbs `ip_adapter_masks` through, so there's no caller to exercise it, and
- the SD path applies masks **spatially**, while the Flux processor only sees packed-sequence latents and doesn't have the spatial shape needed to downsample/map a mask correctly.

So rather than ship a risky reimplementation against Flux's packed layout with no caller, this stops the silent no-op: passing `ip_adapter_masks` now emits a `warning_once` that it's unsupported and ignored. Full regional-mask support for Flux would be a follow-up (and needs spatial info plumbed in) — happy to take that on if you'd like it.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? (Part of #13656, finding from #13584) and discussed on slack with Sayak
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@hlky @sayakpaul @yiyixuxu
