### PR TITLE
support loading pipeline from transformer style (flat) repo 

### DIFF
--- a/src/diffusers/pipelines/pipeline_loading_utils.py
+++ b/src/diffusers/pipelines/pipeline_loading_utils.py
@@ -136,6 +136,8 @@ def is_safetensors_compatible(filenames, passed_components=None, folder_names=No
     )
 
     passed_components = passed_components or []
+    # only weight files matter for safetensors compatibility
+    filenames = filter_model_files(filenames)
     if folder_names:
         filenames = {f for f in filenames if os.path.split(f)[0] in folder_names}
 

--- a/src/diffusers/pipelines/pipeline_loading_utils.py
+++ b/src/diffusers/pipelines/pipeline_loading_utils.py
@@ -69,6 +69,27 @@ DUMMY_MODULES_FOLDER = "diffusers.utils"
 TRANSFORMERS_DUMMY_MODULES_FOLDER = "transformers.utils"
 CONNECTED_PIPES_KEYS = ["prior"]
 
+# Auxiliary (non-weight) files a transformers component saves next to its weights. Repos with a flat,
+# transformers-style layout host a component's files at the repo root instead of in a subfolder, where the
+# folder-based allow patterns of `DiffusionPipeline.download` would miss them. Root-hosted weights and
+# `config.json` are matched by their own patterns, so only these auxiliary filenames need listing.
+TRANSFORMERS_COMPONENT_AUX_FILES = [
+    "added_tokens.json",
+    "chat_template.jinja",
+    "chat_template.json",
+    "generation_config.json",
+    "merges.txt",
+    "preprocessor_config.json",
+    "processor_config.json",
+    "special_tokens_map.json",
+    "spiece.model",
+    "tokenizer.json",
+    "tokenizer.model",
+    "tokenizer_config.json",
+    "vocab.json",
+    "vocab.txt",
+]
+
 logger = logging.get_logger(__name__)
 
 LOADABLE_CLASSES = {

--- a/src/diffusers/pipelines/pipeline_loading_utils.py
+++ b/src/diffusers/pipelines/pipeline_loading_utils.py
@@ -73,21 +73,13 @@ CONNECTED_PIPES_KEYS = ["prior"]
 # transformers-style layout host a component's files at the repo root instead of in a subfolder, where the
 # folder-based allow patterns of `DiffusionPipeline.download` would miss them. Root-hosted weights and
 # `config.json` are matched by their own patterns, so only these auxiliary filenames need listing.
+# Currently the set needed by DiffusionGemma — extend as new flat-layout pipelines require it.
 TRANSFORMERS_COMPONENT_AUX_FILES = [
-    "added_tokens.json",
     "chat_template.jinja",
-    "chat_template.json",
     "generation_config.json",
-    "merges.txt",
-    "preprocessor_config.json",
     "processor_config.json",
-    "special_tokens_map.json",
-    "spiece.model",
     "tokenizer.json",
-    "tokenizer.model",
     "tokenizer_config.json",
-    "vocab.json",
-    "vocab.txt",
 ]
 
 logger = logging.get_logger(__name__)

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1658,6 +1658,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             )
             config_dict = cls._dict_from_json_file(config_file)
             ignore_filenames = config_dict.pop("_ignore_files", [])
+            allow_filenames = config_dict.pop("_allow_files", [])
 
             filenames = {sibling.rfilename for sibling in info.siblings}
             if variant is not None and _check_legacy_sharding_variant_format(filenames=filenames, variant=variant):
@@ -1750,6 +1751,11 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             allow_patterns = [
                 p for p in allow_patterns if not (len(p.split("/")) == 2 and p.split("/")[0] in passed_components)
             ]
+
+            # Files explicitly allow-listed by the repo author via `_allow_files` in `model_index.json` are
+            # added to the download set. This supports repos that keep a component's config/tokenizer files at
+            # the root (instead of in its own subfolder), where the folder-based allow patterns would miss them.
+            allow_patterns += allow_filenames
 
             if pipeline_class._load_connected_pipes:
                 allow_patterns.append("README.md")

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -82,6 +82,7 @@ from .pipeline_loading_utils import (
     CONNECTED_PIPES_KEYS,
     CUSTOM_PIPELINE_FILE_NAME,
     LOADABLE_CLASSES,
+    TRANSFORMERS_COMPONENT_AUX_FILES,
     _download_dduf_file,
     _fetch_class_library_tuple,
     _get_custom_components_and_folders,
@@ -1658,7 +1659,6 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             )
             config_dict = cls._dict_from_json_file(config_file)
             ignore_filenames = config_dict.pop("_ignore_files", [])
-            allow_filenames = config_dict.pop("_allow_files", [])
 
             filenames = {sibling.rfilename for sibling in info.siblings}
             if variant is not None and _check_legacy_sharding_variant_format(filenames=filenames, variant=variant):
@@ -1752,10 +1752,10 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
                 p for p in allow_patterns if not (len(p.split("/")) == 2 and p.split("/")[0] in passed_components)
             ]
 
