### PR TITLE
Add validation for non-positive num_inference_steps in DDPMScheduler

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddpm.py
+++ b/src/diffusers/schedulers/scheduling_ddpm.py
@@ -308,6 +308,8 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
             timesteps = np.array(timesteps, dtype=np.int64)
             self.custom_timesteps = True
         else:
+            if num_inference_steps <= 0:
+                raise ValueError(f"`num_inference_steps`: {num_inference_steps} must be a positive integer.")
             if num_inference_steps > self.config.num_train_timesteps:
                 raise ValueError(
                     f"`num_inference_steps`: {num_inference_steps} cannot be larger than `self.config.train_timesteps`:"


### PR DESCRIPTION
## What

`DDPMScheduler.set_timesteps(0)` (or any negative value) silently produced a zero-length timestep tensor. Downstream, this caused a `ZeroDivisionError` or produced NaN values in the step loop, with no useful error message pointing to the scheduler.

`DDIMScheduler` already guards against this with an explicit `ValueError`. This PR adds the same check to `DDPMScheduler`.

## Changes

`src/diffusers/schedulers/scheduling_ddpm.py` — add a two-line guard in the `else` branch of `set_timesteps`, before the existing `num_train_timesteps` upper-bound check:

```python
if num_inference_steps <= 0:
    raise ValueError(f"`num_inference_steps`: {num_inference_steps} must be a positive integer.")
```

Closes #13394.