### PR TITLE
refactor wan 2.2 image-to-video pipeline tests to the new mixin structure

### DIFF
--- a/tests/pipelines/wan/test_wan_22_image_to_video.py
+++ b/tests/pipelines/wan/test_wan_22_image_to_video.py
@@ -12,44 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tempfile
-import unittest
 
-import numpy as np
+import pytest
 import torch
 from PIL import Image
 from transformers import AutoConfig, AutoTokenizer, T5EncoderModel
 
 from diffusers import AutoencoderKLWan, UniPCMultistepScheduler, WanImageToVideoPipeline, WanTransformer3DModel
 
-from ...testing_utils import (
-    enable_full_determinism,
-    torch_device,
-)
-from ..pipeline_params import TEXT_TO_IMAGE_BATCH_PARAMS, TEXT_TO_IMAGE_IMAGE_PARAMS, TEXT_TO_IMAGE_PARAMS
-from ..test_pipelines_common import PipelineTesterMixin
+from ...testing_utils import assert_tensors_close, torch_device
+from ..testing_utils import BasePipelineTesterConfig, MemoryTesterMixin, PipelineTesterMixin
 
 
-enable_full_determinism()
-
-
-class Wan22ImageToVideoPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
+class Wan22ImageToVideoPipelineTesterConfig(BasePipelineTesterConfig):
     pipeline_class = WanImageToVideoPipeline
-    params = TEXT_TO_IMAGE_PARAMS - {"cross_attention_kwargs"}
-    batch_params = TEXT_TO_IMAGE_BATCH_PARAMS
-    image_params = TEXT_TO_IMAGE_IMAGE_PARAMS
-    image_latents_params = TEXT_TO_IMAGE_IMAGE_PARAMS
-    required_optional_params = frozenset(
-        [
-            "num_inference_steps",
-            "generator",
-            "latents",
-            "return_dict",
-            "callback_on_step_end",
-            "callback_on_step_end_tensor_inputs",
-        ]
+    required_input_params_in_call_signature = frozenset(
+        ["prompt", "negative_prompt", "height", "width", "guidance_scale", "prompt_embeds", "negative_prompt_embeds"]
     )
-    test_xformers_attention = False
+    batch_input_params = frozenset(["prompt"])
+    # Wan is a video pipeline: it exposes `num_videos_per_prompt`, not the base default `num_images_per_prompt`.
+    optional_input_params = frozenset(
+        ["num_inference_steps", "num_videos_per_prompt", "generator", "latents", "output_type", "return_dict"]
+    )
 
     def get_dummy_components(self):
         torch.manual_seed(0)
@@ -99,7 +83,7 @@ class Wan22ImageToVideoPipelineFastTests(PipelineTesterMixin, unittest.TestCase)
             rope_max_seq_len=32,
         )
 
