### PR TITLE
fix wan i2v num_videos batching, vace latent trim, config scale factors, processor config, modular dtype

### DIFF
--- a/src/diffusers/modular_pipelines/wan/before_denoise.py
+++ b/src/diffusers/modular_pipelines/wan/before_denoise.py
@@ -252,7 +252,7 @@ class WanTextInputStep(ModularPipelineBlocks):
         self.check_inputs(components, block_state)
 
         block_state.batch_size = block_state.prompt_embeds.shape[0]
-        block_state.dtype = block_state.prompt_embeds.dtype
+        block_state.dtype = components.transformer.dtype
 
         _, seq_len, _ = block_state.prompt_embeds.shape
         block_state.prompt_embeds = block_state.prompt_embeds.repeat(1, block_state.num_videos_per_prompt, 1)

--- a/src/diffusers/modular_pipelines/wan/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/wan/modular_pipeline.py
@@ -70,14 +70,14 @@ class WanModularPipeline(
     def vae_scale_factor_spatial(self):
         vae_scale_factor = 8
         if hasattr(self, "vae") and self.vae is not None:
-            vae_scale_factor = 2 ** len(self.vae.temperal_downsample)
+            vae_scale_factor = self.vae.config.scale_factor_spatial
         return vae_scale_factor
 
     @property
     def vae_scale_factor_temporal(self):
         vae_scale_factor = 4
         if hasattr(self, "vae") and self.vae is not None:
-            vae_scale_factor = 2 ** sum(self.vae.temperal_downsample)
+            vae_scale_factor = self.vae.config.scale_factor_temporal
         return vae_scale_factor
 
     @property

--- a/src/diffusers/pipelines/wan/image_processor.py
+++ b/src/diffusers/pipelines/wan/image_processor.py
@@ -68,7 +68,17 @@ class WanAnimateImageProcessor(VaeImageProcessor):
         do_convert_grayscale: bool = False,
         fill_color: str | float | tuple[float, ...] | None = 0,
     ):
