### PR TITLE
[Windows] Fix subfolder config.json silently skipped during download

### DIFF
--- a/src/diffusers/pipelines/pipeline_flax_utils.py
+++ b/src/diffusers/pipelines/pipeline_flax_utils.py
@@ -336,7 +336,7 @@ class FlaxDiffusionPipeline(ConfigMixin, PushToHubMixin):
             )
             # make sure we only download sub-folders and `diffusers` filenames
             folder_names = [k for k in config_dict.keys() if not k.startswith("_")]
-            allow_patterns = [os.path.join(k, "*") for k in folder_names]
+            allow_patterns = [f"{k}/*" for k in folder_names]
             allow_patterns += [FLAX_WEIGHTS_NAME, SCHEDULER_CONFIG_NAME, CONFIG_NAME, cls.config_name]
 
             ignore_patterns = ["*.bin", "*.safetensors"] if not from_pt else []

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1738,7 +1738,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             # add custom pipeline file
             allow_patterns += [f"{custom_pipeline}.py"] if f"{custom_pipeline}.py" in filenames else []
             # also allow downloading config.json files with the model
-            allow_patterns += [os.path.join(k, "config.json") for k in model_folder_names]
+            allow_patterns += [f"{k}/config.json" for k in model_folder_names]
             allow_patterns += [
                 SCHEDULER_CONFIG_NAME,
                 CONFIG_NAME,


### PR DESCRIPTION
## What does this PR do?

Fixes #14142.

os.path.join produces backslash paths on Windows, but fnmatch patterns expect forward slashes. This causes subfolder config.json files to be silently excluded from download.

Fixed in both Diffus\ionPipeline.download() and FlaxDiffusionPipeline.download().

## Before submitting
- [x] Read the contributor guideline
- [x] Discussed via GitHub issue
- [ ] This PR adds a new model/pipeline — No
- [ ] New tests — No, this is a targeted bug fix
- [ ] Documentation — No changes needed

## AI agent disclosure
- [x] Did you use an AI agent? Yes (code review and verification)
- [x] Did you read the Coding with AI agents guide? Yes
- [x] Did you self-review against .ai/review-rules.md? Yes

## Who can review?
Anyone in the community.