### PR TITLE
[Fix] Fix three final_layer LoRA conversion bugs in _convert_sd_scripts_to_ai_toolkit

### DIFF
--- a/src/diffusers/loaders/lora_conversion_utils.py
+++ b/src/diffusers/loaders/lora_conversion_utils.py
@@ -551,10 +551,18 @@ def _convert_kohya_flux_lora_to_diffusers(state_dict):
                 for target_fmt, source_fmt, transform in assignments:
                     target_key = target_fmt.format(lora_key=lora_key)
                     source_key = source_fmt.format(orig_lora_key=orig_lora_key)
-                    value = source.pop(source_key)
-                    if transform:
+                    value = source.pop(source_key, None)
+                    if value is None:
+                        continue
+                    if transform and lora_key == "lora_B":
                         value = transform(value)
                     ait_sd[target_key] = value
+
+            # Consume any leftover final_layer alpha keys so they don't
+            # reach the remaining_keys guard and cause a false "Incompatible keys" error.
+            for key in list(source.keys()):
+                if "final_layer" in key and key.endswith(".alpha"):
+                    source.pop(key)
 
         if any("guidance_in" in k for k in sds_sd):
             _convert_to_ai_toolkit(


### PR DESCRIPTION
Fix three final_layer LoRA conversion bugs in _convert_sd_scripts_to_ai_toolkit

Fixes https://github.com/huggingface/diffusers/issues/13998

Three independent bugs in assign_remaining_weights caused failures when loading FLUX LoRAs that include final_layer weights (common in kohya and ComfyUI/SwarmUI exports).

Case A (KeyError): source.pop(source_key) raised KeyError when a LoRA trained final_layer.linear but not final_layer.adaLN_modulation_1. Fixed by using source.pop(source_key, None) and skipping on None.

Case B (Incompatible keys): Unconsumed final_layer .alpha keys were left in the state dict after assign_remaining_weights, which only consumed lora_down/lora_up. These keys then hit the remaining_keys guard that only tolerates lora_te* prefixes, raising ValueError. Fixed by consuming final_layer .alpha keys after the assignment loop.

Case C (Silent weight corruption): swap_scale_shift was applied to both lora_A and lora_B. The correct transform is swap(B) @ A = swap(B) @ A, meaning only lora_B should be swapped. Applying it to lora_A as well produces swap(B) @ swap(A) which silently corrupts the norm_out LoRA for any FLUX LoRA that trains the final-layer adaLN modulation. Fixed by gating transform on lora_key == "lora_B".