### PR TITLE
[docs] remove link to unmaintained HEIM in evaluation guide

### DIFF
--- a/docs/source/en/conceptual/evaluation.md
+++ b/docs/source/en/conceptual/evaluation.md
@@ -18,7 +18,7 @@ specific language governing permissions and limitations under the License.
 
 > [!TIP]
 > This document has now grown outdated given the emergence of existing evaluation frameworks for diffusion models for image generation. Please check
-> out works like [HEIM](https://crfm.stanford.edu/helm/heim/latest/), [T2I-Compbench](https://huggingface.co/papers/2307.06350),
+> out works like [T2I-Compbench](https://huggingface.co/papers/2307.06350) and
 > [GenEval](https://huggingface.co/papers/2310.11513).
 
 Evaluation of generative models like [Stable Diffusion](https://huggingface.co/docs/diffusers/stable_diffusion) is subjective in nature. But as practitioners and researchers, we often have to make careful choices amongst many different possibilities. So, when working with different generative models (like GANs, Diffusion, etc.), how do we choose one over the other?


### PR DESCRIPTION
# What does this PR do?

Removes the link to HEIM from the list of suggested evaluation frameworks in the
evaluation guide. HEIM is no longer officially supported or actively maintained
(see stanford-crfm/helm#2161, stanford-crfm/helm#3741) and no longer works off
the shelf, as reported in the linked issue.

Fixes #14033

**Before** (`docs/source/en/conceptual/evaluation.md`, TIP block):
> ... Please check out works like [HEIM](https://crfm.stanford.edu/helm/heim/latest/), [T2I-Compbench](https://huggingface.co/papers/2307.06350), [GenEval](https://huggingface.co/papers/2310.11513).

**After:**
> ... Please check out works like [T2I-Compbench](https://huggingface.co/papers/2307.06350) and [GenEval](https://huggingface.co/papers/2310.11513).

Note: the Chinese translation (`docs/source/zh/conceptual/evaluation.md`) contains
the same HEIM reference. I left it untouched since the issue targets the English
page — happy to fold it into this PR if preferred.

## Before submitting

- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? — Claude Code
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the `self-review` skill on the diff?
  - [x] Self-review notes shared below
- [x] Did you read the contributor guideline?
- [x] Was this discussed/approved via a GitHub issue? — #14033

**Self-review notes (final round):** docs-only, one-line markdown change; no code
paths, tests, or docstrings affected. Remaining two-item list adjusted from a bare
comma to "and" so the sentence stays grammatical. No remaining `HEIM`/`crfm`
occurrences in the changed file. Verdict: READY; nothing intentionally left unfixed
except the zh translation noted above (left for maintainer preference).

## Who can review?

@stevhliu @sayakpaul
