### PR TITLE
Support native-layout Krea2 checkpoints (community GGUFs) in `from_single_file()`

### DIFF
--- a/docs/source/en/api/models/ideogram4_transformer2d.md
+++ b/docs/source/en/api/models/ideogram4_transformer2d.md
@@ -14,6 +14,19 @@ specific language governing permissions and limitations under the License.
 
 A transformer for image-like data from [Ideogram 4](https://github.com/ideogram-oss/ideogram-4). 
 
+## Loading single-file checkpoints
+
+`Ideogram4Transformer2DModel` supports loading from single-file checkpoints via [`~loaders.FromOriginalModelMixin.from_single_file`]:
+
+```python
+from diffusers import Ideogram4Transformer2DModel
+
+transformer = Ideogram4Transformer2DModel.from_single_file(
+    "path/to/ideogram4_transformer.safetensors",
+    torch_dtype=torch.bfloat16,
+)
+```
+
 ## Ideogram4Transformer2DModel
 
 [[autodoc]] Ideogram4Transformer2DModel

--- a/docs/source/en/api/models/krea2_transformer2d.md
+++ b/docs/source/en/api/models/krea2_transformer2d.md
@@ -14,6 +14,19 @@ specific language governing permissions and limitations under the License.
 
 The single-stream MMDiT flow-matching transformer used by [Krea 2](https://github.com/krea-ai/krea-2).
 
+## Loading single-file checkpoints
+
+`Krea2Transformer2DModel` supports loading from single-file checkpoints via [`~loaders.FromOriginalModelMixin.from_single_file`]:
+
+```python
+from diffusers import Krea2Transformer2DModel
+
+transformer = Krea2Transformer2DModel.from_single_file(
+    "path/to/krea2_transformer.safetensors",
+    torch_dtype=torch.bfloat16,
+)
+```
+
 ## Krea2Transformer2DModel
 
 [[autodoc]] Krea2Transformer2DModel

--- a/src/diffusers/loaders/single_file_model.py
+++ b/src/diffusers/loaders/single_file_model.py
@@ -42,6 +42,8 @@ from .single_file_utils import (
     convert_flux_transformer_checkpoint_to_diffusers,
     convert_hidream_transformer_to_diffusers,
     convert_hunyuan_video_transformer_to_diffusers,
+    convert_ideogram4_transformer_checkpoint_to_diffusers,
+    convert_krea2_transformer_checkpoint_to_diffusers,
     convert_ldm_unet_checkpoint,
     convert_ldm_vae_checkpoint,
     convert_ltx2_audio_vae_to_diffusers,
@@ -213,6 +215,14 @@ SINGLE_FILE_LOADABLE_CLASSES = {
     },
     "MotifVideoTransformer3DModel": {
         "checkpoint_mapping_fn": lambda checkpoint, **kwargs: checkpoint,
+        "default_subfolder": "transformer",
+    },
+    "Ideogram4Transformer2DModel": {
+        "checkpoint_mapping_fn": convert_ideogram4_transformer_checkpoint_to_diffusers,
+        "default_subfolder": "transformer",
+    },
+    "Krea2Transformer2DModel": {
+        "checkpoint_mapping_fn": convert_krea2_transformer_checkpoint_to_diffusers,
         "default_subfolder": "transformer",
     },
 }

--- a/src/diffusers/loaders/single_file_utils.py
+++ b/src/diffusers/loaders/single_file_utils.py
@@ -149,6 +149,12 @@ CHECKPOINT_KEY_NAMES = {
         "net.pos_embedder.dim_spatial_range",
     ],
     "flux2": ["model.diffusion_model.single_stream_modulation.lin.weight", "single_stream_modulation.lin.weight"],
+    "ideogram4": [
+        "diffusion_model.llm_cond_proj.weight",
+        "conditional_transformer.llm_cond_proj.weight",
+        "llm_cond_proj.weight",
+    ],
+    "krea2": ["diffusion_model.txtfusion.projector.weight", "txtfusion.projector.weight"],
     "ltx2": [
         "model.diffusion_model.av_ca_a2v_gate_adaln_single.emb.timestep_embedder.linear_1.weight",
         "vae.per_channel_statistics.mean-of-means",
@@ -237,6 +243,8 @@ DIFFUSERS_DEFAULT_PIPELINE_PATHS = {
     "z-image-turbo-controlnet-2.0": {"pretrained_model_name_or_path": "hlky/Z-Image-Turbo-Fun-Controlnet-Union-2.0"},
     "z-image-turbo-controlnet-2.1": {"pretrained_model_name_or_path": "hlky/Z-Image-Turbo-Fun-Controlnet-Union-2.1"},
     "ltx2-dev": {"pretrained_model_name_or_path": "Lightricks/LTX-2"},
+    "ideogram4": {"pretrained_model_name_or_path": "ideogram-ai/ideogram-v4"},
+    "krea2": {"pretrained_model_name_or_path": "krea/Krea-2-Turbo"},
 }
 
 # Use to configure model sample size when original config is provided
@@ -682,6 +690,12 @@ def infer_diffusers_model_type(checkpoint):
 
     elif any(key in checkpoint for key in CHECKPOINT_KEY_NAMES["flux2"]):
         model_type = "flux-2-dev"
+
+    elif any(key in checkpoint for key in CHECKPOINT_KEY_NAMES["ideogram4"]):
+        model_type = "ideogram4"
+
+    elif any(key in checkpoint for key in CHECKPOINT_KEY_NAMES["krea2"]):
+        model_type = "krea2"
 
     elif any(key in checkpoint for key in CHECKPOINT_KEY_NAMES["flux"]):
         if any(

--- a/src/diffusers/loaders/single_file_utils.py
+++ b/src/diffusers/loaders/single_file_utils.py
@@ -4212,9 +4212,7 @@ def convert_ideogram4_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
 def convert_krea2_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
     converted_state_dict = {key: checkpoint.pop(key) for key in list(checkpoint.keys())}
 
-    converted_state_dict = {
-        k.removeprefix("diffusion_model."): v for k, v in converted_state_dict.items()
-    }
+    converted_state_dict = {k.removeprefix("diffusion_model."): v for k, v in converted_state_dict.items()}
 
     ATTN_MAP = {"wq": "to_q", "wk": "to_k", "wv": "to_v", "wo": "to_out.0", "gate": "to_gate"}
     FF_MAP = {"gate": "ff.gate", "up": "ff.up", "down": "ff.down"}
@@ -4259,7 +4257,7 @@ def convert_krea2_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
 
         # top-level txtfusion.* (e.g. txtfusion.projector)
         if key.startswith("txtfusion."):
-            return "text_fusion." + key[len("txtfusion."):]
+            return "text_fusion." + key[len("txtfusion.") :]
 
         return key
 

--- a/src/diffusers/loaders/single_file_utils.py
+++ b/src/diffusers/loaders/single_file_utils.py
@@ -4180,3 +4180,91 @@ def convert_ernie_image_transformer_checkpoint_to_diffusers(checkpoint, **kwargs
             checkpoint[k.replace("model.diffusion_model.", "")] = checkpoint.pop(k)
 
     return checkpoint
+
+
+def convert_ideogram4_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
+    converted_state_dict = {key: checkpoint.pop(key) for key in list(checkpoint.keys())}
+
+    for prefix in ("diffusion_model.", "conditional_transformer."):
+        if any(k.startswith(prefix) for k in converted_state_dict):
+            converted_state_dict = {k.removeprefix(prefix): v for k, v in converted_state_dict.items()}
+            break
+
+    # attention.o -> attention.to_out.0
+    for key in list(converted_state_dict.keys()):
+        if ".attention.o." in key:
+            new_key = key.replace(".attention.o.", ".attention.to_out.0.")
+            converted_state_dict[new_key] = converted_state_dict.pop(key)
+
+    # Split fused attention.qkv -> to_q / to_k / to_v
+    for key in list(converted_state_dict.keys()):
+        if ".attention.qkv.weight" in key:
+            fused = converted_state_dict.pop(key)
+            q, k, v = torch.chunk(fused, 3, dim=0)
+            base = key[: key.index(".attention.qkv.weight")]
+            converted_state_dict[f"{base}.attention.to_q.weight"] = q.contiguous()
+            converted_state_dict[f"{base}.attention.to_k.weight"] = k.contiguous()
+            converted_state_dict[f"{base}.attention.to_v.weight"] = v.contiguous()
+
+    return converted_state_dict
+
+
+def convert_krea2_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
+    converted_state_dict = {key: checkpoint.pop(key) for key in list(checkpoint.keys())}
+
+    converted_state_dict = {
+        k.removeprefix("diffusion_model."): v for k, v in converted_state_dict.items()
+    }
+
+    ATTN_MAP = {"wq": "to_q", "wk": "to_k", "wv": "to_v", "wo": "to_out.0", "gate": "to_gate"}
+    FF_MAP = {"gate": "ff.gate", "up": "ff.up", "down": "ff.down"}
+
+    def remap_key(key):
+        # transformer blocks: blocks.{i}.*
+        m = re.match(r"^blocks\.(\d+)\.(.+)$", key)
+        if m:
+            idx, tail = m.groups()
+            if tail.startswith("attn."):
+                sub_m = re.match(r"^attn\.(\w+)(.*)$", tail)
+                if sub_m:
+                    sub, rest = sub_m.groups()
+                    if sub in ATTN_MAP:
+                        return f"transformer_blocks.{idx}.attn.{ATTN_MAP[sub]}{rest}"
+            if tail.startswith("mlp."):
+                sub_m = re.match(r"^mlp\.(\w+)(.*)$", tail)
+                if sub_m:
+                    sub, rest = sub_m.groups()
+                    if sub in FF_MAP:
+                        return f"transformer_blocks.{idx}.{FF_MAP[sub]}{rest}"
+            # norm1, norm2, scale_shift_table and any unmatched sub-keys
+            return f"transformer_blocks.{idx}.{tail}"
+
+        # text fusion blocks: txtfusion.(layerwise_blocks|refiner_blocks).{i}.(attn|mlp).*
+        m = re.match(r"^txtfusion\.(layerwise_blocks|refiner_blocks)\.(\d+)\.(.+)$", key)
+        if m:
+            block_group, idx, tail = m.groups()
+            if tail.startswith("attn."):
+                sub_m = re.match(r"^attn\.(\w+)(.*)$", tail)
+                if sub_m:
+                    sub, rest = sub_m.groups()
+                    if sub in ATTN_MAP:
+                        return f"text_fusion.{block_group}.{idx}.attn.{ATTN_MAP[sub]}{rest}"
+            if tail.startswith("mlp."):
+                sub_m = re.match(r"^mlp\.(\w+)(.*)$", tail)
+                if sub_m:
+                    sub, rest = sub_m.groups()
+                    if sub in FF_MAP:
+                        return f"text_fusion.{block_group}.{idx}.{FF_MAP[sub]}{rest}"
+            return f"text_fusion.{block_group}.{idx}.{tail}"
+
+        # top-level txtfusion.* (e.g. txtfusion.projector)
+        if key.startswith("txtfusion."):
+            return "text_fusion." + key[len("txtfusion."):]
+
+        return key
+
+    result = {}
+    for key, value in converted_state_dict.items():
+        result[remap_key(key)] = value
+
+    return result

--- a/src/diffusers/loaders/single_file_utils.py
+++ b/src/diffusers/loaders/single_file_utils.py
@@ -4230,12 +4230,48 @@ def convert_krea2_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
 
     ATTN_MAP = {"wq": "to_q", "wk": "to_k", "wv": "to_v", "wo": "to_out.0", "gate": "to_gate"}
     FF_MAP = {"gate": "ff.gate", "up": "ff.up", "down": "ff.down"}
+    # native layout (krea-ai/krea-2 inference code, also used by community GGUF exports)
+    NORM_MAP = {
+        "prenorm.scale": "norm1.weight",
+        "postnorm.scale": "norm2.weight",
+        "attn.qknorm.qnorm.scale": "attn.norm_q.weight",
+        "attn.qknorm.knorm.scale": "attn.norm_k.weight",
+    }
+    TOP_MAP = {
+        "first.weight": "img_in.weight",
+        "first.bias": "img_in.bias",
+        "tmlp.0.weight": "time_embed.linear_1.weight",
+        "tmlp.0.bias": "time_embed.linear_1.bias",
+        "tmlp.2.weight": "time_embed.linear_2.weight",
+        "tmlp.2.bias": "time_embed.linear_2.bias",
+        "tproj.1.weight": "time_mod_proj.weight",
+        "tproj.1.bias": "time_mod_proj.bias",
+        "txtmlp.0.scale": "txt_in.norm.weight",
+        "txtmlp.1.weight": "txt_in.linear_1.weight",
+        "txtmlp.1.bias": "txt_in.linear_1.bias",
+        "txtmlp.3.weight": "txt_in.linear_2.weight",
+        "txtmlp.3.bias": "txt_in.linear_2.bias",
+        "last.norm.scale": "final_layer.norm.weight",
+        "last.linear.weight": "final_layer.linear.weight",
+        "last.linear.bias": "final_layer.linear.bias",
+        "last.modulation.lin": "final_layer.scale_shift_table",
+    }
+    # present in some native exports but absent from the current LastLayer
+    # (the official diffusers conversion drops them as well)
+    DROP_KEYS = {"last.up.weight", "last.down.weight"}
 
     def remap_key(key):
+        if key in TOP_MAP:
+            return TOP_MAP[key]
+
         # transformer blocks: blocks.{i}.*
         m = re.match(r"^blocks\.(\d+)\.(.+)$", key)
         if m:
             idx, tail = m.groups()
+            if tail in NORM_MAP:
+                return f"transformer_blocks.{idx}.{NORM_MAP[tail]}"
+            if tail == "mod.lin":
+                return f"transformer_blocks.{idx}.scale_shift_table"
             if tail.startswith("attn."):
                 sub_m = re.match(r"^attn\.(\w+)(.*)$", tail)
                 if sub_m:
@@ -4255,6 +4291,8 @@ def convert_krea2_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
         m = re.match(r"^txtfusion\.(layerwise_blocks|refiner_blocks)\.(\d+)\.(.+)$", key)
         if m:
             block_group, idx, tail = m.groups()
+            if tail in NORM_MAP:
+                return f"text_fusion.{block_group}.{idx}.{NORM_MAP[tail]}"
             if tail.startswith("attn."):
                 sub_m = re.match(r"^attn\.(\w+)(.*)$", tail)
                 if sub_m:
@@ -4277,6 +4315,15 @@ def convert_krea2_transformer_checkpoint_to_diffusers(checkpoint, **kwargs):
 
     result = {}
     for key, value in converted_state_dict.items():
-        result[remap_key(key)] = value
+        if key in DROP_KEYS:
+            continue
+        new_key = remap_key(key)
+        # native exports store the modulation tables flat and the projector
+        # squeezed; reshape them to the diffusers parameter shapes
+        if new_key.endswith("scale_shift_table") and value.ndim == 1:
+            value = value.reshape(6 if new_key.startswith("transformer_blocks.") else 2, -1)
+        if new_key == "text_fusion.projector.weight" and value.ndim == 1:
+            value = value.reshape(1, -1)
+        result[new_key] = value
 
     return result

--- a/src/diffusers/models/transformers/transformer_krea2.py
+++ b/src/diffusers/models/transformers/transformer_krea2.py
@@ -21,7 +21,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from ...configuration_utils import ConfigMixin, register_to_config
-from ...loaders import PeftAdapterMixin
+from ...loaders import FromOriginalModelMixin, PeftAdapterMixin
 from ...utils import apply_lora_scale, logging
 from ...utils.torch_utils import maybe_adjust_dtype_for_device
 from ..attention import AttentionMixin, AttentionModuleMixin
@@ -327,7 +327,7 @@ class Krea2RotaryPosEmbed(nn.Module):
         return freqs_cos, freqs_sin
 
 
-class Krea2Transformer2DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftAdapterMixin):
+class Krea2Transformer2DModel(ModelMixin, ConfigMixin, AttentionMixin, PeftAdapterMixin, FromOriginalModelMixin):
     r"""
     The single-stream MMDiT flow-matching backbone used by the Krea 2 pipeline.
 

--- a/tests/single_file/test_model_ideogram4_transformer_single_file.py
+++ b/tests/single_file/test_model_ideogram4_transformer_single_file.py
@@ -1,0 +1,277 @@
+# coding=utf-8
+# Copyright 2026 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for Ideogram4Transformer2DModel from_single_file() support.
+
+Two suites:
+  1. TestIdeogram4ConversionFunction  — offline unit tests for the key-mapping
+     function. No checkpoint, no GPU, no network.
+  2. TestIdeogram4TransformerSingleFile — @nightly integration test that loads
+     an actual single-file checkpoint and compares against from_pretrained().
+     Requires a public checkpoint; fill in ckpt_path / repo_id when available.
+"""
+
+import unittest
+
+import torch
+
+from diffusers import Ideogram4Transformer2DModel
+from diffusers.loaders.single_file_utils import convert_ideogram4_transformer_checkpoint_to_diffusers
+
+from ..testing_utils import enable_full_determinism
+from .single_file_testing_utils import SingleFileModelTesterMixin
+
+
+enable_full_determinism()
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a synthetic "original" state dict for a small Ideogram4 model
+# ---------------------------------------------------------------------------
+
+def _make_ideogram4_original_state_dict(num_layers=2, hidden_size=32, num_heads=4,
+                                         intermediate_size=32, adaln_dim=16,
+                                         in_channels=16, llm_features_dim=24,
+                                         prefix="diffusion_model."):
+    """
+    Produces a synthetic state dict in the pre-diffusers Ideogram4 format:
+      - fused attention.qkv   (3 * head_dim * num_heads, hidden_size)
+      - attention.o           (hidden_size, hidden_size)
+      - feed_forward.w1/w2/w3
+      - adaln_modulation
+      - per-layer norms
+      - top-level embeddings / final_layer
+    All tensors contain random data; shapes match what the model actually expects.
+    """
+    head_dim = hidden_size // num_heads
+    sd = {}
+
+    # Top-level modules
+    sd[f"{prefix}input_proj.weight"] = torch.randn(hidden_size, in_channels)
+    sd[f"{prefix}input_proj.bias"] = torch.randn(hidden_size)
+    sd[f"{prefix}llm_cond_norm.weight"] = torch.randn(llm_features_dim)
+    sd[f"{prefix}llm_cond_proj.weight"] = torch.randn(hidden_size, llm_features_dim)
+    sd[f"{prefix}llm_cond_proj.bias"] = torch.randn(hidden_size)
+    # t_embedding is Ideogram4EmbedScalar: two linear layers (mlp_in, mlp_out) both with bias
+    sd[f"{prefix}t_embedding.mlp_in.weight"] = torch.randn(hidden_size, hidden_size)
+    sd[f"{prefix}t_embedding.mlp_in.bias"] = torch.randn(hidden_size)
+    sd[f"{prefix}t_embedding.mlp_out.weight"] = torch.randn(hidden_size, hidden_size)
+    sd[f"{prefix}t_embedding.mlp_out.bias"] = torch.randn(hidden_size)
+    sd[f"{prefix}adaln_proj.weight"] = torch.randn(adaln_dim, hidden_size)
+    sd[f"{prefix}adaln_proj.bias"] = torch.randn(adaln_dim)
+    # embed_image_indicator is nn.Embedding (weight only, no bias)
+    sd[f"{prefix}embed_image_indicator.weight"] = torch.randn(2, hidden_size)
+    # rotary_emb uses register_buffer with persistent=False -> not in state_dict
+
+    for i in range(num_layers):
+        p = f"{prefix}layers.{i}."
+        # Fused QKV (original format, no bias)
+        sd[f"{p}attention.qkv.weight"] = torch.randn(3 * hidden_size, hidden_size)
+        # Output projection (original name: attention.o, no bias)
+        sd[f"{p}attention.o.weight"] = torch.randn(hidden_size, hidden_size)
+        # q/k norms (RMSNorm with elementwise_affine=True, same names in both formats)
+        sd[f"{p}attention.norm_q.weight"] = torch.randn(head_dim)
+        sd[f"{p}attention.norm_k.weight"] = torch.randn(head_dim)
+        # Feed-forward (no bias)
+        sd[f"{p}feed_forward.w1.weight"] = torch.randn(intermediate_size, hidden_size)
+        sd[f"{p}feed_forward.w2.weight"] = torch.randn(hidden_size, intermediate_size)
+        sd[f"{p}feed_forward.w3.weight"] = torch.randn(intermediate_size, hidden_size)
+        # AdaLN modulation (has bias)
+        sd[f"{p}adaln_modulation.weight"] = torch.randn(4 * hidden_size, adaln_dim)
+        sd[f"{p}adaln_modulation.bias"] = torch.randn(4 * hidden_size)
+        # RMSNorms (same names in both formats)
+        for norm in ("attention_norm1", "attention_norm2", "ffn_norm1", "ffn_norm2"):
+            sd[f"{p}{norm}.weight"] = torch.randn(hidden_size)
+
+    # Final layer (same names in both formats)
+    # norm_final uses elementwise_affine=False -> no weight/bias in state_dict
+    sd[f"{prefix}final_layer.linear.weight"] = torch.randn(in_channels, hidden_size)
+    sd[f"{prefix}final_layer.linear.bias"] = torch.randn(in_channels)
+    # adaln_modulation: nn.Linear(adaln_dim, hidden_size, bias=True)
+    sd[f"{prefix}final_layer.adaln_modulation.weight"] = torch.randn(hidden_size, adaln_dim)
+    sd[f"{prefix}final_layer.adaln_modulation.bias"] = torch.randn(hidden_size)
+
+    return sd
+
+
+class TestIdeogram4ConversionFunction(unittest.TestCase):
+    """Offline unit tests for convert_ideogram4_transformer_checkpoint_to_diffusers."""
+
+    def _convert(self, prefix="diffusion_model.", num_layers=2):
+        sd = _make_ideogram4_original_state_dict(prefix=prefix, num_layers=num_layers)
+        return convert_ideogram4_transformer_checkpoint_to_diffusers(sd)
+
+    # ------------------------------------------------------------------
+    # Prefix stripping
+    # ------------------------------------------------------------------
+
+    def test_strips_diffusion_model_prefix(self):
+        result = self._convert(prefix="diffusion_model.")
+        self.assertFalse(any(k.startswith("diffusion_model.") for k in result))
+
+    def test_strips_conditional_transformer_prefix(self):
+        sd = _make_ideogram4_original_state_dict(prefix="conditional_transformer.")
+        result = convert_ideogram4_transformer_checkpoint_to_diffusers(sd)
+        self.assertFalse(any(k.startswith("conditional_transformer.") for k in result))
+
+    def test_no_prefix_passthrough(self):
+        # If there is no known prefix the keys should survive untouched.
+        sd = _make_ideogram4_original_state_dict(prefix="")
+        result = convert_ideogram4_transformer_checkpoint_to_diffusers(sd)
+        self.assertIn("layers.0.attention.to_q.weight", result)
+
+    # ------------------------------------------------------------------
+    # QKV split
+    # ------------------------------------------------------------------
+
+    def test_fused_qkv_is_split_into_three_projections(self):
+        result = self._convert()
+        for i in range(2):
+            self.assertIn(f"layers.{i}.attention.to_q.weight", result)
+            self.assertIn(f"layers.{i}.attention.to_k.weight", result)
+            self.assertIn(f"layers.{i}.attention.to_v.weight", result)
+            self.assertNotIn(f"layers.{i}.attention.qkv.weight", result)
+
+    def test_split_shapes_are_equal_thirds(self):
+        result = self._convert()
+        # Each split should be hidden_size // 3 of the original fused dim (hidden_size=32 -> 32 each)
+        for proj in ("to_q", "to_k", "to_v"):
+            self.assertEqual(result[f"layers.0.attention.{proj}.weight"].shape, (32, 32))
+
+    def test_split_values_are_contiguous_chunks(self):
+        # Build a deterministic fused weight and verify the three slices.
+        fused = torch.arange(96, dtype=torch.float32).reshape(96, 1)
+        sd = {"diffusion_model.layers.0.attention.qkv.weight": fused}
+        result = convert_ideogram4_transformer_checkpoint_to_diffusers(sd)
+        expected_q = fused[:32]
+        expected_k = fused[32:64]
+        expected_v = fused[64:]
+        self.assertTrue(torch.equal(result["layers.0.attention.to_q.weight"], expected_q))
+        self.assertTrue(torch.equal(result["layers.0.attention.to_k.weight"], expected_k))
+        self.assertTrue(torch.equal(result["layers.0.attention.to_v.weight"], expected_v))
+
+    # ------------------------------------------------------------------
+    # Output projection rename: attention.o -> attention.to_out.0
+    # ------------------------------------------------------------------
+
+    def test_attention_o_renamed_to_to_out_0(self):
+        result = self._convert()
+        for i in range(2):
+            self.assertIn(f"layers.{i}.attention.to_out.0.weight", result)
+            self.assertNotIn(f"layers.{i}.attention.o.weight", result)
+
+    # ------------------------------------------------------------------
+    # Keys that should pass through unchanged
+    # ------------------------------------------------------------------
+
+    def test_feed_forward_keys_unchanged(self):
+        result = self._convert()
+        for i in range(2):
+            for w in ("w1", "w2", "w3"):
+                self.assertIn(f"layers.{i}.feed_forward.{w}.weight", result)
+
+    def test_norm_keys_unchanged(self):
+        result = self._convert()
+        for i in range(2):
+            for norm in ("attention_norm1", "attention_norm2", "ffn_norm1", "ffn_norm2"):
+                self.assertIn(f"layers.{i}.{norm}.weight", result)
+
+    def test_adaln_modulation_unchanged(self):
+        result = self._convert()
+        for i in range(2):
+            self.assertIn(f"layers.{i}.adaln_modulation.weight", result)
+
+    def test_final_layer_keys_unchanged(self):
+        result = self._convert()
+        # norm_final uses elementwise_affine=False, so it has no parameters
+        self.assertNotIn("final_layer.norm_final.weight", result)
+        self.assertIn("final_layer.linear.weight", result)
+        self.assertIn("final_layer.linear.bias", result)
+        self.assertIn("final_layer.adaln_modulation.weight", result)
+        self.assertIn("final_layer.adaln_modulation.bias", result)
+
+    def test_top_level_embedding_keys_unchanged(self):
+        result = self._convert()
+        for key in (
+            "input_proj.weight", "input_proj.bias",
+            "llm_cond_norm.weight",
+            "llm_cond_proj.weight", "llm_cond_proj.bias",
+            # t_embedding is Ideogram4EmbedScalar: two linear layers
+            "t_embedding.mlp_in.weight", "t_embedding.mlp_in.bias",
+            "t_embedding.mlp_out.weight", "t_embedding.mlp_out.bias",
+            "adaln_proj.weight", "adaln_proj.bias",
+            "embed_image_indicator.weight",
+        ):
+            self.assertIn(key, result)
+
+    # ------------------------------------------------------------------
+    # Round-trip key coverage: every diffusers state dict key is produced
+    # ------------------------------------------------------------------
+
+    def test_output_keys_match_diffusers_model_state_dict(self):
+        """
+        Instantiate a tiny Ideogram4 model, read its diffusers-format state dict,
+        then verify that the conversion function produces exactly the same key set
+        when given a synthetic original-format checkpoint.
+        """
+        init_cfg = {
+            "in_channels": 16,
+            "num_layers": 2,
+            "attention_head_dim": 8,
+            "num_attention_heads": 4,
+            "intermediate_size": 32,
+            "adaln_dim": 16,
+            "llm_features_dim": 24,
+            "rope_theta": 10_000,
+            "mrope_section": (2, 1, 1),
+            "norm_eps": 1e-5,
+        }
+        model = Ideogram4Transformer2DModel(**init_cfg)
+        diffusers_keys = set(model.state_dict().keys())
+
+        original_sd = _make_ideogram4_original_state_dict(
+            num_layers=2,
+            hidden_size=32,   # num_heads * head_dim = 4 * 8
+            num_heads=4,
+            intermediate_size=32,
+            adaln_dim=16,
+            in_channels=16,
+            llm_features_dim=24,
+            prefix="diffusion_model.",
+        )
+        converted = convert_ideogram4_transformer_checkpoint_to_diffusers(original_sd)
+        converted_keys = set(converted.keys())
+
+        missing = diffusers_keys - converted_keys
+        extra = converted_keys - diffusers_keys
+        self.assertEqual(missing, set(), msg=f"Keys in diffusers model but missing from conversion: {missing}")
+        self.assertEqual(extra, set(), msg=f"Keys produced by conversion but not in diffusers model: {extra}")
+
+
+# ---------------------------------------------------------------------------
+# Integration test — requires actual single-file checkpoint (nightly / big GPU)
+# ---------------------------------------------------------------------------
+
+# TODO: fill in once a public Ideogram4 single-file checkpoint is released.
+# class TestIdeogram4TransformerSingleFile(SingleFileModelTesterMixin):
+#     model_class = Ideogram4Transformer2DModel
+#     ckpt_path = "https://huggingface.co/<org>/<repo>/blob/main/ideogram4_transformer.safetensors"
+#     repo_id = "<org>/<diffusers-format-repo>"
+#     subfolder = "transformer"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_file/test_model_ideogram4_transformer_single_file.py
+++ b/tests/single_file/test_model_ideogram4_transformer_single_file.py
@@ -32,7 +32,6 @@ from diffusers import Ideogram4Transformer2DModel
 from diffusers.loaders.single_file_utils import convert_ideogram4_transformer_checkpoint_to_diffusers
 
 from ..testing_utils import enable_full_determinism
-from .single_file_testing_utils import SingleFileModelTesterMixin
 
 
 enable_full_determinism()
@@ -42,10 +41,17 @@ enable_full_determinism()
 # Helper: build a synthetic "original" state dict for a small Ideogram4 model
 # ---------------------------------------------------------------------------
 
-def _make_ideogram4_original_state_dict(num_layers=2, hidden_size=32, num_heads=4,
-                                         intermediate_size=32, adaln_dim=16,
-                                         in_channels=16, llm_features_dim=24,
-                                         prefix="diffusion_model."):
+
+def _make_ideogram4_original_state_dict(
+    num_layers=2,
+    hidden_size=32,
+    num_heads=4,
+    intermediate_size=32,
+    adaln_dim=16,
+    in_channels=16,
+    llm_features_dim=24,
+    prefix="diffusion_model.",
+):
     """
     Produces a synthetic state dict in the pre-diffusers Ideogram4 format:
       - fused attention.qkv   (3 * head_dim * num_heads, hidden_size)
@@ -206,13 +212,18 @@ class TestIdeogram4ConversionFunction(unittest.TestCase):
     def test_top_level_embedding_keys_unchanged(self):
         result = self._convert()
         for key in (
-            "input_proj.weight", "input_proj.bias",
+            "input_proj.weight",
+            "input_proj.bias",
             "llm_cond_norm.weight",
-            "llm_cond_proj.weight", "llm_cond_proj.bias",
+            "llm_cond_proj.weight",
+            "llm_cond_proj.bias",
             # t_embedding is Ideogram4EmbedScalar: two linear layers
-            "t_embedding.mlp_in.weight", "t_embedding.mlp_in.bias",
-            "t_embedding.mlp_out.weight", "t_embedding.mlp_out.bias",
-            "adaln_proj.weight", "adaln_proj.bias",
+            "t_embedding.mlp_in.weight",
+            "t_embedding.mlp_in.bias",
+            "t_embedding.mlp_out.weight",
+            "t_embedding.mlp_out.bias",
+            "adaln_proj.weight",
+            "adaln_proj.bias",
             "embed_image_indicator.weight",
         ):
             self.assertIn(key, result)
@@ -244,7 +255,7 @@ class TestIdeogram4ConversionFunction(unittest.TestCase):
 
         original_sd = _make_ideogram4_original_state_dict(
             num_layers=2,
-            hidden_size=32,   # num_heads * head_dim = 4 * 8
+            hidden_size=32,  # num_heads * head_dim = 4 * 8
             num_heads=4,
             intermediate_size=32,
             adaln_dim=16,

--- a/tests/single_file/test_model_krea2_transformer_single_file.py
+++ b/tests/single_file/test_model_krea2_transformer_single_file.py
@@ -31,7 +31,6 @@ from diffusers import Krea2Transformer2DModel
 from diffusers.loaders.single_file_utils import convert_krea2_transformer_checkpoint_to_diffusers
 
 from ..testing_utils import enable_full_determinism
-from .single_file_testing_utils import SingleFileModelTesterMixin
 
 
 enable_full_determinism()
@@ -41,9 +40,10 @@ enable_full_determinism()
 # Helper: build a synthetic "original" Krea2 state dict
 # ---------------------------------------------------------------------------
 
+
 def _make_krea2_original_state_dict(
     num_layers=2,
-    hidden_size=32,      # num_heads * head_dim
+    hidden_size=32,  # num_heads * head_dim
     num_heads=4,
     num_kv_heads=2,
     intermediate_size=32,
@@ -113,8 +113,10 @@ def _make_krea2_original_state_dict(
         sd[f"{b}scale_shift_table"] = torch.randn(6, hidden_size)
 
     # Text fusion blocks (original naming: txtfusion.*)
-    for group, n_blocks in (("layerwise_blocks", num_layerwise_text_blocks),
-                             ("refiner_blocks", num_refiner_text_blocks)):
+    for group, n_blocks in (
+        ("layerwise_blocks", num_layerwise_text_blocks),
+        ("refiner_blocks", num_refiner_text_blocks),
+    ):
         for i in range(n_blocks):
             b = p(f"txtfusion.{group}.{i}.")
             sd[f"{b}attn.wq.weight"] = torch.randn(hidden_size, hidden_size)

--- a/tests/single_file/test_model_krea2_transformer_single_file.py
+++ b/tests/single_file/test_model_krea2_transformer_single_file.py
@@ -1,0 +1,358 @@
+# coding=utf-8
+# Copyright 2026 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for Krea2Transformer2DModel from_single_file() support.
+
+Two suites:
+  1. TestKrea2ConversionFunction  — offline unit tests for the key-mapping
+     function. No checkpoint, no GPU, no network.
+  2. TestKrea2TransformerSingleFile — @nightly integration test stub for when
+     a public single-file checkpoint becomes available.
+"""
+
+import unittest
+
+import torch
+
+from diffusers import Krea2Transformer2DModel
+from diffusers.loaders.single_file_utils import convert_krea2_transformer_checkpoint_to_diffusers
+
+from ..testing_utils import enable_full_determinism
+from .single_file_testing_utils import SingleFileModelTesterMixin
+
+
+enable_full_determinism()
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a synthetic "original" Krea2 state dict
+# ---------------------------------------------------------------------------
+
+def _make_krea2_original_state_dict(
+    num_layers=2,
+    hidden_size=32,      # num_heads * head_dim
+    num_heads=4,
+    num_kv_heads=2,
+    intermediate_size=32,
+    timestep_embed_dim=8,
+    text_hidden_dim=16,
+    num_text_layers=3,
+    text_num_attention_heads=2,
+    text_num_key_value_heads=1,
+    text_intermediate_size=16,
+    num_layerwise_text_blocks=1,
+    num_refiner_text_blocks=1,
+    in_channels=16,
+    prefix="diffusion_model.",
+):
+    """
+    Produces a synthetic state dict in the pre-diffusers Krea2 format:
+      blocks.{i}.attn.{wq,wk,wv,wo,gate}
+      blocks.{i}.mlp.{gate,up,down}
+      blocks.{i}.{norm1,norm2,scale_shift_table}
+      txtfusion.{layerwise_blocks,refiner_blocks}.{i}.attn.*
+      txtfusion.{layerwise_blocks,refiner_blocks}.{i}.mlp.*
+      txtfusion.projector
+      img_in, time_embed.*, time_mod_proj, txt_in.*, final_layer.*, rotary_emb.*
+    """
+    head_dim = hidden_size // num_heads
+    kv_dim = num_kv_heads * head_dim
+    sd = {}
+
+    def p(name):
+        return f"{prefix}{name}"
+
+    # head_dim for text fusion attention (uses text_num_attention_heads, not num_heads)
+    text_head_dim = hidden_size // text_num_attention_heads
+
+    # Top-level pass-through modules
+    sd[p("img_in.weight")] = torch.randn(hidden_size, in_channels)
+    sd[p("img_in.bias")] = torch.randn(hidden_size)
+    sd[p("time_embed.linear_1.weight")] = torch.randn(hidden_size, timestep_embed_dim)
+    sd[p("time_embed.linear_1.bias")] = torch.randn(hidden_size)
+    sd[p("time_embed.linear_2.weight")] = torch.randn(hidden_size, hidden_size)
+    sd[p("time_embed.linear_2.bias")] = torch.randn(hidden_size)
+    sd[p("time_mod_proj.weight")] = torch.randn(6 * hidden_size, hidden_size)
+    sd[p("time_mod_proj.bias")] = torch.randn(6 * hidden_size)
+    sd[p("txt_in.norm.weight")] = torch.randn(text_hidden_dim)
+    sd[p("txt_in.linear_1.weight")] = torch.randn(hidden_size, text_hidden_dim)
+    sd[p("txt_in.linear_1.bias")] = torch.randn(hidden_size)
+    sd[p("txt_in.linear_2.weight")] = torch.randn(hidden_size, hidden_size)
+    sd[p("txt_in.linear_2.bias")] = torch.randn(hidden_size)
+    # rotary_emb (Krea2RotaryPosEmbed) computes frequencies on the fly — no state dict entries
+
+    # Transformer blocks (original naming: blocks.{i})
+    for i in range(num_layers):
+        b = p(f"blocks.{i}.")
+        sd[f"{b}attn.wq.weight"] = torch.randn(hidden_size, hidden_size)
+        sd[f"{b}attn.wk.weight"] = torch.randn(kv_dim, hidden_size)
+        sd[f"{b}attn.wv.weight"] = torch.randn(kv_dim, hidden_size)
+        sd[f"{b}attn.wo.weight"] = torch.randn(hidden_size, hidden_size)
+        sd[f"{b}attn.gate.weight"] = torch.randn(hidden_size, hidden_size)
+        # norm_q/norm_k: same names in both formats, pass through via the block renaming
+        sd[f"{b}attn.norm_q.weight"] = torch.randn(head_dim)
+        sd[f"{b}attn.norm_k.weight"] = torch.randn(head_dim)
+        sd[f"{b}mlp.gate.weight"] = torch.randn(intermediate_size, hidden_size)
+        sd[f"{b}mlp.up.weight"] = torch.randn(intermediate_size, hidden_size)
+        sd[f"{b}mlp.down.weight"] = torch.randn(hidden_size, intermediate_size)
+        sd[f"{b}norm1.weight"] = torch.randn(hidden_size)
+        sd[f"{b}norm2.weight"] = torch.randn(hidden_size)
+        sd[f"{b}scale_shift_table"] = torch.randn(6, hidden_size)
+
+    # Text fusion blocks (original naming: txtfusion.*)
+    for group, n_blocks in (("layerwise_blocks", num_layerwise_text_blocks),
+                             ("refiner_blocks", num_refiner_text_blocks)):
+        for i in range(n_blocks):
+            b = p(f"txtfusion.{group}.{i}.")
+            sd[f"{b}attn.wq.weight"] = torch.randn(hidden_size, hidden_size)
+            sd[f"{b}attn.wk.weight"] = torch.randn(hidden_size, hidden_size)
+            sd[f"{b}attn.wv.weight"] = torch.randn(hidden_size, hidden_size)
+            sd[f"{b}attn.wo.weight"] = torch.randn(hidden_size, hidden_size)
+            sd[f"{b}attn.gate.weight"] = torch.randn(hidden_size, hidden_size)
+            # norm_q/norm_k in text fusion attention use text_head_dim
+            sd[f"{b}attn.norm_q.weight"] = torch.randn(text_head_dim)
+            sd[f"{b}attn.norm_k.weight"] = torch.randn(text_head_dim)
+            sd[f"{b}mlp.gate.weight"] = torch.randn(text_intermediate_size, hidden_size)
+            sd[f"{b}mlp.up.weight"] = torch.randn(text_intermediate_size, hidden_size)
+            sd[f"{b}mlp.down.weight"] = torch.randn(hidden_size, text_intermediate_size)
+            sd[f"{b}norm1.weight"] = torch.randn(hidden_size)
+            sd[f"{b}norm2.weight"] = torch.randn(hidden_size)
+
+    # txtfusion.projector (top-level, maps to text_fusion.projector, no bias)
+    sd[p("txtfusion.projector.weight")] = torch.randn(1, num_text_layers)
+
+    # Final layer (pass-through)
+    sd[p("final_layer.norm.weight")] = torch.randn(hidden_size)
+    sd[p("final_layer.linear.weight")] = torch.randn(in_channels, hidden_size)
+    sd[p("final_layer.linear.bias")] = torch.randn(in_channels)
+    sd[p("final_layer.scale_shift_table")] = torch.randn(2, hidden_size)
+
+    return sd
+
+
+class TestKrea2ConversionFunction(unittest.TestCase):
+    """Offline unit tests for convert_krea2_transformer_checkpoint_to_diffusers."""
+
+    def _convert(self, prefix="diffusion_model.", num_layers=2):
+        sd = _make_krea2_original_state_dict(prefix=prefix, num_layers=num_layers)
+        return convert_krea2_transformer_checkpoint_to_diffusers(sd)
+
+    # ------------------------------------------------------------------
+    # Prefix stripping
+    # ------------------------------------------------------------------
+
+    def test_strips_diffusion_model_prefix(self):
+        result = self._convert(prefix="diffusion_model.")
+        self.assertFalse(any(k.startswith("diffusion_model.") for k in result))
+
+    def test_no_prefix_passthrough(self):
+        sd = _make_krea2_original_state_dict(prefix="")
+        result = convert_krea2_transformer_checkpoint_to_diffusers(sd)
+        self.assertIn("transformer_blocks.0.attn.to_q.weight", result)
+
+    # ------------------------------------------------------------------
+    # Transformer block renaming: blocks.{i} -> transformer_blocks.{i}
+    # ------------------------------------------------------------------
+
+    def test_transformer_block_attention_keys(self):
+        result = self._convert()
+        expected = {
+            "transformer_blocks.0.attn.to_q.weight",
+            "transformer_blocks.0.attn.to_k.weight",
+            "transformer_blocks.0.attn.to_v.weight",
+            "transformer_blocks.0.attn.to_out.0.weight",
+            "transformer_blocks.0.attn.to_gate.weight",
+            "transformer_blocks.0.attn.norm_q.weight",
+            "transformer_blocks.0.attn.norm_k.weight",
+        }
+        for key in expected:
+            self.assertIn(key, result, msg=f"Missing key: {key}")
+
+    def test_original_attn_keys_absent(self):
+        result = self._convert()
+        for i in range(2):
+            self.assertNotIn(f"blocks.{i}.attn.wq.weight", result)
+            self.assertNotIn(f"blocks.{i}.attn.wo.weight", result)
+
+    def test_transformer_block_ff_keys(self):
+        result = self._convert()
+        for i in range(2):
+            self.assertIn(f"transformer_blocks.{i}.ff.gate.weight", result)
+            self.assertIn(f"transformer_blocks.{i}.ff.up.weight", result)
+            self.assertIn(f"transformer_blocks.{i}.ff.down.weight", result)
+
+    def test_original_mlp_keys_absent(self):
+        result = self._convert()
+        for i in range(2):
+            self.assertNotIn(f"blocks.{i}.mlp.gate.weight", result)
+
+    def test_transformer_block_norm_and_scale_shift_keys(self):
+        result = self._convert()
+        for i in range(2):
+            self.assertIn(f"transformer_blocks.{i}.norm1.weight", result)
+            self.assertIn(f"transformer_blocks.{i}.norm2.weight", result)
+            self.assertIn(f"transformer_blocks.{i}.scale_shift_table", result)
+
+    # ------------------------------------------------------------------
+    # Text fusion renaming: txtfusion -> text_fusion
+    # ------------------------------------------------------------------
+
+    def test_text_fusion_attention_keys(self):
+        result = self._convert()
+        for group in ("layerwise_blocks", "refiner_blocks"):
+            self.assertIn(f"text_fusion.{group}.0.attn.to_q.weight", result)
+            self.assertIn(f"text_fusion.{group}.0.attn.to_out.0.weight", result)
+            self.assertIn(f"text_fusion.{group}.0.attn.to_gate.weight", result)
+
+    def test_text_fusion_ff_keys(self):
+        result = self._convert()
+        for group in ("layerwise_blocks", "refiner_blocks"):
+            self.assertIn(f"text_fusion.{group}.0.ff.gate.weight", result)
+            self.assertIn(f"text_fusion.{group}.0.ff.up.weight", result)
+            self.assertIn(f"text_fusion.{group}.0.ff.down.weight", result)
+
+    def test_text_fusion_projector(self):
+        result = self._convert()
+        self.assertIn("text_fusion.projector.weight", result)
+        self.assertNotIn("txtfusion.projector.weight", result)
+
+    def test_original_txtfusion_keys_absent(self):
+        result = self._convert()
+        self.assertFalse(any("txtfusion." in k for k in result))
+
+    # ------------------------------------------------------------------
+    # Pass-through keys (same name in both formats)
+    # ------------------------------------------------------------------
+
+    def test_img_in_unchanged(self):
+        result = self._convert()
+        self.assertIn("img_in.weight", result)
+        self.assertIn("img_in.bias", result)
+
+    def test_time_embed_unchanged(self):
+        result = self._convert()
+        self.assertIn("time_embed.linear_1.weight", result)
+        self.assertIn("time_embed.linear_2.weight", result)
+
+    def test_time_mod_proj_unchanged(self):
+        result = self._convert()
+        self.assertIn("time_mod_proj.weight", result)
+
+    def test_txt_in_unchanged(self):
+        result = self._convert()
+        self.assertIn("txt_in.norm.weight", result)
+        self.assertIn("txt_in.linear_1.weight", result)
+
+    def test_final_layer_unchanged(self):
+        result = self._convert()
+        self.assertIn("final_layer.norm.weight", result)
+        self.assertIn("final_layer.linear.weight", result)
+        self.assertIn("final_layer.scale_shift_table", result)
+
+    def test_rotary_emb_has_no_state_dict_entries(self):
+        # Krea2RotaryPosEmbed computes frequencies on the fly with no parameters or
+        # persistent buffers, so it contributes nothing to the state dict.
+        result = self._convert()
+        self.assertFalse(any(k.startswith("rotary_emb.") for k in result))
+
+    # ------------------------------------------------------------------
+    # Value identity: conversion must not alter tensor data
+    # ------------------------------------------------------------------
+
+    def test_passthrough_values_are_identical(self):
+        orig_weight = torch.randn(32, 16)
+        sd = {"diffusion_model.img_in.weight": orig_weight}
+        result = convert_krea2_transformer_checkpoint_to_diffusers(sd)
+        self.assertTrue(torch.equal(result["img_in.weight"], orig_weight))
+
+    def test_remapped_values_are_identical(self):
+        orig_weight = torch.randn(32, 32)
+        sd = {"diffusion_model.blocks.0.attn.wq.weight": orig_weight}
+        result = convert_krea2_transformer_checkpoint_to_diffusers(sd)
+        self.assertTrue(torch.equal(result["transformer_blocks.0.attn.to_q.weight"], orig_weight))
+
+    # ------------------------------------------------------------------
+    # Round-trip key coverage: every diffusers state dict key is produced
+    # ------------------------------------------------------------------
+
+    def test_output_keys_match_diffusers_model_state_dict(self):
+        """
+        Instantiate a tiny Krea2 model, get its diffusers-format state dict,
+        and verify the conversion function produces the same key set when given
+        a synthetic original-format checkpoint with matching shapes.
+        """
+        init_cfg = {
+            "in_channels": 16,
+            "num_layers": 2,
+            "attention_head_dim": 8,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "intermediate_size": 32,
+            "timestep_embed_dim": 8,
+            "text_hidden_dim": 16,
+            "num_text_layers": 3,
+            "text_num_attention_heads": 2,
+            "text_num_key_value_heads": 1,
+            "text_intermediate_size": 16,
+            "num_layerwise_text_blocks": 1,
+            "num_refiner_text_blocks": 1,
+            "axes_dims_rope": (4, 2, 2),
+            "rope_theta": 1000.0,
+            "norm_eps": 1e-5,
+        }
+        model = Krea2Transformer2DModel(**init_cfg)
+        diffusers_keys = set(model.state_dict().keys())
+
+        original_sd = _make_krea2_original_state_dict(
+            num_layers=2,
+            hidden_size=32,
+            num_heads=4,
+            num_kv_heads=2,
+            intermediate_size=32,
+            timestep_embed_dim=8,
+            text_hidden_dim=16,
+            num_text_layers=3,
+            text_num_attention_heads=2,
+            text_num_key_value_heads=1,
+            text_intermediate_size=16,
+            num_layerwise_text_blocks=1,
+            num_refiner_text_blocks=1,
+            in_channels=16,
+            prefix="diffusion_model.",
+        )
+        converted = convert_krea2_transformer_checkpoint_to_diffusers(original_sd)
+        converted_keys = set(converted.keys())
+
+        missing = diffusers_keys - converted_keys
+        extra = converted_keys - diffusers_keys
+        self.assertEqual(missing, set(), msg=f"Keys in diffusers model but missing from conversion: {missing}")
+        self.assertEqual(extra, set(), msg=f"Keys produced by conversion but not in diffusers model: {extra}")
+
+
+# ---------------------------------------------------------------------------
+# Integration test — requires actual single-file checkpoint (nightly / big GPU)
+# ---------------------------------------------------------------------------
+
+# TODO: fill in once a public Krea2 single-file checkpoint is released.
+# class TestKrea2TransformerSingleFile(SingleFileModelTesterMixin):
+#     model_class = Krea2Transformer2DModel
+#     ckpt_path = "https://huggingface.co/<org>/<repo>/blob/main/krea2_transformer.safetensors"
+#     repo_id = "<org>/<diffusers-format-repo>"
+#     subfolder = "transformer"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# What does this PR do?

Builds on #14126 (includes its commits, happy to rebase once it lands).

The converter there covers the repack layout, but the community GGUF exports of Krea 2 ([vantagewithai/Krea-2-Turbo-GGUF](https://huggingface.co/vantagewithai/Krea-2-Turbo-GGUF), [realrebelai/KREA-2_GGUFs](https://huggingface.co/realrebelai/KREA-2_GGUFs), ~145k downloads combined) keep the native key names from the `krea-ai/krea-2` inference code: `prenorm/postnorm.scale`, `attn.qknorm.*`, flat `mod.lin` tables, `first/tmlp/tproj/txtmlp/last.*`. Those fall through `remap_key` untouched, so loading ends with ~180 unassigned params and crashes on meta tensors.

This extends the converter:
- norm scales → `norm1`/`norm2` and `attn.norm_q`/`norm_k`
- flat `mod.lin` → per-block `scale_shift_table`, `last.modulation.lin` → `final_layer.scale_shift_table`
- `first`/`tmlp`/`tproj`/`txtmlp`/`last.*` → `img_in`/`time_embed`/`time_mod_proj`/`txt_in`/`final_layer`
- drops `last.up/down.weight` (not part of the current `LastLayer`; the official diffusers weights don't ship them either — 430 keys vs 432 in native exports)
- reshapes the squeezed `projector.weight` found in some exports

Tested with `GGUFQuantizationConfig` on Q3_K_M / Q4_K_M / Q8_0 from both repos: all load with zero missing/unexpected keys, and end-to-end `Krea2Pipeline` generation (8 steps, 768x768, mps) produces correct images.

Fixes the GGUF side of #14122.

## Who can review?

cc @buffett0323 @DN6
