### PR TITLE
[Tests] Skip layerwise casting tests on devices without float8_e4m3fn support

### DIFF
--- a/tests/lora/utils.py
+++ b/tests/lora/utils.py
@@ -2105,12 +2105,12 @@ class PeftLoraLoaderMixinTests:
         self.assertTrue(not np.allclose(original_output, lora_output_diff_alpha, atol=1e-3, rtol=1e-3))
         self.assertTrue(not np.allclose(lora_output_diff_alpha, lora_output_same_rank, atol=1e-3, rtol=1e-3))
 
+    @pytest.mark.xfail(
+        condition=torch_device == "mps",
+        reason="MPS does not support float8 casting.",
+        strict=True,
+    )
     def test_layerwise_casting_inference_denoiser(self):
-        try:
-            torch.zeros(1, device=torch_device).to(dtype=torch.float8_e4m3fn)
-        except TypeError:
-            self.skipTest(f"Device {torch_device} does not support float8 storage dtype.")
-
         from diffusers.hooks._common import _GO_LC_SUPPORTED_PYTORCH_LAYERS
         from diffusers.hooks.layerwise_casting import DEFAULT_SKIP_MODULES_PATTERN
 
@@ -2154,6 +2154,11 @@ class PeftLoraLoaderMixinTests:
         pipe_float8_e4m3_bf16 = initialize_pipeline(storage_dtype=torch.float8_e4m3fn, compute_dtype=torch.bfloat16)
         pipe_float8_e4m3_bf16(**inputs, generator=torch.manual_seed(0))[0]
 
+    @pytest.mark.xfail(
+        condition=torch_device == "mps",
+        reason="MPS does not support float8 casting.",
+        strict=True,
+    )
     @require_peft_version_greater("0.14.0")
     def test_layerwise_casting_peft_input_autocast_denoiser(self):
         r"""
@@ -2169,10 +2174,6 @@ class PeftLoraLoaderMixinTests:
 
         See the docstring of [`hooks.layerwise_casting.PeftInputAutocastDisableHook`] for more details.
         """
-        try:
-            torch.zeros(1, device=torch_device).to(dtype=torch.float8_e4m3fn)
-        except TypeError:
-            self.skipTest(f"Device {torch_device} does not support float8 storage dtype.")
 
         from diffusers.hooks._common import _GO_LC_SUPPORTED_PYTORCH_LAYERS
         from diffusers.hooks.layerwise_casting import (

--- a/tests/lora/utils.py
+++ b/tests/lora/utils.py
@@ -2106,6 +2106,11 @@ class PeftLoraLoaderMixinTests:
         self.assertTrue(not np.allclose(lora_output_diff_alpha, lora_output_same_rank, atol=1e-3, rtol=1e-3))
 
     def test_layerwise_casting_inference_denoiser(self):
+        try:
+            torch.zeros(1, device=torch_device).to(dtype=torch.float8_e4m3fn)
+        except TypeError:
+            self.skipTest(f"Device {torch_device} does not support float8 storage dtype.")
+
         from diffusers.hooks._common import _GO_LC_SUPPORTED_PYTORCH_LAYERS
         from diffusers.hooks.layerwise_casting import DEFAULT_SKIP_MODULES_PATTERN
 
@@ -2164,6 +2169,10 @@ class PeftLoraLoaderMixinTests:
 
         See the docstring of [`hooks.layerwise_casting.PeftInputAutocastDisableHook`] for more details.
         """
+        try:
+            torch.zeros(1, device=torch_device).to(dtype=torch.float8_e4m3fn)
+        except TypeError:
+            self.skipTest(f"Device {torch_device} does not support float8 storage dtype.")
 
         from diffusers.hooks._common import _GO_LC_SUPPORTED_PYTORCH_LAYERS
         from diffusers.hooks.layerwise_casting import (

--- a/tests/models/testing_utils/memory.py
+++ b/tests/models/testing_utils/memory.py
@@ -383,13 +383,13 @@ class LayerwiseCastingTesterMixin:
         - get_dummy_inputs(): Returns dict of inputs to pass to the model forward pass
     """
 
+    @pytest.mark.xfail(
+        condition=torch_device == "mps",
+        reason="MPS does not support float8 casting.",
+        strict=True,
+    )
     @torch.no_grad()
     def test_layerwise_casting_memory(self):
-        try:
-            torch.zeros(1, device=torch_device).to(dtype=torch.float8_e4m3fn)
-        except TypeError:
-            pytest.skip(f"Device {torch_device} does not support float8 storage dtype.")
-
         MB_TOLERANCE = 0.2
         LEAST_COMPUTE_CAPABILITY = 8.0
 
@@ -441,12 +441,12 @@ class LayerwiseCastingTesterMixin:
             or abs(fp8_e4m3_fp32_max_memory - fp32_max_memory) < MB_TOLERANCE
         ), "Peak memory should be lower or within tolerance with fp8 storage"
 
+    @pytest.mark.xfail(
+        condition=torch_device == "mps",
+        reason="MPS does not support float8 casting.",
+        strict=True,
+    )
     def test_layerwise_casting_training(self):
