### PR TITLE
[DtoH sync] set scheduler begin index in SD3 T2I

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
+++ b/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
@@ -1058,6 +1058,12 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
                 self._joint_attention_kwargs.update(ip_adapter_image_embeds=ip_adapter_image_embeds)
 
         # 7. Denoising loop
+
+        # We set the index here to remove DtoH sync, helpful especially during compilation.
+        # Check out more details here: https://github.com/huggingface/diffusers/pull/11696
+        if hasattr(self.scheduler, "set_begin_index"):
+            self.scheduler.set_begin_index(0)
+
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 if self.interrupt:


### PR DESCRIPTION
## Description

Sets the scheduler's begin index to 0 before the denoising loop in SD3 T2I, eliminating the implicit GPU→CPU synchronization point from `index_for_timestep.item()`. This enables full `torch.compile` graph capture.

Follows the established pattern from PR #11696 (already deployed in Flux, Flux2, Wan, Z-Image, OVIS-Image, and SDXL).

## Changes
- `src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py`: Added canonical `set_begin_index(0)` block with `hasattr` guard before the denoising loop.

## Verification
- [ ] Fast tests pass: `pytest tests/pipelines/stable_diffusion_3/ -x -v`
- [ ] `make style && make fix-copies && make quality` clean

This is commit 1 of 6 per the Phase 1 plan.