-        super().__init__()
+        super().__init__(
+            do_resize=do_resize,
+            vae_scale_factor=vae_scale_factor,
+            vae_latent_channels=vae_latent_channels,
+            resample=resample,
+            reducing_gap=reducing_gap,
+            do_normalize=do_normalize,
+            do_binarize=do_binarize,
+            do_convert_rgb=do_convert_rgb,
+            do_convert_grayscale=do_convert_grayscale,
+        )
         if do_convert_rgb and do_convert_grayscale:
             raise ValueError(
                 "`do_convert_rgb` and `do_convert_grayscale` can not both be set to `True`,"

--- a/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
@@ -698,7 +698,7 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                     image_embeds = self.encode_image(image, device)
                 else:
                     image_embeds = self.encode_image([image, last_image], device)
-            image_embeds = image_embeds.repeat(batch_size, 1, 1)
+            image_embeds = image_embeds.repeat(batch_size * num_videos_per_prompt, 1, 1)
             image_embeds = image_embeds.to(transformer_dtype)
 
         # 4. Prepare timesteps

--- a/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
@@ -698,7 +698,10 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                     image_embeds = self.encode_image(image, device)
                 else:
                     image_embeds = self.encode_image([image, last_image], device)
-            image_embeds = image_embeds.repeat(batch_size * num_videos_per_prompt, 1, 1)
+            if last_image is None:
+                image_embeds = image_embeds.repeat(batch_size * num_videos_per_prompt, 1, 1)
+            else:
+                image_embeds = image_embeds.repeat(batch_size, 1, 1)
             image_embeds = image_embeds.to(transformer_dtype)
 
         # 4. Prepare timesteps

--- a/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
@@ -351,8 +351,10 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             raise ValueError(
                 "Provide either `image` or `prompt_embeds`. Cannot leave both `image` and `image_embeds` undefined."
             )
-        if image is not None and not isinstance(image, torch.Tensor) and not isinstance(image, PIL.Image.Image):
-            raise ValueError(f"`image` has to be of type `torch.Tensor` or `PIL.Image.Image` but is {type(image)}")
+        if image is not None and not isinstance(image, (torch.Tensor, PIL.Image.Image, list, tuple)):
+            raise ValueError(
+                f"`image` has to be of type `torch.Tensor`, `PIL.Image.Image`, or a list of them but is {type(image)}"
+            )
         if height % 16 != 0 or width % 16 != 0:
             raise ValueError(f"`height` and `width` have to be divisible by 16 but are {height} and {width}.")
 
@@ -453,7 +455,7 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             latent_condition = torch.cat(latent_condition)
         else:
             latent_condition = retrieve_latents(self.vae.encode(video_condition), sample_mode="argmax")
-            latent_condition = latent_condition.repeat(batch_size, 1, 1, 1, 1)
+            latent_condition = latent_condition.repeat_interleave(batch_size // latent_condition.shape[0], dim=0)
 
         latent_condition = latent_condition.to(dtype)
         latent_condition = (latent_condition - latents_mean) * latents_std
@@ -699,7 +701,9 @@ class WanImageToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
                 else:
                     image_embeds = self.encode_image([image, last_image], device)
             if last_image is None:
-                image_embeds = image_embeds.repeat(batch_size * num_videos_per_prompt, 1, 1)
+                image_embeds = image_embeds.repeat_interleave(
+                    batch_size * num_videos_per_prompt // image_embeds.shape[0], dim=0
+                )
             else:
                 image_embeds = image_embeds.repeat(batch_size, 1, 1)
             image_embeds = image_embeds.to(transformer_dtype)

--- a/src/diffusers/pipelines/wan/pipeline_wan_vace.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_vace.py
@@ -196,8 +196,8 @@ class WanVACEPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             scheduler=scheduler,
         )
         self.register_to_config(boundary_ratio=boundary_ratio)
-        self.vae_scale_factor_temporal = 2 ** sum(self.vae.temperal_downsample) if getattr(self, "vae", None) else 4
-        self.vae_scale_factor_spatial = 2 ** len(self.vae.temperal_downsample) if getattr(self, "vae", None) else 8
+        self.vae_scale_factor_temporal = self.vae.config.scale_factor_temporal if getattr(self, "vae", None) else 4
+        self.vae_scale_factor_spatial = self.vae.config.scale_factor_spatial if getattr(self, "vae", None) else 8
         self.video_processor = VideoProcessor(vae_scale_factor=self.vae_scale_factor_spatial)
 
     # Copied from diffusers.pipelines.wan.pipeline_wan.WanPipeline._get_t5_prompt_embeds
@@ -1020,8 +1020,8 @@ class WanVACEPipeline(DiffusionPipeline, WanLoraLoaderMixin):
 
         self._current_timestep = None
 
+        latents = latents[:, :, num_reference_images:]
         if not output_type == "latent":
-            latents = latents[:, :, num_reference_images:]
             latents = latents.to(vae_dtype)
             latents_mean = (
                 torch.tensor(self.vae.config.latents_mean)

--- a/src/diffusers/pipelines/wan/pipeline_wan_video2video.py
+++ b/src/diffusers/pipelines/wan/pipeline_wan_video2video.py
@@ -214,8 +214,8 @@ class WanVideoToVideoPipeline(DiffusionPipeline, WanLoraLoaderMixin):
             scheduler=scheduler,
         )
 
-        self.vae_scale_factor_temporal = 2 ** sum(self.vae.temperal_downsample) if getattr(self, "vae", None) else 4
-        self.vae_scale_factor_spatial = 2 ** len(self.vae.temperal_downsample) if getattr(self, "vae", None) else 8
+        self.vae_scale_factor_temporal = self.vae.config.scale_factor_temporal if getattr(self, "vae", None) else 4
+        self.vae_scale_factor_spatial = self.vae.config.scale_factor_spatial if getattr(self, "vae", None) else 8
         self.video_processor = VideoProcessor(vae_scale_factor=self.vae_scale_factor_spatial)
 
     # Copied from diffusers.pipelines.wan.pipeline_wan.WanPipeline._get_t5_prompt_embeds


### PR DESCRIPTION
# What does this PR do?

Part of #13578 (wan review). Same families of issues as the qwenimage review:

- `WanImageToVideoPipeline` conditioning batching: `image_embeds` was repeated by `batch_size` only (not `num_videos_per_prompt`) while the latents reach `batch_size * num_videos_per_prompt`, so `num_videos_per_prompt > 1` failed the transformer concat; and list image inputs (a documented `PipelineImageInput` type) were rejected in `check_inputs`. Now `check_inputs` accepts lists, and both `image_embeds` and the conditioning latents expand from a single image or a per-prompt list up to the effective batch. The first+last-frame path keeps its two-frame layout.
- `WanVACEPipeline(output_type="latent")`: the decode path trims the prepended reference latents but the latent path returned them untrimmed, so latent output carried extra frames. The trim now runs before the branch.
- `WanVACEPipeline`, `WanVideoToVideoPipeline`, and the modular Wan pipeline derived scale factors from `len(vae.temperal_downsample)` and a hardcoded spatial `8` instead of `vae.config.scale_factor_spatial` / `scale_factor_temporal`. Now read from config, matching the base `WanPipeline`.
- `WanAnimateImageProcessor.__init__` accepted `vae_scale_factor` / `vae_latent_channels` / `resample` etc. but called `super().__init__()` with no args, so the base re-registered defaults over the subclass config. Now forwards them.
- Modular `WanTextInputStep` derived `block_state.dtype` from `prompt_embeds.dtype`; the denoise blocks cast scheduler timesteps to it, losing precision on bf16/fp16 paths. Now uses `transformer.dtype`, matching the comment.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Discussed on Slack with @yiyixuxu
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@yiyixuxu
