### PR TITLE
Fix group offloading for quanto-quantized models

### DIFF
--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -22,7 +22,7 @@ from typing import Set
 import safetensors.torch
 import torch
 
-from ..utils import get_logger, is_accelerate_available, is_torchao_available
+from ..utils import get_logger, is_accelerate_available, is_optimum_quanto_available, is_torchao_available
 from ._common import _GO_LC_SUPPORTED_PYTORCH_LAYERS
 from .hooks import HookRegistry, ModelHook
 
@@ -80,6 +80,31 @@ def _restore_torchao_tensor(param: torch.Tensor, source: torch.Tensor) -> None:
 def _record_stream_torchao_tensor(param: torch.Tensor, stream) -> None:
     """Record stream for all internal tensors of a TorchAO parameter."""
     for attr_name in _get_torchao_inner_tensor_names(param):
+        getattr(param, attr_name).record_stream(stream)
+
+
+def _is_quanto_tensor(tensor: torch.Tensor) -> bool:
+    if not is_optimum_quanto_available():
+        return False
+    from optimum.quanto import QTensor
+
+    return isinstance(tensor, QTensor)
+
+
+def _get_quanto_inner_tensor_names(tensor: torch.Tensor) -> list[str]:
+    """Get names of all internal tensor data attributes from a quanto QTensor (e.g. `_data`, `_scale`)."""
+    return list(tensor.__tensor_flatten__()[0])
+
+
+def _restore_quanto_tensor(param: torch.Tensor, source: torch.Tensor) -> None:
+    """Restore internal tensor data of a quanto QTensor from `source` without mutating `source`."""
+    for attr_name in _get_quanto_inner_tensor_names(source):
+        setattr(param, attr_name, getattr(source, attr_name))
+
+
+def _record_stream_quanto_tensor(param: torch.Tensor, stream) -> None:
+    """Record stream for all internal tensors of a quanto QTensor."""
+    for attr_name in _get_quanto_inner_tensor_names(param):
         getattr(param, attr_name).record_stream(stream)
 
 
@@ -174,10 +199,14 @@ class ModuleGroup:
 
     @staticmethod
     def _to_cpu(tensor, low_cpu_mem_usage):
-        # For TorchAO tensors, `.data` returns an incomplete wrapper without internal attributes
-        # (e.g. `.qdata`, `.scale`), so we must call `.cpu()` on the tensor directly.
-        t = tensor.cpu() if _is_torchao_tensor(tensor) else tensor.data.cpu()
-        return t if low_cpu_mem_usage else t.pin_memory()
+        # For tensor subclasses (TorchAO / quanto), `.data` returns an incomplete wrapper without internal
+        # attributes (e.g. `.qdata`/`.scale`, `._data`/`._scale`), so we must call `.cpu()` on the tensor directly.
+        t = tensor.cpu() if (_is_torchao_tensor(tensor) or _is_quanto_tensor(tensor)) else tensor.data.cpu()
+        # Subclass tensors (quanto / torchao) don't support `pin_memory()`/`is_pinned()` (quanto loses the
+        # subclass, torchao raises on the unimplemented op), so skip pinning for them.
+        if low_cpu_mem_usage or _is_quanto_tensor(tensor) or _is_torchao_tensor(tensor):
+            return t
+        return t.pin_memory()
 
     def _init_cpu_param_dict(self):
         cpu_param_dict = {}
@@ -202,7 +231,9 @@ class ModuleGroup:
     def _pinned_memory_tensors(self):
         try:
             pinned_dict = {
-                param: tensor.pin_memory() if not tensor.is_pinned() else tensor
+                param: tensor
+                if (_is_quanto_tensor(tensor) or _is_torchao_tensor(tensor) or tensor.is_pinned())
+                else tensor.pin_memory()
                 for param, tensor in self.cpu_param_dict.items()
             }
             yield pinned_dict
@@ -213,11 +244,15 @@ class ModuleGroup:
         moved = source_tensor.to(self.onload_device, non_blocking=self.non_blocking)
         if _is_torchao_tensor(tensor):
             _swap_torchao_tensor(tensor, moved)
+        elif _is_quanto_tensor(tensor):
+            torch.utils.swap_tensors(tensor, moved)
         else:
             tensor.data = moved
         if self.record_stream:
             if _is_torchao_tensor(tensor):
                 _record_stream_torchao_tensor(tensor, default_stream)
+            elif _is_quanto_tensor(tensor):
+                _record_stream_quanto_tensor(tensor, default_stream)
             else:
                 tensor.data.record_stream(default_stream)
 
@@ -320,16 +355,22 @@ class ModuleGroup:
                 for param in group_module.parameters():
                     if _is_torchao_tensor(param):
                         _restore_torchao_tensor(param, self.cpu_param_dict[param])
+                    elif _is_quanto_tensor(param):
+                        _restore_quanto_tensor(param, self.cpu_param_dict[param])
                     else:
                         param.data = self.cpu_param_dict[param]
             for param in self.parameters:
                 if _is_torchao_tensor(param):
                     _restore_torchao_tensor(param, self.cpu_param_dict[param])
+                elif _is_quanto_tensor(param):
+                    _restore_quanto_tensor(param, self.cpu_param_dict[param])
                 else:
                     param.data = self.cpu_param_dict[param]
             for buffer in self.buffers:
                 if _is_torchao_tensor(buffer):
                     _restore_torchao_tensor(buffer, self.cpu_param_dict[buffer])
+                elif _is_quanto_tensor(buffer):
+                    _restore_quanto_tensor(buffer, self.cpu_param_dict[buffer])
                 else:
                     buffer.data = self.cpu_param_dict[buffer]
         else:
@@ -339,12 +380,16 @@ class ModuleGroup:
                 if _is_torchao_tensor(param):
                     moved = param.to(self.offload_device, non_blocking=False)
                     _swap_torchao_tensor(param, moved)
+                elif _is_quanto_tensor(param):
+                    torch.utils.swap_tensors(param, param.to(self.offload_device, non_blocking=False))
                 else:
                     param.data = param.data.to(self.offload_device, non_blocking=False)
             for buffer in self.buffers:
                 if _is_torchao_tensor(buffer):
                     moved = buffer.to(self.offload_device, non_blocking=False)
                     _swap_torchao_tensor(buffer, moved)
+                elif _is_quanto_tensor(buffer):
+                    torch.utils.swap_tensors(buffer, buffer.to(self.offload_device, non_blocking=False))
                 else:
                     buffer.data = buffer.data.to(self.offload_device, non_blocking=False)
 

--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -199,12 +199,13 @@ class ModuleGroup:
 
     @staticmethod
     def _to_cpu(tensor, low_cpu_mem_usage):
+        is_torchao_tensor = _is_torchao_tensor(tensor)
+        is_quanto_tensor = _is_quanto_tensor(tensor)
         # For tensor subclasses (TorchAO / quanto), `.data` returns an incomplete wrapper without internal
         # attributes (e.g. `.qdata`/`.scale`, `._data`/`._scale`), so we must call `.cpu()` on the tensor directly.
-        t = tensor.cpu() if (_is_torchao_tensor(tensor) or _is_quanto_tensor(tensor)) else tensor.data.cpu()
-        # Subclass tensors (quanto / torchao) don't support `pin_memory()`/`is_pinned()` (quanto loses the
-        # subclass, torchao raises on the unimplemented op), so skip pinning for them.
-        if low_cpu_mem_usage or _is_quanto_tensor(tensor) or _is_torchao_tensor(tensor):
+        t = tensor.cpu() if (is_torchao_tensor or is_quanto_tensor) else tensor.data.cpu()
+        # Quanto tensors do not keep their subclass identity through `pin_memory()`, so skip pinning for them.
+        if low_cpu_mem_usage or is_quanto_tensor:
             return t
         return t.pin_memory()
 
@@ -231,9 +232,7 @@ class ModuleGroup:
     def _pinned_memory_tensors(self):
         try:
             pinned_dict = {
-                param: tensor
-                if (_is_quanto_tensor(tensor) or _is_torchao_tensor(tensor) or tensor.is_pinned())
-                else tensor.pin_memory()
+                param: tensor if (_is_quanto_tensor(tensor) or tensor.is_pinned()) else tensor.pin_memory()
                 for param, tensor in self.cpu_param_dict.items()
             }
             yield pinned_dict

--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -96,6 +96,16 @@ def _get_quanto_inner_tensor_names(tensor: torch.Tensor) -> list[str]:
     return list(tensor.__tensor_flatten__()[0])
 
 
