### PR TITLE
Fix LoRA hot-swapping recompilation with `different_shapes_for_compilation`

### DIFF
--- a/tests/models/testing_utils/lora.py
+++ b/tests/models/testing_utils/lora.py
@@ -321,6 +321,12 @@ class LoraHotSwappingForModelTesterMixin:
         fine.
         """
         different_shapes = self.different_shapes_for_compilation
+        if different_shapes is not None:
+            # Specifying `use_duck_shape=False` instructs the compiler if it should use the same symbolic
+            # variable to represent input sizes that are the same. For more details,
+            # check out this [comment](https://github.com/huggingface/diffusers/pull/11327#discussion_r2047659790).
+            torch.fx.experimental._config.use_duck_shape = False
+
         # create 2 adapters with different ranks and alphas
         torch.manual_seed(0)
         init_dict = self.get_init_dict()
@@ -557,10 +563,6 @@ class LoraHotSwappingForModelTesterMixin:
         different_shapes_for_compilation = self.different_shapes_for_compilation
         if different_shapes_for_compilation is None:
             pytest.skip(f"Skipping as `different_shapes_for_compilation` is not set for {self.__class__.__name__}.")
-        # Specifying `use_duck_shape=False` instructs the compiler if it should use the same symbolic
-        # variable to represent input sizes that are the same. For more details,
-        # check out this [comment](https://github.com/huggingface/diffusers/pull/11327#discussion_r2047659790).
-        torch.fx.experimental._config.use_duck_shape = False
 
         target_modules = ["to_q", "to_k", "to_v", "to_out.0"]
         with torch._dynamo.config.patch(error_on_recompile=True):

--- a/tests/models/transformers/test_models_transformer_qwenimage.py
+++ b/tests/models/transformers/test_models_transformer_qwenimage.py
@@ -305,14 +305,6 @@ class TestQwenImageTransformerLoRA(QwenImageTransformerTesterConfig, LoraTesterM
 class TestQwenImageTransformerLoRAHotSwap(QwenImageTransformerTesterConfig, LoraHotSwappingForModelTesterMixin):
     """LoRA hot-swapping tests for QwenImage Transformer."""
 
-    @pytest.mark.xfail(True, reason="Recompilation issues.", strict=True)
-    def test_hotswapping_compiled_model_linear(self):
-        super().test_hotswapping_compiled_model_linear()
-
-    @pytest.mark.xfail(True, reason="Recompilation issues.", strict=True)
-    def test_hotswapping_compiled_model_both_linear_and_other(self):
-        super().test_hotswapping_compiled_model_both_linear_and_other()
-
     @property
     def different_shapes_for_compilation(self):
         return [(4, 4), (4, 8), (8, 8)]


### PR DESCRIPTION
## Problem

`test_hotswapping_compiled_model_linear` and `test_hotswapping_compiled_model_both_linear_and_other` fail for every model that sets `different_shapes_for_compilation` (reproduced on both CUDA and XPU):

```
torch._dynamo.exc.RecompileError: Recompiling function forward
    - 0/0: tensor 'hidden_states' size mismatch at index 1. expected 16, actual 32
```

## Cause

`hidden_states` is `(batch, height * width, channels)` with `channels = 16`, and the first traced shape `(4, 4)` makes the sequence length equal the channel count. Duck shaping gives both dims the same symbol, which `img_in` (an `nn.Linear` with constant `in_features`) then specializes to `16` — so the next shape forces a recompile. The models themselves handle dynamic sequence lengths fine.

## Fix

`use_duck_shape = False` was already set in `test_compile_on_different_shapes` and `test_hotswapping_compile_on_different_shapes` (#11327), but the other two multi-shape hot-swapping tests were missed. Moved it into `_check_model_hotswap` so all of them are covered, and dropped the now-redundant duplicate. No shapes changed.

Also removed the two `xfail(strict=True)` markers on `TestQwenImageTransformerLoRAHotSwap`, which were masking this bug.

## Verification

NucleusMoE + QwenImage hot-swap / compile tests: **6 failed → 45 passed, 17 skipped**. Numerics are unaffected (max abs diff vs eager `7.93e-06` vs `7.99e-06`).
