### PR TITLE
[mps] Fix float64 upcast in HeliosDMDScheduler.convert_flow_pred_to_x0

### DIFF
--- a/src/diffusers/schedulers/scheduling_helios_dmd.py
+++ b/src/diffusers/schedulers/scheduling_helios_dmd.py
@@ -275,7 +275,11 @@ class HeliosDMDScheduler(SchedulerMixin, ConfigMixin):
         # use higher precision for calculations
         original_dtype = flow_pred.dtype
         device = flow_pred.device
-        flow_pred, xt, sigmas, timesteps = (x.double().to(device) for x in (flow_pred, xt, sigmas, timesteps))
+        # mps does not support float64
+        compute_dtype = torch.float32 if device.type == "mps" else torch.float64
+        flow_pred, xt, sigmas, timesteps = (
+            x.to(device=device, dtype=compute_dtype) for x in (flow_pred, xt, sigmas, timesteps)
+        )
 
         timestep_id = torch.argmin((timesteps.unsqueeze(0) - timestep.unsqueeze(1)).abs(), dim=1)
         sigma_t = sigmas[timestep_id].reshape(-1, 1, 1, 1, 1)

--- a/tests/schedulers/test_scheduler_helios_dmd.py
+++ b/tests/schedulers/test_scheduler_helios_dmd.py
@@ -1,0 +1,42 @@
+# Copyright 2026 The Helios Team and The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+
+from diffusers import HeliosDMDScheduler
+
+from ..testing_utils import torch_device
+
+
+class HeliosDMDSchedulerTest(unittest.TestCase):
+    @unittest.skipUnless(torch_device == "mps", "test requires the 'mps' backend")
+    def test_convert_flow_pred_to_x0_no_float64_on_mps(self):
+        # mps has no float64; convert_flow_pred_to_x0 must not upcast to double there.
+        scheduler = HeliosDMDScheduler()
+        device = torch.device("mps")
+        batch_size = 2
+        flow_pred = torch.randn(batch_size, 3, 1, 4, 4, device=device)
+        xt = torch.randn(batch_size, 3, 1, 4, 4, device=device)
+        sigmas = torch.linspace(1.0, 0.0, 10, device=device)
+        timesteps = torch.linspace(1000.0, 0.0, 10, device=device)
+        timestep = timesteps[:batch_size]
+
+        # Before the fix this raised "Cannot convert a MPS Tensor to float64 dtype".
+        x0 = scheduler.convert_flow_pred_to_x0(flow_pred, xt, timestep, sigmas, timesteps)
+
+        self.assertEqual(x0.device.type, "mps")
+        self.assertEqual(x0.dtype, flow_pred.dtype)
+        self.assertTrue(torch.isfinite(x0).all())


### PR DESCRIPTION
## What does this PR do?

`HeliosDMDScheduler.convert_flow_pred_to_x0` upcasts its tensors to float64 via
`.double()` for higher-precision math. The MPS backend has no float64, so this
raises `Cannot convert a MPS Tensor to float64 dtype as the MPS framework
doesn't support float64` on Apple Silicon the moment `step()` calls it.

The fix mirrors the existing `# mps does not support float64` pattern already
used across the schedulers (e.g. `scheduling_flow_match_euler_discrete.py`):
compute in float32 on `mps`, keep float64 on CUDA/CPU. Off-MPS numerics are
unchanged. Same fix shape as #13701.

## Testing

Verified locally on Apple Silicon (MPS available):

- New regression test in `tests/schedulers/test_scheduler_helios_dmd.py` fails
  on the unpatched method with the float64 `TypeError`, and passes with the fix
  (red → green).
- `make style && make quality` clean.
- `pytest tests/schedulers/ -k "flow or helios"` → 16 passed.

The test is gated with `@unittest.skipUnless(torch_device == "mps", ...)`, so it
skips on the Linux/CUDA CI runners and runs for contributors on Apple Silicon.

cc @yiyixuxu @sayakpaul
