### PR TITLE
fix(mag_cache): correct per-transformer step count for dual-transformer pipelines

### DIFF
--- a/src/diffusers/hooks/__init__.py
+++ b/src/diffusers/hooks/__init__.py
@@ -23,7 +23,7 @@ if is_torch_available():
     from .hooks import HookRegistry, ModelHook
     from .layer_skip import LayerSkipConfig, apply_layer_skip
     from .layerwise_casting import apply_layerwise_casting, apply_layerwise_casting_hook
-    from .mag_cache import MagCacheConfig, apply_mag_cache
+    from .mag_cache import MagCacheConfig, apply_mag_cache, update_mag_cache_num_steps
     from .pyramid_attention_broadcast import PyramidAttentionBroadcastConfig, apply_pyramid_attention_broadcast
     from .smoothed_energy_guidance_utils import SmoothedEnergyGuidanceConfig
     from .taylorseer_cache import TaylorSeerCacheConfig, apply_taylorseer_cache

--- a/src/diffusers/hooks/__init__.py
+++ b/src/diffusers/hooks/__init__.py
@@ -23,7 +23,7 @@ if is_torch_available():
     from .hooks import HookRegistry, ModelHook
     from .layer_skip import LayerSkipConfig, apply_layer_skip
     from .layerwise_casting import apply_layerwise_casting, apply_layerwise_casting_hook
-    from .mag_cache import MagCacheConfig, apply_mag_cache, update_mag_cache_num_steps
+    from .mag_cache import MagCacheConfig, apply_mag_cache
     from .pyramid_attention_broadcast import PyramidAttentionBroadcastConfig, apply_pyramid_attention_broadcast
     from .smoothed_energy_guidance_utils import SmoothedEnergyGuidanceConfig
     from .taylorseer_cache import TaylorSeerCacheConfig, apply_taylorseer_cache

--- a/src/diffusers/hooks/mag_cache.py
+++ b/src/diffusers/hooks/mag_cache.py
@@ -130,6 +130,7 @@ class MagCacheConfig:
             if not torch.is_tensor(self.mag_ratios):
                 self.mag_ratios = torch.tensor(self.mag_ratios)
 
