### PR TITLE
[modular] detect stale auto docstrings in CI + regenerate current ones

### DIFF
--- a/.github/workflows/pr_modular_tests.yml
+++ b/.github/workflows/pr_modular_tests.yml
@@ -86,17 +86,19 @@ jobs:
         run: |
           echo "Repo consistency check failed. Please ensure the right dependency versions are installed with 'pip install -e .[quality]' and run 'make fix-copies'" >> $GITHUB_STEP_SUMMARY
   check_auto_docs:
-    runs-on: ubuntu-22.04
+    # the check regenerates each docstring from the block declarations, which requires importing diffusers —
+    # so this job runs in the torch container rather than a lint-only environment
+    runs-on:
+      group: aws-highmemory-32-plus
+    container:
+      image: diffusers/diffusers-pytorch-cpu
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
       - name: Install dependencies
         run: |
-          pip install --upgrade pip
-          pip install .[quality]
+          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          uv pip install -e ".[quality]"
+          uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
       - name: Check auto docs
         run: make modular-autodoctrings
       - name: Check if failure

--- a/src/diffusers/modular_pipelines/anima/modular_blocks_anima.py
+++ b/src/diffusers/modular_pipelines/anima/modular_blocks_anima.py
@@ -128,8 +128,8 @@ class AnimaDecodeStep(SequentialPipelineBlocks):
 # auto_docstring
 class AnimaImg2ImgCoreDenoiseStep(SequentialPipelineBlocks):
     """
-    Denoise block for Anima image-to-image generation. Expects ``image_latents`` already in state (produced by
-    ``AnimaImg2ImgVaeEncoderStep`` upstream).
+    Denoise block for Anima image-to-image generation. Uses image_latents already in state from
+    AnimaImg2ImgVaeEncoderStep.
 
       Components:
           text_conditioner (`AnimaTextConditioner`) transformer (`CosmosTransformer3DModel`) scheduler
@@ -155,7 +155,7 @@ class AnimaImg2ImgCoreDenoiseStep(SequentialPipelineBlocks):
           num_images_per_prompt (`int`, *optional*, defaults to 1):
               The number of images to generate per prompt.
           image_latents (`Tensor`):
-              Encoded image latents from ``AnimaImg2ImgVaeEncoderStep``.
+              image latents used to guide the image generation. Can be generated from vae_encoder step.
           height (`int`, *optional*):
               The height in pixels of the generated image.
           width (`int`, *optional*):
@@ -165,7 +165,7 @@ class AnimaImg2ImgCoreDenoiseStep(SequentialPipelineBlocks):
           sigmas (`list`, *optional*):
               Custom sigmas for the denoising process.
           strength (`float`, *optional*, defaults to 0.9):
-              Strength for img2img transformation.
+              Strength for img2img/inpainting.
           generator (`Generator`, *optional*):
               Torch generator for deterministic generation.
           latents (`Tensor`, *optional*):
@@ -203,15 +203,13 @@ class AnimaImg2ImgCoreDenoiseStep(SequentialPipelineBlocks):
 # auto_docstring
 class AnimaAutoCoreDenoiseStep(AutoPipelineBlocks):
     """
-    Denoise step that selects between text-to-image and image-to-image denoising based on whether ``image_latents`` is
-    present in state. - `AnimaCoreDenoiseStep` (text2image) is used when no ``image_latents`` are present. -
-    `AnimaImg2ImgCoreDenoiseStep` (img2img) is used when ``image_latents`` are present (set upstream by
-    ``AnimaAutoVaeImageEncoderStep``).
+    Denoise step that selects between text-to-image and image-to-image denoising based on whether image_latents is
+    present in state. - `AnimaCoreDenoiseStep` (text2image) is used when no image_latents are present. -
+    `AnimaImg2ImgCoreDenoiseStep` (img2img) is used when image_latents are present.
 
       Components:
-          text_conditioner (`AnimaTextConditioner`) transformer (`CosmosTransformer3DModel`) vae
-          (`AutoencoderKLQwenImage`) scheduler (`FlowMatchEulerDiscreteScheduler`) image_processor
-          (`VaeImageProcessor`) guider (`ClassifierFreeGuidance`)
+          text_conditioner (`AnimaTextConditioner`) transformer (`CosmosTransformer3DModel`) scheduler
+          (`FlowMatchEulerDiscreteScheduler`) guider (`ClassifierFreeGuidance`)
 
       Inputs:
           qwen_prompt_embeds (`Tensor`):
@@ -233,21 +231,21 @@ class AnimaAutoCoreDenoiseStep(AutoPipelineBlocks):
           num_images_per_prompt (`int`, *optional*, defaults to 1):
               The number of images to generate per prompt.
           image_latents (`Tensor`, *optional*):