-            # Files explicitly allow-listed by the repo author via `_allow_files` in `model_index.json` are
-            # added to the download set. This supports repos that keep a component's config/tokenizer files at
-            # the root (instead of in its own subfolder), where the folder-based allow patterns would miss them.
-            allow_patterns += allow_filenames
+            # Repos with a flat, transformers-style layout host a component's files at the repo root instead of
+            # in a subfolder, where the folder-based allow patterns above miss its auxiliary files (root-hosted
+            # weights are already included via `model_filenames`, root `config.json` via `CONFIG_NAME`).
+            allow_patterns += TRANSFORMERS_COMPONENT_AUX_FILES
 
             if pipeline_class._load_connected_pipes:
                 allow_patterns.append("README.md")

--- a/tests/pipelines/test_pipeline_utils.py
+++ b/tests/pipelines/test_pipeline_utils.py
@@ -218,6 +218,34 @@ class IsSafetensorsCompatibleTests(unittest.TestCase):
         ]
         self.assertFalse(is_safetensors_compatible(filenames))
 
+    def test_diffusers_is_compatible_no_components_safetensors(self):
+        filenames = [
+            "diffusion_pytorch_model.safetensors",
+        ]
+        self.assertTrue(is_safetensors_compatible(filenames))
+
+    def test_diffusers_is_compatible_no_components_safetensors_only_variants(self):
+        filenames = [
+            "diffusion_pytorch_model.fp16.safetensors",
+        ]
+        self.assertTrue(is_safetensors_compatible(filenames, variant="fp16"))
+
+    def test_diffusers_is_compatible_weightless_subfolder(self):
+        # transformers-style flat layout: safetensors weights at the root + a weight-less subfolder (scheduler/)
+        filenames = [
+            "diffusion_pytorch_model.safetensors",
+            "scheduler/scheduler_config.json",
+        ]
+        self.assertTrue(is_safetensors_compatible(filenames))
+
+    def test_diffusers_is_not_compatible_weightless_subfolder(self):
+        # same flat layout but only .bin weights at the root -> not safetensors compatible
+        filenames = [
+            "diffusion_pytorch_model.bin",
+            "scheduler/scheduler_config.json",
+        ]
+        self.assertFalse(is_safetensors_compatible(filenames))
+
     def test_is_compatible_mixed_variants(self):
         filenames = [
             "unet/diffusion_pytorch_model.fp16.safetensors",

--- a/tests/pipelines/test_pipeline_utils.py
+++ b/tests/pipelines/test_pipeline_utils.py
@@ -230,21 +230,31 @@ class IsSafetensorsCompatibleTests(unittest.TestCase):
         ]
         self.assertTrue(is_safetensors_compatible(filenames, variant="fp16"))
 
-    def test_diffusers_is_compatible_weightless_subfolder(self):
-        # transformers-style flat layout: safetensors weights at the root + a weight-less subfolder (scheduler/)
+    def test_transformers_is_compatible_weightless_subfolder(self):
+        # transformers-style flat layout: transformers-named weights at the root + a weight-less subfolder
         filenames = [
-            "diffusion_pytorch_model.safetensors",
+            "model.safetensors",
             "scheduler/scheduler_config.json",
         ]
         self.assertTrue(is_safetensors_compatible(filenames))
 
-    def test_diffusers_is_not_compatible_weightless_subfolder(self):
+    def test_transformers_is_not_compatible_weightless_subfolder(self):
         # same flat layout but only .bin weights at the root -> not safetensors compatible
         filenames = [
-            "diffusion_pytorch_model.bin",
+            "pytorch_model.bin",
             "scheduler/scheduler_config.json",
         ]
         self.assertFalse(is_safetensors_compatible(filenames))
