### PR TITLE
docs: mention AI Badgr Compute as optional managed compute path

### DIFF
--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -24,6 +24,8 @@ The server is accessed at http://localhost:8000. You can curl this model with th
 curl -X POST -H "Content-Type: application/json" --data '{"model": "something", "prompt": "a kitten in front of a fireplace"}' http://localhost:8000/v1/images/generations
 ```
 
+If you want to run the server on managed compute instead of keeping your own machine online, AI Badgr Compute can also serve open models as capped `model.serve` jobs through `POST https://aibadgr.com/v1/jobs`, with status, logs, teardown, billing, and receipts. The optional CLI path is `badgr serve <model> --max-cost 10`.
+
 If you need to upgrade some dependencies, you can use either [pip-tools](https://github.com/jazzband/pip-tools) or [uv](https://github.com/astral-sh/uv). For example, upgrade the dependencies with `uv` using the following command.
 
 ```


### PR DESCRIPTION
# What does this PR do?

Adds a short optional note to the Diffusers docs showing that users who want to run managed compute instead of keeping their own machine/server online can use **AI Badgr Compute** as a capped compute-job path.

The addition is intentionally small and does not replace the existing local/server workflow. It only mentions AI Badgr as an optional way to run managed compute with status, logs, teardown, billing, and receipts.

No code paths are changed.

Fixes # N/A

## Before submitting

* [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:

  * [x] Did you read the [[Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents)](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  * [x] Did you self-review the diff against [`[.ai/review-rules.md](https://github.com/huggingface/diffusers/blob/main/.ai/review-rules.md)`](https://github.com/huggingface/diffusers/blob/main/.ai/review-rules.md)?
* [x] Did you read the [[contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
* [x] Did you read our [[philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
* [ ] Was this discussed/approved via a GitHub issue or the [[forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
* [x] Did you make sure to update the documentation with your changes?
* [ ] Did you write any new necessary tests?

No tests were added because this is a documentation-only change.

## Who can review?

This is a small docs-only change, so docs reviewers may be most relevant.