### PR TITLE
Preserve hook forward signature

### DIFF
--- a/src/diffusers/hooks/hooks.py
+++ b/src/diffusers/hooks/hooks.py
@@ -205,8 +205,10 @@ class HookRegistry:
             )
 
         rewritten_forward = create_new_forward(fn_ref)
+        # Wrap from the original `forward` so `inspect.signature` follows `__wrapped__` to the real
+        # signature instead of the generic `(module, *args, **kwargs)`, which breaks `torch.export`.
         self._module_ref.forward = functools.update_wrapper(
-            functools.partial(rewritten_forward, self._module_ref), rewritten_forward
+            functools.partial(rewritten_forward, self._module_ref), forward
         )
 
         hook.fn_ref = fn_ref

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -408,7 +408,16 @@ class TestHooks:
         hidden_states = torch.randn(1, 4, 8, device=torch_device)
         timestep = torch.tensor([1.0], device=torch_device)
 
-        assert tuple(model(hidden_states, timestep).shape) == (1, 4, 8)
+        eager_output = model(hidden_states, timestep)
+        assert tuple(eager_output.shape) == (1, 4, 8)
 
         exported = torch.export.export(model, args=(), kwargs={"hidden_states": hidden_states, "timestep": timestep})
         assert exported is not None
+
+        exported_output = exported.module()(hidden_states=hidden_states, timestep=timestep)
+        assert torch.allclose(exported_output, eager_output)
+
+        new_hidden_states = torch.randn(1, 4, 8, device=torch_device)
+        new_timestep = torch.tensor([2.0], device=torch_device)
+        exported_output = exported.module()(hidden_states=new_hidden_states, timestep=new_timestep)
+        assert torch.allclose(exported_output, model(new_hidden_states, new_timestep))

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import inspect
 
 import pytest
 import torch
@@ -60,6 +61,11 @@ class DummyModel(torch.nn.Module):
             x = block(x)
         x = self.linear_2(x)
         return x
+
+
+class SignatureModel(torch.nn.Module):
+    def forward(self, hidden_states, timestep, encoder_hidden_states=None):
+        return hidden_states + timestep.sum()
 
 
 class AddHook(ModelHook):
@@ -372,3 +378,37 @@ class TestHooks:
             .replace("\n", "")
         )
         assert output == expected_invocation_order_log
+
+    def test_register_hook_preserves_forward_signature(self):
+        model = SignatureModel().to(torch_device)
+        sig_before = inspect.signature(model.forward)
+        assert list(sig_before.parameters) == ["hidden_states", "timestep", "encoder_hidden_states"]
+
+        registry = HookRegistry.check_if_exists_or_initialize(model)
+        registry.register_hook(ModelHook(), "noop")
+
+        assert inspect.signature(model.forward) == sig_before
+        assert model.forward.__name__ == "forward"
+
+        registry.register_hook(ModelHook(), "noop_2")
+        assert inspect.signature(model.forward) == sig_before
+        assert model.forward.__name__ == "forward"
+
+        registry.remove_hook("noop_2")
+        assert inspect.signature(model.forward) == sig_before
+        registry.remove_hook("noop")
+        assert inspect.signature(model.forward) == sig_before
+
+    def test_register_hook_preserves_forward_signature_torch_export(self):
+        model = SignatureModel().to(torch_device)
+        registry = HookRegistry.check_if_exists_or_initialize(model)
+        registry.register_hook(ModelHook(), "noop")
+        registry.register_hook(ModelHook(), "noop_2")
+
+        hidden_states = torch.randn(1, 4, 8, device=torch_device)
+        timestep = torch.tensor([1.0], device=torch_device)
+
+        assert tuple(model(hidden_states, timestep).shape) == (1, 4, 8)
+
+        exported = torch.export.export(model, args=(), kwargs={"hidden_states": hidden_states, "timestep": timestep})
+        assert exported is not None

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -416,8 +416,3 @@ class TestHooks:
 
         exported_output = exported.module()(hidden_states=hidden_states, timestep=timestep)
         assert torch.allclose(exported_output, eager_output)
-
-        new_hidden_states = torch.randn(1, 4, 8, device=torch_device)
-        new_timestep = torch.tensor([2.0], device=torch_device)
-        exported_output = exported.module()(hidden_states=new_hidden_states, timestep=new_timestep)
-        assert torch.allclose(exported_output, model(new_hidden_states, new_timestep))


### PR DESCRIPTION
# What does this PR do?

Fixes HookRegistry.register_hook breaking a module's forward signature, and downstream prevents torch.compile / torch.export - specifically affecting context parallel hooks

<!-- Remove if not applicable -->

Fixes #14135


## Before submitting
- [X ] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [ X] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [X ] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [X ] Did you share the final self-review notes in the PR description or a comment?
- [ X] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ X] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [X ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [X ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ X] Did you write any new necessary tests?
- [X ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?


## Who can review?

@sayakpaul 