### PR TITLE
Repro for #14247

### DIFF
--- a/tests/models/transformers/test_models_transformer_cosmos3.py
+++ b/tests/models/transformers/test_models_transformer_cosmos3.py
@@ -1,3 +1,4 @@
+# repro: check if this change triggers pr_tests_gpu.yml
 # coding=utf-8
 # Copyright 2026 HuggingFace Inc.
 #


### PR DESCRIPTION
Reproduction PR for #14247.
   This PR only touches `tests/models/transformers/test_models_transformer_cosmos3.py` to verify that `pr_tests_gpu.yml`'s `paths:` filter does not trigger on `tests/models/**` changes.