+            self._original_mag_ratios = self.mag_ratios.clone()
             if len(self.mag_ratios) != self.num_inference_steps:
                 logger.debug(
                     f"Interpolating mag_ratios from length {len(self.mag_ratios)} to {self.num_inference_steps}"
@@ -407,6 +408,7 @@ def apply_mag_cache(module: torch.nn.Module, config: MagCacheConfig) -> None:
     # Initialize registry on the root module so the Pipeline can set context.
     HookRegistry.check_if_exists_or_initialize(module)
 
+    module._mag_cache_config = config
     state_manager = StateManager(MagCacheState, (), {})
     remaining_blocks = []
 
@@ -466,3 +468,15 @@ def _apply_mag_cache_block_hook(
 
     hook = MagCacheBlockHook(state_manager, is_tail, config)
     registry.register_hook(hook, _MAG_CACHE_BLOCK_HOOK)
+
+
+def update_mag_cache_num_steps(module: torch.nn.Module, num_steps: int) -> None:
+    config: MagCacheConfig = getattr(module, "_mag_cache_config", None)
+    if config is None:
+        return
+    original_ratios = getattr(config, "_original_mag_ratios", config.mag_ratios)
+    config.num_inference_steps = num_steps
+    if original_ratios is not None:
+        config.mag_ratios = nearest_interp(original_ratios, num_steps)
+
+

--- a/src/diffusers/hooks/mag_cache.py
+++ b/src/diffusers/hooks/mag_cache.py
@@ -169,12 +169,25 @@ class MagCacheState(BaseState):
         self.calibration_ratios = []
 
 
+def _get_effective_num_steps(config: MagCacheConfig, root_module: torch.nn.Module) -> int:
+    expected = getattr(root_module, "_mag_cache_expected_steps", None)
+    return expected if expected is not None else config.num_inference_steps
+
+
+def _get_effective_mag_ratios(config: MagCacheConfig, effective_num_steps: int) -> torch.Tensor:
+    if effective_num_steps == config.num_inference_steps:
+        return config.mag_ratios
+    original = getattr(config, "_original_mag_ratios", config.mag_ratios)
+    return nearest_interp(original, effective_num_steps)
+
+
 class MagCacheHeadHook(ModelHook):
     _is_stateful = True
 
-    def __init__(self, state_manager: StateManager, config: MagCacheConfig):
+    def __init__(self, state_manager: StateManager, config: MagCacheConfig, root_module: torch.nn.Module):
         self.state_manager = state_manager
         self.config = config
+        self.root_module = root_module
         self._metadata = None
 
     def initialize_hook(self, module):
@@ -200,13 +213,16 @@ class MagCacheHeadHook(ModelHook):
             should_compute = True
         else:
             # MagCache Logic
+            effective_num_steps = _get_effective_num_steps(self.config, self.root_module)
+            effective_mag_ratios = _get_effective_mag_ratios(self.config, effective_num_steps)
+
             current_step = state.step_index
-            if current_step >= len(self.config.mag_ratios):
+            if current_step >= len(effective_mag_ratios):
                 current_scale = 1.0
             else:
-                current_scale = self.config.mag_ratios[current_step]
+                current_scale = effective_mag_ratios[current_step]
 
-            retention_step = int(self.config.retention_ratio * self.config.num_inference_steps + 0.5)
+            retention_step = int(self.config.retention_ratio * effective_num_steps + 0.5)
 
             if current_step >= retention_step:
                 state.accumulated_ratio *= current_scale
@@ -286,11 +302,18 @@ class MagCacheHeadHook(ModelHook):
 
 
 class MagCacheBlockHook(ModelHook):
-    def __init__(self, state_manager: StateManager, is_tail: bool = False, config: MagCacheConfig = None):
+    def __init__(
+        self,
+        state_manager: StateManager,
+        is_tail: bool = False,
+        config: MagCacheConfig = None,
+        root_module: torch.nn.Module = None,
+    ):
         super().__init__()
         self.state_manager = state_manager
         self.is_tail = is_tail
         self.config = config
+        self.root_module = root_module
         self._metadata = None
 
     def initialize_hook(self, module):
@@ -379,7 +402,8 @@ class MagCacheBlockHook(ModelHook):
 
     def _advance_step(self, state: MagCacheState):
         state.step_index += 1
-        if state.step_index >= self.config.num_inference_steps:
+        effective_num_steps = _get_effective_num_steps(self.config, self.root_module)
+        if state.step_index >= effective_num_steps:
             # End of inference loop
             if self.config.calibrate:
                 print("\n[MagCache] Calibration Complete. Copy these values to MagCacheConfig(mag_ratios=...):")
@@ -426,31 +450,36 @@ def apply_mag_cache(module: torch.nn.Module, config: MagCacheConfig) -> None:
     if len(remaining_blocks) == 1:
         name, block = remaining_blocks[0]
         logger.info(f"MagCache: Applying Head+Tail Hooks to single block '{name}'")
-        _apply_mag_cache_block_hook(block, state_manager, config, is_tail=True)
-        _apply_mag_cache_head_hook(block, state_manager, config)
+        _apply_mag_cache_block_hook(block, state_manager, config, module, is_tail=True)
+        _apply_mag_cache_head_hook(block, state_manager, config, module)
         return
 
     head_block_name, head_block = remaining_blocks.pop(0)
     tail_block_name, tail_block = remaining_blocks.pop(-1)
 
     logger.info(f"MagCache: Applying Head Hook to {head_block_name}")
-    _apply_mag_cache_head_hook(head_block, state_manager, config)
+    _apply_mag_cache_head_hook(head_block, state_manager, config, module)
 
     for name, block in remaining_blocks:
-        _apply_mag_cache_block_hook(block, state_manager, config)
+        _apply_mag_cache_block_hook(block, state_manager, config, module)
 
     logger.info(f"MagCache: Applying Tail Hook to {tail_block_name}")
-    _apply_mag_cache_block_hook(tail_block, state_manager, config, is_tail=True)
+    _apply_mag_cache_block_hook(tail_block, state_manager, config, module, is_tail=True)
 
 
-def _apply_mag_cache_head_hook(block: torch.nn.Module, state_manager: StateManager, config: MagCacheConfig) -> None:
+def _apply_mag_cache_head_hook(
+    block: torch.nn.Module,
+    state_manager: StateManager,
+    config: MagCacheConfig,
+    root_module: torch.nn.Module,
+) -> None:
     registry = HookRegistry.check_if_exists_or_initialize(block)
 
     # Automatically remove existing hook to allow re-application (e.g. switching modes)
     if registry.get_hook(_MAG_CACHE_LEADER_BLOCK_HOOK) is not None:
         registry.remove_hook(_MAG_CACHE_LEADER_BLOCK_HOOK)
 
-    hook = MagCacheHeadHook(state_manager, config)
+    hook = MagCacheHeadHook(state_manager, config, root_module)
     registry.register_hook(hook, _MAG_CACHE_LEADER_BLOCK_HOOK)
 
 
@@ -458,6 +487,7 @@ def _apply_mag_cache_block_hook(
     block: torch.nn.Module,
     state_manager: StateManager,
     config: MagCacheConfig,
+    root_module: torch.nn.Module,
     is_tail: bool = False,
 ) -> None:
     registry = HookRegistry.check_if_exists_or_initialize(block)
@@ -466,17 +496,6 @@ def _apply_mag_cache_block_hook(
     if registry.get_hook(_MAG_CACHE_BLOCK_HOOK) is not None:
         registry.remove_hook(_MAG_CACHE_BLOCK_HOOK)
 
-    hook = MagCacheBlockHook(state_manager, is_tail, config)
+    hook = MagCacheBlockHook(state_manager, is_tail, config, root_module)
     registry.register_hook(hook, _MAG_CACHE_BLOCK_HOOK)
-
-
-def update_mag_cache_num_steps(module: torch.nn.Module, num_steps: int) -> None:
-    config: MagCacheConfig = getattr(module, "_mag_cache_config", None)
-    if config is None:
-        return
-    original_ratios = getattr(config, "_original_mag_ratios", config.mag_ratios)
-    config.num_inference_steps = num_steps
-    if original_ratios is not None:
-        config.mag_ratios = nearest_interp(original_ratios, num_steps)
-
 

--- a/src/diffusers/pipelines/wan/pipeline_wan.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan.py
@@ -586,6 +586,15 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         else:
             boundary_timestep = None
 
+        if boundary_timestep is not None:
+            from ...hooks.mag_cache import update_mag_cache_num_steps
+            n_steps_t1 = sum(1 for t in timesteps if t >= boundary_timestep)
+            n_steps_t2 = len(timesteps) - n_steps_t1
+            if self.transformer is not None:
+                update_mag_cache_num_steps(self.transformer, n_steps_t1)
+            if self.transformer_2 is not None:
+                update_mag_cache_num_steps(self.transformer_2, n_steps_t2)
+
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/src/diffusers/pipelines/wan/pipeline_wan.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan.py
@@ -587,13 +587,12 @@ class WanPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             boundary_timestep = None
 
         if boundary_timestep is not None:
-            from ...hooks.mag_cache import update_mag_cache_num_steps
             n_steps_t1 = sum(1 for t in timesteps if t >= boundary_timestep)
             n_steps_t2 = len(timesteps) - n_steps_t1
             if self.transformer is not None:
-                update_mag_cache_num_steps(self.transformer, n_steps_t1)
+                self.transformer._mag_cache_expected_steps = n_steps_t1
             if self.transformer_2 is not None:
-                update_mag_cache_num_steps(self.transformer_2, n_steps_t2)
+                self.transformer_2._mag_cache_expected_steps = n_steps_t2
 
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):

--- a/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
@@ -742,13 +742,12 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             boundary_timestep = None
 
         if boundary_timestep is not None:
-            from ...hooks.mag_cache import update_mag_cache_num_steps
             n_steps_t1 = sum(1 for t in timesteps if t >= boundary_timestep)
             n_steps_t2 = len(timesteps) - n_steps_t1
             if self.transformer is not None:
-                update_mag_cache_num_steps(self.transformer, n_steps_t1)
+                self.transformer._mag_cache_expected_steps = n_steps_t1
             if self.transformer_2 is not None:
-                update_mag_cache_num_steps(self.transformer_2, n_steps_t2)
+                self.transformer_2._mag_cache_expected_steps = n_steps_t2
 
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):

--- a/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
@@ -741,6 +741,15 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         else:
             boundary_timestep = None
 
+        if boundary_timestep is not None:
+            from ...hooks.mag_cache import update_mag_cache_num_steps
+            n_steps_t1 = sum(1 for t in timesteps if t >= boundary_timestep)
+            n_steps_t2 = len(timesteps) - n_steps_t1
+            if self.transformer is not None:
+                update_mag_cache_num_steps(self.transformer, n_steps_t1)
+            if self.transformer_2 is not None:
+                update_mag_cache_num_steps(self.transformer_2, n_steps_t2)
+
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/src/diffusers/pipelines/wan/pipeline_wan_vace.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_vace.py
@@ -955,6 +955,15 @@ class WanVACEPipeline(DiffusionPipeline, WanLoraLoaderMixin):
         else:
             boundary_timestep = None
 
+        if boundary_timestep is not None:
+            from ...hooks.mag_cache import update_mag_cache_num_steps
+            n_steps_t1 = sum(1 for t in timesteps if t >= boundary_timestep)
+            n_steps_t2 = len(timesteps) - n_steps_t1
+            if self.transformer is not None:
+                update_mag_cache_num_steps(self.transformer, n_steps_t1)
+            if self.transformer_2 is not None:
+                update_mag_cache_num_steps(self.transformer_2, n_steps_t2)
+
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:

--- a/src/diffusers/pipelines/wan/pipeline_wan_vace.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_vace.py
@@ -956,13 +956,12 @@ class WanVACEPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             boundary_timestep = None
 
         if boundary_timestep is not None:
-            from ...hooks.mag_cache import update_mag_cache_num_steps
             n_steps_t1 = sum(1 for t in timesteps if t >= boundary_timestep)
             n_steps_t2 = len(timesteps) - n_steps_t1
             if self.transformer is not None:
-                update_mag_cache_num_steps(self.transformer, n_steps_t1)
+                self.transformer._mag_cache_expected_steps = n_steps_t1
             if self.transformer_2 is not None:
-                update_mag_cache_num_steps(self.transformer_2, n_steps_t2)
+                self.transformer_2._mag_cache_expected_steps = n_steps_t2
 
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):


