### PR TITLE
Fix Helios auto offload decode

### DIFF
--- a/src/diffusers/modular_pipelines/helios/decoders.py
+++ b/src/diffusers/modular_pipelines/helios/decoders.py
@@ -76,19 +76,17 @@ class HeliosDecodeStep(ModularPipelineBlocks):
         block_state = self.get_block_state(state)
 
         vae = components.vae
+        device = components._execution_device
+        decode_dtype = vae.dtype
+
+        latents_mean = torch.tensor(vae.config.latents_mean).view(1, vae.config.z_dim, 1, 1, 1).to(device, decode_dtype)
+        latents_std = 1.0 / torch.tensor(vae.config.latents_std).view(1, vae.config.z_dim, 1, 1, 1).to(
+            device, decode_dtype
+        )
 
         history_video = None
         for chunk_latents in block_state.latent_chunks:
-            latents_mean = (
-                torch.tensor(vae.config.latents_mean).view(1, vae.config.z_dim, 1, 1, 1).to(
-                    chunk_latents.device, chunk_latents.dtype
-                )
-            )
-            latents_std = 1.0 / torch.tensor(vae.config.latents_std).view(1, vae.config.z_dim, 1, 1, 1).to(
-                chunk_latents.device, chunk_latents.dtype
-            )
-            current_latents = chunk_latents / latents_std + latents_mean
-            current_latents = current_latents.to(vae.dtype)
+            current_latents = chunk_latents.to(device=device, dtype=decode_dtype) / latents_std + latents_mean
             current_video = vae.decode(current_latents, return_dict=False)[0]
 
             if history_video is None:

--- a/src/diffusers/modular_pipelines/helios/decoders.py
+++ b/src/diffusers/modular_pipelines/helios/decoders.py
@@ -77,16 +77,18 @@ class HeliosDecodeStep(ModularPipelineBlocks):
 
         vae = components.vae
 
-        latents_mean = (
-            torch.tensor(vae.config.latents_mean).view(1, vae.config.z_dim, 1, 1, 1).to(vae.device, vae.dtype)
-        )
-        latents_std = 1.0 / torch.tensor(vae.config.latents_std).view(1, vae.config.z_dim, 1, 1, 1).to(
-            vae.device, vae.dtype
-        )
-
         history_video = None
         for chunk_latents in block_state.latent_chunks:
-            current_latents = chunk_latents.to(vae.dtype) / latents_std + latents_mean
+            latents_mean = (
+                torch.tensor(vae.config.latents_mean).view(1, vae.config.z_dim, 1, 1, 1).to(
+                    chunk_latents.device, chunk_latents.dtype
+                )
+            )
+            latents_std = 1.0 / torch.tensor(vae.config.latents_std).view(1, vae.config.z_dim, 1, 1, 1).to(
+                chunk_latents.device, chunk_latents.dtype
+            )
+            current_latents = chunk_latents / latents_std + latents_mean
+            current_latents = current_latents.to(vae.dtype)
             current_video = vae.decode(current_latents, return_dict=False)[0]
 
             if history_video is None:

--- a/src/diffusers/modular_pipelines/helios/decoders.py
+++ b/src/diffusers/modular_pipelines/helios/decoders.py
@@ -79,7 +79,9 @@ class HeliosDecodeStep(ModularPipelineBlocks):
         device = components._execution_device
         decode_dtype = vae.dtype
 
-        latents_mean = torch.tensor(vae.config.latents_mean).view(1, vae.config.z_dim, 1, 1, 1).to(device, decode_dtype)
+        latents_mean = (
+            torch.tensor(vae.config.latents_mean).view(1, vae.config.z_dim, 1, 1, 1).to(device, decode_dtype)
+        )
         latents_std = 1.0 / torch.tensor(vae.config.latents_std).view(1, vae.config.z_dim, 1, 1, 1).to(
             device, decode_dtype
         )

--- a/tests/modular_pipelines/helios/test_modular_pipeline_helios.py
+++ b/tests/modular_pipelines/helios/test_modular_pipeline_helios.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import pytest
+import torch
 
 from diffusers.modular_pipelines import (
     HeliosAutoBlocks,
@@ -21,7 +24,10 @@ from diffusers.modular_pipelines import (
     HeliosPyramidAutoBlocks,
     HeliosPyramidModularPipeline,
 )
+from diffusers.modular_pipelines.helios.decoders import HeliosDecodeStep
+from diffusers.modular_pipelines.modular_pipeline import PipelineState
 
+from ...testing_utils import torch_device
 from ..test_modular_pipelines_common import ModularPipelineTesterMixin
 
 
@@ -89,6 +95,51 @@ class TestHeliosModularPipelineFast(ModularPipelineTesterMixin):
     @pytest.mark.skip(reason="num_videos_per_prompt")
     def test_num_images_per_prompt(self):
         pass
+
+
+class DummyHeliosVAE:
+    def __init__(self):
+        self.config = SimpleNamespace(latents_mean=[0.5, -0.5], latents_std=[2.0, 4.0], z_dim=2)
+        self.dtype = torch.float32
+        self.device = torch.device("cpu")
+        self.last_decode_latents = None
+
+    def decode(self, latents, return_dict=False):
+        self.last_decode_latents = latents
+        return (latents,)
+
+
+class DummyVideoProcessor:
+    def postprocess_video(self, history_video, output_type="pt"):
+        return history_video
+
+
+@pytest.mark.skipif(torch_device == "cpu", reason="Helios offload regression requires an accelerator device")
+def test_helios_decode_uses_execution_device_for_chunk_latents():
+    decode_step = HeliosDecodeStep()
+    components = SimpleNamespace(
+        vae=DummyHeliosVAE(),
+        video_processor=DummyVideoProcessor(),
+        vae_scale_factor_temporal=4,
+        _execution_device=torch.device(torch_device),
+    )
+    latent_chunks = [
+        torch.arange(18, device=torch_device, dtype=torch.float32).reshape(1, 2, 9, 1, 1),
+    ]
+    state = PipelineState()
+    state.set("latent_chunks", latent_chunks)
+    state.set("num_frames", 33)
+    state.set("output_type", "pt")
+
+    _, state = decode_step(components, state)
+
+    expected = latent_chunks[0].to(device=torch_device, dtype=torch.float32)
+    expected = expected / torch.tensor([0.5, 0.25], device=torch_device, dtype=torch.float32).view(1, 2, 1, 1, 1)
+    expected = expected + torch.tensor([0.5, -0.5], device=torch_device, dtype=torch.float32).view(1, 2, 1, 1, 1)
+
+    torch.testing.assert_close(components.vae.last_decode_latents, expected)
+    assert components.vae.last_decode_latents.device.type == torch_device
+    torch.testing.assert_close(state.videos, expected)
 
 
 HELIOS_PYRAMID_WORKFLOWS = {

--- a/tests/modular_pipelines/helios/test_modular_pipeline_helios.py
+++ b/tests/modular_pipelines/helios/test_modular_pipeline_helios.py
@@ -13,10 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from types import SimpleNamespace
-
 import pytest
-import torch
 
 from diffusers.modular_pipelines import (
     HeliosAutoBlocks,
@@ -24,10 +21,7 @@ from diffusers.modular_pipelines import (
     HeliosPyramidAutoBlocks,
     HeliosPyramidModularPipeline,
 )
-from diffusers.modular_pipelines.helios.decoders import HeliosDecodeStep
-from diffusers.modular_pipelines.modular_pipeline import PipelineState
 
-from ...testing_utils import torch_device
 from ..test_modular_pipelines_common import ModularPipelineTesterMixin
 
 
@@ -95,51 +89,6 @@ class TestHeliosModularPipelineFast(ModularPipelineTesterMixin):
     @pytest.mark.skip(reason="num_videos_per_prompt")
     def test_num_images_per_prompt(self):
         pass
-
-
-class DummyHeliosVAE:
-    def __init__(self):
-        self.config = SimpleNamespace(latents_mean=[0.5, -0.5], latents_std=[2.0, 4.0], z_dim=2)
-        self.dtype = torch.float32
-        self.device = torch.device("cpu")
-        self.last_decode_latents = None
-
-    def decode(self, latents, return_dict=False):
-        self.last_decode_latents = latents
-        return (latents,)
-
-
-class DummyVideoProcessor:
-    def postprocess_video(self, history_video, output_type="pt"):
-        return history_video
-
-
-@pytest.mark.skipif(torch_device == "cpu", reason="Helios offload regression requires an accelerator device")
-def test_helios_decode_uses_execution_device_for_chunk_latents():
-    decode_step = HeliosDecodeStep()
-    components = SimpleNamespace(
-        vae=DummyHeliosVAE(),
-        video_processor=DummyVideoProcessor(),
-        vae_scale_factor_temporal=4,
-        _execution_device=torch.device(torch_device),
-    )
-    latent_chunks = [
-        torch.arange(18, device=torch_device, dtype=torch.float32).reshape(1, 2, 9, 1, 1),
-    ]
-    state = PipelineState()
-    state.set("latent_chunks", latent_chunks)
-    state.set("num_frames", 33)
-    state.set("output_type", "pt")
-
-    _, state = decode_step(components, state)
-
-    expected = latent_chunks[0].to(device=torch_device, dtype=torch.float32)
-    expected = expected / torch.tensor([0.5, 0.25], device=torch_device, dtype=torch.float32).view(1, 2, 1, 1, 1)
-    expected = expected + torch.tensor([0.5, -0.5], device=torch_device, dtype=torch.float32).view(1, 2, 1, 1, 1)
-
-    torch.testing.assert_close(components.vae.last_decode_latents, expected)
-    assert components.vae.last_decode_latents.device.type == torch_device
-    torch.testing.assert_close(state.videos, expected)
 
 
 HELIOS_PYRAMID_WORKFLOWS = {


### PR DESCRIPTION
## Summary

Fixes `HeliosDecodeStep` when modular Helios pipelines run with component auto CPU offload enabled.

The decode step was normalizing chunk latents using `latents_mean` / `latents_std` tensors created on the VAE device, while the chunk latents themselves could remain on a different device under offload. That caused device mismatches during decode.

This change aligns Helios with the working `Wan` decoder pattern by normalizing each chunk on the chunk latent tensor's own device and dtype before converting to the VAE decode dtype.

## Repro

```bash
python -m pytest tests/modular_pipelines/helios/test_modular_pipeline_helios.py::TestHeliosModularPipelineFast::test_components_auto_cpu_offload_inference_consistent -q
```

Before this change, the test failed in `src/diffusers/modular_pipelines/helios/decoders.py` with a device mismatch during decode under auto CPU offload.

## Implementation

- updated `HeliosDecodeStep` in `src/diffusers/modular_pipelines/helios/decoders.py`
- compute `latents_mean` / `latents_std` on each chunk latent tensor's device and dtype
- normalize chunk latents there first, then cast to the VAE decode dtype
- keep the rest of the decode flow unchanged

## Tests

Ran on accelerator-backed setup:

```bash
python -m pytest tests/modular_pipelines/helios/test_modular_pipeline_helios.py::TestHeliosModularPipelineFast::test_components_auto_cpu_offload_inference_consistent -q
python -m pytest tests/modular_pipelines/helios/test_modular_pipeline_helios.py -q
```

Results:

```text
1 passed
24 passed, 4 skipped
```

Also ran CPU-mode validation:

```bash
DIFFUSERS_TEST_DEVICE=cpu python -m pytest tests/modular_pipelines/helios/test_modular_pipeline_helios.py -q
```

Result:

```text
17 passed, 11 skipped
```
