### PR TITLE
fix(ltx2): wire conv_in to correct widths in LTX2VideoUpBlock3d

### DIFF
--- a/src/diffusers/models/autoencoders/autoencoder_kl_ltx2.py
+++ b/src/diffusers/models/autoencoders/autoencoder_kl_ltx2.py
@@ -598,10 +598,13 @@ class LTX2VideoUpBlock3d(nn.Module):
             self.time_embedder = PixArtAlphaCombinedTimestepSizeEmbeddings(in_channels * 4, 0)
 
         self.conv_in = None
-        if in_channels != out_channels:
+        # conv_in must project onto the width the upsampler expects as input,
+        # i.e. out_channels * upscale_factor, not out_channels (#14307).
+        upsampler_in_channels = out_channels * upscale_factor
+        if in_channels != upsampler_in_channels:
             self.conv_in = LTX2VideoResnetBlock3d(
                 in_channels=in_channels,
-                out_channels=out_channels,
+                out_channels=upsampler_in_channels,
                 dropout=dropout,
                 eps=resnet_eps,
                 non_linearity=resnet_act_fn,
@@ -929,7 +932,11 @@ class LTX2VideoDecoder3d(nn.Module):
         num_block_out_channels = len(block_out_channels)
         self.up_blocks = nn.ModuleList([])
         for i in range(num_block_out_channels):
-            input_channel = output_channel // upsample_factor[i]
+            # The tensor arriving from the previous block (or mid_block for
+            # i=0) is `output_channel` wide.  Do NOT divide by the current
+            # block's upsample_factor — that produces a fictitious width that
+            # corresponds to no tensor in the graph (#14307).
+            input_channel = output_channel
             output_channel = block_out_channels[i] // upsample_factor[i]
 
             up_block = LTX2VideoUpBlock3d(

--- a/tests/models/autoencoders/test_autoencoder_kl_ltx2.py
+++ b/tests/models/autoencoders/test_autoencoder_kl_ltx2.py
@@ -1,0 +1,75 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for LTX2VideoUpBlock3d conv_in width wiring (#14307)."""
+
+import torch
+
+from diffusers.models.autoencoders.autoencoder_kl_ltx2 import LTX2VideoUpBlock3d
+
+
+def test_conv_in_projects_to_upsampler_input_width():
+    """conv_in must project onto out_channels * upscale_factor, not out_channels.
+
+    When in_channels != out_channels * upscale_factor the block needs a conv_in
+    whose output matches the upsampler's expected input width.
+    """
+    block = LTX2VideoUpBlock3d(
+        in_channels=48,
+        out_channels=32,
+        num_layers=1,
+        spatio_temporal_scale=True,
+        upscale_factor=2,
+    )
+    # 48 != 32*2=64, so conv_in must exist
+    assert block.conv_in is not None
+
+    # Forward pass must succeed without shape errors
+    x = torch.randn(1, 48, 4, 8, 8)
+    out = block(x)
+    assert out.shape == (1, 32, 7, 16, 16)
+
+
+def test_no_conv_in_when_widths_match():
+    """When in_channels == out_channels * upscale_factor, conv_in is not needed."""
+    block = LTX2VideoUpBlock3d(
+        in_channels=64,
+        out_channels=32,
+        num_layers=1,
+        spatio_temporal_scale=True,
+        upscale_factor=2,
+    )
+    # 64 == 32*2, so conv_in should be None
+    assert block.conv_in is None
+
+    x = torch.randn(1, 64, 4, 8, 8)
+    out = block(x)
+    assert out.shape == (1, 32, 7, 16, 16)
+
+
+def test_conv_in_with_no_upsampler():
+    """When spatio_temporal_scale is False, upscale_factor is effectively 1."""
+    block = LTX2VideoUpBlock3d(
+        in_channels=48,
+        out_channels=32,
+        num_layers=1,
+        spatio_temporal_scale=False,
+        upscale_factor=1,
+    )
+    # 48 != 32*1=32, so conv_in must exist and project to 32
+    assert block.conv_in is not None
+
+    x = torch.randn(1, 48, 4, 8, 8)
+    out = block(x)
+    assert out.shape == (1, 32, 4, 8, 8)


### PR DESCRIPTION
## Summary

Fixes #14307

Two independent defects in `LTX2VideoUpBlock3d.__init__` made any non-nominal `decoder_block_out_channels` unloadable:

**1. `conv_in` projected onto `out_channels`, but the upsampler expects `out_channels * upscale_factor`.**

The upsampler is built with `in_channels=out_channels * upscale_factor`, so `conv_in` must project onto that same width. The guard should compare `in_channels != out_channels * upscale_factor`.

**2. `LTX2VideoDecoder3d` divided `output_channel` by the current block's `upsample_factor` to compute `input_channel`.**

The tensor arriving from the previous block is `output_channel` wide — no division needed. The division produced a fictitious width corresponding to no tensor in the graph.

Both defects are invisible on released LTX-2 checkpoints because the nominal `decoder_block_out_channels` happen to make `conv_in` unnecessary and the division a no-op.

## Tests

Added `tests/models/autoencoders/test_autoencoder_kl_ltx2.py` with 3 tests:

- `test_conv_in_projects_to_upsampler_input_width` — non-nominal widths trigger conv_in and forward pass succeeds
- `test_no_conv_in_when_widths_match` — nominal case still works without conv_in
- `test_conv_in_with_no_upsampler` — no-upsampler case works correctly

```
$ pytest tests/models/autoencoders/test_autoencoder_kl_ltx2.py -v
3 passed in 0.89s
```