### PR TITLE
fix: correct VaeImageProcessor.blur() docstring

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -274,11 +274,13 @@ class VaeImageProcessor(ConfigMixin):
 
         Args:
             image (`PIL.Image.Image`):
-                The PIL image to convert to grayscale.
+                The input image to blur.
+            blur_factor (`int`, *optional*, defaults to 4):
+                The blur factor to apply. Higher values result in more blur.
 
         Returns:
             `PIL.Image.Image`:
-                The grayscale-converted PIL image.
+                The blurred PIL image.
         """
         image = image.filter(ImageFilter.GaussianBlur(blur_factor))
 


### PR DESCRIPTION
## What does this PR do?

Fixes the `VaeImageProcessor.blur()` docstring which had copy-pasted text from `convert_to_grayscale()`.

### Changes
- **Add missing `blur_factor` parameter** to the Args section (was entirely absent from docstring)
- **Fix `image` arg description**: was "The PIL image to convert to grayscale" → now "The input image to blur"
- **Fix Returns description**: was "The grayscale-converted PIL image" → now "The blurred PIL image"

### Before
```python
def blur(image: PIL.Image.Image, blur_factor: int = 4) -> PIL.Image.Image:
    r"""
    Applies Gaussian blur to an image.

    Args:
        image (`PIL.Image.Image`):
            The PIL image to convert to grayscale.

    Returns:
        `PIL.Image.Image`:
            The grayscale-converted PIL image.
    """
```

### After
```python
def blur(image: PIL.Image.Image, blur_factor: int = 4) -> PIL.Image.Image:
    r"""
    Applies Gaussian blur to an image.

    Args:
        image (`PIL.Image.Image`):
            The input image to blur.
        blur_factor (`int`, *optional*, defaults to 4):
            The blur factor to apply. Higher values result in more blur.

    Returns:
        `PIL.Image.Image`:
            The blurred PIL image.
    """
```

Fixes #14209