+
+    def test_transformers_is_compatible_sharded_root_weights(self):
+        # sharded transformers-style weights at the repo root (e.g. DiffusionGemma's model-00001-of-00011.safetensors)
+        filenames = [
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+            "model.safetensors.index.json",
+            "scheduler/scheduler_config.json",
+        ]
+        self.assertTrue(is_safetensors_compatible(filenames))
 
     def test_is_compatible_mixed_variants(self):
         filenames = [

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -2083,6 +2083,19 @@ class PipelineSlowTests(unittest.TestCase):
             # is not downloaded, but all the expected ones
             assert not os.path.isfile(os.path.join(snapshot_dir, "big_array.npy"))
 
+    def test_download_allow_files(self):
+        # `_allow_files` in model_index.json forces files that the smart-download patterns would otherwise skip.
+        # This repo mirrors `unet-pipeline-dummy` but lists a (tiny stand-in) `big_array.npy` in `_allow_files`,
+        # so it is downloaded here, whereas `test_smart_download` asserts it is skipped without `_allow_files`.
+        model_id = "hf-internal-testing/unet-pipeline-dummy-allow-files"
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            _ = DiffusionPipeline.from_pretrained(model_id, cache_dir=tmpdirname, force_download=True)
+            local_repo_name = "--".join(["models"] + model_id.split("/"))
+            snapshot_dir = os.path.join(tmpdirname, local_repo_name, "snapshots")
+            snapshot_dir = os.path.join(snapshot_dir, os.listdir(snapshot_dir)[0])
+
+            assert os.path.isfile(os.path.join(snapshot_dir, "big_array.npy"))
+
     def test_warning_unused_kwargs(self):
         model_id = "hf-internal-testing/unet-pipeline-dummy"
         logger = logging.get_logger("diffusers.pipelines")

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -2083,18 +2083,27 @@ class PipelineSlowTests(unittest.TestCase):
             # is not downloaded, but all the expected ones
             assert not os.path.isfile(os.path.join(snapshot_dir, "big_array.npy"))
 
-    def test_download_allow_files(self):
-        # `_allow_files` in model_index.json forces files that the smart-download patterns would otherwise skip.
-        # This repo mirrors `unet-pipeline-dummy` but lists a (tiny stand-in) `big_array.npy` in `_allow_files`,
-        # so it is downloaded here, whereas `test_smart_download` asserts it is skipped without `_allow_files`.
-        model_id = "hf-internal-testing/unet-pipeline-dummy-allow-files"
+    def test_download_flat_transformers_style_repo(self):
+        # Repos with a flat, transformers-style layout host a component's files at the repo root instead of in a
+        # subfolder (here `model` and `processor`; only `scheduler/` has a folder). The download patterns must
+        # pick up the transformers auxiliary files at the root, while unrelated root files are still skipped.
+        model_id = "hf-internal-testing/tiny-flat-transformers-style-pipe"
         with tempfile.TemporaryDirectory() as tmpdirname:
-            _ = DiffusionPipeline.from_pretrained(model_id, cache_dir=tmpdirname, force_download=True)
-            local_repo_name = "--".join(["models"] + model_id.split("/"))
-            snapshot_dir = os.path.join(tmpdirname, local_repo_name, "snapshots")
-            snapshot_dir = os.path.join(snapshot_dir, os.listdir(snapshot_dir)[0])
+            snapshot_dir = DiffusionPipeline.download(model_id, cache_dir=tmpdirname, force_download=True)
 
-            assert os.path.isfile(os.path.join(snapshot_dir, "big_array.npy"))
+            assert os.path.isfile(os.path.join(snapshot_dir, "model.safetensors"))
+            assert os.path.isfile(os.path.join(snapshot_dir, CONFIG_NAME))
+            for aux_file in [
+                "tokenizer.json",
+                "tokenizer_config.json",
+                "processor_config.json",
+                "chat_template.jinja",
+                "generation_config.json",
+            ]:
+                assert os.path.isfile(os.path.join(snapshot_dir, aux_file))
+            assert os.path.isfile(os.path.join(snapshot_dir, "scheduler", SCHEDULER_CONFIG_NAME))
+            # unrelated root files are still not downloaded
+            assert not os.path.isfile(os.path.join(snapshot_dir, "big_array.npy"))
 
     def test_warning_unused_kwargs(self):
         model_id = "hf-internal-testing/unet-pipeline-dummy"


### PR DESCRIPTION
With this PR, we want to support loading a pipeline from [`google/diffusiongemma-26B-A4B-it`](https://huggingface.co/google/diffusiongemma-26B-A4B-it), and also future model releases in the same style :
* model released in transformers with the flat structure, i.e., model and processor are hosted at the root folder directly
* pipeline + scheduler in diffusers, and would be able to add a scheduler folder and `model_index.json` file into the same repo

Currently, we have some legacy support for loading components from the root, but very limited (e.g., it does not work if the repo also has a subfolder, or if your component comes with files other than the regular weights, etc.) . Since all our releases use subfolder structure, this was sufficient as it is (I'm actually not sure why the legacy support was there at all; I assume a very early model released that way, and we kept it for backward compatibility).

This PR extends that a bit further to support joint transformer + diffusers release (we will likely see more)
*  make it work with a mixed structure (some components at the root, some in subfolders). Here, `model` and `processor` live in the root, `scheduler` has its own folder)
* always allow a fixed list of known transformers auxiliary filenames at the root (`TRANSFORMERS_COMPONENT_AUX_FILES`: tokenizer/processor/chat-template/generation configs etc), currently, we only allow the list of files DiffusionGemma requires, but we can extend as we support more pipelines

you can test with this
```py
import torch
from diffusers import DiffusionGemmaPipeline

# model_id = "google/diffusiongemma-26B-A4B-it" 
model_id = "dg845/diffusiongemma-test"

pipe = DiffusionGemmaPipeline.from_pretrained(
    model_id,
    torch_dtype=torch.bfloat16,
    # revision="refs/pr/20",   # Omit if merged to main
)
pipe.to("cuda")

output = pipe(
    prompt="Why is the sky blue?",
    gen_length=256,
    num_inference_steps=48,
    cache_implementation="static",
    generator=torch.Generator("cuda").manual_seed(42),
)
print(output.texts[0])
```

