### PR TITLE
fix(pipelines): use forward slash in per-component config.json download allow patterns

### DIFF
--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1784,7 +1784,10 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             # add custom pipeline file
             allow_patterns += [f"{custom_pipeline}.py"] if f"{custom_pipeline}.py" in filenames else []
             # also allow downloading config.json files with the model
-            allow_patterns += [os.path.join(k, "config.json") for k in model_folder_names]
+            # Hub repo paths always use forward slashes, so build the pattern
+            # with "/" instead of os.path.join (which uses "\" on Windows and
+            # fails to match repo paths with fnmatch.fnmatchcase).
+            allow_patterns += [f"{k}/config.json" for k in model_folder_names]
             allow_patterns += [
                 SCHEDULER_CONFIG_NAME,
                 CONFIG_NAME,

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -1740,7 +1740,10 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             # add custom pipeline file
             allow_patterns += [f"{custom_pipeline}.py"] if f"{custom_pipeline}.py" in filenames else []
             # also allow downloading config.json files with the model
-            allow_patterns += [os.path.join(k, "config.json") for k in model_folder_names]
+            # Hub repo paths always use forward slashes, so build the pattern
+            # with "/" instead of os.path.join (which uses "\" on Windows and
+            # fails to match repo paths with fnmatch.fnmatchcase).
+            allow_patterns += [f"{k}/config.json" for k in model_folder_names]
             allow_patterns += [
                 SCHEDULER_CONFIG_NAME,
                 CONFIG_NAME,

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -535,6 +535,27 @@ class DownloadTests(unittest.TestCase):
             assert set(offline_kwargs["allow_patterns"]) == set(online_kwargs["allow_patterns"])
             assert set(offline_kwargs["ignore_patterns"]) == set(online_kwargs["ignore_patterns"])
 
+    def test_download_allow_patterns_use_forward_slash_for_component_configs(self):
+        # Hub repo paths always use forward slashes, so per-component config.json allow patterns
+        # must be built with "/" rather than os.path.join (which yields "\" on Windows and then
+        # fails to match repo paths once huggingface_hub matches patterns case-sensitively).
+        # See https://github.com/huggingface/diffusers/issues/14142
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            with mock.patch(
+                "diffusers.pipelines.pipeline_utils.snapshot_download", side_effect=snapshot_download
+            ) as mock_snapshot_download:
+                DiffusionPipeline.download(
+                    "hf-internal-testing/tiny-stable-diffusion-torch", cache_dir=tmpdirname
+                )
+                allow_patterns = mock_snapshot_download.call_args.kwargs["allow_patterns"]
+
+            component_config_patterns = [p for p in allow_patterns if p.endswith("/config.json")]
+            # tiny-stable-diffusion-torch has unet, vae and text_encoder model folders, so there
+            # must be at least one component config pattern and every one must use "/".
+            assert len(component_config_patterns) > 0
+            for pattern in component_config_patterns:
+                assert "\\" not in pattern, f"component config pattern {pattern!r} must use forward slash"
+
     def test_local_files_only_raises_for_snapshot_with_missing_weights(self):
         # An interrupted download leaves a cached snapshot without some weights; loading it offline must
         # surface `huggingface_hub`'s incomplete-snapshot error instead of failing later at model load time.

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -519,6 +519,24 @@ class TestDownload:
         assert set(offline_kwargs["allow_patterns"]) == set(online_kwargs["allow_patterns"])
         assert set(offline_kwargs["ignore_patterns"]) == set(online_kwargs["ignore_patterns"])
 
+    def test_download_allow_patterns_use_forward_slash_for_component_configs(self, tmp_path):
+        # Hub repo paths always use forward slashes, so per-component config.json allow patterns
+        # must be built with "/" rather than os.path.join (which yields "\" on Windows and then
+        # fails to match repo paths once huggingface_hub matches patterns case-sensitively).
+        # See https://github.com/huggingface/diffusers/issues/14142
+        with mock.patch(
+            "diffusers.pipelines.pipeline_utils.snapshot_download", side_effect=snapshot_download
+        ) as mock_snapshot_download:
+            DiffusionPipeline.download("hf-internal-testing/tiny-stable-diffusion-torch", cache_dir=tmp_path)
+            allow_patterns = mock_snapshot_download.call_args.kwargs["allow_patterns"]
+
+        component_config_patterns = [p for p in allow_patterns if p.endswith("/config.json")]
+        # tiny-stable-diffusion-torch has unet, vae and text_encoder model folders, so there
+        # must be at least one component config pattern and every one must use "/".
+        assert len(component_config_patterns) > 0
+        for pattern in component_config_patterns:
+            assert "\\" not in pattern, f"component config pattern {pattern!r} must use forward slash"
+
     def test_local_files_only_raises_for_snapshot_with_missing_weights(self, tmp_path):
         # An interrupted download leaves a cached snapshot without some weights; loading it offline must
         # surface `huggingface_hub`'s incomplete-snapshot error instead of failing later at model load time.


### PR DESCRIPTION
DiffusionPipeline.download() builds the allow pattern for each model folder's config.json with os.path.join(folder, "config.json"), which produces a backslash on Windows. Hub repo paths always use forward slashes, and since huggingface_hub 1.22.0 patterns are matched case-sensitively with fnmatch.fnmatchcase (no separator normalization), the backslash patterns match nothing on Windows and every per-component config.json (unet/config.json, vae/config.json, text_encoder/config.json) is silently skipped from the download. The pipeline then fails to load and keeps failing because the incomplete snapshot is treated as fully cached.

This changes that single line to build the pattern with a literal forward slash, which is exactly what every other allow_patterns entry in this function already does (e.g. the custom component and non-model-folder patterns above it). I added a regression test in DownloadTests that asserts the component config patterns never contain a backslash, so the invariant holds on every platform.

Fixes #14142
