### PR TITLE
Fix TorchAO v1 group offloading with use_stream=True

### DIFF
--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -173,14 +173,24 @@ class ModuleGroup:
         )
 
     @staticmethod
+    def _pin_memory(tensor):
+        try:
+            return tensor if tensor.is_pinned() else tensor.pin_memory()
+        except NotImplementedError:
+            if _is_torchao_tensor(tensor):
+                # Some legacy TorchAO tensor subclasses do not implement aten.is_pinned.
+                return tensor
+            raise
+
+    @staticmethod
     def _to_cpu(tensor, low_cpu_mem_usage):
         is_torchao_tensor = _is_torchao_tensor(tensor)
         # For TorchAO tensors, `.data` returns an incomplete wrapper without internal attributes
         # (e.g. `.qdata`, `.scale`), so we must call `.cpu()` on the tensor directly.
         t = tensor.cpu() if is_torchao_tensor else tensor.data.cpu()
-        if low_cpu_mem_usage or is_torchao_tensor:
+        if low_cpu_mem_usage:
             return t
-        return t.pin_memory()
+        return ModuleGroup._pin_memory(t)
 
     def _init_cpu_param_dict(self):
         cpu_param_dict = {}
@@ -205,7 +215,7 @@ class ModuleGroup:
     def _pinned_memory_tensors(self):
         try:
             pinned_dict = {
-                param: tensor if (_is_torchao_tensor(tensor) or tensor.is_pinned()) else tensor.pin_memory()
+                param: self._pin_memory(tensor)
                 for param, tensor in self.cpu_param_dict.items()
             }
             yield pinned_dict

--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -174,10 +174,13 @@ class ModuleGroup:
 
     @staticmethod
     def _to_cpu(tensor, low_cpu_mem_usage):
+        is_torchao_tensor = _is_torchao_tensor(tensor)
         # For TorchAO tensors, `.data` returns an incomplete wrapper without internal attributes
         # (e.g. `.qdata`, `.scale`), so we must call `.cpu()` on the tensor directly.
-        t = tensor.cpu() if _is_torchao_tensor(tensor) else tensor.data.cpu()
-        return t if low_cpu_mem_usage else t.pin_memory()
+        t = tensor.cpu() if is_torchao_tensor else tensor.data.cpu()
+        if low_cpu_mem_usage or is_torchao_tensor:
+            return t
+        return t.pin_memory()
 
     def _init_cpu_param_dict(self):
         cpu_param_dict = {}
@@ -202,7 +205,7 @@ class ModuleGroup:
     def _pinned_memory_tensors(self):
         try:
             pinned_dict = {
-                param: tensor.pin_memory() if not tensor.is_pinned() else tensor
+                param: tensor if (_is_torchao_tensor(tensor) or tensor.is_pinned()) else tensor.pin_memory()
                 for param, tensor in self.cpu_param_dict.items()
             }
             yield pinned_dict

--- a/tests/quantization/torchao/test_torchao.py
+++ b/tests/quantization/torchao/test_torchao.py
@@ -522,6 +522,29 @@ class TorchAoTest(unittest.TestCase):
         inputs = self.get_dummy_inputs(torch_device)
         _ = pipe(**inputs)
 
+    def test_group_offloading(self):
+        inputs = self.get_dummy_tensor_inputs(torch_device)
+        transformer = self.get_dummy_components(TorchAoConfig(Int8WeightOnlyConfig()))["transformer"].to(torch_device)
+        with torch.no_grad():
+            output_without_offloading = transformer(**inputs)[0]
+        del transformer
+        backend_empty_cache(torch_device)
+        gc.collect()
+
+        for offload_kwargs in (
+            {"offload_type": "leaf_level"},
+            {"offload_type": "leaf_level", "use_stream": True},
+            {"offload_type": "block_level", "num_blocks_per_group": 1, "use_stream": True},
+        ):
+            transformer = self.get_dummy_components(TorchAoConfig(Int8WeightOnlyConfig()))["transformer"]
+            transformer.enable_group_offload(torch_device, **offload_kwargs)
+            with torch.no_grad():
+                output = transformer(**inputs)[0]
+            assert torch.allclose(output_without_offloading, output, atol=1e-3, rtol=1e-3)
+            del transformer
+            backend_empty_cache(torch_device)
+            gc.collect()
+
     @require_torchao_version_greater_or_equal("0.15.0")
     def test_aobase_config(self):
         quantization_config = TorchAoConfig(Int8WeightOnlyConfig())

