### PR TITLE
fix: preserve method docstring through apply_forward_hook decorator

### DIFF
--- a/src/diffusers/utils/accelerate_utils.py
+++ b/src/diffusers/utils/accelerate_utils.py
@@ -24,6 +24,9 @@ if is_accelerate_available():
     import accelerate
 
 
+import functools
+
+
 def apply_forward_hook(method):
     """
     Decorator that applies a registered CpuOffload hook to an arbitrary function rather than `forward`. This is useful
@@ -40,6 +43,7 @@ def apply_forward_hook(method):
     if version.parse(accelerate_version) < version.parse("0.17.0"):
         return method
 
+    @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
         if hasattr(self, "_hf_hook") and hasattr(self._hf_hook, "pre_forward"):
             self._hf_hook.pre_forward(self)


### PR DESCRIPTION
The `@apply_forward_hook` decorator wraps methods like `AutoencoderKL.encode()` and `AutoencoderKL.decode()` in a `wrapper` function without preserving the original method metadata. This causes the doc generator to miss these methods, making them absent from the online docs.

Using `functools.wraps` preserves `__doc__`, `__name__`, `__module__`, and `__qualname__` through the decorator, ensuring the doc generator can discover these methods.

Fixes #6575