### PR TITLE
docs: improve docstring scheduling_unclip.py

### DIFF
--- a/src/diffusers/schedulers/scheduling_unclip.py
+++ b/src/diffusers/schedulers/scheduling_unclip.py
@@ -112,30 +112,32 @@ class UnCLIPScheduler(SchedulerMixin, ConfigMixin):
     See [`~DDPMScheduler`] for more information on DDPM scheduling
 
     Args:
-        num_train_timesteps (`int`): number of diffusion steps used to train the model.
-        variance_type (`str`):
-            options to clip the variance used when adding noise to the denoised sample. Choose from `fixed_small_log`
-            or `learned_range`.
-        clip_sample (`bool`, default `True`):
-            option to clip predicted sample between `-clip_sample_range` and `clip_sample_range` for numerical
+        num_train_timesteps (`int`, defaults to `1000`):
+            The number of diffusion steps used to train the model.
+        variance_type (`"fixed_small_log"` or `"learned_range"`, defaults to `"fixed_small_log"`):
+            The variance type used when adding noise to the denoised sample.
+        clip_sample (`bool`, defaults to `True`):
+            Whether to clip the predicted sample between `-clip_sample_range` and `clip_sample_range` for numerical
             stability.
-        clip_sample_range (`float`, default `1.0`):
+        clip_sample_range (`float`, defaults to `1.0`):
             The range to clip the sample between. See `clip_sample`.