-              Encoded image latents. When present in state, img2img denoising is selected.
+              image latents used to guide the image generation. Can be generated from vae_encoder step.
           height (`int`, *optional*):
               The height in pixels of the generated image.
           width (`int`, *optional*):
               The width in pixels of the generated image.
-          latents (`Tensor`, *optional*):
-              Pre-generated noisy latents for image generation.
-          generator (`Generator`, *optional*):
-              Torch generator for deterministic generation.
-          num_inference_steps (`int`, *optional*, defaults to 50):
+          num_inference_steps (`int`):
               The number of denoising steps.
           sigmas (`list`, *optional*):
               Custom sigmas for the denoising process.
           strength (`float`, *optional*, defaults to 0.9):
-              Strength for img2img transformation.
+              Strength for img2img/inpainting.
+          generator (`Generator`, *optional*):
+              Torch generator for deterministic generation.
+          latents (`Tensor`):
+              Pre-generated noisy latents for image generation.
           **denoiser_input_fields (`None`, *optional*):
               The conditional model inputs for the Anima denoiser.
 
@@ -273,26 +271,29 @@ class AnimaAutoCoreDenoiseStep(AutoPipelineBlocks):
 # auto_docstring
 class AnimaAutoVaeImageEncoderStep(AutoPipelineBlocks):
     """
-    VAE Image Encoder step that encodes the input image to produce ``image_latents``. This step is skipped when no
-    image is provided (text-to-image workflow).
+    VAE Image Encoder step that encodes the input image to produce image_latents. Skipped when no image is provided
+    (text-to-image workflow).
 
       Components:
           vae (`AutoencoderKLQwenImage`) image_processor (`VaeImageProcessor`)
 
       Inputs:
-          image (`Image`, *optional*):
-              Input image for image-to-image generation. When provided, the image is encoded to ``image_latents``. When
-              not provided, this step is skipped.
+          image (`Image | list`, *optional*):
+              Reference image(s) for denoising. Can be a single image or list of images.
           height (`int`, *optional*):
-              Height of the output image.
+              The height in pixels of the generated image.
           width (`int`, *optional*):
-              Width of the output image.
+              The width in pixels of the generated image.
           generator (`Generator`, *optional*):
               Torch generator for deterministic generation.
 
       Outputs:
           image_latents (`Tensor`):
-              Encoded image latents used by ``AnimaAutoCoreDenoiseStep`` to trigger img2img denoising.
+              Encoded image latents.
+          height (`int`):
+              Image height used for generation.
+          width (`int`):
+              Image width used for generation.
     """
 
     block_classes = [AnimaImg2ImgVaeEncoderStep]
@@ -314,13 +315,13 @@ class AnimaAutoBlocks(SequentialPipelineBlocks):
 
       Supported workflows:
         - `text2image`: requires `prompt`
-        - `img2img`: requires `prompt`, `image`
+        - `img2img`: requires `image`, `prompt`
 
       Components:
           text_encoder (`Qwen3Model`) tokenizer (`Qwen2Tokenizer`) t5_tokenizer (`T5Tokenizer`) guider
-          (`ClassifierFreeGuidance`) text_conditioner (`AnimaTextConditioner`) transformer (`CosmosTransformer3DModel`)
-          scheduler (`FlowMatchEulerDiscreteScheduler`) vae (`AutoencoderKLQwenImage`) image_processor
-          (`VaeImageProcessor`)
+          (`ClassifierFreeGuidance`) vae (`AutoencoderKLQwenImage`) image_processor (`VaeImageProcessor`)
+          text_conditioner (`AnimaTextConditioner`) transformer (`CosmosTransformer3DModel`) scheduler
+          (`FlowMatchEulerDiscreteScheduler`)
 
       Inputs:
           prompt (`str`):
@@ -329,24 +330,26 @@ class AnimaAutoBlocks(SequentialPipelineBlocks):
               The prompt or prompts not to guide the image generation.
           max_sequence_length (`int`, *optional*, defaults to 512):
               Maximum sequence length for prompt encoding.
-          num_images_per_prompt (`int`, *optional*, defaults to 1):
-              The number of images to generate per prompt.
           image (`Image | list`, *optional*):
-              Reference image(s) for image-to-image generation. When provided, img2img workflow is used.
+              Reference image(s) for denoising. Can be a single image or list of images.
           height (`int`, *optional*):
               The height in pixels of the generated image.
           width (`int`, *optional*):
               The width in pixels of the generated image.
-          latents (`Tensor`, *optional*):
-              Pre-generated noisy latents for image generation.
           generator (`Generator`, *optional*):
               Torch generator for deterministic generation.
-          num_inference_steps (`int`, *optional*, defaults to 50):
+          num_images_per_prompt (`int`, *optional*, defaults to 1):
+              The number of images to generate per prompt.
+          image_latents (`Tensor`, *optional*):
+              image latents used to guide the image generation. Can be generated from vae_encoder step.
+          num_inference_steps (`int`):
               The number of denoising steps.
           sigmas (`list`, *optional*):
               Custom sigmas for the denoising process.
           strength (`float`, *optional*, defaults to 0.9):
