### PR TITLE
Fix Qwen Image edit pipelines to forward multimodal token type IDs

### DIFF
--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit.py
@@ -245,12 +245,20 @@ class QwenImageEditPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
             return_tensors="pt",
         ).to(device)
 
+        text_encoder_kwargs = {}
+        if (
+            "mm_token_type_ids" in model_inputs
+            and "mm_token_type_ids" in inspect.signature(self.text_encoder.forward).parameters
+        ):
+            text_encoder_kwargs["mm_token_type_ids"] = model_inputs["mm_token_type_ids"]
+
         outputs = self.text_encoder(
             input_ids=model_inputs["input_ids"],
             attention_mask=model_inputs["attention_mask"],
             pixel_values=model_inputs.get("pixel_values"),
             image_grid_thw=model_inputs.get("image_grid_thw"),
             output_hidden_states=True,
+            **text_encoder_kwargs,
         )
 
         hidden_states = outputs.hidden_states[-1]

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_inpaint.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_inpaint.py
@@ -256,12 +256,20 @@ class QwenImageEditInpaintPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
             return_tensors="pt",
         ).to(device)
 
+        text_encoder_kwargs = {}
+        if (
+            "mm_token_type_ids" in model_inputs
+            and "mm_token_type_ids" in inspect.signature(self.text_encoder.forward).parameters
+        ):
+            text_encoder_kwargs["mm_token_type_ids"] = model_inputs["mm_token_type_ids"]
+
         outputs = self.text_encoder(
             input_ids=model_inputs["input_ids"],
             attention_mask=model_inputs["attention_mask"],
             pixel_values=model_inputs.get("pixel_values"),
             image_grid_thw=model_inputs.get("image_grid_thw"),
             output_hidden_states=True,
+            **text_encoder_kwargs,
         )
 
         hidden_states = outputs.hidden_states[-1]

--- a/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_plus.py
+++ b/src/diffusers/pipelines/qwenimage/pipeline_qwenimage_edit_plus.py
@@ -258,12 +258,20 @@ class QwenImageEditPlusPipeline(DiffusionPipeline, QwenImageLoraLoaderMixin):
             return_tensors="pt",
         ).to(device)
 
+        text_encoder_kwargs = {}
+        if (
+            "mm_token_type_ids" in model_inputs
+            and "mm_token_type_ids" in inspect.signature(self.text_encoder.forward).parameters
+        ):
+            text_encoder_kwargs["mm_token_type_ids"] = model_inputs["mm_token_type_ids"]
+
         outputs = self.text_encoder(
             input_ids=model_inputs["input_ids"],
             attention_mask=model_inputs["attention_mask"],
             pixel_values=model_inputs.get("pixel_values"),
             image_grid_thw=model_inputs.get("image_grid_thw"),
             output_hidden_states=True,
+            **text_encoder_kwargs,
         )
 
         hidden_states = outputs.hidden_states[-1]

--- a/tests/pipelines/qwenimage/test_qwenimage_edit_plus.py
+++ b/tests/pipelines/qwenimage/test_qwenimage_edit_plus.py
@@ -171,6 +171,65 @@ class QwenImageEditPlusPipelineFastTests(PipelineTesterMixin, unittest.TestCase)
         generated_slice = torch.cat([generated_slice[:8], generated_slice[-8:]])
         self.assertTrue(torch.allclose(generated_slice, expected_slice, atol=1e-3))
 
