### PR TITLE
Fix LTX2 dynamic timestep shift ignoring the sequence length

### DIFF
--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
@@ -1108,7 +1108,7 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
                 raise ValueError(
                     f"Provided `latents` tensor has shape {latents.shape}, but the expected shape is either [batch_size, seq_len, num_features] or [batch_size, latent_dim, latent_frames, latent_height, latent_width]."
                 )
-        # video_sequence_length = latent_num_frames * latent_height * latent_width
+        video_sequence_length = latent_num_frames * latent_height * latent_width
 
         num_channels_latents = self.transformer.config.in_channels
         latents = self.prepare_latents(
@@ -1165,7 +1165,7 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
         # 5. Prepare timesteps
         sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps) if sigmas is None else sigmas
         mu = calculate_shift(
-            self.scheduler.config.get("max_image_seq_len", 4096),
+            video_sequence_length,
             self.scheduler.config.get("base_image_seq_len", 1024),
             self.scheduler.config.get("max_image_seq_len", 4096),
             self.scheduler.config.get("base_shift", 0.95),


### PR DESCRIPTION
Fixes #14243.

`LTX2Pipeline.__call__` computes the dynamic timestep-shift `mu` by passing `max_image_seq_len` as the `image_seq_len` argument of `calculate_shift`. Because `calculate_shift` also receives `max_image_seq_len` as its `max_seq_len`, the two cancel and `mu` collapses to `max_shift` for every call, regardless of resolution or frame count — so the resolution/length-dependent shift that the scheduler config requests (`use_dynamic_shifting=True`, distinct `base_shift`/`max_shift`) never takes effect.

This passes the actual packed sequence length (`latent_num_frames * latent_height * latent_width`) instead, which is the value the commented-out `video_sequence_length` line already spelled out, and what the Flux/SD3 pipelines and the Lightricks/ComfyUI reference implementations use (`math.prod(latent.shape[2:])`).

See #14243 for the derivation, the match against the reference implementation and the scheduler config, and the `git blame` evidence that this appears to be an unfinished port rather than an intentional constant.

---
<sub>Drafted by Claude.</sub>
