### PR TITLE
[LDM3D] Fix rgblike_to_depthmap truncating 16-bit depth back to 8 bits

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -1048,28 +1048,28 @@ class VaeImageProcessorLDM3D(VaeImageProcessor):
         #    for return value from a library function.
 
         if isinstance(image, torch.Tensor):
-            # Cast to a safe dtype (e.g., int32 or int64) for the calculation
-            original_dtype = image.dtype
+            # Cast to a wider integer type so the 16-bit combination does not
+            # overflow the 8-bit input dtype.
             image_safe = image.to(torch.int32)
 
-            # Calculate the depth map
+            # Calculate the 16-bit depth map: high-byte * 256 + low-byte.
             depth_map = image_safe[:, :, 1] * 256 + image_safe[:, :, 2]
 
-            # You may want to cast the final result to uint16, but casting to a
-            # larger int type (like int32) is sufficient to fix the overflow.
-            # depth_map = depth_map.to(torch.uint16) # Uncomment if uint16 is strictly required
-            return depth_map.to(original_dtype)
+            # The result is 16-bit and must not be truncated back to the 8-bit
+            # input dtype; keep the wider integer type.
+            return depth_map
 
         elif isinstance(image, np.ndarray):
-            # NumPy equivalent: Cast to a safe dtype (e.g., np.int32)
-            original_dtype = image.dtype
+            # NumPy equivalent: cast to a wider dtype to avoid overflow.
             image_safe = image.astype(np.int32)
 
-            # Calculate the depth map
+            # Calculate the 16-bit depth map: high-byte * 256 + low-byte.
             depth_map = image_safe[:, :, 1] * 256 + image_safe[:, :, 2]
 
-            # depth_map = depth_map.astype(np.uint16) # Uncomment if uint16 is strictly required
-            return depth_map.astype(original_dtype)
+            # Return a 16-bit-wide array as the ``mode="I;16"`` consumer in
+            # ``numpy_to_depth`` requires; truncating to the 8-bit input dtype
+            # would drop the high byte and break that consumer.
+            return depth_map.astype(np.uint16)
         else:
             raise TypeError("Input image must be a torch.Tensor or np.ndarray")
 

--- a/tests/others/test_image_processor.py
+++ b/tests/others/test_image_processor.py
@@ -19,7 +19,7 @@ import numpy as np
 import PIL.Image
 import torch
 
-from diffusers.image_processor import VaeImageProcessor
+from diffusers.image_processor import VaeImageProcessor, VaeImageProcessorLDM3D
 
 
 class ImageProcessorTest(unittest.TestCase):
@@ -308,3 +308,37 @@ class ImageProcessorTest(unittest.TestCase):
         assert out_np.shape == exp_np_shape, (
             f"resized image output shape '{out_np.shape}' didn't match expected shape '{exp_np_shape}'."
         )
+
+
+class Ldm3dImageProcessorTest(unittest.TestCase):
+    def test_rgblike_to_depthmap_combines_two_bytes_into_16bit(self):
+        # green * 256 + blue must be a 16-bit value; casting the result back to
+        # the 8-bit input dtype drops the high byte (e.g. 1480 -> 200).
+        processor = VaeImageProcessorLDM3D()
+
+        rgb_np = np.zeros((2, 2, 3), dtype=np.uint8)
+        rgb_np[..., 1] = 5  # green (high byte)
+        rgb_np[..., 2] = 200  # blue (low byte)
+        depth_np = processor.rgblike_to_depthmap(rgb_np)
+        assert depth_np.dtype == np.uint16
+        assert int(depth_np.max()) == 5 * 256 + 200
+
+        rgb_pt = torch.zeros(2, 2, 3, dtype=torch.uint8)
+        rgb_pt[..., 1] = 5
+        rgb_pt[..., 2] = 200
+        depth_pt = processor.rgblike_to_depthmap(rgb_pt)
+        assert int(depth_pt.max()) == 5 * 256 + 200
+
+    def test_postprocess_pil_depth_does_not_crash(self):
+        # numpy_to_depth feeds rgblike_to_depthmap into Image.fromarray(mode="I;16"),
+        # which requires 16-bit-wide data; an 8-bit result raised
+        # "ValueError: buffer is not large enough".
+        processor = VaeImageProcessorLDM3D()
+        image = torch.zeros(1, 6, 4, 4)
+        image[:, 4] = 5 / 255.0
+        image[:, 5] = 200 / 255.0
+
+        rgb, depth = processor.postprocess(image, output_type="pil")
+
+        assert len(depth) == 1
+        assert depth[0].mode == "I;16"


### PR DESCRIPTION
## What does this PR do?

`VaeImageProcessorLDM3D.rgblike_to_depthmap` combines two 8-bit channels into a 16-bit depth value (`green * 256 + blue`, range 0–65535). It correctly casts up to a wider integer type for the multiplication, but then casts the result **back to the input's dtype** (uint8) via `.to(original_dtype)` / `.astype(original_dtype)`, dropping the entire high byte — so it returned only `depth % 256`.

`numpy_to_depth` feeds this into `Image.fromarray(..., mode="I;16")`, which requires 16-bit-wide data, so with a uint8 buffer `VaeImageProcessorLDM3D.postprocess(image, output_type="pil")` — the normal way an LDM3D pipeline returns a depth image for a 6-channel output — crashes with `ValueError: buffer is not large enough`.

```python
from diffusers.image_processor import VaeImageProcessorLDM3D
import torch, numpy as np
p = VaeImageProcessorLDM3D()

rgb = np.zeros((2, 2, 3), dtype=np.uint8); rgb[..., 1] = 5; rgb[..., 2] = 200
p.rgblike_to_depthmap(rgb).max()   # before: 200   after: 1480  (5*256+200)

img = torch.zeros(1, 6, 4, 4); img[:, 4] = 5/255.; img[:, 5] = 200/255.
p.postprocess(img, output_type="pil")   # before: ValueError: buffer is not large enough
                                         # after:  returns a valid mode="I;16" depth image
```

The fix keeps the 16-bit result instead of truncating: return the wider integer type directly (numpy → `uint16` to match the `mode="I;16"` consumer, torch → the `int32` combination). The function's whole purpose is to produce a 16-bit depth map from 8-bit RGB, so casting back to the 8-bit input dtype was never correct.

This regression was introduced by #12546 (which fixed a real NumPy 2.0 `uint8 * 256` overflow but replaced it with this truncation). `tests/others/test_image_processor.py` had no `VaeImageProcessorLDM3D` coverage, which is why it shipped — this adds a small regression test class.

> Note (kept out of this PR to stay focused): the `output_type="np"` branch of `postprocess` passes float `[0, 1]` arrays into `rgblike_to_depthmap`, where the int cast collapses them to 0. That's an independent caller-side issue in the same function's contract and is better handled separately.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the documentation with your changes? (no user-facing doc change — internal correctness fix)
- [x] Did you write any new necessary tests? (added `Ldm3dImageProcessorTest`: 16-bit combination for numpy + torch, and the pil postprocess path; red before the fix, green after. Full `test_image_processor.py`: 12 passed. `ruff` 0.9.10 check + format clean.)

## Who can review?

@yiyixuxu @sayakpaul

---

_Found via an AI-assisted (Claude) review pass over `image_processor.py`; independently reproduced, fixed, and verified before submitting._