### PR TITLE
fix: handle CLIP text_model prefix change in transformers>=5 for FLUX LoRA loading

### DIFF
--- a/src/diffusers/loaders/lora_base.py
+++ b/src/diffusers/loaders/lora_base.py
@@ -381,6 +381,12 @@ def _load_lora_into_text_encoder(
                 rank_key = f"{name}.lora_B.weight"
                 if rank_key in state_dict:
                     rank[rank_key] = state_dict[rank_key].shape[1]
+                else:
+                    # Handle transformers>=5 where CLIPTextModel was flattened and no longer
+                    # includes the `text_model.` wrapper prefix in named_modules().
+                    alt_rank_key = f"text_model.{name}.lora_B.weight"
+                    if alt_rank_key in state_dict:
+                        rank[alt_rank_key] = state_dict[alt_rank_key].shape[1]
 
         if network_alphas is not None:
             alpha_keys = [k for k in network_alphas.keys() if k.startswith(prefix) and k.split(".")[0] == prefix]


### PR DESCRIPTION
Resolves #13984

Under transformers>=5, CLIPTextModel was flattened and no longer includes the  wrapper prefix in named_modules(). This caused kohya-style FLUX LoRA weights with CLIP text-encoder keys to fail with IndexError because the rank dict stayed empty. The fix normalizes module name matching in _load_lora_into_text_encoder to handle both prefixed and unprefixed names.