### PR TITLE
Fix ControlNet img2img and inpaint control image validation

### DIFF
--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_img2img.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_img2img.py
@@ -575,6 +575,7 @@ class StableDiffusionControlNetImg2ImgPipeline(
         self,
         prompt,
         image,
+        control_image,
         callback_steps,
         negative_prompt=None,
         prompt_embeds=None,
@@ -634,7 +635,7 @@ class StableDiffusionControlNetImg2ImgPipeline(
                     " prompts. The conditionings will be fixed across the prompts."
                 )
 
-        # Check `image`
+        # Check `control_image`
         is_compiled = hasattr(F, "scaled_dot_product_attention") and isinstance(
             self.controlnet, torch._dynamo.eval_frame.OptimizedModule
         )
@@ -643,25 +644,25 @@ class StableDiffusionControlNetImg2ImgPipeline(
             or is_compiled
             and isinstance(self.controlnet._orig_mod, ControlNetModel)
         ):
-            self.check_image(image, prompt, prompt_embeds)
+            self.check_image(control_image, prompt, prompt_embeds)
         elif (
             isinstance(self.controlnet, MultiControlNetModel)
             or is_compiled
             and isinstance(self.controlnet._orig_mod, MultiControlNetModel)
         ):
-            if not isinstance(image, list):
-                raise TypeError("For multiple controlnets: `image` must be type `list`")
+            if not isinstance(control_image, list):
+                raise TypeError("For multiple controlnets: `control_image` must be type `list`")
 
-            # When `image` is a nested list:
+            # When `control_image` is a nested list:
             # (e.g. [[canny_image_1, pose_image_1], [canny_image_2, pose_image_2]])
-            elif any(isinstance(i, list) for i in image):
+            elif any(isinstance(i, list) for i in control_image):
                 raise ValueError("A single batch of multiple conditionings are supported at the moment.")
-            elif len(image) != len(self.controlnet.nets):
+            elif len(control_image) != len(self.controlnet.nets):
                 raise ValueError(
-                    f"For multiple controlnets: `image` must have the same length as the number of controlnets, but got {len(image)} images and {len(self.controlnet.nets)} ControlNets."
+                    f"For multiple controlnets: `control_image` must have the same length as the number of controlnets, but got {len(control_image)} images and {len(self.controlnet.nets)} ControlNets."
                 )
 
-            for image_ in image:
+            for image_ in control_image:
                 self.check_image(image_, prompt, prompt_embeds)
         else:
             assert False
@@ -1074,6 +1075,7 @@ class StableDiffusionControlNetImg2ImgPipeline(
         # 1. Check inputs. Raise error if not correct
         self.check_inputs(
             prompt,
+            image,
             control_image,
             callback_steps,
             negative_prompt,

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint.py
@@ -593,6 +593,7 @@ class StableDiffusionControlNetInpaintPipeline(
         self,
         prompt,
         image,
+        control_image,
         mask_image,
         height,
         width,
@@ -673,7 +674,7 @@ class StableDiffusionControlNetInpaintPipeline(
                     " prompts. The conditionings will be fixed across the prompts."
                 )
 
-        # Check `image`
+        # Check `control_image`
         is_compiled = hasattr(F, "scaled_dot_product_attention") and isinstance(
             self.controlnet, torch._dynamo.eval_frame.OptimizedModule
         )
@@ -682,25 +683,25 @@ class StableDiffusionControlNetInpaintPipeline(
             or is_compiled
             and isinstance(self.controlnet._orig_mod, ControlNetModel)
         ):
-            self.check_image(image, prompt, prompt_embeds)
+            self.check_image(control_image, prompt, prompt_embeds)
         elif (
             isinstance(self.controlnet, MultiControlNetModel)
             or is_compiled
             and isinstance(self.controlnet._orig_mod, MultiControlNetModel)
         ):
-            if not isinstance(image, list):
-                raise TypeError("For multiple controlnets: `image` must be type `list`")
+            if not isinstance(control_image, list):
+                raise TypeError("For multiple controlnets: `control_image` must be type `list`")
 
-            # When `image` is a nested list:
+            # When `control_image` is a nested list:
             # (e.g. [[canny_image_1, pose_image_1], [canny_image_2, pose_image_2]])
-            elif any(isinstance(i, list) for i in image):
+            elif any(isinstance(i, list) for i in control_image):
                 raise ValueError("A single batch of multiple conditionings are supported at the moment.")
-            elif len(image) != len(self.controlnet.nets):
+            elif len(control_image) != len(self.controlnet.nets):
                 raise ValueError(
-                    f"For multiple controlnets: `image` must have the same length as the number of controlnets, but got {len(image)} images and {len(self.controlnet.nets)} ControlNets."
+                    f"For multiple controlnets: `control_image` must have the same length as the number of controlnets, but got {len(control_image)} images and {len(self.controlnet.nets)} ControlNets."
                 )
 
-            for image_ in image:
+            for image_ in control_image:
                 self.check_image(image_, prompt, prompt_embeds)
         else:
             assert False
@@ -1183,6 +1184,7 @@ class StableDiffusionControlNetInpaintPipeline(
         # 1. Check inputs. Raise error if not correct
         self.check_inputs(
             prompt,
+            image,
             control_image,
             mask_image,
             height,

--- a/tests/pipelines/controlnet/test_controlnet_img2img.py
+++ b/tests/pipelines/controlnet/test_controlnet_img2img.py
@@ -335,6 +335,30 @@ class StableDiffusionMultiControlNetPipelineFastTests(
 
         return inputs
 
+    def test_multi_controlnet_check_inputs_validates_control_image(self):
+        components = self.get_dummy_components()
+        pipe = self.pipeline_class(**components)
+
+        inputs = self.get_dummy_inputs(torch_device)
+        pipe.check_inputs(
+            prompt=inputs["prompt"],
+            image=inputs["image"],
+            control_image=inputs["control_image"],
+            callback_steps=1,
+            control_guidance_start=[0.0, 0.0],
+            control_guidance_end=[1.0, 1.0],
+        )
+
+        with self.assertRaisesRegex(TypeError, "`control_image` must be type `list`"):
+            pipe.check_inputs(
+                prompt=inputs["prompt"],
+                image=inputs["image"],
+                control_image=inputs["control_image"][0],
+                callback_steps=1,
+                control_guidance_start=[0.0, 0.0],
+                control_guidance_end=[1.0, 1.0],
+            )
+
     def test_control_guidance_switch(self):
         components = self.get_dummy_components()
         pipe = self.pipeline_class(**components)

--- a/tests/pipelines/controlnet/test_controlnet_inpaint.py
+++ b/tests/pipelines/controlnet/test_controlnet_inpaint.py
@@ -393,6 +393,40 @@ class MultiControlNetInpaintPipelineFastTests(
 
         return inputs
 
+    def test_multi_controlnet_check_inputs_validates_control_image(self):
+        components = self.get_dummy_components()
+        pipe = self.pipeline_class(**components)
+
+        inputs = self.get_dummy_inputs(torch_device)
+        pipe.check_inputs(
+            prompt=inputs["prompt"],
+            image=inputs["image"],
+            control_image=inputs["control_image"],
+            mask_image=inputs["mask_image"],
+            height=64,
+            width=64,
+            callback_steps=1,
+            output_type="pil",
+            control_guidance_start=[0.0, 0.0],
+            control_guidance_end=[1.0, 1.0],
+            padding_mask_crop=8,
+        )
+
+        with self.assertRaisesRegex(TypeError, "`control_image` must be type `list`"):
+            pipe.check_inputs(
+                prompt=inputs["prompt"],
+                image=inputs["image"],
+                control_image=inputs["control_image"][0],
+                mask_image=inputs["mask_image"],
+                height=64,
+                width=64,
+                callback_steps=1,
+                output_type="pil",
+                control_guidance_start=[0.0, 0.0],
+                control_guidance_end=[1.0, 1.0],
+                padding_mask_crop=8,
+            )
+
     def test_control_guidance_switch(self):
         components = self.get_dummy_components()
         pipe = self.pipeline_class(**components)


### PR DESCRIPTION
Fixes #14057.

- Pass the initial image and ControlNet conditioning image separately into SD1.5 ControlNet img2img/inpaint input checks.
- Validate `control_image` for single and multi-ControlNet paths instead of reusing the img2img/inpaint `image` variable.
- Add regression coverage for multi-ControlNet img2img and inpaint checks, including inpaint padding-mask validation.

Tests:
- `PYTHONPATH=src python -m pytest tests/pipelines/controlnet/test_controlnet_img2img.py::StableDiffusionMultiControlNetPipelineFastTests::test_multi_controlnet_check_inputs_validates_control_image tests/pipelines/controlnet/test_controlnet_inpaint.py::MultiControlNetInpaintPipelineFastTests::test_multi_controlnet_check_inputs_validates_control_image -q`
- `PYTHONPATH=src python -m pytest tests/pipelines/controlnet/test_controlnet_img2img.py::StableDiffusionMultiControlNetPipelineFastTests tests/pipelines/controlnet/test_controlnet_inpaint.py::MultiControlNetInpaintPipelineFastTests -q`