### PR TITLE
Fix clip_skip AttributeError on Stable Diffusion pipelines with transformers>=5.6

### DIFF
--- a/src/diffusers/pipelines/animatediff/pipeline_animatediff.py
+++ b/src/diffusers/pipelines/animatediff/pipeline_animatediff.py
@@ -256,7 +256,11 @@ class AnimateDiffPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/animatediff/pipeline_animatediff_controlnet.py
+++ b/src/diffusers/pipelines/animatediff/pipeline_animatediff_controlnet.py
@@ -301,7 +301,11 @@ class AnimateDiffControlNetPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/animatediff/pipeline_animatediff_sparsectrl.py
+++ b/src/diffusers/pipelines/animatediff/pipeline_animatediff_sparsectrl.py
@@ -310,7 +310,11 @@ class AnimateDiffSparseControlNetPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/animatediff/pipeline_animatediff_video2video.py
+++ b/src/diffusers/pipelines/animatediff/pipeline_animatediff_video2video.py
@@ -358,7 +358,11 @@ class AnimateDiffVideoToVideoPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/animatediff/pipeline_animatediff_video2video_controlnet.py
+++ b/src/diffusers/pipelines/animatediff/pipeline_animatediff_video2video_controlnet.py
@@ -389,7 +389,11 @@ class AnimateDiffVideoToVideoControlNetPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet.py
@@ -400,7 +400,11 @@ class StableDiffusionControlNetPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_img2img.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_img2img.py
@@ -378,7 +378,11 @@ class StableDiffusionControlNetImg2ImgPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
@@ -384,7 +384,11 @@ class StableDiffusionControlNetInpaintPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/alt_diffusion/pipeline_alt_diffusion.py
+++ b/src/diffusers/pipelines/deprecated/alt_diffusion/pipeline_alt_diffusion.py
@@ -429,7 +429,11 @@ class AltDiffusionPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/alt_diffusion/pipeline_alt_diffusion_img2img.py
+++ b/src/diffusers/pipelines/deprecated/alt_diffusion/pipeline_alt_diffusion_img2img.py
@@ -457,7 +457,11 @@ class AltDiffusionImg2ImgPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/controlnet_xs/pipeline_controlnet_xs.py
+++ b/src/diffusers/pipelines/deprecated/controlnet_xs/pipeline_controlnet_xs.py
@@ -334,7 +334,11 @@ class StableDiffusionControlNetXSPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/i2vgen_xl/pipeline_i2vgen_xl.py
+++ b/src/diffusers/pipelines/deprecated/i2vgen_xl/pipeline_i2vgen_xl.py
@@ -245,7 +245,11 @@ class I2VGenXLPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype
@@ -315,7 +319,11 @@ class I2VGenXLPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                negative_prompt_embeds = self.text_encoder.text_model.final_layer_norm(negative_prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                negative_prompt_embeds = text_model.final_layer_norm(negative_prompt_embeds)
 
         if self.do_classifier_free_guidance:
             # duplicate unconditional embeddings for each generation per prompt, using mps friendly method

--- a/src/diffusers/pipelines/deprecated/pia/pipeline_pia.py
+++ b/src/diffusers/pipelines/deprecated/pia/pipeline_pia.py
@@ -318,7 +318,11 @@ class PIAPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_attend_and_excite/pipeline_stable_diffusion_attend_and_excite.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_attend_and_excite/pipeline_stable_diffusion_attend_and_excite.py
@@ -398,7 +398,11 @@ class StableDiffusionAttendAndExcitePipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_diffedit/pipeline_stable_diffusion_diffedit.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_diffedit/pipeline_stable_diffusion_diffedit.py
@@ -524,7 +524,11 @@ class StableDiffusionDiffEditPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_gligen/pipeline_stable_diffusion_gligen.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_gligen/pipeline_stable_diffusion_gligen.py
@@ -322,7 +322,11 @@ class StableDiffusionGLIGENPipeline(DeprecatedPipelineMixin, DiffusionPipeline, 
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_gligen/pipeline_stable_diffusion_gligen_text_image.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_gligen/pipeline_stable_diffusion_gligen_text_image.py
@@ -353,7 +353,11 @@ class StableDiffusionGLIGENTextImagePipeline(DeprecatedPipelineMixin, DiffusionP
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_ldm3d/pipeline_stable_diffusion_ldm3d.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_ldm3d/pipeline_stable_diffusion_ldm3d.py
@@ -414,7 +414,11 @@ class StableDiffusionLDM3DPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_panorama/pipeline_stable_diffusion_panorama.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_panorama/pipeline_stable_diffusion_panorama.py
@@ -385,7 +385,11 @@ class StableDiffusionPanoramaPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_sag/pipeline_stable_diffusion_sag.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_sag/pipeline_stable_diffusion_sag.py
@@ -313,7 +313,11 @@ class StableDiffusionSAGPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_cycle_diffusion.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_cycle_diffusion.py
@@ -390,7 +390,11 @@ class CycleDiffusionPipeline(DiffusionPipeline, TextualInversionLoaderMixin, Sta
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_stable_diffusion_inpaint_legacy.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_stable_diffusion_inpaint_legacy.py
@@ -361,7 +361,11 @@ class StableDiffusionInpaintPipelineLegacy(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_stable_diffusion_model_editing.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_stable_diffusion_model_editing.py
@@ -294,7 +294,11 @@ class StableDiffusionModelEditingPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_stable_diffusion_paradigms.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_stable_diffusion_paradigms.py
@@ -291,7 +291,11 @@ class StableDiffusionParadigmsPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_stable_diffusion_pix2pix_zero.py
+++ b/src/diffusers/pipelines/deprecated/stable_diffusion_variants/pipeline_stable_diffusion_pix2pix_zero.py
@@ -509,7 +509,11 @@ class StableDiffusionPix2PixZeroPipeline(DiffusionPipeline, StableDiffusionMixin
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/text_to_video_synthesis/pipeline_text_to_video_synth.py
+++ b/src/diffusers/pipelines/deprecated/text_to_video_synthesis/pipeline_text_to_video_synth.py
@@ -261,7 +261,11 @@ class TextToVideoSDPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/text_to_video_synthesis/pipeline_text_to_video_synth_img2img.py
+++ b/src/diffusers/pipelines/deprecated/text_to_video_synthesis/pipeline_text_to_video_synth_img2img.py
@@ -296,7 +296,11 @@ class VideoToVideoSDPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/text_to_video_synthesis/pipeline_text_to_video_zero.py
+++ b/src/diffusers/pipelines/deprecated/text_to_video_synthesis/pipeline_text_to_video_zero.py
@@ -918,7 +918,11 @@ class TextToVideoZeroPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/deprecated/unidiffuser/pipeline_unidiffuser.py
+++ b/src/diffusers/pipelines/deprecated/unidiffuser/pipeline_unidiffuser.py
@@ -523,7 +523,11 @@ class UniDiffuserPipeline(DeprecatedPipelineMixin, DiffusionPipeline):
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/latent_consistency_models/pipeline_latent_consistency_img2img.py
+++ b/src/diffusers/pipelines/latent_consistency_models/pipeline_latent_consistency_img2img.py
@@ -343,7 +343,11 @@ class LatentConsistencyModelImg2ImgPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/latent_consistency_models/pipeline_latent_consistency_text2img.py
+++ b/src/diffusers/pipelines/latent_consistency_models/pipeline_latent_consistency_text2img.py
@@ -328,7 +328,11 @@ class LatentConsistencyModelPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/ledits_pp/pipeline_leditspp_stable_diffusion.py
+++ b/src/diffusers/pipelines/ledits_pp/pipeline_leditspp_stable_diffusion.py
@@ -680,7 +680,11 @@ class LEditsPPPipelineStableDiffusion(
                     # representations. The `last_hidden_states` that we typically use for
                     # obtaining the final prompt representations passes through the LayerNorm
                     # layer.
-                    editing_prompt_embeds = self.text_encoder.text_model.final_layer_norm(editing_prompt_embeds)
+                    # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                    text_model = (
+                        self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                    )
+                    editing_prompt_embeds = text_model.final_layer_norm(editing_prompt_embeds)
 
             editing_prompt_embeds = editing_prompt_embeds.to(dtype=negative_prompt_embeds.dtype, device=device)
 

--- a/src/diffusers/pipelines/pag/pipeline_pag_controlnet_sd.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_controlnet_sd.py
@@ -377,7 +377,11 @@ class StableDiffusionControlNetPAGPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/pag/pipeline_pag_controlnet_sd_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_controlnet_sd_inpaint.py
@@ -353,7 +353,11 @@ class StableDiffusionControlNetPAGInpaintPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd.py
@@ -406,7 +406,11 @@ class StableDiffusionPAGPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_animatediff.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_animatediff.py
@@ -267,7 +267,11 @@ class AnimateDiffPAGPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_img2img.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_img2img.py
@@ -401,7 +401,11 @@ class StableDiffusionPAGImg2ImgPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_inpaint.py
@@ -436,7 +436,11 @@ class StableDiffusionPAGInpaintPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py
@@ -434,7 +434,11 @@ class StableDiffusionPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_depth2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_depth2img.py
@@ -306,7 +306,11 @@ class StableDiffusionDepth2ImgPipeline(DiffusionPipeline, TextualInversionLoader
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py
@@ -460,7 +460,11 @@ class StableDiffusionImg2ImgPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_inpaint.py
@@ -414,7 +414,11 @@ class StableDiffusionInpaintPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_upscale.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_upscale.py
@@ -319,7 +319,11 @@ class StableDiffusionUpscalePipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_unclip.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_unclip.py
@@ -399,7 +399,11 @@ class StableUnCLIPPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/stable_diffusion/pipeline_stable_unclip_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion/pipeline_stable_unclip_img2img.py
@@ -361,7 +361,11 @@ class StableUnCLIPImg2ImgPipeline(
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/src/diffusers/pipelines/t2i_adapter/pipeline_stable_diffusion_adapter.py
+++ b/src/diffusers/pipelines/t2i_adapter/pipeline_stable_diffusion_adapter.py
@@ -413,7 +413,11 @@ class StableDiffusionAdapterPipeline(DiffusionPipeline, StableDiffusionMixin, Fr
                 # representations. The `last_hidden_states` that we typically use for
                 # obtaining the final prompt representations passes through the LayerNorm
                 # layer.
-                prompt_embeds = self.text_encoder.text_model.final_layer_norm(prompt_embeds)
+                # CLIPTextModel was flattened in transformers>=5.6 (no longer wrapped in .text_model).
+                text_model = (
+                    self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
+                )
+                prompt_embeds = text_model.final_layer_norm(prompt_embeds)
 
         if self.text_encoder is not None:
             prompt_embeds_dtype = self.text_encoder.dtype

--- a/tests/pipelines/stable_diffusion/test_stable_diffusion.py
+++ b/tests/pipelines/stable_diffusion/test_stable_diffusion.py
@@ -185,6 +185,22 @@ class StableDiffusionPipelineFastTests(
 
         assert np.abs(image_slice.flatten() - expected_slice).max() < 1e-2
 
+    def test_stable_diffusion_clip_skip(self):
+        # `clip_skip` re-applies the text encoder's final_layer_norm by hand, so it must run on
+        # transformers>=5.6 where `CLIPTextModel` no longer exposes a `.text_model` wrapper.
+        device = "cpu"  # ensure determinism for the device-dependent torch.Generator
+
+        components = self.get_dummy_components()
+        sd_pipe = StableDiffusionPipeline(**components)
+        sd_pipe = sd_pipe.to(torch_device)
+        sd_pipe.set_progress_bar_config(disable=None)
+
+        output_default = sd_pipe(**self.get_dummy_inputs(device)).images
+        output_clip_skip = sd_pipe(**self.get_dummy_inputs(device), clip_skip=1).images
+
+        assert output_clip_skip.shape == (1, 64, 64, 3)
+        assert not np.allclose(output_default, output_clip_skip, atol=1e-3), "clip_skip should change the output"
+
     def test_stable_diffusion_lcm(self):
         device = "cpu"  # ensure determinism for the device-dependent torch.Generator
 


### PR DESCRIPTION

# What does this PR do?

Passing `clip_skip` to any SD1.x-family pipeline crashes on transformers>=5.6:

```
AttributeError: 'CLIPTextModel' object has no attribute 'text_model'
```

transformers 5.6 flattened `CLIPTextModel` (huggingface/transformers#46285): `embeddings` / `encoder` / `final_layer_norm` became direct submodules and the `text_model` wrapper was removed (`CLIPTextModelWithProjection` still wraps via `text_model`). The `clip_skip` branch of `encode_prompt` re-applies the final LayerNorm by hand via `self.text_encoder.text_model.final_layer_norm(...)`, so it raises as soon as `clip_skip` is set. The default `clip_skip=None` path is unaffected because it uses `last_hidden_state` (already normalized) and never touches `.text_model`. diffusers declares no upper bound on transformers and is actively migrating to 5.x, so this is a live defect rather than an out-of-range version.

This reuses the exact guard already merged for the `from_single_file` path in #13843:

```python
text_model = self.text_encoder.text_model if hasattr(self.text_encoder, "text_model") else self.text_encoder
prompt_embeds = text_model.final_layer_norm(prompt_embeds)
```

`StableDiffusionPipeline.encode_prompt` is the source; `make fix-copies` propagates it to 39 `# Copied from` consumers, and 6 hand-written siblings (alt_diffusion x2, animatediff video2video x2, i2vgen_xl, ledits_pp) are updated to match, 46 files in total. **SDXL is not affected**: its `encode_prompt` reads `hidden_states[-(clip_skip + 2)]` and never calls `final_layer_norm`, and `text_encoder_2` is a `CLIPTextModelWithProjection` (still has `.text_model`).

<details>
<summary>Reproduction (CPU, no GPU; transformers 5.12.1)</summary>

```python
import torch
from diffusers import StableDiffusionPipeline

pipe = StableDiffusionPipeline.from_pretrained("hf-internal-testing/tiny-stable-diffusion-pipe", safety_checker=None)
pipe.set_progress_bar_config(disable=True)
print(type(pipe.text_encoder).__name__, "has .text_model:", hasattr(pipe.text_encoder, "text_model"))

pipe(prompt="a cat", num_inference_steps=2, guidance_scale=0.0, output_type="np")                 # clip_skip=None: OK
pipe(prompt="a cat", num_inference_steps=2, guidance_scale=0.0, output_type="np", clip_skip=1)     # crashes on main
```

```
# main:  CLIPTextModel has .text_model: False
#        clip_skip=None -> image (1, 64, 64, 3)
#        clip_skip=1    -> AttributeError: 'CLIPTextModel' object has no attribute 'text_model'
# this:  clip_skip=None and clip_skip=1 both produce (1, 64, 64, 3)
```

Confirmed identically on real weights (`stabilityai/sd-turbo`, a `CLIPTextModel`): `clip_skip=None` fine, `clip_skip=1` raises on main and works with this PR. The crash is in `encode_prompt`, before the denoise loop, so it is weight-independent and CPU-reproducible.
</details>

<details>
<summary>Tests</summary>

Added `test_stable_diffusion_clip_skip` to `StableDiffusionPipelineFastTests`: it asserts a `clip_skip=1` call runs and that its output differs from `clip_skip=None`. The test errors on main (the AttributeError) and passes with this PR.

```
tests/pipelines/stable_diffusion/test_stable_diffusion.py::...::test_stable_diffusion_clip_skip  PASSED
```

`ruff` (0.9.10), `check_copies`, and `check_dummies` are clean on the changed files.
</details>

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you self-review the diff against [`.ai/review-rules.md`](https://github.com/huggingface/diffusers/blob/main/.ai/review-rules.md)?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Did you write any new necessary tests?

## Who can review?

@asomoza @DN6