-              How much to transform the reference image (img2img only).
+              Strength for img2img/inpainting.
+          latents (`Tensor`):
+              Pre-generated noisy latents for image generation.
           **denoiser_input_fields (`None`, *optional*):
               The conditional model inputs for the Anima denoiser.
           output_type (`str`, *optional*, defaults to pil):

--- a/src/diffusers/modular_pipelines/cosmos/modular_blocks_cosmos3.py
+++ b/src/diffusers/modular_pipelines/cosmos/modular_blocks_cosmos3.py
@@ -123,6 +123,9 @@ class Cosmos3AutoTextEncoderStep(AutoPipelineBlocks):
       Components:
           video_processor (`VideoProcessor`) text_tokenizer (`AutoTokenizer`)
 
+      Configs:
+          default_use_system_prompt (default: True) enable_safety_checker (default: True)
+
       Inputs:
           control_videos (`dict`, *optional*):
               Mapping of hint name (edge/blur/depth/seg/wsm) to the control video for that modality.
@@ -140,9 +143,8 @@ class Cosmos3AutoTextEncoderStep(AutoPipelineBlocks):
               The text prompt that guides Cosmos3 generation.
           negative_prompt (`str`, *optional*):
               The negative text prompt used for classifier-free guidance.
-          use_system_prompt (`bool`, *optional*):
-              Whether to prepend the system prompt. Defaults to the pipeline configuration for standard and action
-              workflows and to True for transfer.
+          use_system_prompt (`bool`, *optional*, defaults to True):
+              Whether to prepend the Cosmos3 transfer system prompt.
           action (`CosmosActionCondition`, *optional*):
               Action-conditioning metadata and its reference visual input.
           fps (`float`, *optional*, defaults to 24.0):
@@ -368,6 +370,9 @@ class Cosmos3VisionCoreDenoiseStep(SequentialPipelineBlocks):
       Components:
           transformer (`Cosmos3OmniTransformer`) scheduler (`UniPCMultistepScheduler`)
 
+      Configs:
+          use_native_flow_schedule (default: False)
+
       Inputs:
           cond_input_ids (`None`):
               Token IDs for the conditional prompt.
@@ -435,6 +440,9 @@ class Cosmos3VisionSoundCoreDenoiseStep(SequentialPipelineBlocks):
 
       Components:
           transformer (`Cosmos3OmniTransformer`) scheduler (`UniPCMultistepScheduler`)
+
+      Configs:
+          use_native_flow_schedule (default: False)
 
       Inputs:
           cond_input_ids (`None`):
@@ -516,6 +524,9 @@ class Cosmos3VisionActionCoreDenoiseStep(SequentialPipelineBlocks):
 
       Components:
           transformer (`Cosmos3OmniTransformer`) scheduler (`UniPCMultistepScheduler`)
+
+      Configs:
+          use_native_flow_schedule (default: False)
 
       Inputs:
           cond_input_ids (`None`):
@@ -601,6 +612,9 @@ class Cosmos3VisionSoundActionCoreDenoiseStep(SequentialPipelineBlocks):
 
       Components:
           transformer (`Cosmos3OmniTransformer`) scheduler (`UniPCMultistepScheduler`)
+
+      Configs:
+          use_native_flow_schedule (default: False)
 
       Inputs:
           cond_input_ids (`None`):
@@ -962,6 +976,9 @@ class Cosmos3AutoCoreDenoiseStep(ConditionalPipelineBlocks):
           transformer (`Cosmos3OmniTransformer`) vae (`AutoencoderKLWan`) video_processor (`VideoProcessor`) scheduler
           (`UniPCMultistepScheduler`)
 
+      Configs:
+          use_native_flow_schedule (default: False)
+
       Inputs:
           cond_input_ids (`None`):
               Token IDs for the conditional prompt.
@@ -1149,6 +1166,10 @@ class Cosmos3OmniBlocks(SequentialPipelineBlocks):
           (`Cosmos3OmniTransformer`) scheduler (`UniPCMultistepScheduler`) sound_tokenizer
           (`Cosmos3AVAEAudioTokenizer`)
 
+      Configs:
+          default_use_system_prompt (default: True) enable_safety_checker (default: True) use_native_flow_schedule
+          (default: False)
+
       Inputs:
           control_videos (`dict`, *optional*):
               Mapping of hint name (edge/blur/depth/seg/wsm) to the control video for that modality.
@@ -1166,9 +1187,8 @@ class Cosmos3OmniBlocks(SequentialPipelineBlocks):
               The text prompt that guides Cosmos3 generation.
           negative_prompt (`str`, *optional*):
               The negative text prompt used for classifier-free guidance.
