### PR TITLE
Fix duplicated words in documentation

### DIFF
--- a/docs/source/en/api/pipelines/flux2.md
+++ b/docs/source/en/api/pipelines/flux2.md
@@ -28,7 +28,7 @@ Original model checkpoints for Flux can be found [here](https://huggingface.co/b
 
 ## Caption upsampling
 
-Flux.2 can potentially generate better better outputs with better prompts. We can "upsample"
+Flux.2 can potentially generate better outputs with better prompts. We can "upsample"
 an input prompt by setting the `caption_upsample_temperature` argument in the pipeline call arguments.
 The [official implementation](https://github.com/black-forest-labs/flux2/blob/5a5d316b1b42f6b59a8c9194b77c8256be848432/src/flux2/text_encoder.py#L140) recommends this value to be 0.15.
 

--- a/docs/source/en/quantization/bitsandbytes.md
+++ b/docs/source/en/quantization/bitsandbytes.md
@@ -123,7 +123,7 @@ Once a model is quantized, you can push the model to the Hub with the [`~ModelMi
 
 Quantizing a model in 4-bit reduces your memory-usage by 4x:
 
-bitsandbytes is supported in both Transformers and Diffusers, so you can can quantize both the
+bitsandbytes is supported in both Transformers and Diffusers, so you can quantize both the
 [`FluxTransformer2DModel`] and [`~transformers.T5EncoderModel`].
 
 For Ada and higher-series GPUs. we recommend changing `torch_dtype` to `torch.bfloat16`.

--- a/docs/source/en/using-diffusers/schedulers.md
+++ b/docs/source/en/using-diffusers/schedulers.md
@@ -148,7 +148,7 @@ image = pipeline(prompt, guidance_rescale=0.7).images[0]
 
 ## Timestep spacing
 
-Timestep spacing refers to the specific steps *t* to sample from from the schedule. Diffusers provides three spacing types as shown below.
+Timestep spacing refers to the specific steps *t* to sample from the schedule. Diffusers provides three spacing types as shown below.
 
 | spacing strategy | spacing calculation | example timesteps |
 |---|---|---|


### PR DESCRIPTION
Fixes three duplicated words in user-facing documentation:

- `can can` in the bitsandbytes quantization guide
- `from from` in the scheduler timestep spacing guide
- `better better` in the Flux.2 caption upsampling guide

No code examples, APIs, or runtime behavior change.

Validation:
- asserted that each corrected sentence is present and each duplicated phrase is absent
- ran `git diff --check`
- verified the branch diff contains only the three documentation lines