### PR TITLE
Fix FA3 varlen wrapper when hub kernel returns single tensor

### DIFF
--- a/src/diffusers/models/attention_dispatch.py
+++ b/src/diffusers/models/attention_dispatch.py
@@ -3042,7 +3042,7 @@ def _flash_attention_3_varlen_hub(
     value_packed = torch.cat(value_valid, dim=0)
 
     func = _HUB_KERNELS_REGISTRY[AttentionBackendName._FLASH_3_VARLEN_HUB].kernel_fn
-    out, lse, *_ = func(
+    result = func(
         q=query_packed,
         k=key_packed,
         v=value_packed,
@@ -3053,6 +3053,11 @@ def _flash_attention_3_varlen_hub(
         softmax_scale=scale,
         causal=is_causal,
     )
+    if isinstance(result, tuple):
+        out, lse, *_ = result
+    else:
+        out = result
+        lse = None
     out = out.unflatten(0, (batch_size, -1))
 
     return (out, lse) if return_lse else out


### PR DESCRIPTION
Fixes #13999

**Bug:** `_flash_attention_3_varlen_hub` assumes `flash_attn_varlen_func` always returns a tuple and uses `out, lse, *_ = func(...)`. However, the hub FA3 varlen function can return a single tensor with shape `[total_q, heads, dim]` instead of a tuple, causing Python destructuring to take the first sequence row as `out`.

**Fix:** Check if the result is a tuple before destructuring. If it is a single tensor, assign it to `out` and set `lse = None`.