### PR DESCRIPTION
Fixes #14025

## Root cause

`MagCacheConfig` was applied to both `transformer` and `transformer_2` with `num_inference_steps` set to the full pipeline step count. In dual transformer pipelines such as Wan 2.2, `transformer` only runs the high noise stage and `transformer_2` only runs the low noise stage. Each of them executes a subset of the total steps, never the full count.

This causes three downstream problems:

- `_advance_step`: the check `state.step_index >= config.num_inference_steps` never fires for either transformer, since neither ever reaches the full step count. State never resets and calibration never completes.
- Retention window: `int(retention_ratio * num_inference_steps)` is computed against the full step count instead of the actual per transformer step count, so it protects more steps from skipping than intended.
- `mag_ratios` indexing: since `mag_ratios` is sized to the full step count, `step_index` no longer maps to the correct entry, so each transformer reads ratios that do not correspond to its own denoising timestep.

## First attempt and why it changed

The initial fix added `update_mag_cache_num_steps(module, actual_steps)`, which mutated `config.num_inference_steps` and `config.mag_ratios` in place on the attached `MagCacheConfig`.

Review feedback identified two problems with that approach:

1. If the same `MagCacheConfig` object is passed to both `transformer` and `transformer_2`, calling this function for one transformer corrupts the config for the other, since they share the same object.
2. The pipeline had to `import` a hook internal function directly, coupling pipeline code to hook implementation details.