-          use_system_prompt (`bool`, *optional*):
-              Whether to prepend the system prompt. Defaults to the pipeline configuration for standard and action
-              workflows and to True for transfer.
+          use_system_prompt (`bool`, *optional*, defaults to True):
+              Whether to prepend the Cosmos3 transfer system prompt.
           action (`CosmosActionCondition`, *optional*):
               Action-conditioning metadata and its reference visual input.
           fps (`float`, *optional*, defaults to 24.0):

--- a/src/diffusers/modular_pipelines/cosmos/modular_blocks_cosmos3_distilled.py
+++ b/src/diffusers/modular_pipelines/cosmos/modular_blocks_cosmos3_distilled.py
@@ -165,7 +165,8 @@ class Cosmos3DistilledBlocks(SequentialPipelineBlocks):
           (`Cosmos3OmniTransformer`) scheduler (`FlowMatchEulerDiscreteScheduler`)
 
       Configs:
-          is_distilled (default: True) distilled_sigmas (default: None)
+          default_use_system_prompt (default: True) enable_safety_checker (default: True) is_distilled (default: True)
+          distilled_sigmas (default: None)
 
       Inputs:
           prompt (`str`):

--- a/src/diffusers/modular_pipelines/ernie_image/modular_blocks_ernie_image.py
+++ b/src/diffusers/modular_pipelines/ernie_image/modular_blocks_ernie_image.py
@@ -36,7 +36,7 @@ class ErnieImageAutoPromptEnhancerStep(ConditionalPipelineBlocks):
        - If `use_pe` is `None` or `False`, the step is skipped.
 
       Components:
-          pe (`AutoModelForCausalLM`) pe_tokenizer (`AutoTokenizer`)
+          pe (`Ministral3ForCausalLM`) pe_tokenizer (`AutoTokenizer`)
 
       Inputs:
           prompt (`str`, *optional*):
@@ -140,9 +140,10 @@ class ErnieImageAutoBlocks(SequentialPipelineBlocks):
         - `text2image`: requires `prompt`
 
       Components:
-          pe (`AutoModelForCausalLM`) pe_tokenizer (`AutoTokenizer`) text_encoder (`AutoModel`) tokenizer
+          pe (`Ministral3ForCausalLM`) pe_tokenizer (`AutoTokenizer`) text_encoder (`Mistral3Model`) tokenizer
           (`AutoTokenizer`) guider (`ClassifierFreeGuidance`) transformer (`ErnieImageTransformer2DModel`) scheduler
           (`FlowMatchEulerDiscreteScheduler`) vae (`AutoencoderKLFlux2`) pachifier (`ErnieImagePachifier`)
+          image_processor (`VaeImageProcessor`)
 
       Inputs:
           prompt (`str`, *optional*):

--- a/src/diffusers/modular_pipelines/flux/modular_blocks_flux.py
+++ b/src/diffusers/modular_pipelines/flux/modular_blocks_flux.py
@@ -521,7 +521,7 @@ class FluxAutoBlocks(SequentialPipelineBlocks):
 
       Components:
           text_encoder (`CLIPTextModel`) tokenizer (`CLIPTokenizer`) text_encoder_2 (`T5EncoderModel`) tokenizer_2
-          (`T5TokenizerFast`) image_processor (`VaeImageProcessor`) vae (`AutoencoderKL`) scheduler
+          (`T5Tokenizer`) image_processor (`VaeImageProcessor`) vae (`AutoencoderKL`) scheduler
           (`FlowMatchEulerDiscreteScheduler`) transformer (`FluxTransformer2DModel`)
 
       Inputs:

--- a/src/diffusers/modular_pipelines/flux/modular_blocks_flux_kontext.py
+++ b/src/diffusers/modular_pipelines/flux/modular_blocks_flux_kontext.py
@@ -521,7 +521,7 @@ class FluxKontextAutoBlocks(SequentialPipelineBlocks):
 
       Components:
           text_encoder (`CLIPTextModel`) tokenizer (`CLIPTokenizer`) text_encoder_2 (`T5EncoderModel`) tokenizer_2
-          (`T5TokenizerFast`) image_processor (`VaeImageProcessor`) vae (`AutoencoderKL`) scheduler
+          (`T5Tokenizer`) image_processor (`VaeImageProcessor`) vae (`AutoencoderKL`) scheduler
           (`FlowMatchEulerDiscreteScheduler`) transformer (`FluxTransformer2DModel`)
 
       Inputs:

--- a/src/diffusers/modular_pipelines/flux2/modular_blocks_flux2_klein.py
+++ b/src/diffusers/modular_pipelines/flux2/modular_blocks_flux2_klein.py
@@ -330,9 +330,8 @@ class Flux2KleinAutoBlocks(SequentialPipelineBlocks):
         - `image_conditioned`: requires `image`, `prompt`
 
       Components:
