### PR TITLE
Fix pr_tests_gpu.yml paths filter to match push_tests.yml

### DIFF
--- a/.github/workflows/pr_tests_gpu.yml
+++ b/.github/workflows/pr_tests_gpu.yml
@@ -7,15 +7,14 @@ on:
   pull_request:
     branches: main
     paths:
-      - "src/diffusers/models/modeling_utils.py"
-      - "src/diffusers/models/model_loading_utils.py"
-      - "src/diffusers/pipelines/pipeline_utils.py"
-      - "src/diffusers/pipeline_loading_utils.py"
+      - "src/diffusers/models/**.py"
+      - "src/diffusers/pipelines/**.py"
       - "src/diffusers/loaders/lora_base.py"
       - "src/diffusers/loaders/lora_pipeline.py"
       - "src/diffusers/loaders/peft.py"
-      - "tests/pipelines/test_pipelines_common.py"
-      - "tests/models/test_modeling_common.py"
+      - "src/diffusers/pipeline_loading_utils.py"
+      - "tests/models/**.py"
+      - "tests/pipelines/**.py"
       - "examples/**/*.py"
   workflow_dispatch:
 


### PR DESCRIPTION
Fixes #14247

paths filter missed src/diffusers/models/** and tests/models/**, so PRs adding only a new model + tests never triggered GPU CI here. Tests then ran for the first time on some unrelated PR (see #14247, Cosmos3 case).

Added the missing wildcard paths, dropped the specific entries they now cover.

Also touches test_models_transformer_cosmos3.py so Checks on this PR show the workflow actually firing.

Not included: scoping pytest to only changed files (issue point 2), leaving that for a follow-up tied to DN6's test fetcher work.

Couldn't verify the trigger locally (paths filtering happens server-side on the PR event, not reproducible outside it). Flag anything that looks off and I'll follow up.