-        components = {
+        return {
             "transformer": transformer,
             "vae": vae,
             "scheduler": scheduler,
@@ -110,122 +94,91 @@ class Wan22ImageToVideoPipelineFastTests(PipelineTesterMixin, unittest.TestCase)
             "image_processor": None,
             "boundary_ratio": 0.875,
         }
-        return components
 
-    def get_dummy_inputs(self, device, seed=0):
-        if str(device).startswith("mps"):
-            generator = torch.manual_seed(seed)
-        else:
-            generator = torch.Generator(device=device).manual_seed(seed)
+    def get_dummy_inputs(self):
         image_height = 16
         image_width = 16
         image = Image.new("RGB", (image_width, image_height))
-        inputs = {
+        return {
             "image": image,
             "prompt": "dance monkey",
             "negative_prompt": "negative",  # TODO
             "height": image_height,
             "width": image_width,
-            "generator": generator,
+            "generator": self.get_generator(0),
             "num_inference_steps": 2,
             "guidance_scale": 6.0,
             "num_frames": 9,
             "max_sequence_length": 16,
+            # Request torch outputs so tests compare torch tensors directly (see `BasePipelineTesterConfig`).
             "output_type": "pt",
         }
-        return inputs
 
+
+class TestWan22ImageToVideoPipeline(Wan22ImageToVideoPipelineTesterConfig, PipelineTesterMixin):
     def test_inference(self):
-        device = "cpu"
+        # Run on CPU: the expected slice below is CPU-specific.
+        pipe = self.get_pipeline()
 
-        components = self.get_dummy_components()
-        pipe = self.pipeline_class(
-            **components,
-        )
-        pipe.to(device)
-        pipe.set_progress_bar_config(disable=None)
-
-        inputs = self.get_dummy_inputs(device)
+        inputs = self.get_dummy_inputs()
         video = pipe(**inputs).frames
         generated_video = video[0]
-        self.assertEqual(generated_video.shape, (9, 3, 16, 16))
+        assert generated_video.shape == (9, 3, 16, 16)
 
         # fmt: off
-        expected_slice = torch.tensor([0.4527, 0.4526, 0.4498, 0.4539, 0.4521, 0.4524, 0.4533, 0.4535, 0.5154,
-                                       0.5353, 0.5200, 0.5174, 0.5434, 0.5301, 0.5199, 0.5216])
+        expected_slice = torch.tensor([0.4527, 0.4526, 0.4498, 0.4539, 0.4521, 0.4524, 0.4533, 0.4535, 0.5154, 0.5353, 0.5200, 0.5174, 0.5434, 0.5301, 0.5199, 0.5216])
         # fmt: on
 
         generated_slice = generated_video.flatten()
         generated_slice = torch.cat([generated_slice[:8], generated_slice[-8:]])
-        self.assertTrue(
-            torch.allclose(generated_slice, expected_slice, atol=1e-3),
-            f"generated_slice: {generated_slice}, expected_slice: {expected_slice}",
-        )
+        assert torch.allclose(generated_slice, expected_slice, atol=1e-3)
 
-    @unittest.skip("Test not supported")
-    def test_attention_slicing_forward_pass(self):
-        pass
-
-    def test_save_load_optional_components(self, expected_max_difference=1e-4):
-        optional_component = ["transformer", "image_encoder", "image_processor"]
-
+    def test_save_load_optional_components(self, tmp_path, expected_max_difference=1e-4):
+        # `_optional_components` lists `transformer`, `transformer_2`, `image_encoder` and `image_processor`. For the
+        # wan2.2 14B i2v pipeline `transformer` is not used when `boundary_ratio` is 1.0, so null it (plus the unused
+        # image encoder/processor) rather than every optional component, which would leave no denoiser.
         components = self.get_dummy_components()
-        for component in optional_component:
-            components[component] = None
-        components["boundary_ratio"] = 1.0  # for wan 2.2 14B, transformer is not used when boundary_ratio is 1.0
+        for name in ["transformer", "image_encoder", "image_processor"]:
+            components[name] = None
+        components["boundary_ratio"] = 1.0
+        pipe = self.get_pipeline(**components).to(torch_device)
 
-        pipe = self.pipeline_class(**components)
-        for component in pipe.components.values():
-            if hasattr(component, "set_default_attn_processor"):
-                component.set_default_attn_processor()
-        pipe.to(torch_device)
-        pipe.set_progress_bar_config(disable=None)
-
-        generator_device = "cpu"
-        inputs = self.get_dummy_inputs(generator_device)
-        torch.manual_seed(0)
+        inputs = self.get_dummy_inputs()
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            pipe.save_pretrained(tmpdir, safe_serialization=False)
-            pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
-            for component in pipe_loaded.components.values():
-                if hasattr(component, "set_default_attn_processor"):
-                    component.set_default_attn_processor()
-            pipe_loaded.to(torch_device)
-            pipe_loaded.set_progress_bar_config(disable=None)
+        pipe.save_pretrained(tmp_path, safe_serialization=False)
+        pipe_loaded = self.pipeline_class.from_pretrained(tmp_path)
+        pipe_loaded.to(torch_device)
+        pipe_loaded.set_progress_bar_config(disable=None)
 
-        for component in optional_component:
-            self.assertTrue(
-                getattr(pipe_loaded, component) is None,
-                f"`{component}` did not stay set to None after loading.",
-            )
+        for name in ["transformer", "image_encoder", "image_processor"]:
+            assert getattr(pipe_loaded, name) is None, f"`{name}` did not stay set to None after loading."
 
-        inputs = self.get_dummy_inputs(generator_device)
-        torch.manual_seed(0)
+        inputs = self.get_dummy_inputs()
         output_loaded = pipe_loaded(**inputs)[0]
 
-        max_diff = np.abs(output.detach().cpu().numpy() - output_loaded.detach().cpu().numpy()).max()
-        self.assertLess(max_diff, expected_max_difference)
+        assert_tensors_close(
+            output_loaded,
+            output,
+            atol=expected_max_difference,
+            msg="Output changed after dropping the optional components.",
+        )
 
 
-class Wan225BImageToVideoPipelineFastTests(PipelineTesterMixin, unittest.TestCase):
+class TestWan22ImageToVideoPipelineMemory(Wan22ImageToVideoPipelineTesterConfig, MemoryTesterMixin):
+    pass
+
+
+class Wan225BImageToVideoPipelineTesterConfig(BasePipelineTesterConfig):
     pipeline_class = WanImageToVideoPipeline
-    params = TEXT_TO_IMAGE_PARAMS - {"cross_attention_kwargs"}
-    batch_params = TEXT_TO_IMAGE_BATCH_PARAMS
-    image_params = TEXT_TO_IMAGE_IMAGE_PARAMS
-    image_latents_params = TEXT_TO_IMAGE_IMAGE_PARAMS
-    required_optional_params = frozenset(
-        [
-            "num_inference_steps",
-            "generator",
-            "latents",
-            "return_dict",
-            "callback_on_step_end",
-            "callback_on_step_end_tensor_inputs",
-        ]
+    required_input_params_in_call_signature = frozenset(
+        ["prompt", "negative_prompt", "height", "width", "guidance_scale", "prompt_embeds", "negative_prompt_embeds"]
     )
-    test_xformers_attention = False
+    batch_input_params = frozenset(["prompt"])
+    # Wan is a video pipeline: it exposes `num_videos_per_prompt`, not the base default `num_images_per_prompt`.
+    optional_input_params = frozenset(
+        ["num_inference_steps", "num_videos_per_prompt", "generator", "latents", "output_type", "return_dict"]
+    )
 
     def get_dummy_components(self):
         torch.manual_seed(0)
@@ -267,7 +220,7 @@ class Wan225BImageToVideoPipelineFastTests(PipelineTesterMixin, unittest.TestCas
             rope_max_seq_len=32,
         )
 
-        components = {
+        return {
             "transformer": transformer,
             "vae": vae,
             "scheduler": scheduler,
@@ -279,114 +232,92 @@ class Wan225BImageToVideoPipelineFastTests(PipelineTesterMixin, unittest.TestCas
             "boundary_ratio": None,
             "expand_timesteps": True,
         }
-        return components
 
-    def get_dummy_inputs(self, device, seed=0):
-        if str(device).startswith("mps"):
-            generator = torch.manual_seed(seed)
-        else:
-            generator = torch.Generator(device=device).manual_seed(seed)
+    def get_dummy_inputs(self):
         image_height = 32
         image_width = 32
         image = Image.new("RGB", (image_width, image_height))
-        inputs = {
+        return {
             "image": image,
             "prompt": "dance monkey",
             "negative_prompt": "negative",  # TODO
             "height": image_height,
             "width": image_width,
-            "generator": generator,
+            "generator": self.get_generator(0),
             "num_inference_steps": 2,
             "guidance_scale": 6.0,
             "num_frames": 9,
             "max_sequence_length": 16,
+            # Request torch outputs so tests compare torch tensors directly (see `BasePipelineTesterConfig`).
             "output_type": "pt",
         }
-        return inputs
 
+
+class TestWan225BImageToVideoPipeline(Wan225BImageToVideoPipelineTesterConfig, PipelineTesterMixin):
     def test_inference(self):
-        device = "cpu"
+        # Run on CPU: the expected slice below is CPU-specific.
+        pipe = self.get_pipeline()
 
-        components = self.get_dummy_components()
-        pipe = self.pipeline_class(
-            **components,
-        )
-        pipe.to(device)
-        pipe.set_progress_bar_config(disable=None)
-
-        inputs = self.get_dummy_inputs(device)
+        inputs = self.get_dummy_inputs()
         video = pipe(**inputs).frames
         generated_video = video[0]
-        self.assertEqual(generated_video.shape, (9, 3, 32, 32))
+        assert generated_video.shape == (9, 3, 32, 32)
 
         # fmt: off
-        expected_slice = torch.tensor([[0.4833, 0.4305, 0.5100, 0.4299, 0.5056, 0.4298, 0.5052, 0.4332, 0.5550,
-                                       0.6092, 0.5536, 0.5928, 0.5199, 0.5864, 0.6705, 0.5493]])
+        expected_slice = torch.tensor([[0.4833, 0.4305, 0.5100, 0.4299, 0.5056, 0.4298, 0.5052, 0.4332, 0.5550, 0.6092, 0.5536, 0.5928, 0.5199, 0.5864, 0.6705, 0.5493]])
         # fmt: on
 
         generated_slice = generated_video.flatten()
         generated_slice = torch.cat([generated_slice[:8], generated_slice[-8:]])
-        self.assertTrue(
-            torch.allclose(generated_slice, expected_slice, atol=1e-3),
-            f"generated_slice: {generated_slice}, expected_slice: {expected_slice}",
-        )
-
-    @unittest.skip("Test not supported")
-    def test_attention_slicing_forward_pass(self):
-        pass
+        assert torch.allclose(generated_slice, expected_slice, atol=1e-3)
 
     def test_components_function(self):
         init_components = self.get_dummy_components()
         init_components.pop("boundary_ratio")
         init_components.pop("expand_timesteps")
-        pipe = self.pipeline_class(**init_components)
+        pipe = self.get_pipeline(**init_components)
 
-        self.assertTrue(hasattr(pipe, "components"))
-        self.assertTrue(set(pipe.components.keys()) == set(init_components.keys()))
+        assert hasattr(pipe, "components")
+        assert set(pipe.components.keys()) == set(init_components.keys())
 
-    def test_save_load_optional_components(self, expected_max_difference=1e-4):
-        optional_component = ["transformer_2", "image_encoder", "image_processor"]
-
+    def test_save_load_optional_components(self, tmp_path, expected_max_difference=1e-4):
+        # `_optional_components` lists `transformer`, `transformer_2`, `image_encoder` and `image_processor`, but the
+        # 5B wan2.2 i2v pipeline denoises with `transformer` alone, so only `transformer_2`/`image_encoder`/
+        # `image_processor` are optional. The base test nulls every optional component, dropping the required
+        # `transformer` and leaving no denoiser, so restrict this to those three.
         components = self.get_dummy_components()
-        for component in optional_component:
-            components[component] = None
-        pipe = self.pipeline_class(**components)
-        for component in pipe.components.values():
-            if hasattr(component, "set_default_attn_processor"):
-                component.set_default_attn_processor()
-        pipe.to(torch_device)
-        pipe.set_progress_bar_config(disable=None)
+        for name in ["transformer_2", "image_encoder", "image_processor"]:
+            components[name] = None
+        pipe = self.get_pipeline(**components).to(torch_device)
 
-        generator_device = "cpu"
-        inputs = self.get_dummy_inputs(generator_device)
-        torch.manual_seed(0)
+        inputs = self.get_dummy_inputs()
         output = pipe(**inputs)[0]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            pipe.save_pretrained(tmpdir, safe_serialization=False)
-            pipe_loaded = self.pipeline_class.from_pretrained(tmpdir)
-            for component in pipe_loaded.components.values():
-                if hasattr(component, "set_default_attn_processor"):
-                    component.set_default_attn_processor()
-            pipe_loaded.to(torch_device)
-            pipe_loaded.set_progress_bar_config(disable=None)
+        pipe.save_pretrained(tmp_path, safe_serialization=False)
+        pipe_loaded = self.pipeline_class.from_pretrained(tmp_path)
+        pipe_loaded.to(torch_device)
+        pipe_loaded.set_progress_bar_config(disable=None)
 
-        for component in optional_component:
-            self.assertTrue(
-                getattr(pipe_loaded, component) is None,
-                f"`{component}` did not stay set to None after loading.",
-            )
+        for name in ["transformer_2", "image_encoder", "image_processor"]:
+            assert getattr(pipe_loaded, name) is None, f"`{name}` did not stay set to None after loading."
 
-        inputs = self.get_dummy_inputs(generator_device)
-        torch.manual_seed(0)
+        inputs = self.get_dummy_inputs()
         output_loaded = pipe_loaded(**inputs)[0]
 
-        max_diff = np.abs(output.detach().cpu().numpy() - output_loaded.detach().cpu().numpy()).max()
-        self.assertLess(max_diff, expected_max_difference)
+        assert_tensors_close(
+            output_loaded,
+            output,
+            atol=expected_max_difference,
+            msg="Output changed after dropping the optional components.",
+        )
 
     def test_inference_batch_single_identical(self):
-        self._test_inference_batch_single_identical(expected_max_diff=2e-3)
+        super().test_inference_batch_single_identical(expected_max_diff=2e-3)
 
-    @unittest.skip("Test not supported")
+    @pytest.mark.skip(reason="Test not supported")
     def test_callback_inputs(self):
         pass
+
+
+class TestWan225BImageToVideoPipelineMemory(Wan225BImageToVideoPipelineTesterConfig, MemoryTesterMixin):
+    pass


### PR DESCRIPTION
# What does this PR do?

Refactors the wan 2.2 image-to-video pipeline tests to the new mixin structure from #14113. The file covers two variants, so it keeps two config/test/memory triads: the 14B `Wan22ImageToVideoPipeline` (both transformers, `boundary_ratio`) and the 5B ti2v `Wan225BImageToVideoPipeline` (`expand_timesteps`). Both run on `WanImageToVideoPipeline`.

Existing coverage is kept for both: `test_inference` and `test_save_load_optional_components` (the 14B nulls `transformer`, `image_encoder` and `image_processor` via `boundary_ratio=1.0`; the 5B nulls `transformer_2`, `image_encoder` and `image_processor`). The 5B also keeps its `test_components_function`, the batch-single tolerance override, and the skipped `test_callback_inputs`. No caching tests are added since the old suite had none, and the attention-slicing test is dropped as the new framework has no equivalent.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Discussed on Slack with @sayakpaul
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@sayakpaul
