### PR TITLE
fix: resolve leftover conflict marker in bria pipeline docstring

### DIFF
--- a/src/diffusers/pipelines/bria/pipeline_bria.py
+++ b/src/diffusers/pipelines/bria/pipeline_bria.py
@@ -491,21 +491,12 @@ class BriaPipeline(DiffusionPipeline):
                         argument in their `set_timesteps` method. If not defined, the default behavior when
                         `num_inference_steps` is passed will be used. Must be in descending order.
                     guidance_scale (`float`, *optional*, defaults to 5.0):
-        <<<<<<< HEAD
-                        Guidance scale as defined in [Classifier-Free Diffusion
-                        Guidance](https://arxiv.org/abs/2207.12598). `guidance_scale` is defined as `w` of equation 2.
-                        of [Imagen Paper](https://arxiv.org/pdf/2205.11487.pdf). Guidance scale is enabled by setting
-                        `guidance_scale > 1`. Higher guidance scale encourages to generate images that are closely
-                        linked to the text `prompt`, usually at the expense of lower image quality.
-                    negative_prompt (`str` or `list[str]`, *optional*):
-        =======
                         Guidance scale as defined in [Classifier-Free Diffusion
                         Guidance](https://huggingface.co/papers/2207.12598). `guidance_scale` is defined as `w` of
                         equation 2. of [Imagen Paper](https://huggingface.co/papers/2205.11487). Guidance scale is
                         enabled by setting `guidance_scale > 1`. Higher guidance scale encourages to generate images
                         that are closely linked to the text `prompt`, usually at the expense of lower image quality.
                     negative_prompt (`str` or `list[str]`, *optional*):
-        >>>>>>> main
                         The prompt or prompts not to guide the image generation. If not defined, one has to pass
                         `negative_prompt_embeds` instead. Ignored when not using guidance (i.e., ignored if
                         `guidance_scale` is less than `1`).


### PR DESCRIPTION
# What does this PR do?

Fixes a leftover merge conflict marker in the `guidance_scale` docstring of `pipelines/bria/pipeline_bria.py`. Kept the `huggingface.co/papers` URLs over the `arxiv.org` ones, consistent with the rest of the codebase.

## Before submitting
- [ ] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [ ] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [ ] Did you self-review the diff against [`.ai/review-rules.md`](https://github.com/huggingface/diffusers/blob/main/.ai/review-rules.md)?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)?
- [ ] Was this discussed/approved via a GitHub issue or the forum?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline?