### PR TITLE
Preserve HookRegistry forward signatures

### DIFF
--- a/src/diffusers/hooks/hooks.py
+++ b/src/diffusers/hooks/hooks.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import inspect
 from typing import Any
 
 import torch
@@ -192,6 +193,7 @@ class HookRegistry:
             return new_forward
 
         forward = self._module_ref.forward
+        forward_signature = inspect.signature(forward)
 
         fn_ref = HookFunctionReference()
         fn_ref.pre_forward = hook.pre_forward
@@ -208,6 +210,7 @@ class HookRegistry:
         self._module_ref.forward = functools.update_wrapper(
             functools.partial(rewritten_forward, self._module_ref), rewritten_forward
         )
+        self._module_ref.forward.__signature__ = forward_signature
 
         hook.fn_ref = fn_ref
         self.hooks[name] = hook

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import inspect
 
 import pytest
 import torch
@@ -60,6 +61,16 @@ class DummyModel(torch.nn.Module):
             x = block(x)
         x = self.linear_2(x)
         return x
+
+
+class ExportModel(torch.nn.Module):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return hidden_states + timestep.float().reshape(1, 1, 1)
 
 
 class AddHook(ModelHook):
@@ -177,6 +188,54 @@ class TestHooks:
 
         assert len(registry.hooks) == 1
         assert registry._hook_order == ["multiply_hook"]
+
+    def test_hook_registry_preserves_forward_signature(self):
+        model = ExportModel().to(torch_device)
+        expected_signature = inspect.signature(model.forward)
+
+        registry = HookRegistry.check_if_exists_or_initialize(model)
+        registry.register_hook(ModelHook(), "noop_hook")
+
+        assert inspect.signature(model.forward) == expected_signature
+
+    def test_hook_registry_preserves_forward_signature_with_multiple_hooks(self):
+        model = ExportModel().to(torch_device)
+        original_signature = inspect.signature(model.forward)
+
+        registry = HookRegistry.check_if_exists_or_initialize(model)
+        registry.register_hook(ModelHook(), "noop_hook")
+        registry.register_hook(ModelHook(), "noop_hook_2")
+
+        assert inspect.signature(model.forward) == original_signature
+
+    def test_hook_registry_keeps_torch_export_keyword_binding(self):
+        model = ExportModel().to(torch_device)
+        registry = HookRegistry.check_if_exists_or_initialize(model)
+        registry.register_hook(ModelHook(), "noop_hook")
+
+        hidden_states = torch.randn(1, 4, 8, device=torch_device)
+        timestep = torch.tensor([1], device=torch_device)
+
+        torch.export.export(
+            model,
+            args=(),
+            kwargs={"hidden_states": hidden_states, "timestep": timestep},
+        )
+
+    def test_hook_registry_multiple_hooks_keep_torch_export_keyword_binding(self):
+        model = ExportModel().to(torch_device)
+        registry = HookRegistry.check_if_exists_or_initialize(model)
+        registry.register_hook(ModelHook(), "noop_hook")
+        registry.register_hook(ModelHook(), "noop_hook_2")
+
+        hidden_states = torch.randn(1, 4, 8, device=torch_device)
+        timestep = torch.tensor([1], device=torch_device)
+
+        torch.export.export(
+            model,
+            args=(),
+            kwargs={"hidden_states": hidden_states, "timestep": timestep},
+        )
 
     def test_stateful_hook(self):
         registry = HookRegistry.check_if_exists_or_initialize(self.model)


### PR DESCRIPTION
## Bug

`HookRegistry.register_hook` wrapped `module.forward` with a generic callable. After hook registration, `inspect.signature(module.forward)` reported:

```text
(module, *args, **kwargs)
```

instead of the original model `forward` signature.

This broke `torch.export` keyword binding because kwargs such as `hidden_states` and `timestep` were bound against the wrapper signature.

## Root cause

The replacement `forward` used `functools.partial` plus `functools.update_wrapper`, but it did not carry the original bound `forward` signature onto the installed wrapper.

## Fix

Capture `inspect.signature(forward)` before wrapping, then assign it to `self._module_ref.forward.__signature__` after installing the wrapped partial.

This keeps introspection aligned with the model API while leaving hook execution unchanged.

## Tests

1. Added a regression test that a single hook registration preserves `inspect.signature(model.forward)`.
2. Added a regression test that `torch.export.export` still accepts keyword inputs after hook registration.
3. Added regression tests for repeated instrumentation: after registering two hooks, `inspect.signature(model.forward)` still equals the original, and `torch.export.export` still binds keyword inputs. This covers the case where a second `register_hook` could otherwise capture the wrapper signature instead of the model signature.
4. Ran the relevant hooks suite:

```bash
DIFFUSERS_TEST_DEVICE=cpu python -m pytest -q tests/hooks/test_hooks.py
```

5. Ran targeted ruff and format checks on the changed files.

Fixes #14135.
