### PR TITLE
Fix duplicated words and a misspelling in messages and docstrings

### DIFF
--- a/src/diffusers/models/unets/unet_spatio_temporal_condition.py
+++ b/src/diffusers/models/unets/unet_spatio_temporal_condition.py
@@ -50,7 +50,7 @@ class UNetSpatioTemporalConditionModel(ModelMixin, AttentionMixin, ConfigMixin, 
         block_out_channels (`tuple[int]`, *optional*, defaults to `(320, 640, 1280, 1280)`):
             The tuple of output channels for each block.
         addition_time_embed_dim: (`int`, defaults to 256):
-            Dimension to to encode the additional time ids.
+            Dimension to encode the additional time ids.
         projection_class_embeddings_input_dim (`int`, defaults to 768):
             The dimension of the projection of encoded `added_time_ids`.
         layers_per_block (`int`, *optional*, defaults to 2): The number of layers per block.

--- a/src/diffusers/modular_pipelines/anima/before_denoise.py
+++ b/src/diffusers/modular_pipelines/anima/before_denoise.py
@@ -109,7 +109,7 @@ def repeat_tensor_to_batch_size(
         repeat_by = num_images_per_prompt
     else:
         raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
+            f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
         )
 
     # expand the tensor to match the batch_size * num_images_per_prompt

--- a/src/diffusers/modular_pipelines/anima/before_denoise.py
+++ b/src/diffusers/modular_pipelines/anima/before_denoise.py
@@ -108,9 +108,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_images_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_images_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)

--- a/src/diffusers/modular_pipelines/flux/before_denoise.py
+++ b/src/diffusers/modular_pipelines/flux/before_denoise.py
@@ -470,7 +470,7 @@ class FluxImg2ImgPrepareLatentsStep(ModularPipelineBlocks):
     def check_inputs(image_latents, latents):
         if image_latents.shape[0] != latents.shape[0]:
             raise ValueError(
-                f"`image_latents` must have have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
+                f"`image_latents` must have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
             )
 
         if image_latents.ndim != 3:

--- a/src/diffusers/modular_pipelines/helios/before_denoise.py
+++ b/src/diffusers/modular_pipelines/helios/before_denoise.py
@@ -168,7 +168,7 @@ def repeat_tensor_to_batch_size(
         repeat_by = num_videos_per_prompt
     else:
         raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
+            f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
         )
 
     # expand the tensor to match the batch_size * num_videos_per_prompt

--- a/src/diffusers/modular_pipelines/helios/before_denoise.py
+++ b/src/diffusers/modular_pipelines/helios/before_denoise.py
@@ -167,9 +167,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_videos_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_videos_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)

--- a/src/diffusers/modular_pipelines/qwenimage/before_denoise.py
+++ b/src/diffusers/modular_pipelines/qwenimage/before_denoise.py
@@ -426,7 +426,7 @@ class QwenImagePrepareLatentsWithStrengthStep(ModularPipelineBlocks):
     def check_inputs(image_latents, latents):
         if image_latents.shape[0] != latents.shape[0]:
             raise ValueError(
-                f"`image_latents` must have have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
+                f"`image_latents` must have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
             )
 
         if image_latents.ndim != 3:

--- a/src/diffusers/modular_pipelines/qwenimage/inputs.py
+++ b/src/diffusers/modular_pipelines/qwenimage/inputs.py
@@ -68,7 +68,7 @@ def repeat_tensor_to_batch_size(
         repeat_by = num_images_per_prompt
     else:
         raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
+            f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
         )
 
     # expand the tensor to match the batch_size * num_images_per_prompt

--- a/src/diffusers/modular_pipelines/qwenimage/inputs.py
+++ b/src/diffusers/modular_pipelines/qwenimage/inputs.py
@@ -67,9 +67,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_images_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_images_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)

--- a/src/diffusers/modular_pipelines/stable_diffusion_3/inputs.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_3/inputs.py
@@ -71,7 +71,7 @@ def repeat_tensor_to_batch_size(
         repeat_by = num_images_per_prompt
     else:
         raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
+            f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
         )
 
     # expand the tensor to match the batch_size * num_images_per_prompt

--- a/src/diffusers/modular_pipelines/stable_diffusion_3/inputs.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_3/inputs.py
@@ -70,9 +70,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_images_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_images_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)

--- a/src/diffusers/modular_pipelines/wan/before_denoise.py
+++ b/src/diffusers/modular_pipelines/wan/before_denoise.py
@@ -81,7 +81,7 @@ def repeat_tensor_to_batch_size(
         repeat_by = num_videos_per_prompt
     else:
         raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
+            f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
         )
 
     # expand the tensor to match the batch_size * num_videos_per_prompt

--- a/src/diffusers/modular_pipelines/wan/before_denoise.py
+++ b/src/diffusers/modular_pipelines/wan/before_denoise.py
@@ -80,9 +80,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_videos_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_videos_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)

--- a/src/diffusers/modular_pipelines/z_image/before_denoise.py
+++ b/src/diffusers/modular_pipelines/z_image/before_denoise.py
@@ -81,7 +81,7 @@ def repeat_tensor_to_batch_size(
         repeat_by = num_images_per_prompt
     else:
         raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
+            f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
         )
 
     # expand the tensor to match the batch_size * num_images_per_prompt