-          text_encoder (`Qwen3ForCausalLM`) tokenizer (`Qwen2TokenizerFast`) image_processor (`Flux2ImageProcessor`)
-          vae (`AutoencoderKLFlux2`) scheduler (`FlowMatchEulerDiscreteScheduler`) transformer
-          (`Flux2Transformer2DModel`)
+          text_encoder (`Qwen3ForCausalLM`) tokenizer (`Qwen2Tokenizer`) image_processor (`Flux2ImageProcessor`) vae
+          (`AutoencoderKLFlux2`) scheduler (`FlowMatchEulerDiscreteScheduler`) transformer (`Flux2Transformer2DModel`)
 
       Configs:
           is_distilled (default: True)

--- a/src/diffusers/modular_pipelines/flux2/modular_blocks_flux2_klein_base.py
+++ b/src/diffusers/modular_pipelines/flux2/modular_blocks_flux2_klein_base.py
@@ -343,7 +343,7 @@ class Flux2KleinBaseAutoBlocks(SequentialPipelineBlocks):
         - `image_conditioned`: requires `image`, `prompt`
 
       Components:
-          text_encoder (`Qwen3ForCausalLM`) tokenizer (`Qwen2TokenizerFast`) guider (`ClassifierFreeGuidance`)
+          text_encoder (`Qwen3ForCausalLM`) tokenizer (`Qwen2Tokenizer`) guider (`ClassifierFreeGuidance`)
           image_processor (`Flux2ImageProcessor`) vae (`AutoencoderKLFlux2`) scheduler
           (`FlowMatchEulerDiscreteScheduler`) transformer (`Flux2Transformer2DModel`)
 

--- a/src/diffusers/modular_pipelines/ideogram4/encoders.py
+++ b/src/diffusers/modular_pipelines/ideogram4/encoders.py
@@ -41,32 +41,33 @@ QWEN3_VL_ACTIVATION_LAYERS = (0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 35)
 # auto_docstring
 class Ideogram4PromptUpsampleStep(ModularPipelineBlocks):
     """
-    Optional step that rewrites the prompt(s) into Ideogram4's native structured JSON caption (the format the model is
-    trained on) when ``prompt_upsampling=True``. Requires the optional ``prompt_enhancer_head`` component, which is
-    grafted onto the shared ``text_encoder`` body to make it generative; install ``outlines`` for schema-constrained
-    captions.
+    Optional step that rewrites the prompt(s) into Ideogram4's native structured JSON caption when
+    `prompt_upsampling=True` (the format the model is trained on). Requires a generative `text_encoder` (a
+    `Qwen3VLForConditionalGeneration`); install `outlines` for schema-constrained captions.
 
       Components:
           text_encoder (`Qwen3VLModel`): The Qwen3-VL text encoder. tokenizer (`Qwen2Tokenizer`): The tokenizer paired
-          with the text encoder. prompt_enhancer_head (`Ideogram4PromptEnhancerHead`): The LM head grafted onto the
-          text encoder for upsampling.
+          with the text encoder. prompt_enhancer_head (`Ideogram4PromptEnhancerHead`): LM head grafted onto the text
+          encoder for prompt upsampling.
 
       Inputs:
           prompt (`str`):
               The prompt or prompts to guide image generation.
           prompt_upsampling (`bool`, *optional*, defaults to False):
-              If True, rewrite the prompt into the native JSON caption before encoding.
+              If True, rewrite the prompt into Ideogram4's native JSON caption before encoding.
           prompt_upsampling_temperature (`float`, *optional*, defaults to 1.0):
               Sampling temperature for prompt upsampling.
           height (`int`, *optional*):
-              Together with width, sets the caption's target aspect ratio.
+              The height in pixels of the generated image.
           width (`int`, *optional*):
-              Together with height, sets the caption's target aspect ratio.
+              The width in pixels of the generated image.
+          max_sequence_length (`int`, *optional*, defaults to 2048):
+              Maximum sequence length for prompt encoding.
           generator (`Generator`, *optional*):
-              Reused to make the upsampling reproducible.
+              Torch generator for deterministic generation.
 
       Outputs:
-          prompt (`str`):
+          prompt (`list`):
               The (possibly upsampled) prompt forwarded to the text encoder.
     """
 