+    def test_mm_token_type_ids_forwarding_is_backward_compatible(self):
+        components = self.get_dummy_components()
+        pipe = self.pipeline_class(**components)
+        pipe.to("cpu")
+
+        image = Image.new("RGB", (32, 32))
+        original_processor = pipe.processor
+
+        class ProcessorWithMMTokenTypeIds:
+            def __call__(self, *args, **kwargs):
+                model_inputs = original_processor(*args, **kwargs)
+                model_inputs["mm_token_type_ids"] = torch.zeros_like(model_inputs["input_ids"])
+                return model_inputs
+
+        pipe.processor = ProcessorWithMMTokenTypeIds()
+        original_forward = pipe.text_encoder.forward
+        received_mm_token_type_ids = []
+
+        def current_forward(
+            input_ids,
+            attention_mask,
+            pixel_values,
+            image_grid_thw,
+            output_hidden_states,
+            mm_token_type_ids=None,
+        ):
+            received_mm_token_type_ids.append(mm_token_type_ids)
+            return original_forward(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+                output_hidden_states=output_hidden_states,
+                mm_token_type_ids=mm_token_type_ids,
+            )
+
+        pipe.text_encoder.forward = current_forward
+        pipe.encode_prompt(prompt="dance monkey", image=[image, image], device="cpu")
+
+        self.assertEqual(len(received_mm_token_type_ids), 1)
+        self.assertIsNotNone(received_mm_token_type_ids[0])
+
+        legacy_forward_called = []
+
+        def legacy_forward(input_ids, attention_mask, pixel_values, image_grid_thw, output_hidden_states):
+            legacy_forward_called.append(True)
+            return original_forward(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+                output_hidden_states=output_hidden_states,
+            )
+
+        pipe.text_encoder.forward = legacy_forward
+        pipe.encode_prompt(prompt="dance monkey", image=[image, image], device="cpu")
+
+        self.assertEqual(legacy_forward_called, [True])
+
     def test_attention_slicing_forward_pass(
         self, test_max_difference=True, test_mean_pixel_difference=True, expected_max_diff=1e-3
     ):


### PR DESCRIPTION
Fixes #14194

## What does this PR do?

  This PR forwards `mm_token_type_ids` from the processor to the Qwen2.5-VL text encoder in the following pipelines:

  - `QwenImageEditPipeline`
  - `QwenImageEditPlusPipeline`
  - `QwenImageEditInpaintPipeline`

  The argument is forwarded only when:

  1. The processor returns `mm_token_type_ids`.
  2. The text encoder explicitly supports it in its `forward` signature.

  This keeps the change backward compatible with older Transformers versions and processors.

  ## Why is this needed?

  Recent Transformers versions moved multimodal token classification into the processor. The processor now returns `mm_token_type_ids`, where text, image, and video tokens are identified explicitly.

  Qwen2.5-VL uses these token type IDs to compute multimodal 3D RoPE position IDs. However, the Qwen Image edit pipelines currently select processor outputs manually and do not forward `mm_token_type_ids` to the
  text encoder.

  As a result, the text encoder cannot compute the correct multimodal position IDs. This does not raise an exception because `position_ids=None` is a valid fallback for the language model. Instead, inference
  silently falls back to regular position inference, which changes prompt embeddings and generated images.

  Older Transformers versions did not require this argument because Qwen2.5-VL inferred multimodal positions directly from special image and video tokens in `input_ids`.

## Backward compatibility

  The new argument is not passed unconditionally.

  ```python
  text_encoder_kwargs = {}
  if (
      "mm_token_type_ids" in model_inputs
      and "mm_token_type_ids" in inspect.signature(self.text_encoder.forward).parameters
  ):
      text_encoder_kwargs["mm_token_type_ids"] = model_inputs["mm_token_type_ids"]
```
  Therefore:

  - Older processors that do not return mm_token_type_ids retain the existing behavior.
  - Older text encoders that do not accept the argument retain the existing call signature.
  - Current processor and text encoder combinations receive the multimodal token types required for 3D RoPE.

  ## Validation

  The issue was traced through the Qwen2.5-VL encoding path:

  - Token IDs, attention masks, pixel values, token embeddings, and all vision encoder outputs were identical across the tested Transformers versions.
  - The first numerical difference appeared in decoder layer 0 attention.
  - Forwarding mm_token_type_ids restored identical multimodal position IDs.
  - All 28 language model hidden states and both positive and negative prompt embeddings became element-wise identical to the previous correct path.
  - Full denoising inference also produced pixel-identical final output.

  Tests added in this PR verify that:

  - mm_token_type_ids is forwarded when both the processor output and text encoder support it.
  - The argument is omitted for a legacy-style text encoder signature.

  Existing CPU inference tests were also run with an older processor that does not emit mm_token_type_ids, and their expected outputs remained unchanged.

  ## Tests
  ```bash
  pytest -q tests/pipelines/qwenimage/test_qwenimage_edit_plus.py::QwenImageEditPlusPipelineFastTests::test_mm_token_type_ids_forwarding_is_backward_compatible

  pytest -q \
    tests/pipelines/qwenimage/test_qwenimage_edit.py::QwenImageEditPipelineFastTests::test_inference \
    tests/pipelines/qwenimage/test_qwenimage_edit_plus.py::QwenImageEditPlusPipelineFastTests::test_inference

  ruff check <modified files>
  ruff format --check <modified files>
  python utils/check_copies.py
  ```
  All targeted tests and checks pass.