### PR TITLE
Fix local LoRA weight auto-discovery in offline mode

### DIFF
--- a/src/diffusers/loaders/lora_base.py
+++ b/src/diffusers/loaders/lora_base.py
@@ -277,15 +277,14 @@ def _fetch_state_dict(
 def _best_guess_weight_name(
     pretrained_model_name_or_path_or_dict, file_extension=".safetensors", local_files_only=False
 ):
-    if local_files_only or HF_HUB_OFFLINE:
-        raise ValueError("When using the offline mode, you must specify a `weight_name`.")
-
     targeted_files = []
 
     if os.path.isfile(pretrained_model_name_or_path_or_dict):
         return
     elif os.path.isdir(pretrained_model_name_or_path_or_dict):
         targeted_files = [f for f in os.listdir(pretrained_model_name_or_path_or_dict) if f.endswith(file_extension)]
+    elif local_files_only or HF_HUB_OFFLINE:
+        raise ValueError("When using the offline mode, you must specify a `weight_name`.")
     else:
         files_in_repo = model_info(pretrained_model_name_or_path_or_dict).siblings
         targeted_files = [f.rfilename for f in files_in_repo if f.rfilename.endswith(file_extension)]

--- a/tests/lora/test_lora_loader_utils.py
+++ b/tests/lora/test_lora_loader_utils.py
@@ -1,0 +1,109 @@
+# coding=utf-8
+# Copyright 2026 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import save_file
+
+from diffusers.loaders import StableDiffusionLoraLoaderMixin
+from diffusers.loaders.lora_base import _best_guess_weight_name
+
+
+LORA_KEY = "unet.test.lora_A.weight"
+
+
+def _write_lora_weights(path):
+    save_file({LORA_KEY: torch.ones(1)}, path)
+
+
+class LoraWeightNameDiscoveryTests(unittest.TestCase):
+    def test_local_directory_in_offline_mode(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            _write_lora_weights(Path(tmpdirname) / "adapter.safetensors")
+
+            with (
+                patch("diffusers.loaders.lora_base.HF_HUB_OFFLINE", True),
+                patch("diffusers.loaders.lora_base.model_info") as model_info_mock,
+            ):
+                state_dict, _ = StableDiffusionLoraLoaderMixin.lora_state_dict(tmpdirname)
+
+            self.assertTrue(torch.equal(state_dict[LORA_KEY], torch.ones(1)))
+            model_info_mock.assert_not_called()
+
+    def test_local_directory_with_local_files_only(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            _write_lora_weights(Path(tmpdirname) / "adapter.safetensors")
+
+            with patch("diffusers.loaders.lora_base.model_info") as model_info_mock:
+                state_dict, _ = StableDiffusionLoraLoaderMixin.lora_state_dict(tmpdirname, local_files_only=True)
+
+            self.assertTrue(torch.equal(state_dict[LORA_KEY], torch.ones(1)))
+            model_info_mock.assert_not_called()
+
+    def test_local_file_in_offline_mode(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            weight_path = Path(tmpdirname) / "adapter.safetensors"
+            _write_lora_weights(weight_path)
+
+            with (
+                patch("diffusers.loaders.lora_base.HF_HUB_OFFLINE", True),
+                patch("diffusers.loaders.lora_base.model_info") as model_info_mock,
+            ):
+                state_dict, _ = StableDiffusionLoraLoaderMixin.lora_state_dict(weight_path)
+
+            self.assertTrue(torch.equal(state_dict[LORA_KEY], torch.ones(1)))
+            model_info_mock.assert_not_called()
+
+    def test_remote_repository_in_offline_mode_requires_weight_name(self):
+        with (
+            patch("diffusers.loaders.lora_base.HF_HUB_OFFLINE", True),
+            patch("diffusers.loaders.lora_base.model_info") as model_info_mock,
+        ):
+            with self.assertRaisesRegex(ValueError, "offline mode.*weight_name"):
+                StableDiffusionLoraLoaderMixin.lora_state_dict("organization/repository")
+
+        model_info_mock.assert_not_called()
+
+    def test_local_directory_without_matching_files_returns_none(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            (Path(tmpdirname) / "notes.txt").touch()
+
+            with patch("diffusers.loaders.lora_base.HF_HUB_OFFLINE", True):
+                weight_name = _best_guess_weight_name(tmpdirname)
+
+        self.assertIsNone(weight_name)
+
+    def test_local_directory_with_multiple_files_warns_and_uses_first(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            first_path = Path(tmpdirname) / "first.safetensors"
+            second_path = Path(tmpdirname) / "second.safetensors"
+            first_path.touch()
+            second_path.touch()
+
+            with (
+                patch("diffusers.loaders.lora_base.HF_HUB_OFFLINE", True),
+                patch(
+                    "diffusers.loaders.lora_base.os.listdir",
+                    return_value=[first_path.name, second_path.name],
+                ),
+                self.assertLogs("diffusers.loaders.lora_base", level="WARNING") as logs,
+            ):
+                weight_name = _best_guess_weight_name(tmpdirname)
+
+        self.assertEqual(weight_name, first_path.name)
+        self.assertIn("contains more than one weights file", logs.output[0])

--- a/tests/lora/test_lora_loader_utils.py
+++ b/tests/lora/test_lora_loader_utils.py
@@ -12,16 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import tempfile
-import unittest
-from pathlib import Path
-from unittest.mock import patch
+import logging
+from unittest.mock import Mock
 
+import pytest
 import torch
 from safetensors.torch import save_file
 
-from diffusers.loaders import StableDiffusionLoraLoaderMixin
-from diffusers.loaders.lora_base import _best_guess_weight_name
+from diffusers.loaders import StableDiffusionLoraLoaderMixin, lora_base
 
 
 LORA_KEY = "unet.test.lora_A.weight"
@@ -31,79 +29,74 @@ def _write_lora_weights(path):
     save_file({LORA_KEY: torch.ones(1)}, path)
 
 
-class LoraWeightNameDiscoveryTests(unittest.TestCase):
-    def test_local_directory_in_offline_mode(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            _write_lora_weights(Path(tmpdirname) / "adapter.safetensors")
+@pytest.fixture
+def lora_weight_path(tmp_path):
+    weight_path = tmp_path / "adapter.safetensors"
+    _write_lora_weights(weight_path)
+    return weight_path
 
-            with (
-                patch("diffusers.loaders.lora_base.HF_HUB_OFFLINE", True),
-                patch("diffusers.loaders.lora_base.model_info") as model_info_mock,
-            ):
-                state_dict, _ = StableDiffusionLoraLoaderMixin.lora_state_dict(tmpdirname)
 
-            self.assertTrue(torch.equal(state_dict[LORA_KEY], torch.ones(1)))
-            model_info_mock.assert_not_called()
+@pytest.fixture
+def model_info_mock(monkeypatch):
+    model_info_mock = Mock()
+    monkeypatch.setattr(lora_base, "model_info", model_info_mock)
+    return model_info_mock
 
-    def test_local_directory_with_local_files_only(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            _write_lora_weights(Path(tmpdirname) / "adapter.safetensors")
 
-            with patch("diffusers.loaders.lora_base.model_info") as model_info_mock:
-                state_dict, _ = StableDiffusionLoraLoaderMixin.lora_state_dict(tmpdirname, local_files_only=True)
+def test_local_directory_in_offline_mode(lora_weight_path, monkeypatch, model_info_mock):
+    monkeypatch.setattr(lora_base, "HF_HUB_OFFLINE", True)
 
-            self.assertTrue(torch.equal(state_dict[LORA_KEY], torch.ones(1)))
-            model_info_mock.assert_not_called()
+    state_dict, _ = StableDiffusionLoraLoaderMixin.lora_state_dict(lora_weight_path.parent)
 
-    def test_local_file_in_offline_mode(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            weight_path = Path(tmpdirname) / "adapter.safetensors"
-            _write_lora_weights(weight_path)
+    assert torch.equal(state_dict[LORA_KEY], torch.ones(1))
+    model_info_mock.assert_not_called()
 
-            with (
-                patch("diffusers.loaders.lora_base.HF_HUB_OFFLINE", True),
-                patch("diffusers.loaders.lora_base.model_info") as model_info_mock,
-            ):
-                state_dict, _ = StableDiffusionLoraLoaderMixin.lora_state_dict(weight_path)
 
-            self.assertTrue(torch.equal(state_dict[LORA_KEY], torch.ones(1)))
-            model_info_mock.assert_not_called()
+def test_local_directory_with_local_files_only(lora_weight_path, model_info_mock):
+    state_dict, _ = StableDiffusionLoraLoaderMixin.lora_state_dict(lora_weight_path.parent, local_files_only=True)
 
-    def test_remote_repository_in_offline_mode_requires_weight_name(self):
-        with (
-            patch("diffusers.loaders.lora_base.HF_HUB_OFFLINE", True),
-            patch("diffusers.loaders.lora_base.model_info") as model_info_mock,
-        ):
-            with self.assertRaisesRegex(ValueError, "offline mode.*weight_name"):
-                StableDiffusionLoraLoaderMixin.lora_state_dict("organization/repository")
+    assert torch.equal(state_dict[LORA_KEY], torch.ones(1))
+    model_info_mock.assert_not_called()
 
-        model_info_mock.assert_not_called()
 
-    def test_local_directory_without_matching_files_returns_none(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            (Path(tmpdirname) / "notes.txt").touch()
+def test_local_file_in_offline_mode(lora_weight_path, monkeypatch, model_info_mock):
+    monkeypatch.setattr(lora_base, "HF_HUB_OFFLINE", True)
 
-            with patch("diffusers.loaders.lora_base.HF_HUB_OFFLINE", True):
-                weight_name = _best_guess_weight_name(tmpdirname)
+    state_dict, _ = StableDiffusionLoraLoaderMixin.lora_state_dict(lora_weight_path)
 
-        self.assertIsNone(weight_name)
+    assert torch.equal(state_dict[LORA_KEY], torch.ones(1))
+    model_info_mock.assert_not_called()
 
-    def test_local_directory_with_multiple_files_warns_and_uses_first(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            first_path = Path(tmpdirname) / "first.safetensors"
-            second_path = Path(tmpdirname) / "second.safetensors"
-            first_path.touch()
-            second_path.touch()
 
-            with (
-                patch("diffusers.loaders.lora_base.HF_HUB_OFFLINE", True),
-                patch(
-                    "diffusers.loaders.lora_base.os.listdir",
-                    return_value=[first_path.name, second_path.name],
-                ),
-                self.assertLogs("diffusers.loaders.lora_base", level="WARNING") as logs,
-            ):
-                weight_name = _best_guess_weight_name(tmpdirname)
+def test_remote_repository_in_offline_mode_requires_weight_name(monkeypatch, model_info_mock):
+    monkeypatch.setattr(lora_base, "HF_HUB_OFFLINE", True)
 
-        self.assertEqual(weight_name, first_path.name)
-        self.assertIn("contains more than one weights file", logs.output[0])
+    with pytest.raises(ValueError, match="offline mode.*weight_name"):
+        StableDiffusionLoraLoaderMixin.lora_state_dict("organization/repository")
+
+    model_info_mock.assert_not_called()
+
+
+def test_local_directory_without_matching_files_returns_none(tmp_path, monkeypatch):
+    (tmp_path / "notes.txt").touch()
+    monkeypatch.setattr(lora_base, "HF_HUB_OFFLINE", True)
+
+    weight_name = lora_base._best_guess_weight_name(tmp_path)
+
+    assert weight_name is None
+
+
+def test_local_directory_with_multiple_files_warns_and_uses_first(tmp_path, monkeypatch, caplog):
+    first_path = tmp_path / "first.safetensors"
+    second_path = tmp_path / "second.safetensors"
+    first_path.touch()
+    second_path.touch()
+    monkeypatch.setattr(lora_base, "HF_HUB_OFFLINE", True)
+    monkeypatch.setattr(lora_base.os, "listdir", lambda _: [first_path.name, second_path.name])
+    monkeypatch.setattr(lora_base.logger, "propagate", True)
+
+    with caplog.at_level(logging.WARNING, logger="diffusers.loaders.lora_base"):
+        weight_name = lora_base._best_guess_weight_name(tmp_path)
+
+    assert weight_name == first_path.name
+    assert "contains more than one weights file" in caplog.text


### PR DESCRIPTION
# What does this PR do?

Fixes #14195

`_best_guess_weight_name()` currently checks `local_files_only` and `HF_HUB_OFFLINE` before determining whether the supplied path is a local file or directory. As a result, local LoRA weights without an explicit `weight_name` are rejected in offline mode before Diffusers inspects the local filesystem.

This PR moves the offline-mode guard after the local file and directory checks. With this change:

- a direct local LoRA file works in offline mode;
- a local directory can auto-discover its LoRA weight file with either `HF_HUB_OFFLINE=1` or `local_files_only=True`;
- a remote repository ID without `weight_name` still raises the existing offline-mode error;
- `model_info()` is not called in offline mode.

Checking `os.path.isfile()` and `os.path.isdir()` only accesses the local filesystem and cannot trigger a Hub request, so this preserves the network restrictions of offline mode. There are no public API changes.

Coordination: #14195 and the related discussion in #14198.

## Tests

The regression tests cover local files, local directories, both offline controls, remote repository IDs without `weight_name`, the absence of `model_info()` calls, and the existing behavior for zero or multiple matching files.

```text
$ .venv/bin/python -m pytest -q tests/lora/test_lora_loader_utils.py
......                                                                   [100%]
6 passed in 0.05s

$ PATH=".venv/bin:$PATH" make style
All checks passed!
1999 files left unchanged

$ PATH=".venv/bin:$PATH" make fix-copies
Passed

$ PATH=".venv/bin:$PATH" make quality
All checks passed!
1999 files already formatted
```

## AI assistance

This PR received substantial assistance from OpenAI Codex. I identified and reproduced the original problem, defined the expected behavior and regression cases, and made the final contribution decisions. Codex was used to inspect the repository instructions and related history, implement the minimal fix, add regression tests, run the relevant checks, perform the final self-review, and help draft the PR description. The final diff and test results were presented to me before submission.

## Final self-review

- **Blocking issues:** None.
- **Non-blocking issues:** None.
- **Dead code:** None introduced; all new test helpers and constants are used.
- **Documentation impact:** No documentation update is needed. This is a focused bug fix with no public API or default changes, and remote repository behavior remains unchanged.
- **Verdict:** **READY**.
- **Fix before submitting:** Nothing.
- **Leave for the actual review:** Nothing.

## Before submitting

- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Discussed in #14195 and #14198.
- [x] Did you make sure to update the documentation with your changes? No update is needed for this focused bug fix; the public API is unchanged.
- [x] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline? Not applicable; this PR does not add a model or pipeline.

## Who can review?

@sayakpaul