### PR TITLE
Fix clip_skip being ignored for negative prompt embeddings in SDXL pipelines

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py
@@ -470,7 +470,11 @@ class StableDiffusionXLPipeline(
                 # We are only ALWAYS interested in the pooled output of the final text encoder
                 if negative_pooled_prompt_embeds is None and negative_prompt_embeds[0].ndim == 2:
                     negative_pooled_prompt_embeds = negative_prompt_embeds[0]
-                negative_prompt_embeds = negative_prompt_embeds.hidden_states[-2]
+                if clip_skip is None:
+                    negative_prompt_embeds = negative_prompt_embeds.hidden_states[-2]
+                else:
+                    # "2" because SDXL always indexes from the penultimate layer.
+                    negative_prompt_embeds = negative_prompt_embeds.hidden_states[-(clip_skip + 2)]
 
                 negative_prompt_embeds_list.append(negative_prompt_embeds)
 

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -488,7 +488,11 @@ class StableDiffusionXLImg2ImgPipeline(
                 # We are only ALWAYS interested in the pooled output of the final text encoder
                 if negative_pooled_prompt_embeds is None and negative_prompt_embeds[0].ndim == 2:
                     negative_pooled_prompt_embeds = negative_prompt_embeds[0]
-                negative_prompt_embeds = negative_prompt_embeds.hidden_states[-2]
+                if clip_skip is None:
+                    negative_prompt_embeds = negative_prompt_embeds.hidden_states[-2]
+                else:
+                    # "2" because SDXL always indexes from the penultimate layer.
+                    negative_prompt_embeds = negative_prompt_embeds.hidden_states[-(clip_skip + 2)]
 
                 negative_prompt_embeds_list.append(negative_prompt_embeds)
 

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -592,7 +592,11 @@ class StableDiffusionXLInpaintPipeline(
                 # We are only ALWAYS interested in the pooled output of the final text encoder
                 if negative_pooled_prompt_embeds is None and negative_prompt_embeds[0].ndim == 2:
                     negative_pooled_prompt_embeds = negative_prompt_embeds[0]
-                negative_prompt_embeds = negative_prompt_embeds.hidden_states[-2]
+                if clip_skip is None:
+                    negative_prompt_embeds = negative_prompt_embeds.hidden_states[-2]
+                else:
+                    # "2" because SDXL always indexes from the penultimate layer.
+                    negative_prompt_embeds = negative_prompt_embeds.hidden_states[-(clip_skip + 2)]
 
                 negative_prompt_embeds_list.append(negative_prompt_embeds)
 

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl.py
@@ -844,6 +844,39 @@ class StableDiffusionXLPipelineFastTests(
         # ensure the results are not equal
         assert np.abs(image_slice_1.flatten() - image_slice_3.flatten()).max() > 1e-4
 
+    def test_encode_prompt_clip_skip_applies_to_negative_embeds(self):
+        device = "cpu"
+        components = self.get_dummy_components()
+        sd_pipe = StableDiffusionXLPipeline(**components).to(device)
+
+        prompt = "A painting of a squirrel eating a burger"
+        negative_prompt = "blurry, low quality"
+
+        # encode without clip_skip
+        prompt_embeds_no_skip, negative_embeds_no_skip, _, _ = sd_pipe.encode_prompt(
+            prompt=prompt,
+            device=device,
+            num_images_per_prompt=1,
+            do_classifier_free_guidance=True,
+            negative_prompt=negative_prompt,
+            clip_skip=None,
+        )
+
+        # encode with clip_skip=1
+        prompt_embeds_skip, negative_embeds_skip, _, _ = sd_pipe.encode_prompt(
+            prompt=prompt,
+            device=device,
+            num_images_per_prompt=1,
+            do_classifier_free_guidance=True,
+            negative_prompt=negative_prompt,
+            clip_skip=1,
+        )
+
+        # positive embeds already respected clip_skip (sanity check)
+        assert not torch.allclose(prompt_embeds_no_skip, prompt_embeds_skip)
+        # negative embeds must also change with clip_skip (this is the bug fix)
+        assert not torch.allclose(negative_embeds_no_skip, negative_embeds_skip)
+
     def test_stable_diffusion_xl_negative_conditions(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
         components = self.get_dummy_components()


### PR DESCRIPTION
# What does this PR do?

`clip_skip` was silently ignored when computing negative prompt embeddings
in all three SDXL `encode_prompt` methods. The positive prompt path
correctly branches on `clip_skip`:

```python
if clip_skip is None:
    prompt_embeds = prompt_embeds.hidden_states[-2]
else:
    prompt_embeds = prompt_embeds.hidden_states[-(clip_skip + 2)]
```

but the negative prompt path unconditionally used `hidden_states[-2]`
regardless of the `clip_skip` value. This means that whenever `clip_skip`
is set, positive and negative embeddings are extracted from different hidden
layers, breaking the symmetry that classifier-free guidance relies on.

Fixed by mirroring the existing conditional to the negative path in:
- `pipeline_stable_diffusion_xl.py`
- `pipeline_stable_diffusion_xl_img2img.py`
- `pipeline_stable_diffusion_xl_inpaint.py`

A test is added to `test_stable_diffusion_xl.py` that calls `encode_prompt`
with `clip_skip=1` vs `clip_skip=None` and asserts that negative embeddings
differ between the two calls (i.e. clip_skip now actually affects them).

Fixes # (issue)

## Before submitting
- [ ] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [ ] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [ ] Did you self-review the diff against [`.ai/review-rules.md`](https://github.com/huggingface/diffusers/blob/main/.ai/review-rules.md)?
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@yiyixuxu @asomoza