--- a/src/diffusers/modular_pipelines/z_image/before_denoise.py
+++ b/src/diffusers/modular_pipelines/z_image/before_denoise.py
@@ -80,9 +80,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_images_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_images_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)

--- a/src/diffusers/pipelines/flux/pipeline_flux_kontext_inpaint.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_kontext_inpaint.py
@@ -923,8 +923,8 @@ class FluxKontextInpaintPipeline(
 
         Args:
             image (`torch.Tensor`, `PIL.Image.Image`, `np.ndarray`, `list[torch.Tensor]`, `list[PIL.Image.Image]`, or `list[np.ndarray]`):
-                `Image`, numpy array or tensor representing an image batch to be be inpainted (which parts of the image
-                to be masked out with `mask_image` and repainted according to `prompt` and `image_reference`). For both
+                `Image`, numpy array or tensor representing an image batch to be inpainted (which parts of the image to
+                be masked out with `mask_image` and repainted according to `prompt` and `image_reference`). For both
                 numpy array and pytorch tensor, the expected value range is between `[0, 1]` If it's a tensor or a list
                 or tensors, the expected shape should be `(B, C, H, W)` or `(C, H, W)`. If it is a numpy array or a
                 list of arrays, the expected shape should be `(B, H, W, C)` or `(H, W, C)` It can also accept image

--- a/src/diffusers/pipelines/flux/pipeline_flux_kontext_inpaint.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_kontext_inpaint.py
@@ -923,7 +923,7 @@ class FluxKontextInpaintPipeline(
 
         Args:
             image (`torch.Tensor`, `PIL.Image.Image`, `np.ndarray`, `list[torch.Tensor]`, `list[PIL.Image.Image]`, or `list[np.ndarray]`):
-                `Image`, numpy array or tensor representing an image batch to be be inpainted (which parts of the image
+                `Image`, numpy array or tensor representing an image batch to be inpainted (which parts of the image
                 to be masked out with `mask_image` and repainted according to `prompt` and `image_reference`). For both
                 numpy array and pytorch tensor, the expected value range is between `[0, 1]` If it's a tensor or a list
                 or tensors, the expected shape should be `(B, C, H, W)` or `(C, H, W)`. If it is a numpy array or a

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
@@ -235,7 +235,7 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
 
 class LTX2ConditionPipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
     r"""
-    Pipeline for video generation which allows image conditions to be inserted at arbitary parts of the video.
+    Pipeline for video generation which allows image conditions to be inserted at arbitrary parts of the video.
 
     Reference: https://github.com/Lightricks/LTX-Video
 

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_condition.py
@@ -262,7 +262,7 @@ def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
 
 class LTX2ConditionPipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
     r"""
-    Pipeline for video generation which allows image conditions to be inserted at arbitary parts of the video.
+    Pipeline for video generation which allows image conditions to be inserted at arbitrary parts of the video.
 
     Reference: https://github.com/Lightricks/LTX-Video
 


### PR DESCRIPTION
# What does this PR do?

Removes accidental repeated words and fixes one misspelling. Text only, no behavior change.

Eight of these are in user-facing `ValueError` messages raised by the modular pipelines, which currently read "must have have batch size ...":

- `modular_pipelines/anima/before_denoise.py`
- `modular_pipelines/helios/before_denoise.py`
- `modular_pipelines/wan/before_denoise.py`
- `modular_pipelines/z_image/before_denoise.py`
- `modular_pipelines/qwenimage/inputs.py`
- `modular_pipelines/qwenimage/before_denoise.py`
- `modular_pipelines/stable_diffusion_3/inputs.py`
- `modular_pipelines/flux/before_denoise.py`

The remaining three are docstrings:

- `models/unets/unet_spatio_temporal_condition.py`: "Dimension to to encode" becomes "Dimension to encode"
- `pipelines/flux/pipeline_flux_kontext_inpaint.py`: "image batch to be be inpainted" becomes "to be inpainted"
- `pipelines/ltx2/pipeline_ltx2_condition.py`: "arbitary" becomes "arbitrary"

No linked issue; this is a small text-only cleanup.

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)  (N/A: trivial text-only change)
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)?  (N/A: typo fix)
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).  (The docstrings themselves are what this PR corrects.)
- [ ] Did you write any new necessary tests?  (N/A: no behavior change)
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?  (N/A)

### Self-review notes

Claude Code was used to locate the typos and prepare the diff; I reviewed and verified every change myself before submitting.

Blocking issues: none. The diff is 11 files, 11 insertions, 11 deletions, each removing one repeated word or correcting one spelling. No code paths, control flow, or public signatures are touched, and no dead code is introduced.

Findings intentionally not fixed:

1. `pipelines/visualcloze/pipeline_visualcloze_combined.py` and `pipeline_visualcloze_generation.py` contain "Images are missing in in-context examples." That looks like a repeated word but is correct English ("in" followed by "in-context"), so it is left alone.
2. `dataframe`-style near misses such as "cast to to avoid" were checked for and only genuine repeats were changed.

Verification: all 11 changed files byte-compile, and a repeat scan of `src/` for these patterns returns no remaining matches. The branch is based on current `main` (`ed58810`).

## Who can review?

@stevhliu @sayakpaul (docs and general text), since this is a documentation and message wording change.