### PR TITLE
Fix typos across the codebase (concating→concatenating, tbe→the, corrct→correct, etc.)

### DIFF
--- a/docs/source/ko/tutorials/basic_training.md
+++ b/docs/source/ko/tutorials/basic_training.md
@@ -329,7 +329,7 @@ TensorBoard에 로깅, 그래디언트 누적 및 혼합 정밀도 학습을 쉽
 ...             )
 
 ...             # 각 타임스텝의 노이즈 크기에 따라 깨끗한 이미지에 노이즈를 추가합니다.
-...             # (이는 foward diffusion 과정입니다.)
+...             # (이는 forward diffusion 과정입니다.)
 ...             noisy_images = noise_scheduler.add_noise(clean_images, noise, timesteps)
 
 ...             with accelerator.accumulate(model):

--- a/src/diffusers/pipelines/chroma/pipeline_chroma_inpainting.py
+++ b/src/diffusers/pipelines/chroma/pipeline_chroma_inpainting.py
@@ -703,7 +703,7 @@ class ChromaInpaintPipeline(
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         masked_image_latents = self._pack_latents(
             masked_image_latents,

--- a/src/diffusers/pipelines/deprecated/paint_by_example/pipeline_paint_by_example.py
+++ b/src/diffusers/pipelines/deprecated/paint_by_example/pipeline_paint_by_example.py
@@ -350,7 +350,7 @@ class PaintByExamplePipeline(DeprecatedPipelineMixin, DiffusionPipeline, StableD
             torch.cat([masked_image_latents] * 2) if do_classifier_free_guidance else masked_image_latents
         )
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         return mask, masked_image_latents
 

--- a/src/diffusers/pipelines/deprecated/unidiffuser/modeling_uvit.py
+++ b/src/diffusers/pipelines/deprecated/unidiffuser/modeling_uvit.py
@@ -1068,7 +1068,7 @@ class UniDiffuserModel(ModelMixin, ConfigMixin):
 
 
         Returns:
-            `tuple`: Returns relevant parts of the model's noise prediction: the first element of the tuple is tbe VAE
+            `tuple`: Returns relevant parts of the model's noise prediction: the first element of the tuple is the VAE
             image embedding, the second element is the CLIP image embedding, and the third element is the CLIP text
             embedding.
         """

--- a/src/diffusers/pipelines/easyanimate/pipeline_easyanimate_inpaint.py
+++ b/src/diffusers/pipelines/easyanimate/pipeline_easyanimate_inpaint.py
@@ -681,7 +681,7 @@ class EasyAnimateInpaintPipeline(DiffusionPipeline):
             masked_image_latents = torch.cat(new_mask_pixel_values, dim=0)
             masked_image_latents = masked_image_latents * self.vae.config.scaling_factor
 
-            # aligning device to prevent device errors when concating it with the latent model input
+            # aligning device to prevent device errors when concatenating it with the latent model input
             masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         else:
             masked_image_latents = None

--- a/src/diffusers/pipelines/flux/pipeline_flux_control_inpaint.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_control_inpaint.py
@@ -766,7 +766,7 @@ class FluxControlInpaintPipeline(
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         masked_image_latents = self._pack_latents(
             masked_image_latents,

--- a/src/diffusers/pipelines/flux/pipeline_flux_controlnet_inpainting.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_controlnet_inpainting.py
@@ -666,7 +666,7 @@ class FluxControlNetInpaintPipeline(DiffusionPipeline, FluxLoraLoaderMixin, From
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         masked_image_latents = self._pack_latents(
             masked_image_latents,

--- a/src/diffusers/pipelines/flux/pipeline_flux_inpaint.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_inpaint.py
@@ -737,7 +737,7 @@ class FluxInpaintPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FluxIPAdapterM
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         masked_image_latents = self._pack_latents(
             masked_image_latents,

--- a/src/diffusers/pipelines/flux/pipeline_flux_kontext_inpaint.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_kontext_inpaint.py
@@ -898,7 +898,7 @@ class FluxKontextInpaintPipeline(
                 )
             masked_image_latents = masked_image_latents.repeat(batch_size // masked_image_latents.shape[0], 1, 1, 1)
 
-        # aligning device to prevent device errors when concating it with the latent model input
+        # aligning device to prevent device errors when concatenating it with the latent model input
         masked_image_latents = masked_image_latents.to(device=device, dtype=dtype)
         masked_image_latents = self._pack_latents(
             masked_image_latents,

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
@@ -244,7 +244,7 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
         self.vae_temporal_compression_ratio = (
             self.vae.temporal_compression_ratio if getattr(self, "vae", None) is not None else 8
         )
-        # TODO: check whether the MEL compression ratio logic here is corrct
+        # TODO: check whether the MEL compression ratio logic here is correct
         self.audio_vae_mel_compression_ratio = (
             self.audio_vae.mel_compression_ratio if getattr(self, "audio_vae", None) is not None else 4
         )

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
@@ -235,7 +235,7 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
 
 class LTX2ConditionPipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
     r"""
-    Pipeline for video generation which allows image conditions to be inserted at arbitary parts of the video.
+    Pipeline for video generation which allows image conditions to be inserted at arbitrary parts of the video.
 
     Reference: https://github.com/Lightricks/LTX-Video
 

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_image2video.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_image2video.py
@@ -247,7 +247,7 @@ class LTX2ImageToVideoPipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraL
         self.vae_temporal_compression_ratio = (
             self.vae.temporal_compression_ratio if getattr(self, "vae", None) is not None else 8
         )
-        # TODO: check whether the MEL compression ratio logic here is corrct
+        # TODO: check whether the MEL compression ratio logic here is correct
         self.audio_vae_mel_compression_ratio = (
             self.audio_vae.mel_compression_ratio if getattr(self, "audio_vae", None) is not None else 4
         )

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -759,7 +759,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
         >>> pipeline.scheduler = scheduler
         ```
         """
-        # Copy the kwargs to re-use during loading connected pipeline.
+        # Copy the kwargs to reuse during loading connected pipeline.
         kwargs_copied = kwargs.copy()
 
         cache_dir = kwargs.pop("cache_dir", None)


### PR DESCRIPTION
Fixes various typos found across the codebase using codespell:

| Typo | Fix | Files |
|------|-----|-------|
| concating | concatenating | 8 files (flux inpaint pipelines, chroma, easyanimate, paint_by_example) |
| tbe | the | 1 file (unidiffuser docstring) |
| corrct | correct | 2 files (ltx2 pipelines) |
| arbitary | arbitrary | 1 file (ltx2 condition pipeline) |
| re-use | reuse | 1 file (pipeline_utils.py comment) |
| foward | forward | 1 file (Korean docs) |

All changes are in comments, docstrings, and documentation only — no logic modified.