--- a/tests/quantization/torchao/test_torchao.py
+++ b/tests/quantization/torchao/test_torchao.py
@@ -522,9 +522,10 @@ class TorchAoTest(unittest.TestCase):
         inputs = self.get_dummy_inputs(torch_device)
         _ = pipe(**inputs)
 
-    def test_group_offloading(self):
+    def test_group_offloading_torchao_int8wo_v1(self):
+        quantization_config = TorchAoConfig(Int8WeightOnlyConfig(version=1))
         inputs = self.get_dummy_tensor_inputs(torch_device)
-        transformer = self.get_dummy_components(TorchAoConfig(Int8WeightOnlyConfig()))["transformer"].to(torch_device)
+        transformer = self.get_dummy_components(quantization_config)["transformer"].to(torch_device)
         with torch.no_grad():
             output_without_offloading = transformer(**inputs)[0]
         del transformer
@@ -536,7 +537,7 @@ class TorchAoTest(unittest.TestCase):
             {"offload_type": "leaf_level", "use_stream": True},
             {"offload_type": "block_level", "num_blocks_per_group": 1, "use_stream": True},
         ):
-            transformer = self.get_dummy_components(TorchAoConfig(Int8WeightOnlyConfig()))["transformer"]
+            transformer = self.get_dummy_components(quantization_config)["transformer"]
             transformer.enable_group_offload(torch_device, **offload_kwargs)
             with torch.no_grad():
                 output = transformer(**inputs)[0]


### PR DESCRIPTION

# What does this PR do?

Refs #13281.

This PR is scoped to the legacy TorchAO int8 weight-only path that produces `AffineQuantizedTensor` (`Int8WeightOnlyConfig(version=1)`). The current `Float8WeightOnlyConfig` path reported in #13281, and the int8 compile path that uses TorchAO `version=2`, both support `is_pinned()` and `pin_memory()` on current main.

The streamed group-offload path keeps a CPU copy of each tensor and normally pins that copy before transferring a group back to the accelerator. `AffineQuantizedTensor` is still a TorchAO tensor subclass, so `_to_cpu()` must call `tensor.cpu()`, but its pinning ops raise `NotImplementedError: ... aten.is_pinned`.

This PR keeps pinned memory for tensors whose pinning ops work, including TorchAO v2 tensors, and falls back to the CPU copy only when a TorchAO tensor does not implement those pinning ops.

<details>
<summary>End-to-end reproduction</summary>

Environment: NVIDIA RTX 4090, `torch==2.8.0+cu128`, `torchao==0.17.0`.

The script uses the public tiny Flux pipeline, quantizes the transformer with `Int8WeightOnlyConfig(version=1)`, enables `pipe.transformer.enable_group_offload(..., use_stream=True)`, moves the remaining modules to CUDA, and runs `pipe(...)`.

```python
import numpy as np
import torch

import diffusers
from diffusers import DiffusionPipeline, TorchAoConfig
from diffusers.quantizers import PipelineQuantizationConfig
from torchao.quantization import Int8WeightOnlyConfig

print(f"diffusers_file={diffusers.__file__}")
print(f"torch={torch.__version__}")
print(f"cuda={torch.cuda.get_device_name(0)}")

quantization_config = PipelineQuantizationConfig(
    quant_mapping={"transformer": TorchAoConfig(Int8WeightOnlyConfig(version=1))}
)
pipe = DiffusionPipeline.from_pretrained(
    "hf-internal-testing/tiny-flux-pipe",
    quantization_config=quantization_config,
    torch_dtype=torch.bfloat16,
)
pipe.set_progress_bar_config(disable=True)
pipe.transformer.enable_group_offload(
    onload_device=torch.device("cuda"),
    offload_device=torch.device("cpu"),
    offload_type="leaf_level",
    use_stream=True,
    non_blocking=True,
)

for name, component in pipe.components.items():
    if name != "transformer" and isinstance(component, torch.nn.Module):
        if torch.device(component.device).type == "cpu":
            component.to("cuda")

images = pipe(
    "a dog",
    num_inference_steps=2,
    max_sequence_length=16,
    height=32,
    width=32,
    output_type="np",
).images
arr = np.asarray(images)
print("RESULT=PASS")
print(f"output_shape={arr.shape}")
print(f"finite={np.isfinite(arr).all()}")
print(f"mean={arr.mean():.6f}")
```