## Fix

`MagCacheConfig` is now never mutated after construction. Instead:

- Pipelines set a plain attribute on each transformer, `transformer._mag_cache_expected_steps = n_steps`, no hook internals imported.
- The hooks hold a reference to the root transformer module (passed in at `apply_mag_cache` time) and read `_mag_cache_expected_steps` off it live, at forward and reset time, falling back to `config.num_inference_steps` if the attribute was never set.
- `mag_ratios` are computed on demand from `_original_mag_ratios` at the effective step count, never written back to `config.mag_ratios`.

This means a shared config object across both transformers can no longer be corrupted, since nothing ever writes to it after construction.

Files changed:

| File | Change |
| --- | --- |
| `src/diffusers/hooks/mag_cache.py` | Add `_get_effective_num_steps` and `_get_effective_mag_ratios`, both pure functions that read from a root module attribute and a config, no mutation. Hooks now take a `root_module` reference. Remove `update_mag_cache_num_steps`. |
| `src/diffusers/hooks/__init__.py` | Remove the export of the now deleted `update_mag_cache_num_steps`. |
| `src/diffusers/pipelines/wan/pipeline_wan.py` | Set `transformer._mag_cache_expected_steps` / `transformer_2._mag_cache_expected_steps` instead of calling into hook internals. |
| `src/diffusers/pipelines/wan/pipeline_wan_i2v.py` | Same as above. |
| `src/diffusers/pipelines/wan/pipeline_wan_vace.py` | Same as above. |