--- a/src/diffusers/modular_pipelines/ideogram4/modular_blocks_ideogram4.py
+++ b/src/diffusers/modular_pipelines/ideogram4/modular_blocks_ideogram4.py
@@ -108,15 +108,16 @@ class Ideogram4CoreDenoiseStep(SequentialPipelineBlocks):
 # auto_docstring
 class Ideogram4AutoBlocks(SequentialPipelineBlocks):
     """
-    Auto Modular pipeline for text-to-image generation using Ideogram4: encode text -> core denoise (asymmetric CFG
-    over two transformers) -> decode.
+    Auto Modular pipeline for text-to-image generation using Ideogram4: (optional) prompt upsampling -> encode text ->
+    core denoise (asymmetric CFG over two transformers) -> decode.
 
       Supported workflows:
         - `text2image`: requires `prompt`
 
       Components:
           text_encoder (`Qwen3VLModel`): The Qwen3-VL text encoder. tokenizer (`Qwen2Tokenizer`): The tokenizer paired
-          with the text encoder. transformer (`Ideogram4Transformer2DModel`) scheduler
+          with the text encoder. prompt_enhancer_head (`Ideogram4PromptEnhancerHead`): LM head grafted onto the text
+          encoder for prompt upsampling. transformer (`Ideogram4Transformer2DModel`) scheduler
           (`FlowMatchEulerDiscreteScheduler`) unconditional_transformer (`Ideogram4Transformer2DModel`) vae
           (`AutoencoderKLFlux2`) image_processor (`VaeImageProcessor`)
 
@@ -124,21 +125,21 @@ class Ideogram4AutoBlocks(SequentialPipelineBlocks):
           prompt (`str`):
               The prompt or prompts to guide image generation.
           prompt_upsampling (`bool`, *optional*, defaults to False):
-              Rewrite the prompt into Ideogram4's native structured JSON caption before encoding.
+              If True, rewrite the prompt into Ideogram4's native JSON caption before encoding.
           prompt_upsampling_temperature (`float`, *optional*, defaults to 1.0):
               Sampling temperature for prompt upsampling.
+          height (`int`, *optional*):
+              The height in pixels of the generated image.
+          width (`int`, *optional*):
+              The width in pixels of the generated image.
           max_sequence_length (`int`, *optional*, defaults to 2048):
               Maximum sequence length for prompt encoding.
+          generator (`Generator`, *optional*):
+              Torch generator for deterministic generation.
           num_images_per_prompt (`int`, *optional*, defaults to 1):
               The number of images to generate per prompt.
           latents (`Tensor`, *optional*):
               Pre-generated noisy latents for image generation.
-          height (`int`):
-              The height in pixels of the generated image.
-          width (`int`):
-              The width in pixels of the generated image.
-          generator (`Generator`, *optional*):
-              Torch generator for deterministic generation.
           num_inference_steps (`int`, *optional*, defaults to 48):
               The number of denoising steps.
           mu (`float`, *optional*, defaults to 0.0):

--- a/src/diffusers/modular_pipelines/ltx/modular_blocks_ltx.py
+++ b/src/diffusers/modular_pipelines/ltx/modular_blocks_ltx.py
@@ -166,7 +166,7 @@ class LTXBlocks(SequentialPipelineBlocks):
     Modular pipeline blocks for LTX Video text-to-video.
 
       Components:
-          text_encoder (`T5EncoderModel`) tokenizer (`T5TokenizerFast`) guider (`ClassifierFreeGuidance`) scheduler
+          text_encoder (`T5EncoderModel`) tokenizer (`T5Tokenizer`) guider (`ClassifierFreeGuidance`) scheduler
           (`FlowMatchEulerDiscreteScheduler`) pachifier (`LTXVideoPachifier`) transformer
           (`LTXVideoTransformer3DModel`) vae (`AutoencoderKLLTXVideo`) video_processor (`VideoProcessor`)
 
@@ -343,7 +343,7 @@ class LTXAutoBlocks(SequentialPipelineBlocks):
         - `image2video`: requires `image`, `prompt`
 
       Components:
-          text_encoder (`T5EncoderModel`) tokenizer (`T5TokenizerFast`) guider (`ClassifierFreeGuidance`) vae
+          text_encoder (`T5EncoderModel`) tokenizer (`T5Tokenizer`) guider (`ClassifierFreeGuidance`) vae
           (`AutoencoderKLLTXVideo`) video_processor (`VideoProcessor`) scheduler (`FlowMatchEulerDiscreteScheduler`)
           pachifier (`LTXVideoPachifier`) transformer (`LTXVideoTransformer3DModel`)
 
@@ -420,7 +420,7 @@ class LTXImage2VideoBlocks(SequentialPipelineBlocks):
     Modular pipeline blocks for LTX Video image-to-video.
 
       Components:
-          text_encoder (`T5EncoderModel`) tokenizer (`T5TokenizerFast`) guider (`ClassifierFreeGuidance`) vae
+          text_encoder (`T5EncoderModel`) tokenizer (`T5Tokenizer`) guider (`ClassifierFreeGuidance`) vae
           (`AutoencoderKLLTXVideo`) video_processor (`VideoProcessor`) scheduler (`FlowMatchEulerDiscreteScheduler`)
           pachifier (`LTXVideoPachifier`) transformer (`LTXVideoTransformer3DModel`)
 

--- a/src/diffusers/modular_pipelines/stable_diffusion_3/modular_blocks_stable_diffusion_3.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_3/modular_blocks_stable_diffusion_3.py
@@ -298,7 +298,7 @@ class StableDiffusion3AutoBlocks(SequentialPipelineBlocks):
       Components:
           text_encoder (`CLIPTextModelWithProjection`) tokenizer (`CLIPTokenizer`) text_encoder_2
           (`CLIPTextModelWithProjection`) tokenizer_2 (`CLIPTokenizer`) text_encoder_3 (`T5EncoderModel`) tokenizer_3
-          (`T5TokenizerFast`) image_processor (`VaeImageProcessor`) vae (`AutoencoderKL`) scheduler
+          (`T5Tokenizer`) image_processor (`VaeImageProcessor`) vae (`AutoencoderKL`) scheduler
           (`FlowMatchEulerDiscreteScheduler`) guider (`ClassifierFreeGuidance`) transformer (`SD3Transformer2DModel`)
 
       Inputs:

--- a/utils/modular_auto_docstring.py
+++ b/utils/modular_auto_docstring.py
@@ -23,7 +23,8 @@ Run from the root of the repo:
     python utils/modular_auto_docstring.py [path] [--fix_and_overwrite]
 
 Examples:
-    # Check for auto_docstring markers (will error if found without proper docstring)
+    # Check mode (will error if a marked class's docstring is missing or out of date — the check regenerates
+    # each docstring the same way --fix_and_overwrite would and compares the result with the file)
     python utils/modular_auto_docstring.py
 
     # Check specific directory
@@ -50,6 +51,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 
 
 # All paths are set with the intent you should run this script from the root of the repo
@@ -198,7 +200,7 @@ def format_docstring(doc: str, indent: str = "    ") -> str:
         return "".join(result)
 
 
-def run_ruff_format(filepath: str):
+def run_ruff_format(filepath: str, quiet: bool = False):
     """Run ruff check --fix, ruff format, and doc-builder style on a file to ensure consistent formatting."""
     try:
         # First run ruff check --fix to fix any linting issues (including line length)
@@ -222,13 +224,27 @@ def run_ruff_format(filepath: str):
             capture_output=True,
             text=True,
         )
-        print(f"Formatted {filepath}")
+        if not quiet:
+            print(f"Formatted {filepath}")
     except subprocess.CalledProcessError as e:
         print(f"Warning: formatting failed for {filepath}: {e.stderr}")
     except FileNotFoundError as e:
         print(f"Warning: tool not found ({e}). Skipping formatting.")
     except Exception as e:
         print(f"Warning: unexpected error formatting {filepath}: {e}")
+
+
+def format_content(content: str, filepath: str) -> str:
+    """Run the same formatters fix mode uses on a temporary copy of `content` and return the result."""
+    fd, tmp_path = tempfile.mkstemp(suffix=".py", dir=os.path.dirname(filepath) or ".")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+            f.write(content)
+        run_ruff_format(tmp_path, quiet=True)
+        with open(tmp_path, "r", encoding="utf-8", newline="\n") as f:
+            return f.read()
+    finally:
+        os.remove(tmp_path)
 
 
 def get_existing_docstring(lines: list, class_line: int, docstring_end_line: int) -> str:
@@ -239,35 +255,18 @@ def get_existing_docstring(lines: list, class_line: int, docstring_end_line: int
     return "".join(docstring_lines)
 
 
-def process_file(filepath: str, overwrite: bool = False) -> list:
+def build_updated_lines(filepath: str, classes_to_update: list) -> tuple:
     """