Before:

```text
diffusers_file=/root/autodl-tmp/code/diffusers-14-e2e-before/src/diffusers/__init__.py
torch=2.8.0+cu128
cuda=NVIDIA GeForce RTX 4090
RESULT=FAIL
exception:
Traceback (most recent call last):
  File "/root/autodl-tmp/code/diffusers-14-e2e-before/repro_torchao_stream_e2e.py", line 39, in main
    pipe.transformer.enable_group_offload(
  File "/root/autodl-tmp/code/diffusers-14-e2e-before/src/diffusers/models/modeling_utils.py", line 573, in enable_group_offload
    apply_group_offloading(
  File "/root/autodl-tmp/code/diffusers-14-e2e-before/src/diffusers/hooks/group_offloading.py", line 702, in apply_group_offloading
    _apply_group_offloading(module, config)
  File "/root/autodl-tmp/code/diffusers-14-e2e-before/src/diffusers/hooks/group_offloading.py", line 709, in _apply_group_offloading
    _apply_group_offloading_leaf_level(module, config)
  File "/root/autodl-tmp/code/diffusers-14-e2e-before/src/diffusers/hooks/group_offloading.py", line 827, in _apply_group_offloading_leaf_level
    group = ModuleGroup(
  File "/root/autodl-tmp/code/diffusers-14-e2e-before/src/diffusers/hooks/group_offloading.py", line 167, in __init__
    self.cpu_param_dict = self._init_cpu_param_dict()
  File "/root/autodl-tmp/code/diffusers-14-e2e-before/src/diffusers/hooks/group_offloading.py", line 189, in _init_cpu_param_dict
    cpu_param_dict[param] = self._to_cpu(param, self.low_cpu_mem_usage)
  File "/root/autodl-tmp/code/diffusers-14-e2e-before/src/diffusers/hooks/group_offloading.py", line 180, in _to_cpu
    return t if low_cpu_mem_usage else t.pin_memory()
  File "/root/autodl-tmp/code/diffusers-14-e2e-before/pydeps/torchao/utils.py", line 684, in _dispatch__torch_dispatch__
    raise NotImplementedError(
NotImplementedError: AffineQuantizedTensor dispatch: attempting to run unimplemented operator/function: func=<OpOverload(op='aten.is_pinned', overload='default')>, types=(<class 'torchao.dtypes.affine_quantized_tensor.AffineQuantizedTensor'>,), arg_types=(<class 'torchao.dtypes.affine_quantized_tensor.AffineQuantizedTensor'>,), kwarg_types={}
EXIT_CODE=1
```

After:

```text
diffusers_file=/root/autodl-tmp/code/diffusers-14-retarget-codex/src/diffusers/__init__.py
torch=2.8.0+cu128
cuda=NVIDIA GeForce RTX 4090
UserWarning: Config Deprecation: version 1 of Int8WeightOnlyConfig is deprecated and will no longer be supported in a future release
UserWarning: Deprecation: AffineQuantizedTensor is deprecated and will be removed in a future release of torchao
RESULT=PASS
output_shape=(1, 32, 32, 3)
finite=True
mean=0.504391
```

</details>

Additional checks:

```text
python -m py_compile src/diffusers/hooks/group_offloading.py tests/quantization/torchao/test_torchao.py
git diff --check
ruff check src/diffusers/hooks/group_offloading.py tests/quantization/torchao/test_torchao.py
All checks passed!
```

```text
python -m pytest tests/quantization/torchao/test_torchao.py::TorchAoTest::test_group_offloading_torchao_int8wo_v1 -q -rs
1 passed, 11 warnings in 34.10s
```

```text
TestFluxTransformerTorchAoCompile._test_torch_compile_with_group_offload(TorchAoConfigMixin.TORCHAO_QUANT_TYPES["int8wo"], use_stream=True)
RESULT=PASS
```

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you self-review the diff against [`.ai/review-rules.md`](https://github.com/huggingface/diffusers/blob/main/.ai/review-rules.md)?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case. Related: #13281
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?

## Who can review?

cc @sayakpaul