-        try:
-            torch.zeros(1, device=torch_device).to(dtype=torch.float8_e4m3fn)
-        except TypeError:
-            pytest.skip(f"Device {torch_device} does not support float8 storage dtype.")
-
         def test_fn(storage_dtype, compute_dtype):
             if torch.device(torch_device).type == "cpu" and compute_dtype == torch.bfloat16:
                 pytest.skip("Skipping test because CPU doesn't go well with bfloat16.")

--- a/tests/models/testing_utils/memory.py
+++ b/tests/models/testing_utils/memory.py
@@ -385,6 +385,11 @@ class LayerwiseCastingTesterMixin:
 
     @torch.no_grad()
     def test_layerwise_casting_memory(self):
+        try:
+            torch.zeros(1, device=torch_device).to(dtype=torch.float8_e4m3fn)
+        except TypeError:
+            pytest.skip(f"Device {torch_device} does not support float8 storage dtype.")
+
         MB_TOLERANCE = 0.2
         LEAST_COMPUTE_CAPABILITY = 8.0
 
@@ -437,6 +442,11 @@ class LayerwiseCastingTesterMixin:
         ), "Peak memory should be lower or within tolerance with fp8 storage"
 
     def test_layerwise_casting_training(self):
+        try:
+            torch.zeros(1, device=torch_device).to(dtype=torch.float8_e4m3fn)
+        except TypeError:
+            pytest.skip(f"Device {torch_device} does not support float8 storage dtype.")
+
         def test_fn(storage_dtype, compute_dtype):
             if torch.device(torch_device).type == "cpu" and compute_dtype == torch.bfloat16:
                 pytest.skip("Skipping test because CPU doesn't go well with bfloat16.")

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -2296,6 +2296,11 @@ class PipelineTesterMixin:
         if not self.test_layerwise_casting:
             return
 
+        try:
+            torch.zeros(1, device=torch_device).to(dtype=torch.float8_e4m3fn)
+        except TypeError:
+            self.skipTest(f"Device {torch_device} does not support float8 storage dtype.")
+
         components = self.get_dummy_components()
         pipe = self.pipeline_class(**components)
         pipe.to(torch_device, dtype=torch.bfloat16)

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -2292,14 +2292,14 @@ class PipelineTesterMixin:
         elif isinstance(pipeline_out, torch.Tensor) and isinstance(loaded_pipeline_out, torch.Tensor):
             assert torch.allclose(pipeline_out, loaded_pipeline_out, atol=atol, rtol=rtol)
 
+    @pytest.mark.xfail(
+        condition=torch_device == "mps",
+        reason="MPS does not support float8 casting.",
+        strict=True,
+    )
     def test_layerwise_casting_inference(self):
         if not self.test_layerwise_casting:
             return
-
-        try:
-            torch.zeros(1, device=torch_device).to(dtype=torch.float8_e4m3fn)
-        except TypeError:
-            self.skipTest(f"Device {torch_device} does not support float8 storage dtype.")
 
         components = self.get_dummy_components()
         pipe = self.pipeline_class(**components)


### PR DESCRIPTION
# What does this PR do?

`torch.float8_e4m3fn` is a storage-only dtype that is not supported on all hardware backends. On Apple Silicon (MPS), attempting to cast a tensor to this dtype raises a `TypeError`:

```
TypeError: Cannot convert a MPS Tensor to float8_e4m3fn dtype as the MPS framework doesn't support float8 types.
```

This causes five layerwise-casting tests to **crash** instead of being skipped:

| File | Test |
|------|------|
| `tests/pipelines/test_pipelines_common.py` | `test_layerwise_casting_inference` |
| `tests/models/testing_utils/memory.py` | `test_layerwise_casting_memory` |
| `tests/models/testing_utils/memory.py` | `test_layerwise_casting_training` |
| `tests/lora/utils.py` | `test_layerwise_casting_inference_denoiser` |
| `tests/lora/utils.py` | `test_layerwise_casting_peft_input_autocast_denoiser` |

### Fix

Each affected test now includes a runtime check at the very top:

```python
try:
    torch.zeros(1, device=torch_device).to(dtype=torch.float8_e4m3fn)
except TypeError:
    self.skipTest(f"Device {torch_device} does not support float8 storage dtype.")
```

If the device cannot handle `float8_e4m3fn`, the test is **skipped** with a clear message rather than crashing the entire test suite.

Fixes #14072


## Before submitting
- [ ] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [ ] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [ ] Did you self-review the diff against [`.ai/review-rules.md`](https://github.com/huggingface/diffusers/blob/main/.ai/review-rules.md)?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
  - Issue: https://github.com/huggingface/diffusers/issues/14072
- [ ] Did you make sure to update the documentation with your changes? *(N/A — no docs changes needed)*
- [ ] Did you write any new necessary tests? *(N/A — this fixes existing tests)*
- [ ] Are you the author (or part of the team) of the model/pipeline? *(N/A)*


## Who can review?

@pcuenca (MPS), @sayakpaul @DN6 (General functionalities)
