### PR TITLE
Fix KeyError for non-attention LoRA sublayers in Flux/Chroma mixture-format converter

### DIFF
--- a/src/diffusers/loaders/lora_conversion_utils.py
+++ b/src/diffusers/loaders/lora_conversion_utils.py
@@ -757,6 +757,27 @@ def _convert_kohya_flux_lora_to_diffusers(state_dict):
                 elif any(add_qkv in k for add_qkv in ["add_q_proj", "add_k_proj", "add_v_proj"]):
                     remaining = k.split("attn_")[-1]
                     diffusers_key += f".attn.{remaining}"
+            elif k.startswith(("lora_transformer_single_transformer_blocks_", "lora_transformer_transformer_blocks_")):
+                # Non-attention sublayers of a transformer block. Without an explicit mapping here,
+                # `diffusers_key` stays at the bare block path (e.g. "transformer_blocks.0"), which is a
+                # container module, not a leaf parameter, and later lookups against it raise KeyError.
+                non_attn_block_mapping = {
+                    "_norm1_context_linear": ".norm1_context.linear",
+                    "_norm1_linear": ".norm1.linear",
+                    "_norm_linear": ".norm.linear",
+                    "_proj_mlp": ".proj_mlp",
+                    "_proj_out": ".proj_out",
+                    "_ff_context_net_0_proj": ".ff_context.net.0.proj",
+                    "_ff_context_net_2": ".ff_context.net.2",
+                    "_ff_net_0_proj": ".ff.net.0.proj",
+                    "_ff_net_2": ".ff.net.2",
+                }
+                for suffix, mapped in non_attn_block_mapping.items():
+                    if k.endswith(suffix):
+                        diffusers_key += mapped
+                        break
+                else:
+                    raise NotImplementedError(f"Handling for key ({k}) is not implemented.")
 
             _convert(k, diffusers_key, state_dict, new_state_dict)
 


### PR DESCRIPTION
# What does this PR do?

Fixes the `KeyError` described in #14009 — `_convert_kohya_flux_lora_to_diffusers`'s mixture-format branch only mapped attention sublayers of a transformer block to their real submodule path; every other sublayer (`norm1.linear`, `ff.net.*`, `proj_mlp`, ...) fell through to the bare block path, which is a container module, not a leaf parameter. See #14009 for the full repro and root cause.

This adds explicit mapping for the remaining block sublayers (mirroring the equivalent target names already used elsewhere in this file, e.g. `TRANSFORMER_KEYS_RENAME_DICT`), and raises `NotImplementedError` for any genuinely unhandled key instead of silently falling back to the bare block path.

Fixes #14009

## Who can review?

@sayakpaul @yiyixuxu

---
Drafted by Claude
