### PR TITLE
[LTX2] Fix from_single_file: missing 2.3 key mappings and shared checkpoint dict draining

### DIFF
--- a/src/diffusers/loaders/single_file_utils.py
+++ b/src/diffusers/loaders/single_file_utils.py
@@ -4048,6 +4048,18 @@ def convert_ltx2_transformer_to_diffusers(checkpoint, **kwargs):
         if ".weight" not in key and ".bias" not in key:
             return
 
+        if key.startswith("prompt_adaln_single."):
+            new_key = key.replace("prompt_adaln_single.", "prompt_adaln.")
+            param = state_dict.pop(key)
+            state_dict[new_key] = param
+            return
+
+        if key.startswith("audio_prompt_adaln_single."):
+            new_key = key.replace("audio_prompt_adaln_single.", "audio_prompt_adaln.")
+            param = state_dict.pop(key)
+            state_dict[new_key] = param
+            return
+
         if key.startswith("adaln_single."):
             new_key = key.replace("adaln_single.", "time_embed.")
             param = state_dict.pop(key)
@@ -4066,7 +4078,7 @@ def convert_ltx2_transformer_to_diffusers(checkpoint, **kwargs):
         "adaln_single": convert_ltx2_transformer_adaln_single,
     }
 
-    converted_state_dict = {key: checkpoint.pop(key) for key in list(checkpoint.keys())}
+    converted_state_dict = {key: checkpoint.pop(key) for key in list(checkpoint.keys()) if key.startswith("model.diffusion_model.")}
 
     # Handle official code --> diffusers key remapping via the remap dict
     for key in list(converted_state_dict.keys()):
@@ -4109,6 +4121,8 @@ def convert_ltx2_vae_to_diffusers(checkpoint, **kwargs):
         "up_blocks.4": "up_blocks.1",
         "up_blocks.5": "up_blocks.2.upsamplers.0",
         "up_blocks.6": "up_blocks.2",
+        "up_blocks.7": "up_blocks.3.upsamplers.0",
+        "up_blocks.8": "up_blocks.3",
         # Common
         # For all 3D ResNets
         "res_blocks": "resnets",
@@ -4127,7 +4141,7 @@ def convert_ltx2_vae_to_diffusers(checkpoint, **kwargs):
         "per_channel_statistics.mean-of-stds": remove_keys_inplace,
     }
 
-    converted_state_dict = {key: checkpoint.pop(key) for key in list(checkpoint.keys())}
+    converted_state_dict = {key: checkpoint.pop(key) for key in list(checkpoint.keys()) if key.startswith("vae.")}
 
     # Handle official code --> diffusers key remapping via the remap dict
     for key in list(converted_state_dict.keys()):
@@ -4159,7 +4173,7 @@ def convert_ltx2_audio_vae_to_diffusers(checkpoint, **kwargs):
     def update_state_dict_inplace(state_dict, old_key: str, new_key: str) -> None:
         state_dict[new_key] = state_dict.pop(old_key)
 
-    converted_state_dict = {key: checkpoint.pop(key) for key in list(checkpoint.keys())}
+    converted_state_dict = {key: checkpoint.pop(key) for key in list(checkpoint.keys()) if key.startswith("audio_vae.")}
 
     # Handle official code --> diffusers key remapping via the remap dict
     for key in list(converted_state_dict.keys()):


### PR DESCRIPTION
## What does this PR do?

Fixes #14145.

Two bugs in LTX2 single_file loading:

1. LTX 2.3 checkpoints have prompt_adaln_single and audio_prompt_adaln_single keys that were missing from the key remapping. Added handlers with early returns (more specific than the existing adaln_single handlers). Also added up_blocks.7 and up_blocks.8 entries to the VAE rename dict.

2. All three converters were popping ALL keys from the shared checkpoint dict instead of filtering by their component prefix. Fixed by scoping to model.diffusion_model., vae., and audio_vae. prefixes respectively.

## Before submitting
- [x] Read the contributor guideline
- [x] Discussed via GitHub issue
- [ ] This PR adds a new model/pipeline — No
- [ ] New tests — No, this is a targeted bug fix
- [ ] Documentation — No changes needed

## AI agent disclosure
- [x] Did you use an AI agent? Yes (code review and verification)
- [x] Did you read the Coding with AI agents guide? Yes
- [x] Did you self-review against .ai/review-rules.md? Yes

## Who can review?
Anyone in the community.