All pipeline changes are no-ops when MagCache is not applied.

## Evidence

Run locally, CPU only, no GPU or model weights required. Uses tiny `WanTransformerBlock` instances (`dim=32`) just to satisfy the hook registry.

### 1. The bug this PR fixes: shared config corruption under asymmetric split

Before this PR, the mutating approach corrupted a config object shared across two transformers. Reproduced directly against a plain `MagCacheConfig`, no pipeline needed:

```python
from diffusers.hooks.mag_cache import MagCacheConfig, nearest_interp

shared = MagCacheConfig(mag_ratios=[1.0, 0.9, 0.8, 0.7], num_inference_steps=10)

# old mutating approach, simulated inline since update_mag_cache_num_steps is removed
shared.num_inference_steps = 7
shared.mag_ratios = nearest_interp(shared._original_mag_ratios, 7)
print("after setting for transformer:", shared.num_inference_steps)

shared.num_inference_steps = 3
shared.mag_ratios = nearest_interp(shared._original_mag_ratios, 3)
print("after setting for transformer_2:", shared.num_inference_steps)

print("what transformer now reads:", shared.num_inference_steps)
```

Output:
after setting for transformer: 7
after setting for transformer_2: 3
what transformer now reads: 3

`transformer` was supposed to run 7 steps but the shared config now reports 3, because `transformer_2`'s update overwrote it. This is the exact corruption the reviewer flagged.

### 2. After the fix, the same shared config is never touched

```python
from diffusers.hooks.mag_cache import MagCacheConfig, apply_mag_cache, _get_effective_num_steps
import torch.nn as nn
from diffusers.models.transformers.transformer_wan import WanTransformerBlock

def make_tiny():
    class T(nn.Module):
        def __init__(self):
            super().__init__()
            self.transformer_blocks = nn.ModuleList([
                WanTransformerBlock(dim=32, ffn_dim=64, num_heads=2,
                    qk_norm="rms_norm_across_heads", cross_attn_norm=True,
                    eps=1e-6, added_kv_proj_dim=None)
                for _ in range(3)
            ])
    return T()

shared = MagCacheConfig(mag_ratios=[1.0, 0.9, 0.8, 0.7], num_inference_steps=10)
t1, t2 = make_tiny(), make_tiny()
apply_mag_cache(t1, shared)
apply_mag_cache(t2, shared)

t1._mag_cache_expected_steps = 7
t2._mag_cache_expected_steps = 3

print("t1 effective steps:", _get_effective_num_steps(shared, t1))
print("t2 effective steps:", _get_effective_num_steps(shared, t2))
print("shared.num_inference_steps, unchanged:", shared.num_inference_steps)
```

Output:
t1 effective steps: 7
t2 effective steps: 3
shared.num_inference_steps, unchanged: 10

Each transformer sees its own correct step count and the shared config object is never written to.

### 3. Full unit test suite
$ python -m pytest tests/hooks/test_mag_cache_wan22_steps.py -v
19 passed in 0.30s

Covers, beyond the case above:

- Retention window computed against the effective per transformer step count, not the global one.
- `mag_ratios` re-interpolated per transformer without mutating `config.mag_ratios`.
- Asymmetric splits `(3,2)`, `(7,3)`, `(1,9)` on a single shared config object.
- Single transformer pipelines (Flux, SDXL, Wan 2.1) fall back to `config.num_inference_steps` unchanged when `_mag_cache_expected_steps` was never set, confirming no behavior change there.
- Hooks correctly hold a reference to the root module they were applied to.

### 4. Double interpolation is still avoided

Unchanged from the original fix, still verified by the test suite: `mag_ratios` are always re-computed from `_original_mag_ratios`, never from an already interpolated `mag_ratios`, so calling this multiple times at different step counts does not compound rounding error.

## Scope note

This PR only fixes the step accounting and config mutation issues described above. The separately reported quality degradation on heavily step distilled models (50 step calibration collapsed into a 4 step schedule) is a distinct issue tracked in #14025 and not addressed here.