### PR TITLE
Avoid eager transformers>=5.0.0 requirement for ErnieImage prompt enhancer

### DIFF
--- a/src/diffusers/modular_pipelines/ernie_image/encoders.py
+++ b/src/diffusers/modular_pipelines/ernie_image/encoders.py
@@ -15,21 +15,14 @@
 import json
 
 import torch
-from transformers import AutoTokenizer, Mistral3Model
+from transformers import AutoModelForCausalLM, AutoTokenizer, Mistral3Model
 
 from ...configuration_utils import FrozenDict
 from ...guiders import ClassifierFreeGuidance
 from ...utils import logging
-from ...utils.import_utils import is_transformers_version
 from ..modular_pipeline import ModularPipelineBlocks, PipelineState
 from ..modular_pipeline_utils import ComponentSpec, InputParam, OutputParam
 from .modular_pipeline import ErnieImageModularPipeline
-
-
-if is_transformers_version("<", "5.0.0"):
-    raise ImportError("`ErnieImageModularPipeline` requires `transformers>=5.0.0` for `Ministral3ForCausalLM`.")
-
-from transformers import Ministral3ForCausalLM  # noqa: E402
 
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
@@ -45,7 +38,7 @@ class ErnieImagePromptEnhancerStep(ModularPipelineBlocks):
     @property
     def expected_components(self) -> list[ComponentSpec]:
         return [
-            ComponentSpec("pe", Ministral3ForCausalLM),
+            ComponentSpec("pe", AutoModelForCausalLM),
             ComponentSpec("pe_tokenizer", AutoTokenizer),
         ]
 
@@ -90,7 +83,7 @@ class ErnieImagePromptEnhancerStep(ModularPipelineBlocks):
 
     @staticmethod
     def _enhance_prompt(
-        pe: Ministral3ForCausalLM,
+        pe: AutoModelForCausalLM,
         pe_tokenizer: AutoTokenizer,
         prompt: str,
         device: torch.device,

--- a/src/diffusers/pipelines/ernie_image/pipeline_ernie_image.py
+++ b/src/diffusers/pipelines/ernie_image/pipeline_ernie_image.py
@@ -20,7 +20,7 @@ import json
 from typing import Callable, List, Optional, Union
 
 import torch
-from transformers import AutoTokenizer, Mistral3Model
+from transformers import AutoModelForCausalLM, AutoTokenizer, Mistral3Model
 
 from ...image_processor import VaeImageProcessor
 from ...loaders import ErnieImageLoraLoaderMixin
@@ -28,15 +28,8 @@ from ...models import AutoencoderKLFlux2
 from ...models.transformers import ErnieImageTransformer2DModel
 from ...pipelines.pipeline_utils import DiffusionPipeline
 from ...schedulers import FlowMatchEulerDiscreteScheduler
-from ...utils.import_utils import is_transformers_version
 from ...utils.torch_utils import randn_tensor
 from .pipeline_output import ErnieImagePipelineOutput
-
-
-if is_transformers_version("<", "5.0.0"):
-    raise ImportError("`ErnieImagePipeline` requires `transformers>=5.0.0` for `Ministral3ForCausalLM`.")
-
-from transformers import Ministral3ForCausalLM  # noqa: E402
 
 
 class ErnieImagePipeline(DiffusionPipeline, ErnieImageLoraLoaderMixin):
@@ -62,7 +55,7 @@ class ErnieImagePipeline(DiffusionPipeline, ErnieImageLoraLoaderMixin):
         text_encoder: Mistral3Model,
         tokenizer: AutoTokenizer,
         scheduler: FlowMatchEulerDiscreteScheduler,
-        pe: Optional[Ministral3ForCausalLM] = None,
+        pe: Optional[AutoModelForCausalLM] = None,
         pe_tokenizer: Optional[AutoTokenizer] = None,
     ):
         super().__init__()


### PR DESCRIPTION
# What does this PR do?

Fixes #13935.

The obvious solution would be to make the import and the version check local to the function that uses the prompt enhancer. But Claude thinks it has found a solution that is more in line with your architecture, because `AutoModelForCausalLM` is already used elsewhere.

The error is then printed by transformers, with an already quite clear message that you need a newer transformers.

Let me know what you think:

Replaces `Ministral3ForCausalLM` with `AutoModelForCausalLM` as the type hint/`ComponentSpec` type for the optional `pe` prompt-enhancer component in `ErnieImagePipeline` / `ErnieImagePromptEnhancerStep`. `AutoModelForCausalLM` is available on any transformers version, and resolves the concrete architecture lazily through transformers' own Auto* machinery only when `pe` is actually loaded via `from_pretrained`. So `transformers>=5.0.0` is now only required when the prompt enhancer is actually used, with a clear error from transformers itself at that point:

---
ValueError: The checkpoint you are trying to load has model type `ministral3` but Transformers does not recognize this architecture. This could be because of an issue with the checkpoint, or because your version of Transformers is out of date.

**You can update Transformers with the command `pip install --upgrade transformers`.** 

---

No behavior change for users already on transformers>=5.0.0.

🤖 Drafted by Claude

## Who can review?

- Pipelines and models: @yiyixuxu