### PR TITLE
Make `WanTransformer3DModel` hidden states contiguous before the block loop

### DIFF
--- a/src/diffusers/models/transformers/transformer_wan.py
+++ b/src/diffusers/models/transformers/transformer_wan.py
@@ -670,6 +670,9 @@ class WanTransformer3DModel(
         hidden_states = self.patch_embedding(hidden_states)
         hidden_states = hidden_states.flatten(2).transpose(1, 2)
 
+        # flatten+transpose produces a non-contiguous tensor; make it contiguous before the block loop.
+        hidden_states = hidden_states.contiguous()
+
         # timestep shape: batch_size, or batch_size, seq_len (wan 2.2 ti2v)
         if timestep.ndim == 2:
             ts_seq_len = timestep.shape[1]


### PR DESCRIPTION
# What does this PR do?

Similar to #14186

The non-contiguous tensor originates from `hidden_states.flatten(2).transpose(1, 2)` produces a non-contiguous layout whose overhead accumulates across transformer blocks in `WanTransformer3DModel`.

This patch improves performance on both CUDA and ROCm, though the gain is more pronounced on ROCm.


**Benchmarks** (Wan-AI/Wan2.2-TI2V-5B-Diffuser, 1280x704, 50 steps, bf16):

| Platform | PyTorch | Default | +contiguous | Speedup |
|---|---|---|---|---|
| NVIDIA RTX 5090 | 2.12.1+cu132 | 5.38 s/it | 5.22 s/it | +3.0% |
| AMD Radeon AI PRO R9700 (gfx1201) | 2.12.0+rocm7.15.0a20260713 | 12.23 s/it | 9.62 s/it | +21.3% |
| AMD Radeon(TM) 8060S Graphics (gfx1151) | 2.12.0+rocm7.15.0a20260711 | 115.73 s/it | 79.30 s/it | +31.5% 




## Before submitting
- [ ] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [ ] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [ ] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [ ] Did you share the final self-review notes in the PR description or a comment?
- [X] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [X] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?


## Who can review?

@sayakpaul

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
