### PR TITLE
Fix Flux2LoraLoaderMixin crash on modular pipeline sub-pipes

### DIFF
--- a/src/diffusers/loaders/lora_pipeline.py
+++ b/src/diffusers/loaders/lora_pipeline.py
@@ -5914,9 +5914,19 @@ class Flux2LoraLoaderMixin(LoraBaseMixin):
         if not is_correct_format:
             raise ValueError("Invalid LoRA checkpoint. Make sure all LoRA param names contain `'lora'` substring.")
 
+        try:
+            transformer = getattr(self, self.transformer_name) if not hasattr(self, "transformer") else self.transformer
+        except AttributeError:
+            logger.warning(
+                f"Could not load LoRA weights into {type(self).__name__}. "
+                f"The `{self.transformer_name}` attribute is not available on this sub-pipeline. "
+                "Load LoRA weights on the main pipeline instance instead."
+            )
+            return
+
         self.load_lora_into_transformer(
             state_dict,
-            transformer=getattr(self, self.transformer_name) if not hasattr(self, "transformer") else self.transformer,
+            transformer=transformer,
             adapter_name=adapter_name,
             metadata=metadata,
             _pipeline=self,


### PR DESCRIPTION
`load_lora_weights()` crashes with `AttributeError` on modular pipelines that dont have a `transformer` attribute directly. Added a fallback lookup.`

Fixes #13487