### PR TITLE
fix(ltx2): use actual video sequence length for dynamic timestep shift

### DIFF
--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
@@ -1108,7 +1108,6 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
                 raise ValueError(
                     f"Provided `latents` tensor has shape {latents.shape}, but the expected shape is either [batch_size, seq_len, num_features] or [batch_size, latent_dim, latent_frames, latent_height, latent_width]."
                 )
-        # video_sequence_length = latent_num_frames * latent_height * latent_width
 
         num_channels_latents = self.transformer.config.in_channels
         latents = self.prepare_latents(
@@ -1164,8 +1163,9 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
 
         # 5. Prepare timesteps
         sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps) if sigmas is None else sigmas
+        video_sequence_length = latent_num_frames * latent_height * latent_width
         mu = calculate_shift(
-            self.scheduler.config.get("max_image_seq_len", 4096),
+            video_sequence_length,
             self.scheduler.config.get("base_image_seq_len", 1024),
             self.scheduler.config.get("max_image_seq_len", 4096),
             self.scheduler.config.get("base_shift", 0.95),

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
@@ -1276,7 +1276,6 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
                 raise ValueError(
                     f"Provided `latents` tensor has shape {latents.shape}, but the expected shape is either [batch_size, seq_len, num_features] or [batch_size, latent_dim, latent_frames, latent_height, latent_width]."
                 )
-        # video_sequence_length = latent_num_frames * latent_height * latent_width
 
         num_channels_latents = self.transformer.config.in_channels
         latents = self.prepare_latents(
@@ -1332,8 +1331,9 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
 
         # 5. Prepare timesteps
         sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps) if sigmas is None else sigmas
+        video_sequence_length = latent_num_frames * latent_height * latent_width
         mu = calculate_shift(
-            latents.shape[1],
+            video_sequence_length,
             self.scheduler.config.get("base_image_seq_len", 1024),
             self.scheduler.config.get("max_image_seq_len", 4096),
             self.scheduler.config.get("base_shift", 0.95),


### PR DESCRIPTION
LTX2Pipeline computed the dynamic-shift mu with max_image_seq_len as the image_seq_len argument to calculate_shift(), which collapses mu to a constant (the max_shift value) regardless of resolution or frame count. With use_dynamic_shifting=True enabled this had no effect at all — the shift never actually varied with the sample.

The fix passes the sample's real packed sequence length (latent_num_frames * latent_height * latent_width) as image_seq_len, matching the Flux/SD3 pipelines and the LTX reference implementation (math.prod(latent.shape[2:])). This value was already computed earlier in the call (it even existed as a commented-out line), and the latent dims are defined a few lines above the timestep section. I also removed the stale commented line since the variable is now used for real.

This is a behavior change: mu will now scale with the actual sequence length rather than always hitting max_shift, so the timestep distribution will shift for all LTX2 generations. That's the intended behavior of dynamic shifting, but flagging it since it's not a no-op. Fixes #14243.