### PR TITLE
fix(flux): enable true CFG with precomputed negative embeds

### DIFF
--- a/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
@@ -878,7 +878,10 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
         lora_scale = (
             self.joint_attention_kwargs.get("scale", None) if self.joint_attention_kwargs is not None else None
         )
-        do_true_cfg = true_cfg_scale > 1 and negative_prompt is not None
+        has_neg_prompt = negative_prompt is not None or (
+            negative_prompt_embeds is not None and negative_pooled_prompt_embeds is not None
+        )
+        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
         (
             prompt_embeds,
             pooled_prompt_embeds,

--- a/src/diffusers/pipelines/flux/pipeline_flux_img2img.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_img2img.py
@@ -917,7 +917,10 @@ class FluxImg2ImgPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleFile
         lora_scale = (
             self.joint_attention_kwargs.get("scale", None) if self.joint_attention_kwargs is not None else None
         )
-        do_true_cfg = true_cfg_scale > 1 and negative_prompt is not None
+        has_neg_prompt = negative_prompt is not None or (
+            negative_prompt_embeds is not None and negative_pooled_prompt_embeds is not None
+        )
+        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
         (
             prompt_embeds,
             pooled_prompt_embeds,

--- a/src/diffusers/pipelines/flux/pipeline_flux_inpaint.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_inpaint.py
@@ -992,7 +992,10 @@ class FluxInpaintPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FluxIPAdapterM
         lora_scale = (
             self.joint_attention_kwargs.get("scale", None) if self.joint_attention_kwargs is not None else None
         )
-        do_true_cfg = true_cfg_scale > 1 and negative_prompt is not None
+        has_neg_prompt = negative_prompt is not None or (
+            negative_prompt_embeds is not None and negative_pooled_prompt_embeds is not None
+        )
+        do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
         (
             prompt_embeds,
             pooled_prompt_embeds,

--- a/tests/pipelines/flux/test_pipeline_flux_img2img.py
+++ b/tests/pipelines/flux/test_pipeline_flux_img2img.py
@@ -127,6 +127,34 @@ class FluxImg2ImgPipelineFastTests(unittest.TestCase, PipelineTesterMixin, FluxI
         # For some reasons, they don't show large differences
         assert max_diff > 1e-6
 
+    def test_flux_true_cfg_with_negative_embeds(self):
+        pipe = self.pipeline_class(**self.get_dummy_components()).to(torch_device)
+        inputs = self.get_dummy_inputs(torch_device)
+        inputs.pop("generator")
+        prompt = inputs.pop("prompt")
+
+        prompt_embeds, pooled_prompt_embeds, _ = pipe.encode_prompt(
+            prompt=prompt, prompt_2=None, device=torch_device, num_images_per_prompt=1, max_sequence_length=48
+        )
+        negative_prompt_embeds, negative_pooled_prompt_embeds, _ = pipe.encode_prompt(
+            prompt="bad quality", prompt_2=None, device=torch_device, num_images_per_prompt=1, max_sequence_length=48
+        )
+        inputs.update(
+            prompt_embeds=prompt_embeds,
+            pooled_prompt_embeds=pooled_prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            negative_pooled_prompt_embeds=negative_pooled_prompt_embeds,
+        )
+
+        inputs["true_cfg_scale"] = 1.0
+        cfg_off = pipe(**inputs, generator=torch.manual_seed(0)).images[0]
+        inputs["true_cfg_scale"] = 2.0
+        cfg_on = pipe(**inputs, generator=torch.manual_seed(0)).images[0]
+        self.assertFalse(
+            np.allclose(cfg_off, cfg_on),
+            "Precomputed negative embeds should enable true CFG when negative_prompt is None.",
+        )
+
     def test_flux_image_output_shape(self):
         pipe = self.pipeline_class(**self.get_dummy_components()).to(torch_device)
         inputs = self.get_dummy_inputs(torch_device)


### PR DESCRIPTION
# What does this PR do?

Addresses the flux review (#13584), Issue 2: `FluxImg2ImgPipeline`, `FluxInpaintPipeline`, and `FluxControlNetPipeline` gated true CFG on `true_cfg_scale > 1 and negative_prompt is not None`, so passing precomputed `negative_prompt_embeds` / `negative_pooled_prompt_embeds` (with `negative_prompt=None`) silently did not enable CFG.

Base `FluxPipeline` (and `FluxKontextPipeline`) already handle this correctly:

```python
has_neg_prompt = negative_prompt is not None or (
    negative_prompt_embeds is not None and negative_pooled_prompt_embeds is not None
)
do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
```

This brings the three pipelines in line. The downstream `if do_true_cfg:` block already forwards the precomputed embeds through `encode_prompt`, so only the gate needed fixing. Verified the gate flips `False -> True` for the precomputed-embeds case and copies/ruff stay clean.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? (Part of #13656, finding from #13584) and discussed on slack with @sayakpaul 
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@hlky @sayakpaul @yiyixuxu