+def _swap_quanto_tensor(param: torch.Tensor, source: torch.Tensor) -> None:
+    """Move a quanto QTensor to the device of `source` via `swap_tensors`.
+
+    `param.data = source` does not work for quanto tensor subclasses because it updates only the outer wrapper while
+    leaving the subclass internal tensors (e.g. `._data`, `._scale`) on the original device. `swap_tensors` swaps the
+    full tensor contents in-place, preserving the parameter's identity.
+    """
+    torch.utils.swap_tensors(param, source)
+
+
 def _restore_quanto_tensor(param: torch.Tensor, source: torch.Tensor) -> None:
     """Restore internal tensor data of a quanto QTensor from `source` without mutating `source`."""
     for attr_name in _get_quanto_inner_tensor_names(source):
@@ -244,7 +254,7 @@ class ModuleGroup:
         if _is_torchao_tensor(tensor):
             _swap_torchao_tensor(tensor, moved)
         elif _is_quanto_tensor(tensor):
-            torch.utils.swap_tensors(tensor, moved)
+            _swap_quanto_tensor(tensor, moved)
         else:
             tensor.data = moved
         if self.record_stream:
@@ -272,18 +282,19 @@ class ModuleGroup:
             source = pinned_memory[buffer] if pinned_memory else buffer.data
             self._transfer_tensor_to_device(buffer, source, default_stream)
 
-    def _check_disk_offload_torchao(self):
+    def _check_disk_offload_tensor_subclasses(self):
         all_tensors = list(self.tensor_to_key.keys())
         has_torchao = any(_is_torchao_tensor(t) for t in all_tensors)
-        if has_torchao:
+        has_quanto = any(_is_quanto_tensor(t) for t in all_tensors)
+        if has_torchao or has_quanto:
             raise ValueError(
-                "Disk offloading is not supported for TorchAO quantized tensors because safetensors "
-                "cannot serialize TorchAO subclass tensors. Use memory offloading instead by not "
+                "Disk offloading is not supported for TorchAO or quanto tensor subclasses because saving only "
+                "`.data` would drop the subclass tensor internals. Use memory offloading instead by not "
                 "setting `offload_to_disk_path`."
             )
 
     def _onload_from_disk(self):
-        self._check_disk_offload_torchao()
+        self._check_disk_offload_tensor_subclasses()
 
         if self.stream is not None:
             # Wait for previous Host->Device transfer to complete
@@ -326,7 +337,7 @@ class ModuleGroup:
                 self._process_tensors_from_modules(None)
 
     def _offload_to_disk(self):
-        self._check_disk_offload_torchao()
+        self._check_disk_offload_tensor_subclasses()
 
         # TODO: we can potentially optimize this code path by checking if the _all_ the desired
         # safetensor files exist on the disk and if so, skip this step entirely, reducing IO
@@ -380,7 +391,7 @@ class ModuleGroup:
                     moved = param.to(self.offload_device, non_blocking=False)
                     _swap_torchao_tensor(param, moved)
                 elif _is_quanto_tensor(param):
-                    torch.utils.swap_tensors(param, param.to(self.offload_device, non_blocking=False))
+                    _swap_quanto_tensor(param, param.to(self.offload_device, non_blocking=False))
                 else:
                     param.data = param.data.to(self.offload_device, non_blocking=False)
             for buffer in self.buffers:
@@ -388,7 +399,7 @@ class ModuleGroup:
                     moved = buffer.to(self.offload_device, non_blocking=False)
                     _swap_torchao_tensor(buffer, moved)
                 elif _is_quanto_tensor(buffer):
-                    torch.utils.swap_tensors(buffer, buffer.to(self.offload_device, non_blocking=False))
+                    _swap_quanto_tensor(buffer, buffer.to(self.offload_device, non_blocking=False))
                 else:
                     buffer.data = buffer.data.to(self.offload_device, non_blocking=False)
 

--- a/tests/quantization/quanto/test_quanto.py
+++ b/tests/quantization/quanto/test_quanto.py
@@ -273,6 +273,30 @@ class FluxTransformerQuantoMixin(QuantoBaseTesterMixin):
         pipe.enable_model_cpu_offload(device=torch_device)
         _ = pipe("a cat holding a sign that says hello", num_inference_steps=2)
 
