### PR TITLE
Fix uintx safe-globals import for torchao 0.17.0

### DIFF
--- a/src/diffusers/quantizers/torchao/torchao_quantizer.py
+++ b/src/diffusers/quantizers/torchao/torchao_quantizer.py
@@ -97,7 +97,13 @@ def _update_torch_safe_globals():
     ]
     try:
         from torchao.dtypes import NF4Tensor
-        from torchao.dtypes.uintx.uintx_layout import UintxAQTTensorImpl, UintxTensor
+
+        # note: is_torchao_version(">=", "0.17.0") does not work correctly
+        # with torchao nightly, so using a ">" check which does work correctly
+        if is_torchao_version(">", "0.16.0"):
+            from torchao.prototype.dtypes.uintx.uintx_utils import UintxAQTTensorImpl, UintxTensor
+        else:
+            from torchao.dtypes.uintx.uintx_layout import UintxAQTTensorImpl, UintxTensor
 
         safe_globals.extend([UintxTensor, UintxAQTTensorImpl, NF4Tensor])
 

--- a/tests/quantization/torchao/test_torchao.py
+++ b/tests/quantization/torchao/test_torchao.py
@@ -87,6 +87,19 @@ if is_torchao_available():
 
 
 @require_torch
+@require_torchao_version_greater_or_equal("0.15.0")
+class TestTorchAoSafeGlobals:
+    def test_uintx_tensor_subclasses_are_registered(self):
+        """
+        `UintxTensor`/`UintxAQTTensorImpl` moved between torchao releases. If the import in
+        `_update_torch_safe_globals` goes stale, they are silently skipped and loading a uintx
+        checkpoint with `weights_only=True` fails.
+        """
+        registered = {getattr(safe_global, "__name__", None) for safe_global in torch.serialization.get_safe_globals()}
+        assert {"UintxTensor", "UintxAQTTensorImpl"}.issubset(registered)
+
+
+@require_torch
 @require_torch_accelerator
 @require_torchao_version_greater_or_equal("0.15.0")
 class TestTorchAoConfig:


### PR DESCRIPTION
Fixes #14303

## What's wrong

`_update_torch_safe_globals()` imports `UintxAQTTensorImpl`/`UintxTensor` from the hardcoded path
`torchao.dtypes.uintx.uintx_layout`, which torchao removed in 0.17.0 - the classes now live in
`torchao.prototype.dtypes.uintx.uintx_utils` (in 0.16.0 the old path was still there as a deprecation
shim). Since that import shares a `try` block with `from torchao.dtypes import NF4Tensor`, the whole
block raises, gets swallowed into a `logger.warning`, and the uintx tensor subclasses are never passed
to `torch.serialization.add_safe_globals` - so `torch.load(..., weights_only=True)` on a
uintx-quantized checkpoint fails with `UnpicklingError`.

The fix version-gates the import using the same `is_torchao_version(">", ...)` idiom the function
already uses a few lines below (a `>=` check misbehaves on torchao nightlies, per the existing
comment).

Two corrections to the report: `from torchao.dtypes import NF4Tensor` still resolves fine on 0.17.0,
so it is left untouched; and the suggested fallback `from torchao.prototype.dtypes import ...` does
not work - `torchao/prototype/dtypes/__init__.py` in 0.17.0 has an empty `__all__` and re-exports
nothing, so the submodule path is required.

## Verified

Linux, NVIDIA A40 (sm_86), driver 560.35.03 / CUDA 12.6, Python 3.13, torch 2.13.0+cu126. torchao
pinned per-run from the real PyPI wheels.

- torchao 0.17.0, before the patch: `torch.save` a `UintxTensor` → `torch.load(weights_only=True)`
  fails with `UnpicklingError`. After the patch: loads.
- New test `TestTorchAoSafeGlobals::test_uintx_tensor_subclasses_are_registered` fails on 0.17.0
  without the patch, passes with it.
- Passes on torchao 0.15.0 and 0.16.0 too, so the `else` branch is not a regression.
- `tests/quantization/torchao/test_torchao.py`: identical results with and without the patch
  (5 failed / 11 passed before, 5 failed / 12 passed after - the delta is the new test). The 5
  failures are pre-existing on this box and unrelated: they abort with
  `ImportError: Requires mslk >= 1.0.0`.
- `ruff check`, `ruff format --check` and `utils/check_copies.py` clean.

## Not covered

This fixes torchao 0.17.0 (current latest release). It does **not** fix torchao `main` / an eventual
0.18.0: upstream has since deleted `UintxAQTTensorImpl` and `UintxLayout` entirely (only `UintxTensor`
remains) and moved `NF4Tensor` from `torchao.dtypes` to `torchao.quantization`. On nightly this block
still degrades to the same warning it does today - no regression, but a follow-up will be needed once
0.18.0 ships, and it will have to drop `UintxAQTTensorImpl` rather than relocate it. I didn't guess at
that here since the layout is still moving.

Also untested: Windows (the report was on Python 3.13 / Win11 - the failure is a pure import-path
lookup, so OS should not matter, but I only ran Linux), and a full quantize → `save_pretrained` →
`from_pretrained` round trip with a uintx config.

Thanks to @lisi31415926 for the report and the diagnosis.