### PR TITLE
Flux2 pipelines: expose the hardcoded 1MP condition-image downscale threshold (max_area)

### DIFF
--- a/src/diffusers/pipelines/flux2/pipeline_flux2.py
+++ b/src/diffusers/pipelines/flux2/pipeline_flux2.py
@@ -765,6 +765,7 @@ class Flux2Pipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
         max_sequence_length: int = 512,
         text_encoder_out_layers: tuple[int] = (10, 20, 30),
         caption_upsample_temperature: float = None,
+        max_area: int = 1024**2,
     ):
         r"""
         Function invoked when calling the pipeline for generation.
@@ -832,6 +833,9 @@ class Flux2Pipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
             caption_upsample_temperature (`float`):
                 When specified, we will try to perform caption upsampling for potentially improved outputs. We
                 recommend setting it to 0.15 if caption upsampling is to be performed.
+            max_area (`int`, defaults to `1024 ** 2`):
+                The maximum area (in pixels) allowed for each condition image. Condition images whose area exceeds
+                this value are downscaled to fit it while preserving their aspect ratio.
 
         Examples:
 
@@ -891,8 +895,8 @@ class Flux2Pipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
             condition_images = []
             for img in image:
                 image_width, image_height = img.size
-                if image_width * image_height > 1024 * 1024:
-                    img = self.image_processor._resize_to_target_area(img, 1024 * 1024)
+                if image_width * image_height > max_area:
+                    img = self.image_processor._resize_to_target_area(img, max_area)
                     image_width, image_height = img.size
 
                 multiple_of = self.vae_scale_factor * 2

--- a/src/diffusers/pipelines/flux2/pipeline_flux2_klein.py
+++ b/src/diffusers/pipelines/flux2/pipeline_flux2_klein.py
@@ -632,6 +632,7 @@ class Flux2KleinPipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
         max_sequence_length: int = 512,
         text_encoder_out_layers: tuple[int] = (9, 18, 27),
+        max_area: int = 1024**2,
     ):
         r"""
         Function invoked when calling the pipeline for generation.
@@ -700,6 +701,9 @@ class Flux2KleinPipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
             max_sequence_length (`int` defaults to 512): Maximum sequence length to use with the `prompt`.
             text_encoder_out_layers (`tuple[int]`):
                 Layer indices to use in the `text_encoder` to derive the final prompt embeddings.
+            max_area (`int`, defaults to `1024 ** 2`):
+                The maximum area (in pixels) allowed for each condition image. Condition images whose area exceeds
+                this value are downscaled to fit it while preserving their aspect ratio.
 
         Examples:
 
@@ -769,8 +773,8 @@ class Flux2KleinPipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
             condition_images = []
             for img in image:
                 image_width, image_height = img.size
-                if image_width * image_height > 1024 * 1024:
-                    img = self.image_processor._resize_to_target_area(img, 1024 * 1024)
+                if image_width * image_height > max_area:
+                    img = self.image_processor._resize_to_target_area(img, max_area)
                     image_width, image_height = img.size
 
                 multiple_of = self.vae_scale_factor * 2

--- a/src/diffusers/pipelines/flux2/pipeline_flux2_klein_kv.py
+++ b/src/diffusers/pipelines/flux2/pipeline_flux2_klein_kv.py
@@ -627,6 +627,7 @@ class Flux2KleinKVPipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
         max_sequence_length: int = 512,
         text_encoder_out_layers: tuple[int] = (9, 18, 27),