-    Process a file and find/insert docstrings for # auto_docstring marked classes.
-
-    Returns list of classes that need updating.
+    Return the file's lines with every marked class's docstring regenerated (pre-formatting), plus the names of the
+    classes that were regenerated.
     """
-    classes_to_update = find_auto_docstring_classes(filepath)
-
-    if not classes_to_update:
-        return []
-
-    if not overwrite:
-        # Check mode: only verify that docstrings exist
-        # Content comparison is not reliable due to formatting differences
-        classes_needing_update = []
-        for class_name, class_line, has_docstring, docstring_end_line in classes_to_update:
-            if not has_docstring:
-                # No docstring exists, needs update
-                classes_needing_update.append((filepath, class_name, class_line))
-        return classes_needing_update
-
-    # Load the module to get doc properties
     module = load_module(filepath)
 
     with open(filepath, "r", encoding="utf-8", newline="\n") as f:
         lines = f.readlines()
 
     # Process in reverse order to maintain line numbers
-    updated = False
+    updated_names = []
     for class_name, class_line, has_docstring, docstring_end_line in reversed(classes_to_update):
         doc = get_doc_from_class(module, class_name)
 
@@ -291,16 +290,66 @@ def process_file(filepath: str, overwrite: bool = False) -> list:
             # Insert at position class_line (which is right after the class line)
             lines = lines[:class_line] + [new_docstring] + lines[class_line:]
 
-        updated = True
-        print(f"Updated docstring for {class_name} in {filepath}")
+        updated_names.append(class_name)
 
-    if updated:
-        with open(filepath, "w", encoding="utf-8", newline="\n") as f:
-            f.writelines(lines)
-        # Run ruff format to ensure consistent line wrapping
-        run_ruff_format(filepath)
+    return lines, updated_names
 
-    return [(filepath, cls_name, line) for cls_name, line, _, _ in classes_to_update]
+
+def _class_docstrings(content: str) -> dict:
+    """Map class name -> raw docstring value for every class in `content`."""
+    tree = ast.parse(content)
+    return {
+        node.name: ast.get_docstring(node, clean=False) for node in ast.walk(tree) if isinstance(node, ast.ClassDef)
+    }
+
+
+def process_file(filepath: str, overwrite: bool = False) -> list:
+    """
+    Process a file and find/insert docstrings for # auto_docstring marked classes.
+
+    In fix mode, regenerates every marked docstring in place. In check mode, regenerates them on a temporary copy
+    through the same formatting pipeline and returns the classes whose checked-in docstring differs from the
+    regenerated one (missing docstrings included).
+
+    Returns list of classes that need updating.
+    """
+    classes_to_update = find_auto_docstring_classes(filepath)
+
+    if not classes_to_update:
+        return []
+
+    lines, updated_names = build_updated_lines(filepath, classes_to_update)
+
+    if overwrite:
+        if updated_names:
+            with open(filepath, "w", encoding="utf-8", newline="\n") as f:
+                f.writelines(lines)
+            # Run ruff format to ensure consistent line wrapping
+            run_ruff_format(filepath)
+            for class_name in reversed(updated_names):
+                print(f"Updated docstring for {class_name} in {filepath}")
+        return [(filepath, cls_name, line) for cls_name, line, _, _ in classes_to_update]
+
+    # Check mode: regenerate through the same formatting pipeline and compare with the checked-in file
+    with open(filepath, "r", encoding="utf-8", newline="\n") as f:
+        current_content = f.read()
+
+    new_content = format_content("".join(lines), filepath)
+    if new_content == current_content:
+        return []
+
+    current_docs = _class_docstrings(current_content)
+    new_docs = _class_docstrings(new_content)
+    stale = [
+        (filepath, class_name, class_line)
+        for class_name, class_line, _, _ in classes_to_update
+        if current_docs.get(class_name) != new_docs.get(class_name)
+    ]
+    if not stale:
+        # the regenerated file differs outside the marked docstrings (e.g. the file itself is not
+        # ruff/doc-builder clean); attribute it to the file so the mismatch is not silently ignored
+        stale = [(filepath, classes_to_update[0][0], classes_to_update[0][1])]
+    return stale
 
 
 def check_auto_docstrings(path: str = None, overwrite: bool = False):
@@ -324,14 +373,16 @@ def check_auto_docstrings(path: str = None, overwrite: bool = False):
     if not overwrite and len(all_markers) > 0:
         message = "\n".join([f"- {f}: {cls} at line {line}" for f, cls, line in all_markers])
         raise ValueError(
-            f"Found the following # auto_docstring markers that need docstrings:\n{message}\n\n"
-            f"Run `python utils/modular_auto_docstring.py --fix_and_overwrite` to fix them."
+            f"The following # auto_docstring docstrings are missing or out of date:\n{message}\n\n"
+            f"These docstrings are generated from the block declarations (which may live in other files), so a "
+            f"change elsewhere can make them stale. Run `python utils/modular_auto_docstring.py --fix_and_overwrite` "
+            f"from the root of the repo to regenerate them."
         )
 
     if overwrite and len(all_markers) > 0:
         print(f"\nProcessed {len(all_markers)} docstring(s).")
     elif not overwrite and len(all_markers) == 0:
-        print("All # auto_docstring markers have valid docstrings.")
+        print("All # auto_docstring markers have up-to-date docstrings.")
     elif len(all_markers) == 0:
         print("No # auto_docstring markers found.")
 


### PR DESCRIPTION
The `# auto_docstring` check only verified that a docstring exists, regardless of whether its contents are up to date  https://github.com/huggingface/diffusers/blob/main/utils/modular_auto_docstring.py#L254  

so whenever a user updates something on the block that would cause the docstring to change (e.g., the block `description` field, `InputParam) and forgets to run the `utils/modular_auto_docstring.py --fix_and_overwrite` again, the docstring would go stale, and our CI will not catch it 
 
this PR:
 (1) regenerates the currently stale docstrings.
 (2) makes check mode work like `check_copies`: regenerate each docstring in memory through the exact same workflow as --fix_and_overwrite (generate → insert → ruff/doc-builder format on a temp copy) and fail with the list of stale classes if the result differs from the file. 

For contributors: if CI fails, run python utils/modular_auto_docstring.py --fix_and_overwrite from the repo root and push — same as make fix-copies.