+    def test_group_offloading(self):
+        inputs = self.get_dummy_inputs()
+        model = self.model_cls.from_pretrained(**self.get_dummy_model_init_kwargs()).to(torch_device)
+        with torch.no_grad():
+            output_without_offloading = model(**inputs).sample
+        model.to("cpu")
+        del model
+        backend_empty_cache(torch_device)
+        gc.collect()
+
+        for offload_kwargs in (
+            {"offload_type": "leaf_level"},
+            {"offload_type": "leaf_level", "use_stream": True},
+            {"offload_type": "block_level", "num_blocks_per_group": 1, "use_stream": True},
+        ):
+            model = self.model_cls.from_pretrained(**self.get_dummy_model_init_kwargs())
+            model.enable_group_offload(torch_device, **offload_kwargs)
+            with torch.no_grad():
+                output = model(**inputs).sample
+            assert torch.allclose(output_without_offloading, output, atol=1e-3, rtol=1e-3)
+            del model
+            backend_empty_cache(torch_device)
+            gc.collect()
+
     def test_training(self):
         quantization_config = QuantoConfig(**self.get_dummy_init_kwargs())
         quantized_model = self.model_cls.from_pretrained(

--- a/tests/quantization/quanto/test_quanto.py
+++ b/tests/quantization/quanto/test_quanto.py
@@ -297,6 +297,17 @@ class FluxTransformerQuantoMixin(QuantoBaseTesterMixin):
             backend_empty_cache(torch_device)
             gc.collect()
 
+    def test_group_offloading_disk_offload_raises(self):
+        model = self.model_cls.from_pretrained(**self.get_dummy_model_init_kwargs())
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaisesRegex(ValueError, "Disk offloading is not supported for TorchAO or quanto"):
+                model.enable_group_offload(torch_device, offload_type="leaf_level", offload_to_disk_path=tmp_dir)
+
+        del model
+        backend_empty_cache(torch_device)
+        gc.collect()
+
     def test_training(self):
         quantization_config = QuantoConfig(**self.get_dummy_init_kwargs())
         quantized_model = self.model_cls.from_pretrained(

--- a/tests/quantization/torchao/test_torchao.py
+++ b/tests/quantization/torchao/test_torchao.py
@@ -522,6 +522,33 @@ class TorchAoTest(unittest.TestCase):
         inputs = self.get_dummy_inputs(torch_device)
         _ = pipe(**inputs)
 
+    def test_group_offloading(self):
+        r"""
+        A test that checks if inference runs as expected when group offloading is enabled, including the
+        `use_stream` path that pins tensors, which the quantized subclass tensors do not support.
+        """
+        inputs = self.get_dummy_tensor_inputs(torch_device)
+        transformer = self.get_dummy_components(TorchAoConfig(Int8WeightOnlyConfig()))["transformer"].to(torch_device)
+        with torch.no_grad():
+            output_without_offloading = transformer(**inputs)[0]
+        del transformer
+        backend_empty_cache(torch_device)
+        gc.collect()
+
+        for offload_kwargs in (
+            {"offload_type": "leaf_level"},
+            {"offload_type": "leaf_level", "use_stream": True},
+            {"offload_type": "block_level", "num_blocks_per_group": 1, "use_stream": True},
+        ):
+            transformer = self.get_dummy_components(TorchAoConfig(Int8WeightOnlyConfig()))["transformer"]
+            transformer.enable_group_offload(torch_device, **offload_kwargs)
+            with torch.no_grad():
+                output = transformer(**inputs)[0]
+            assert torch.allclose(output_without_offloading, output, atol=1e-3, rtol=1e-3)
+            del transformer
+            backend_empty_cache(torch_device)
+            gc.collect()
+
     @require_torchao_version_greater_or_equal("0.15.0")
     def test_aobase_config(self):
         quantization_config = TorchAoConfig(Int8WeightOnlyConfig())

--- a/tests/quantization/torchao/test_torchao.py
+++ b/tests/quantization/torchao/test_torchao.py
@@ -522,33 +522,6 @@ class TorchAoTest(unittest.TestCase):
         inputs = self.get_dummy_inputs(torch_device)
         _ = pipe(**inputs)
 
-    def test_group_offloading(self):
-        r"""
-        A test that checks if inference runs as expected when group offloading is enabled, including the
-        `use_stream` path that pins tensors, which the quantized subclass tensors do not support.
-        """
-        inputs = self.get_dummy_tensor_inputs(torch_device)
-        transformer = self.get_dummy_components(TorchAoConfig(Int8WeightOnlyConfig()))["transformer"].to(torch_device)
-        with torch.no_grad():
-            output_without_offloading = transformer(**inputs)[0]
-        del transformer
-        backend_empty_cache(torch_device)
-        gc.collect()
-
-        for offload_kwargs in (
-            {"offload_type": "leaf_level"},
-            {"offload_type": "leaf_level", "use_stream": True},
-            {"offload_type": "block_level", "num_blocks_per_group": 1, "use_stream": True},
-        ):
-            transformer = self.get_dummy_components(TorchAoConfig(Int8WeightOnlyConfig()))["transformer"]
-            transformer.enable_group_offload(torch_device, **offload_kwargs)
-            with torch.no_grad():
-                output = transformer(**inputs)[0]
-            assert torch.allclose(output_without_offloading, output, atol=1e-3, rtol=1e-3)
-            del transformer
-            backend_empty_cache(torch_device)
-            gc.collect()
-
     @require_torchao_version_greater_or_equal("0.15.0")
     def test_aobase_config(self):
         quantization_config = TorchAoConfig(Int8WeightOnlyConfig())


### PR DESCRIPTION

# What does this PR do?

Fixes #12610

Group offloading moves a group's parameters between CPU and the accelerator by reassigning `param.data`:

```python
param.data = source_tensor.to(device)
```

This is correct for plain tensors but wrong for quanto tensor subclasses. A quanto `WeightQBytesTensor` stores the real payload in internal tensors such as `_data` and `_scale`; replacing `.data` only swaps the outer wrapper and leaves those internal tensors on the source device. The next matmul then fails with `mat2 is on cpu, different from cuda:0`.

#13276 fixed the same subclass-storage issue for TorchAO tensors by swapping the full tensor subclass instead of assigning `.data`, but quanto tensors still fall through to the plain tensor path. This PR adds the corresponding quanto path and keeps the TorchAO stream fix split out in #14112.

## Changes

- Detect quanto `QTensor` parameters without importing optimum-quanto unless it is installed.
- Use `torch.utils.swap_tensors` for quanto onload/offload instead of assigning `.data`.
- Restore and record streams for quanto internal tensors using the subclass tensor names from `__tensor_flatten__()`.
- Skip pinned-memory conversion for quanto tensors, since `pin_memory()` does not preserve the quanto subclass.

## Tests

Environment: NVIDIA RTX 4090, `torch==2.8.0+cu128`, `optimum-quanto==0.2.7`.

<details>
<summary>Reproduction and before/after</summary>

Minimal standalone repro for #12610:

```python
import torch
from diffusers import UNet2DConditionModel
from diffusers.hooks import apply_group_offloading
from optimum.quanto import quantize, freeze, qint8

m = UNet2DConditionModel.from_pretrained(
    "hf-internal-testing/tiny-stable-diffusion-pipe", subfolder="unet"
).to(torch.float32).eval()
quantize(m, weights=qint8)
freeze(m)
apply_group_offloading(
    m,
    onload_device=torch.device("cuda"),
    offload_device=torch.device("cpu"),
    offload_type="leaf_level",
)
x = torch.randn(2, m.config.in_channels, m.config.sample_size, m.config.sample_size, device="cuda")
t = torch.tensor([10, 10], device="cuda")
e = torch.randn(2, 4, m.config.cross_attention_dim, device="cuda")
with torch.no_grad():
    m(x, t, e)
```

On main, this fails with:

```text
RuntimeError: mat2 is on cpu, different from cuda:0
```

With this PR, quanto group offload matches the fully-on-accelerator quantized baseline across `leaf_level`, `block_level`, non-stream, `use_stream`, and `record_stream` configs. The maximum absolute difference is `0.0`.

</details>

Regression tests:

```bash
python -m pytest tests/quantization/quanto/test_quanto.py::FluxTransformerInt8WeightsTest::test_group_offloading -q
python -m pytest tests/quantization/quanto/test_quanto.py::FluxTransformerFloat8WeightsTest::test_group_offloading -q
```

Both tests fail on main with the device mismatch and pass with this PR.

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you self-review the diff against [`.ai/review-rules.md`](https://github.com/huggingface/diffusers/blob/main/.ai/review-rules.md)?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case. #12610
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?

## Who can review?

cc @sayakpaul