+        max_area: int = 1024**2,
     ):
         r"""
         Function invoked when calling the pipeline for generation.
@@ -668,6 +669,9 @@ class Flux2KleinKVPipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
                 Maximum sequence length for the prompt.
             text_encoder_out_layers (`tuple[int]`):
                 Layer indices for text encoder hidden state extraction.
+            max_area (`int`, defaults to `1024 ** 2`):
+                The maximum area (in pixels) allowed for each condition image. Condition images whose area exceeds
+                this value are downscaled to fit it while preserving their aspect ratio.
 
         Examples:
 
@@ -720,8 +724,8 @@ class Flux2KleinKVPipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
             condition_images = []
             for img in image:
                 image_width, image_height = img.size
-                if image_width * image_height > 1024 * 1024:
-                    img = self.image_processor._resize_to_target_area(img, 1024 * 1024)
+                if image_width * image_height > max_area:
+                    img = self.image_processor._resize_to_target_area(img, max_area)
                     image_width, image_height = img.size
 
                 multiple_of = self.vae_scale_factor * 2

--- a/tests/pipelines/flux2/test_pipeline_flux2.py
+++ b/tests/pipelines/flux2/test_pipeline_flux2.py
@@ -1,4 +1,5 @@
 import torch
+from PIL import Image
 from transformers import AutoProcessor, Mistral3Config, Mistral3ForConditionalGeneration
 
 from diffusers import (
@@ -183,6 +184,18 @@ class TestFlux2Pipeline(Flux2PipelineTesterConfig, PipelineTesterMixin):
             assert (output_height, output_width) == (expected_height, expected_width), (
                 f"Output shape {image.shape} does not match expected shape {(expected_height, expected_width)}"
             )
+
+    def test_image_input_max_area(self):
+        # `max_area` (previously hardcoded to 1024**2) is the condition-image downscale threshold:
+        # condition images whose area exceeds it are downscaled while preserving aspect ratio.
+        pipe = self.get_pipeline().to(torch_device)
+        inputs = self.get_dummy_inputs()
+        height, width = inputs["height"], inputs["width"]
+
+        inputs.update({"image": Image.new("RGB", (128, 128)), "max_area": 64 * 64})
+        image = pipe(**inputs).images[0]
+        _, output_height, output_width = image.shape
+        assert (output_height, output_width) == (height, width)
 
 
 class TestFlux2PipelineMemory(Flux2PipelineTesterConfig, MemoryTesterMixin):

--- a/tests/pipelines/flux2/test_pipeline_flux2.py
+++ b/tests/pipelines/flux2/test_pipeline_flux2.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 import torch
+from PIL import Image
 from transformers import AutoProcessor, Mistral3Config, Mistral3ForConditionalGeneration
 
 from diffusers import (
@@ -186,3 +187,15 @@ class Flux2PipelineFastTests(PipelineTesterMixin, unittest.TestCase):
                 (expected_height, expected_width),
                 f"Output shape {image.shape} does not match expected shape {(expected_height, expected_width)}",
             )
+
+    def test_image_input_max_area(self):
+        # `max_area` (previously hardcoded to 1024**2) is the condition-image downscale threshold:
+        # condition images whose area exceeds it are downscaled while preserving aspect ratio.
+        pipe = self.pipeline_class(**self.get_dummy_components()).to(torch_device)
+        inputs = self.get_dummy_inputs(torch_device)
+        height, width = inputs["height"], inputs["width"]
+
+        inputs.update({"image": Image.new("RGB", (128, 128)), "max_area": 64 * 64})
+        image = pipe(**inputs).images[0]
+        output_height, output_width, _ = image.shape
+        self.assertEqual((output_height, output_width), (height, width))

--- a/tests/pipelines/flux2/test_pipeline_flux2_klein.py
+++ b/tests/pipelines/flux2/test_pipeline_flux2_klein.py
@@ -17,6 +17,8 @@ from diffusers import (
 from ...testing_utils import (
     backend_empty_cache,
     backend_synchronize,
+    nightly,
+    require_big_accelerator,
     require_torch_neuron,
     torch_device,
 )
@@ -183,6 +185,18 @@ class Flux2KleinPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         # fmt: on
         assert np.allclose(expected_slice, generated_slice, atol=1e-4, rtol=1e-4)
 
+    def test_image_input_max_area(self):
+        # `max_area` (previously hardcoded to 1024**2) is the condition-image downscale threshold:
+        # condition images whose area exceeds it are downscaled while preserving aspect ratio.
+        pipe = self.pipeline_class(**self.get_dummy_components()).to(torch_device)
+        inputs = self.get_dummy_inputs(torch_device)
+        height, width = inputs["height"], inputs["width"]
+
+        inputs.update({"image": Image.new("RGB", (128, 128)), "max_area": 64 * 64})
+        image = pipe(**inputs).images[0]
+        output_height, output_width, _ = image.shape
+        self.assertEqual((output_height, output_width), (height, width))
+
     @unittest.skip("Needs to be revisited")
     def test_encode_prompt_works_in_isolation(self):
         pass
@@ -274,6 +288,52 @@ class Flux2KleinPipelineIntegrationTests(unittest.TestCase):
         ).images
 
         self.assertEqual(image.shape, (1, 128, 128, 3))
+        self.assertFalse(np.isnan(image).any(), "Output contains NaN values")
+        self.assertTrue(
+            (image >= 0.0).all() and (image <= 1.0).all(),
+            "Output pixel values outside [0, 1]",
+        )
+
+
+@nightly
+@require_big_accelerator
+class Flux2KleinPipelineConditionImageSlowTests(unittest.TestCase):
+    ckpt_id = "black-forest-labs/FLUX.2-klein-4B"
+    prompt = "A small cactus with a happy face in the Sahara desert."
+
+    def setUp(self):
+        super().setUp()
+        gc.collect()
+        backend_empty_cache(torch_device)
+
+    def tearDown(self):
+        super().tearDown()
+        gc.collect()
+        backend_empty_cache(torch_device)
+
+    def test_flux2_klein_2048_condition_image(self):
+        # A 2048x2048 condition image used to be silently downscaled to fit the hardcoded
+        # 1024**2 threshold; passing max_area=2048**2 lets the pipeline consume it at full
+        # resolution.
+        pipe = Flux2KleinPipeline.from_pretrained(self.ckpt_id, torch_dtype=torch.bfloat16)
+        pipe.to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
+
+        generator = torch.Generator("cpu").manual_seed(0)
+        condition_image = Image.new("RGB", (2048, 2048), (128, 128, 128))
+        image = pipe(
+            prompt=self.prompt,
+            image=condition_image,
+            height=512,
+            width=512,
+            num_inference_steps=4,
+            guidance_scale=1.0,
+            generator=generator,
+            max_area=2048 * 2048,
+            output_type="np",
+        ).images
+
+        self.assertEqual(image.shape, (1, 512, 512, 3))
         self.assertFalse(np.isnan(image).any(), "Output contains NaN values")
         self.assertTrue(
             (image >= 0.0).all() and (image <= 1.0).all(),

--- a/tests/pipelines/flux2/test_pipeline_flux2_klein.py
+++ b/tests/pipelines/flux2/test_pipeline_flux2_klein.py
@@ -18,6 +18,8 @@ from ...testing_utils import (
     assert_tensors_close,
     backend_empty_cache,
     backend_synchronize,
+    nightly,
+    require_big_accelerator,
     require_torch_neuron,
     torch_device,
 )
@@ -189,6 +191,18 @@ class TestFlux2KleinPipeline(Flux2KleinPipelineTesterConfig, PipelineTesterMixin
         # fmt: on
         assert_tensors_close(generated_slice, expected_slice, atol=1e-4, rtol=1e-4)
 
+    def test_image_input_max_area(self):
+        # `max_area` (previously hardcoded to 1024**2) is the condition-image downscale threshold:
+        # condition images whose area exceeds it are downscaled while preserving aspect ratio.
+        pipe = self.get_pipeline().to(torch_device)
+        inputs = self.get_dummy_inputs()
+        height, width = inputs["height"], inputs["width"]
+
+        inputs.update({"image": Image.new("RGB", (128, 128)), "max_area": 64 * 64})
+        image = pipe(**inputs).images[0]
+        _, output_height, output_width = image.shape
+        assert (output_height, output_width) == (height, width)
+
     @pytest.mark.skip("Needs to be revisited")
     def test_encode_prompt_works_in_isolation(self):
         pass
@@ -281,5 +295,46 @@ class TestFlux2KleinPipelineIntegration:
         ).images
 
         assert image.shape == (1, 128, 128, 3)
+        assert not np.isnan(image).any(), "Output contains NaN values"
+        assert (image >= 0.0).all() and (image <= 1.0).all(), "Output pixel values outside [0, 1]"
+
+
+@nightly
+@require_big_accelerator
+class TestFlux2KleinPipelineConditionImageSlow:
+    ckpt_id = "black-forest-labs/FLUX.2-klein-4B"
+    prompt = "A small cactus with a happy face in the Sahara desert."
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self):
+        gc.collect()
+        backend_empty_cache(torch_device)
+        yield
+        gc.collect()
+        backend_empty_cache(torch_device)
+
+    def test_flux2_klein_2048_condition_image(self):
+        # A 2048x2048 condition image used to be silently downscaled to fit the hardcoded
+        # 1024**2 threshold; passing max_area=2048**2 lets the pipeline consume it at full
+        # resolution.
+        pipe = Flux2KleinPipeline.from_pretrained(self.ckpt_id, torch_dtype=torch.bfloat16)
+        pipe.to(torch_device)
+        pipe.set_progress_bar_config(disable=None)
+
+        generator = torch.Generator("cpu").manual_seed(0)
+        condition_image = Image.new("RGB", (2048, 2048), (128, 128, 128))
+        image = pipe(
+            prompt=self.prompt,
+            image=condition_image,
+            height=512,
+            width=512,
+            num_inference_steps=4,
+            guidance_scale=1.0,
+            generator=generator,
+            max_area=2048 * 2048,
+            output_type="np",
+        ).images
+
+        assert image.shape == (1, 512, 512, 3)
         assert not np.isnan(image).any(), "Output contains NaN values"
         assert (image >= 0.0).all() and (image <= 1.0).all(), "Output pixel values outside [0, 1]"

--- a/tests/pipelines/flux2/test_pipeline_flux2_klein_kv.py
+++ b/tests/pipelines/flux2/test_pipeline_flux2_klein_kv.py
@@ -167,6 +167,19 @@ class TestFlux2KleinKVPipeline(Flux2KleinKVPipelineTesterConfig, PipelineTesterM
         image = pipe(**inputs).images
         assert image.shape == (1, *self.output_shape)
 
+    def test_image_input_max_area(self):
+        # `max_area` (previously hardcoded to 1024**2) is the condition-image downscale threshold:
+        # condition images whose area exceeds it are downscaled while preserving aspect ratio.
+        pipe = self.get_pipeline().to(torch_device)
+        inputs = self.get_dummy_inputs()
+        height, width = inputs["height"], inputs["width"]
+
+        # the dummy 64x64 condition image exceeds max_area -> downscale path
+        inputs["max_area"] = 32 * 32
+        image = pipe(**inputs).images[0]
+        _, output_height, output_width = image.shape
+        assert (output_height, output_width) == (height, width)
+
     @pytest.mark.skip("Needs to be revisited")
     def test_encode_prompt_works_in_isolation(self):
         pass

--- a/tests/pipelines/flux2/test_pipeline_flux2_klein_kv.py
+++ b/tests/pipelines/flux2/test_pipeline_flux2_klein_kv.py
@@ -167,6 +167,19 @@ class Flux2KleinKVPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         image = pipe(**inputs).images
         self.assertEqual(image.shape, (1, 8, 8, 3))
 
+    def test_image_input_max_area(self):
+        # `max_area` (previously hardcoded to 1024**2) is the condition-image downscale threshold:
+        # condition images whose area exceeds it are downscaled while preserving aspect ratio.
+        pipe = self.pipeline_class(**self.get_dummy_components()).to(torch_device)
+        inputs = self.get_dummy_inputs(torch_device)
+        height, width = inputs["height"], inputs["width"]
+
+        # the dummy 64x64 condition image exceeds max_area -> downscale path
+        inputs["max_area"] = 32 * 32
+        image = pipe(**inputs).images[0]
+        output_height, output_width, _ = image.shape
+        self.assertEqual((output_height, output_width), (height, width))
+
     @unittest.skip("Needs to be revisited")
     def test_encode_prompt_works_in_isolation(self):
         pass


### PR DESCRIPTION
  # What does this PR do?

   Exposes the condition/reference image area threshold in the FLUX.2 pipelines as a public max_area argument, instead of hardcoding 1024 * 1024.

   Currently Flux2Pipeline, Flux2KleinPipeline and Flux2KleinKVPipeline silently downscale any condition/reference image larger than ~1MP before conditioning (e.g. if image_width * image_height > 1024 * 1024 in pipeline_flux2_klein.py). There is no public way to keep higher-resolution conditioning — the only workaround today is patching the private image_processor._resize_to_target_area.

   Fixes the inability to override the reference-image resolution cap without touching private image-processor internals. Useful for users who want to condition on higher-resolution references.

   Simple change,  i think no-issue-needed :).

 ## Changes
  - Add a max_area: int = 1024**2 argument to __call__ on Flux2Pipeline, Flux2KleinPipeline and Flux2KleinKVPipeline, and use it in place of the hardcoded 1024 * 1024 threshold.
  - Mirrors the existing max_area parameter of FluxKontextPipeline for API consistency.
  - Default value is unchanged, so existing behavior is fully preserved (fully backward compatible).



  ##   Before submitting
  - [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
  - [x] Did you read the contributor guideline (https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
  - [x] Did you read our philosophy doc (https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
  - [ ] Was this discussed/approved via a GitHub issue or the forum (https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)?
  - [ ] Did you make sure to update the documentation with your changes?
  - [x] Did you write any new necessary tests? (tests/pipelines/flux2 passes.)

   ##    Who can review?
  @yiyixuxu @sayakpaul @DN6 @dg845 @asomoza — Small, backward-compatible API addition to the FLUX.2 pipelines exposing the existing max_area behavior as a public argument.