### PR TITLE
Use requests instead of urllib in convert_consistency_decoder _download

### DIFF
--- a/scripts/convert_consistency_decoder.py
+++ b/scripts/convert_consistency_decoder.py
@@ -1,9 +1,9 @@
 import math
 import os
-import urllib
 import warnings
 from argparse import ArgumentParser
 
+import requests
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -57,21 +57,26 @@ def _download(url: str, root: str):
         else:
             warnings.warn(f"{download_target} exists, but the SHA256 checksum does not match; re-downloading the file")
 
-    with urllib.request.urlopen(url) as source, open(download_target, "wb") as output:
-        with tqdm(
-            total=int(source.info().get("Content-Length")),
-            ncols=80,
-            unit="iB",
-            unit_scale=True,
-            unit_divisor=1024,
-        ) as loop:
-            while True:
-                buffer = source.read(8192)
-                if not buffer:
-                    break
-
-                output.write(buffer)
-                loop.update(len(buffer))
+    with requests.get(url, stream=True) as response:
+        response.raise_for_status()
+        # Content-Length may be absent; tqdm handles total=None gracefully.
+        total = response.headers.get("Content-Length")
+        total = int(total) if total is not None else None
+        with (
+            open(download_target, "wb") as output,
+            tqdm(
+                total=total,
+                ncols=80,
+                unit="iB",
+                unit_scale=True,
+                unit_divisor=1024,
+            ) as loop,
+        ):
+            for chunk in response.iter_content(chunk_size=8192):
+                if not chunk:
+                    continue
+                output.write(chunk)
+                loop.update(len(chunk))
 
     if insecure_hashlib.sha256(open(download_target, "rb").read()).hexdigest() != expected_sha256:
         raise RuntimeError("Model has been downloaded but the SHA256 checksum does not match")


### PR DESCRIPTION
# What does this PR do?

Refactors the `_download` helper in `scripts/convert_consistency_decoder.py` to use `requests`
(already a diffusers dependency) instead of `urllib.request`. The streaming download, SHA-256
verification, and `tqdm` progress bar are preserved. It is also slightly more robust: the original
did `int(source.info().get("Content-Length"))`, which raises if the header is absent; this version
tolerates a missing `Content-Length` (passes `total=None` to `tqdm`).

```python
with requests.get(url, stream=True) as response:
    response.raise_for_status()
    total = response.headers.get("Content-Length")
    total = int(total) if total is not None else None
    ... iter_content(8192) ...
```

No new dependency. `ruff check` and `ruff format --check` pass.

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you self-review the diff against [`.ai/review-rules.md`](https://github.com/huggingface/diffusers/blob/main/.ai/review-rules.md)?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Was this discussed/approved via a GitHub issue? (No, small, self-contained script refactor)
- [ ] Documentation update (None)
- [ ] Did you write any new necessary tests?  (one-off conversion script; behavior preserved)