### PR TITLE
Make `HunyuanDiT2DModel` and `HunyuanDiT2DControlNetModel` hidden states contiguous

### DIFF
--- a/src/diffusers/models/controlnets/controlnet_hunyuan.py
+++ b/src/diffusers/models/controlnets/controlnet_hunyuan.py
@@ -262,6 +262,8 @@ class HunyuanDiT2DControlNetModel(ModelMixin, ConfigMixin):
         height, width = hidden_states.shape[-2:]
 
         hidden_states = self.pos_embed(hidden_states)  # b,c,H,W -> b, N, C
+        # pos_embed output is non-contiguous due to flatten+transpose in PatchEmbed (BCHW -> BNC).
+        hidden_states = hidden_states.contiguous()
 
         # 2. pre-process
         hidden_states = hidden_states + self.input_block(self.pos_embed(controlnet_cond))

--- a/src/diffusers/models/transformers/hunyuan_transformer_2d.py
+++ b/src/diffusers/models/transformers/hunyuan_transformer_2d.py
@@ -401,6 +401,8 @@ class HunyuanDiT2DModel(ModelMixin, AttentionMixin, ConfigMixin):
         height, width = hidden_states.shape[-2:]
 
         hidden_states = self.pos_embed(hidden_states)
+        # pos_embed output is non-contiguous due to flatten+transpose in PatchEmbed (BCHW -> BNC).
+        hidden_states = hidden_states.contiguous()
 
         temb = self.time_extra_emb(
             timestep, encoder_hidden_states_t5, image_meta_size, style, hidden_dtype=timestep.dtype


### PR DESCRIPTION
# What does this PR do?

Similar to https://github.com/huggingface/diffusers/pull/14186


The non-contiguous tensor originates from `PatchEmbed.forward` — `flatten(2).transpose(1, 2) (BCHW → BNC)` produces a non-contiguous layout whose overhead accumulates across transformer blocks in `HunyuanDiT2DModel` and `HunyuanDiT2DControlNetModel`. 
Unlike SD3 where the benefit is limited to ROCm, this patch improves performance on both ROCm and NVIDIA for HunyuanDiT, though the gain on NVIDIA is smaller.

**Benchmarks** (HunyuanDiT-v1.1-Diffusers, 512×512, 50 steps, fp16):

| Platform | PyTorch | Default | +contiguous | Speedup |
|---|---|---|---|---|
| NVIDIA RTX 5090 | 2.12.1+cu132 | 3.16 it/s | 3.29 it/s | +4.1% |
| AMD Radeon AI PRO R9700 (gfx1201) | 2.12.0+rocm7.15.0a20260713 | 1.34 it/s | 1.52 it/s | +13.4% |
| AMD Radeon(TM) 8060S Graphics (gfx1151) | 2.12.0+rocm7.15.0a20260711 | 3.23 s/it | 3.05 s/it | +5.8% |

**Benchmarks** (HunyuanDiT-v1.2-Diffusers, 512×512, 50 steps, fp16):

| Platform | PyTorch | Default | +contiguous | Speedup |
|---|---|---|---|---|
| NVIDIA RTX 5090 | 2.12.1+cu132 | 3.16 it/s | 3.30 it/s | +4.4% |
| AMD Radeon AI PRO R9700 (gfx1201) | 2.12.0+rocm7.15.0a20260713 | 1.35 it/s | 1.53 it/s | +13.3% |
| AMD Radeon(TM) 8060S Graphics (gfx1151) | 2.12.0+rocm7.15.0a20260711 | 3.23 s/it | 3.05 s/it | +5.6% |

**Benchmarks** (HunyuanDiT-v1.2-ControlNet-Diffusers-Canny + HunyuanDiT-v1.2-Diffusers-Distilled, 512×512, 50 steps, fp16):

| Platform | PyTorch | Default | +contiguous | Speedup |
|---|---|---|---|---|
| NVIDIA RTX 5090 | 2.12.1+cu132 | 2.12 it/s | 2.26 it/s | +6.6% |
| AMD Radeon AI PRO R9700 (gfx1201) | 2.12.0+rocm7.15.0a20260713 | 1.13 s/it | 1.04 it/s | +8.0% |
| AMD Radeon(TM) 8060S Graphics (gfx1151) | 2.12.0+rocm7.15.0a20260711 | 4.73 s/it | 3.79 s/it | +19.9% |


## Before submitting
- [ ] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [ ] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [ ] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [ ] Did you share the final self-review notes in the PR description or a comment?
- [X] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [X] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?


## Who can review?

@sayakpaul @yiyixuxu

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

