### PR TITLE
refactor qwenimage pipeline tests to the new mixin structure

### DIFF
--- a/tests/pipelines/qwenimage/test_qwenimage.py
+++ b/tests/pipelines/qwenimage/test_qwenimage.py
@@ -42,13 +42,13 @@ class QwenImagePipelineTesterConfig(BasePipelineTesterConfig):
     )
     batch_input_params = frozenset(["prompt"])
 
-    def get_dummy_components(self):
+    def get_dummy_components(self, num_layers: int = 2):
         torch.manual_seed(0)
         transformer = QwenImageTransformer2DModel(
             patch_size=2,
             in_channels=16,
             out_channels=4,
-            num_layers=2,
+            num_layers=num_layers,
             attention_head_dim=16,
             num_attention_heads=3,
             joint_attention_dim=16,

--- a/tests/pipelines/qwenimage/test_qwenimage.py
+++ b/tests/pipelines/qwenimage/test_qwenimage.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-
-import numpy as np
 import torch
 from transformers import Qwen2_5_VLConfig, Qwen2_5_VLForConditionalGeneration, Qwen2Tokenizer
 
@@ -25,33 +22,25 @@ from diffusers import (
     QwenImageTransformer2DModel,
 )
 
-from ...testing_utils import enable_full_determinism, torch_device
-from ..pipeline_params import TEXT_TO_IMAGE_BATCH_PARAMS, TEXT_TO_IMAGE_IMAGE_PARAMS, TEXT_TO_IMAGE_PARAMS
-from ..test_pipelines_common import PipelineTesterMixin, to_np
+from ...testing_utils import torch_device
+from ..testing_utils import (
+    BasePipelineTesterConfig,
+    FasterCacheTesterMixin,
+    FirstBlockCacheTesterMixin,
+    MagCacheTesterMixin,
+    MemoryTesterMixin,
+    PipelineTesterMixin,
+    PyramidAttentionBroadcastTesterMixin,
+    TaylorSeerCacheTesterMixin,
+)
 
 
-enable_full_determinism()
-
-
-class QwenImagePipelineFastTests(PipelineTesterMixin, unittest.TestCase):
+class QwenImagePipelineTesterConfig(BasePipelineTesterConfig):
     pipeline_class = QwenImagePipeline
-    params = TEXT_TO_IMAGE_PARAMS - {"cross_attention_kwargs"}
-    batch_params = TEXT_TO_IMAGE_BATCH_PARAMS
-    image_params = TEXT_TO_IMAGE_IMAGE_PARAMS
-    image_latents_params = TEXT_TO_IMAGE_IMAGE_PARAMS
-    required_optional_params = frozenset(
-        [
-            "num_inference_steps",
-            "generator",
-            "latents",
-            "return_dict",
-            "callback_on_step_end",
-            "callback_on_step_end_tensor_inputs",
-        ]
+    required_input_params_in_call_signature = frozenset(
+        ["prompt", "negative_prompt", "true_cfg_scale", "height", "width", "guidance_scale", "prompt_embeds"]
     )
-    test_xformers_attention = False
-    test_layerwise_casting = True
-    test_group_offloading = True
+    batch_input_params = frozenset(["prompt"])
 
     def get_dummy_components(self):
         torch.manual_seed(0)
@@ -75,10 +64,8 @@ class QwenImagePipelineFastTests(PipelineTesterMixin, unittest.TestCase):
             dim_mult=[1, 2, 4],
             num_res_blocks=1,
             temperal_downsample=[False, True],
-            # fmt: off
             latents_mean=[0.0] * 4,
             latents_std=[1.0] * 4,
-            # fmt: on
         )
 
         torch.manual_seed(0)
@@ -115,134 +102,62 @@ class QwenImagePipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         text_encoder = Qwen2_5_VLForConditionalGeneration(config).eval()
         tokenizer = Qwen2Tokenizer.from_pretrained("hf-internal-testing/tiny-random-Qwen2VLForConditionalGeneration")
 
-        components = {
+        return {
             "transformer": transformer,
             "vae": vae,
             "scheduler": scheduler,
             "text_encoder": text_encoder,
             "tokenizer": tokenizer,
         }
-        return components
 
-    def get_dummy_inputs(self, device, seed=0):
-        if str(device).startswith("mps"):
-            generator = torch.manual_seed(seed)
-        else:
-            generator = torch.Generator(device=device).manual_seed(seed)
-
-        inputs = {
+    def get_dummy_inputs(self):
+        return {
             "prompt": "dance monkey",
             "negative_prompt": "bad quality",
-            "generator": generator,
+            "generator": self.get_generator(0),
             "num_inference_steps": 2,
             "guidance_scale": 3.0,
             "true_cfg_scale": 1.0,
             "height": 32,
             "width": 32,
             "max_sequence_length": 16,
+            # Request torch outputs so tests compare torch tensors directly (see `BasePipelineTesterConfig`).
             "output_type": "pt",
         }
 
-        return inputs
 
-    def test_inference(self):
-        device = "cpu"
-
-        components = self.get_dummy_components()
-        pipe = self.pipeline_class(**components)
-        pipe.to(device)
-        pipe.set_progress_bar_config(disable=None)
-
-        inputs = self.get_dummy_inputs(device)
-        image = pipe(**inputs).images
-        generated_image = image[0]
-        self.assertEqual(generated_image.shape, (3, 32, 32))
-
-        # fmt: off
-        expected_slice = torch.tensor([0.5633, 0.6368, 0.6015, 0.5637, 0.5817, 0.5528, 0.5718, 0.6326, 0.4147, 0.3556, 0.5623, 0.4833, 0.4971, 0.5262, 0.4087, 0.5021])
-        # fmt: on
-
-        generated_slice = generated_image.flatten()
-        generated_slice = torch.cat([generated_slice[:8], generated_slice[-8:]])
-        self.assertTrue(torch.allclose(generated_slice, expected_slice, atol=5e-3))
-
+class TestQwenImagePipeline(QwenImagePipelineTesterConfig, PipelineTesterMixin):
     def test_inference_batch_single_identical(self):
-        self._test_inference_batch_single_identical(batch_size=3, expected_max_diff=1e-1)
-
-    def test_attention_slicing_forward_pass(
-        self, test_max_difference=True, test_mean_pixel_difference=True, expected_max_diff=1e-3
-    ):
-        if not self.test_attention_slicing:
-            return
-
-        components = self.get_dummy_components()
-        pipe = self.pipeline_class(**components)
-        for component in pipe.components.values():
-            if hasattr(component, "set_default_attn_processor"):
-                component.set_default_attn_processor()
-        pipe.to(torch_device)
-        pipe.set_progress_bar_config(disable=None)
-
-        generator_device = "cpu"
-        inputs = self.get_dummy_inputs(generator_device)
-        output_without_slicing = pipe(**inputs)[0]
-
-        pipe.enable_attention_slicing(slice_size=1)
-        inputs = self.get_dummy_inputs(generator_device)
-        output_with_slicing1 = pipe(**inputs)[0]
-
-        pipe.enable_attention_slicing(slice_size=2)
-        inputs = self.get_dummy_inputs(generator_device)
-        output_with_slicing2 = pipe(**inputs)[0]
-
-        if test_max_difference:
-            max_diff1 = np.abs(to_np(output_with_slicing1) - to_np(output_without_slicing)).max()
-            max_diff2 = np.abs(to_np(output_with_slicing2) - to_np(output_without_slicing)).max()
-            self.assertLess(
-                max(max_diff1, max_diff2),
-                expected_max_diff,
-                "Attention slicing should not affect the inference results",
-            )
+        super().test_inference_batch_single_identical(expected_max_diff=1e-1)
 
     def test_vae_tiling(self, expected_diff_max: float = 0.2):
-        generator_device = "cpu"
-        components = self.get_dummy_components()
-
-        pipe = self.pipeline_class(**components)
-        pipe.to("cpu")
+        pipe = self.pipeline_class(**self.get_dummy_components()).to(torch_device)
         pipe.set_progress_bar_config(disable=None)
 
-        # Without tiling
-        inputs = self.get_dummy_inputs(generator_device)
+        inputs = self.get_dummy_inputs()
         inputs["height"] = inputs["width"] = 128
         output_without_tiling = pipe(**inputs)[0]
 
-        # With tiling
         pipe.vae.enable_tiling(
             tile_sample_min_height=96,
             tile_sample_min_width=96,
             tile_sample_stride_height=64,
             tile_sample_stride_width=64,
         )
-        inputs = self.get_dummy_inputs(generator_device)
+        inputs = self.get_dummy_inputs()
         inputs["height"] = inputs["width"] = 128
         output_with_tiling = pipe(**inputs)[0]
 
-        self.assertLess(
-            (to_np(output_without_tiling) - to_np(output_with_tiling)).max(),
-            expected_diff_max,
-            "VAE tiling should not affect the inference results",
+        assert (output_without_tiling - output_with_tiling).abs().max() < expected_diff_max, (
+            "VAE tiling should not affect the inference results."
         )
 
     def test_true_cfg_without_negative_prompt_embeds_mask(self):
-        components = self.get_dummy_components()
-        pipe = self.pipeline_class(**components)
-        pipe.to(torch_device)
+        pipe = self.pipeline_class(**self.get_dummy_components()).to(torch_device)
         pipe.set_progress_bar_config(disable=None)
 
-        inputs = self.get_dummy_inputs(torch_device)
+        inputs = self.get_dummy_inputs()
         prompt = inputs.pop("prompt")
-
         prompt_embeds, prompt_embeds_mask = pipe.encode_prompt(
             prompt=prompt,
             device=torch_device,
@@ -258,4 +173,30 @@ class QwenImagePipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         inputs["true_cfg_scale"] = 2.0
 
         image = pipe(**inputs).images
-        self.assertIsNotNone(image)
+        assert image is not None
+
+
+class TestQwenImagePipelineMemory(QwenImagePipelineTesterConfig, MemoryTesterMixin):
+    pass
+
+
+class TestQwenImagePipelinePyramidAttentionBroadcast(
+    QwenImagePipelineTesterConfig, PyramidAttentionBroadcastTesterMixin
+):
+    pass
+
+
+class TestQwenImagePipelineFasterCache(QwenImagePipelineTesterConfig, FasterCacheTesterMixin):
+    pass
+
+
+class TestQwenImagePipelineFirstBlockCache(QwenImagePipelineTesterConfig, FirstBlockCacheTesterMixin):
+    pass
+
+
+class TestQwenImagePipelineTaylorSeerCache(QwenImagePipelineTesterConfig, TaylorSeerCacheTesterMixin):
+    pass
+
+
+class TestQwenImagePipelineMagCache(QwenImagePipelineTesterConfig, MagCacheTesterMixin):
+    pass

--- a/tests/pipelines/qwenimage/test_qwenimage.py
+++ b/tests/pipelines/qwenimage/test_qwenimage.py
@@ -25,12 +25,8 @@ from diffusers import (
 from ...testing_utils import torch_device
 from ..testing_utils import (
     BasePipelineTesterConfig,
-    FirstBlockCacheTesterMixin,
-    MagCacheTesterMixin,
     MemoryTesterMixin,
     PipelineTesterMixin,
-    PyramidAttentionBroadcastTesterMixin,
-    TaylorSeerCacheTesterMixin,
 )
 
 
@@ -126,6 +122,23 @@ class QwenImagePipelineTesterConfig(BasePipelineTesterConfig):
 
 
 class TestQwenImagePipeline(QwenImagePipelineTesterConfig, PipelineTesterMixin):
+    def test_inference(self):
+        # Run on CPU: the expected slice below is CPU-specific.
+        pipe = self.get_pipeline()
+
+        inputs = self.get_dummy_inputs()
+        image = pipe(**inputs).images
+        generated_image = image[0]
+        assert generated_image.shape == (3, 32, 32)
+
+        # fmt: off
+        expected_slice = torch.tensor([0.5633, 0.6368, 0.6015, 0.5637, 0.5817, 0.5528, 0.5718, 0.6326, 0.4147, 0.3556, 0.5623, 0.4833, 0.4971, 0.5262, 0.4087, 0.5021])
+        # fmt: on
+
+        generated_slice = generated_image.flatten()
+        generated_slice = torch.cat([generated_slice[:8], generated_slice[-8:]])
+        assert torch.allclose(generated_slice, expected_slice, atol=5e-3)
+
     def test_inference_batch_single_identical(self):
         super().test_inference_batch_single_identical(expected_max_diff=1e-1)
 
@@ -176,22 +189,4 @@ class TestQwenImagePipeline(QwenImagePipelineTesterConfig, PipelineTesterMixin):
 
 
 class TestQwenImagePipelineMemory(QwenImagePipelineTesterConfig, MemoryTesterMixin):
-    pass
-
-
-class TestQwenImagePipelinePyramidAttentionBroadcast(
-    QwenImagePipelineTesterConfig, PyramidAttentionBroadcastTesterMixin
-):
-    pass
-
-
-class TestQwenImagePipelineFirstBlockCache(QwenImagePipelineTesterConfig, FirstBlockCacheTesterMixin):
-    pass
-
-
-class TestQwenImagePipelineTaylorSeerCache(QwenImagePipelineTesterConfig, TaylorSeerCacheTesterMixin):
-    pass
-
-
-class TestQwenImagePipelineMagCache(QwenImagePipelineTesterConfig, MagCacheTesterMixin):
     pass

--- a/tests/pipelines/qwenimage/test_qwenimage.py
+++ b/tests/pipelines/qwenimage/test_qwenimage.py
@@ -25,7 +25,6 @@ from diffusers import (
 from ...testing_utils import torch_device
 from ..testing_utils import (
     BasePipelineTesterConfig,
-    FasterCacheTesterMixin,
     FirstBlockCacheTesterMixin,
     MagCacheTesterMixin,
     MemoryTesterMixin,
@@ -183,10 +182,6 @@ class TestQwenImagePipelineMemory(QwenImagePipelineTesterConfig, MemoryTesterMix
 class TestQwenImagePipelinePyramidAttentionBroadcast(
     QwenImagePipelineTesterConfig, PyramidAttentionBroadcastTesterMixin
 ):
-    pass
-
-
-class TestQwenImagePipelineFasterCache(QwenImagePipelineTesterConfig, FasterCacheTesterMixin):
     pass
 
 

--- a/tests/pipelines/qwenimage/test_qwenimage.py
+++ b/tests/pipelines/qwenimage/test_qwenimage.py
@@ -139,9 +139,6 @@ class TestQwenImagePipeline(QwenImagePipelineTesterConfig, PipelineTesterMixin):
         generated_slice = torch.cat([generated_slice[:8], generated_slice[-8:]])
         assert torch.allclose(generated_slice, expected_slice, atol=5e-3)
 
-    def test_inference_batch_single_identical(self):
-        super().test_inference_batch_single_identical(expected_max_diff=1e-1)
-
     def test_vae_tiling(self, expected_diff_max: float = 0.2):
         pipe = self.pipeline_class(**self.get_dummy_components()).to(torch_device)
         pipe.set_progress_bar_config(disable=None)


### PR DESCRIPTION
# What does this PR do?

Refactors the qwenimage pipeline tests to the new mixin structure from #14113: a `QwenImagePipelineTesterConfig` holding the components and inputs, `TestQwenImagePipeline(PipelineTesterMixin)` for the fast tests, and `TestQwenImagePipelineMemory(MemoryTesterMixin)` for the offload and casting tests.

Existing coverage is kept as-is: `test_inference` and the qwen-specific tests (VAE tiling, true-CFG without a negative mask). No new tests are introduced since the old suite had no caching tests. The attention-slicing test is dropped since the new framework has no equivalent.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Discussed on Slack with @sayakpaul
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@sayakpaul