-        prediction_type (`str`, default `epsilon`, optional):
-            prediction type of the scheduler function, one of `epsilon` (predicting the noise of the diffusion process)
-            or `sample` (directly predicting the noisy sample`)
+        prediction_type (`"epsilon"` or `"sample"`, defaults to `"epsilon"`):
+            The prediction type of the scheduler function. Choose `epsilon` to predict the noise of the diffusion
+            process or `sample` to directly predict the noisy sample.
+        beta_schedule (`"squaredcos_cap_v2"`, defaults to `"squaredcos_cap_v2"`):
+            The beta schedule used to generate the beta values. Only `squaredcos_cap_v2` is supported.
     """
 
     @register_to_config
     def __init__(
         self,
         num_train_timesteps: int = 1000,
-        variance_type: str = "fixed_small_log",
+        variance_type: Literal["fixed_small_log", "learned_range"] = "fixed_small_log",
         clip_sample: bool = True,
         clip_sample_range: float = 1.0,
-        prediction_type: str = "epsilon",
-        beta_schedule: str = "squaredcos_cap_v2",
-    ):
+        prediction_type: Literal["epsilon", "sample"] = "epsilon",
+        beta_schedule: Literal["squaredcos_cap_v2"] = "squaredcos_cap_v2",
+    ) -> None:
         if beta_schedule != "squaredcos_cap_v2":
             raise ValueError("UnCLIPScheduler only supports `beta_schedule`: 'squaredcos_cap_v2'")
 
@@ -160,15 +162,18 @@ class UnCLIPScheduler(SchedulerMixin, ConfigMixin):
         current timestep.
 
         Args:
-            sample (`torch.Tensor`): input sample
-            timestep (`int`, optional): current timestep
+            sample (`torch.Tensor`):
+                The input sample.
+            timestep (`int`, *optional*):
+                The current timestep in the diffusion chain.
 
         Returns:
-            `torch.Tensor`: scaled input sample
+            `torch.Tensor`:
+                A scaled input sample.
         """
         return sample
 
-    def set_timesteps(self, num_inference_steps: int, device: str | torch.device = None):
+    def set_timesteps(self, num_inference_steps: int, device: str | torch.device | None = None) -> None:
         """
         Sets the discrete timesteps used for the diffusion chain. Supporting function to be run before inference.
 
@@ -178,14 +183,22 @@ class UnCLIPScheduler(SchedulerMixin, ConfigMixin):
 
         Args:
             num_inference_steps (`int`):
-                the number of diffusion steps used when generating samples with a pre-trained model.
+                The number of diffusion steps used when generating samples with a pre-trained model.
+            device (`str` or `torch.device`, *optional*):
+                The device to which the timesteps are moved. If `None`, the timesteps are not moved.
         """
         self.num_inference_steps = num_inference_steps
         step_ratio = (self.config.num_train_timesteps - 1) / (self.num_inference_steps - 1)
         timesteps = (np.arange(0, num_inference_steps) * step_ratio).round()[::-1].copy().astype(np.int64)
         self.timesteps = torch.from_numpy(timesteps).to(device)
 
-    def _get_variance(self, t, prev_timestep=None, predicted_variance=None, variance_type=None):
+    def _get_variance(
+        self,
+        t: int,
+        prev_timestep: int | None = None,
+        predicted_variance: torch.Tensor | None = None,
+        variance_type: Literal["fixed_small_log", "learned_range"] | None = None,
+    ) -> torch.Tensor:
         if prev_timestep is None:
             prev_timestep = t - 1
 
@@ -227,7 +240,7 @@ class UnCLIPScheduler(SchedulerMixin, ConfigMixin):
         timestep: int,
         sample: torch.Tensor,
         prev_timestep: int | None = None,
-        generator=None,
+        generator: torch.Generator | None = None,
         return_dict: bool = True,
     ) -> UnCLIPSchedulerOutput | tuple:
         """
@@ -235,20 +248,24 @@ class UnCLIPScheduler(SchedulerMixin, ConfigMixin):
         process from the learned model outputs (most often the predicted noise).
 
         Args:
-            model_output (`torch.Tensor`): direct output from learned diffusion model.
-            timestep (`int`): current discrete timestep in the diffusion chain.
+            model_output (`torch.Tensor`):
+                The direct output from the learned diffusion model.
+            timestep (`int`):
+                The current discrete timestep in the diffusion chain.
             sample (`torch.Tensor`):
-                current instance of sample being created by diffusion process.
-            prev_timestep (`int`, *optional*): The previous timestep to predict the previous sample at.
-                Used to dynamically compute beta. If not given, `t-1` is used and the pre-computed beta is used.
-            generator: random number generator.
-            return_dict (`bool`): option for returning tuple rather than UnCLIPSchedulerOutput class
+                A current instance of a sample created by the diffusion process.
+            prev_timestep (`int`, *optional*):
+                The previous timestep for which to predict the previous sample. It is used to dynamically compute beta.
+                If `None`, `t-1` and the precomputed beta are used.
+            generator (`torch.Generator`, *optional*):
+                A random number generator.
+            return_dict (`bool`, defaults to `True`):
+                Whether to return an [`~schedulers.scheduling_unclip.UnCLIPSchedulerOutput`] or a `tuple`.
 
         Returns:
-            [`~schedulers.scheduling_utils.UnCLIPSchedulerOutput`] or `tuple`:
-            [`~schedulers.scheduling_utils.UnCLIPSchedulerOutput`] if `return_dict` is True, otherwise a `tuple`. When
-            returning a tuple, the first element is the sample tensor.
-
+            [`~schedulers.scheduling_unclip.UnCLIPSchedulerOutput`] or `tuple`:
+                If `return_dict` is `True`, an [`~schedulers.scheduling_unclip.UnCLIPSchedulerOutput`] is returned;
+                otherwise, a tuple is returned where the first element is the sample tensor.
         """
         t = timestep
 


### PR DESCRIPTION
# What does this PR do?

This PR improves the docstrings and type hints in `src/diffusers/schedulers/scheduling_unclip.py` to follow the project conventions as described in #9567.
Fixes #9567 

## Context

This is part of a broader effort to improve documentation across all scheduler files in `src/diffusers/schedulers/`. See issue #9567 for details.

## Testing
- [x] Code passes `make style`
- [x] Code passes `make quality`
- [x] Code passes  `make fix-copies`
- [x] Existing tests still pass

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? [issue](https://github.com/huggingface/diffusers/issues/9567).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? (N/A - documentation only changes)

## Who can review?

cc @stevhliu for review