### PR TITLE
Fix LTX-2 context parallel plan and Ulysses attn mask head sharding

### DIFF
--- a/src/diffusers/hooks/context_parallel.py
+++ b/src/diffusers/hooks/context_parallel.py
@@ -57,6 +57,9 @@ class ModuleForwardMetadata:
             index = self.cached_parameter_indices.get(identifier, None)
             if index is None:
                 raise ValueError(f"Parameter '{identifier}' not found in cached indices.")
+            if index >= len(args):
+                # Not passed positionally or as a kwarg; the forward will use its default value.
+                return None, False, index
             return args[index], False, index
 
         if self._cls is None:
@@ -72,7 +75,8 @@ class ModuleForwardMetadata:
         index = self.cached_parameter_indices[identifier]
 
         if index >= len(args):
-            raise ValueError(f"Expected {index} arguments but got {len(args)}.")
+            # Not passed positionally or as a kwarg; the forward will use its default value.
+            return None, False, index
 
         return args[index], False, index
 

--- a/src/diffusers/models/attention_dispatch.py
+++ b/src/diffusers/models/attention_dispatch.py
@@ -2395,6 +2395,10 @@ class TemplatedUlyssesAttention(torch.autograd.Function):
             mask_list = [torch.empty_like(attn_mask) for _ in range(world_size)]
             dist.all_gather(mask_list, attn_mask, group=group)
             attn_mask = torch.cat(mask_list, dim=-1)
+        if attn_mask is not None and attn_mask.ndim == 4 and attn_mask.shape[1] == H:
+            # QKV carry H // world_size heads after the all-to-all; shard the mask's head axis to match.
+            local_rank = _parallel_config.context_parallel_config._ulysses_local_rank
+            attn_mask = attn_mask.chunk(world_size, dim=1)[local_rank]
 
         out = forward_op(
             ctx,

--- a/src/diffusers/models/transformers/transformer_ltx2.py
+++ b/src/diffusers/models/transformers/transformer_ltx2.py
@@ -1091,18 +1091,6 @@ class LTX2VideoTransformer3DModel(
     _supports_gradient_checkpointing = True
     _skip_layerwise_casting_patterns = ["norm"]
     _repeated_blocks = ["LTX2VideoTransformerBlock"]
-    _cp_plan = {
-        "": {
-            "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
-            "encoder_hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
-            "encoder_attention_mask": ContextParallelInput(split_dim=1, expected_dims=2, split_output=False),
-        },
-        "rope": {
-            0: ContextParallelInput(split_dim=1, expected_dims=3, split_output=True),
-            1: ContextParallelInput(split_dim=1, expected_dims=3, split_output=True),
-        },
-        "proj_out": ContextParallelOutput(gather_dim=1, expected_dims=3),
-    }
 
     @register_to_config
     def __init__(
@@ -1317,6 +1305,37 @@ class LTX2VideoTransformer3DModel(
         self.audio_proj_out = nn.Linear(audio_inner_dim, audio_out_channels)
 
         self.gradient_checkpointing = False
+
+        # RoPE modules return (cos, sin) shaped (B, T, D) for rope_type="interleaved" and (B, H, T, D // 2)
+        # for rope_type="split", so the sequence dim to shard depends on the config.
+        if rope_type == "split":
+            rope_plan = {
+                0: ContextParallelInput(split_dim=2, expected_dims=4, split_output=True),
+                1: ContextParallelInput(split_dim=2, expected_dims=4, split_output=True),
+            }
+        else:
+            rope_plan = {
+                0: ContextParallelInput(split_dim=1, expected_dims=3, split_output=True),
+                1: ContextParallelInput(split_dim=1, expected_dims=3, split_output=True),
+            }
+        self._cp_plan = {
+            "": {
+                "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
+                "timestep": ContextParallelInput(split_dim=1, expected_dims=2, split_output=False),
+                "audio_hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
+                "audio_timestep": ContextParallelInput(split_dim=1, expected_dims=2, split_output=False),
+                "encoder_hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
+                "encoder_attention_mask": ContextParallelInput(split_dim=1, expected_dims=2, split_output=False),
+                "audio_encoder_hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
+                "audio_encoder_attention_mask": ContextParallelInput(split_dim=1, expected_dims=2, split_output=False),
+            },
+            "rope": rope_plan,
+            "audio_rope": rope_plan,
+            "cross_attn_rope": rope_plan,
+            "cross_attn_audio_rope": rope_plan,
+            "proj_out": ContextParallelOutput(gather_dim=1, expected_dims=3),
+            "audio_proj_out": ContextParallelOutput(gather_dim=1, expected_dims=3),
+        }
 
     @apply_lora_scale("attention_kwargs")
     def forward(


### PR DESCRIPTION
LTX-2's `_cp_plan` was a copy of LTX-1's, so `enable_parallelism()` crashed on the per-token timestep and never sharded the audio stream or 3 of the 4 RoPE modules — and sharding video only would be silently wrong for the bidirectional a2v/v2a cross-attention. The plan is now set in `__init__` because the RoPE sequence dim depends on config: `(B, T, D)` for `rope_type="interleaved"` vs `(B, H, T, D//2)` for `"split"` (what the released checkpoint uses). Two adjacent fixes this surfaced: `TemplatedUlyssesAttention` now shards a 4-D attn mask's head axis to match the post-all-to-all QKV heads, and the CP hook now skips planned params the caller didn't pass (LTX-2's optional `audio_timestep`) instead of raising.

CPU repro from #14316 on this branch (2 ranks, gloo, built-in plan, both rope types):

```
[interleaved] ran. max|delta| vs single-rank: video=4.768e-07 audio=2.384e-07
[split]       ran. max|delta| vs single-rank: video=3.576e-07 audio=2.980e-07
```

Also validated on 2xH100 (NVLink) with the released `Lightricks/LTX-2` checkpoint (`LTX2Pipeline`, 1280x704, 121 frames, bf16): a single transformer forward under `ulysses_degree=2` matches single-GPU exactly (fp32 max|delta| <= 4.2e-7, bf16 bitwise on a small config), and the full 20-step run produces the same video+audio take with bf16 accumulation drift 4-9x below the delta between two seeds (latent rel-RMS 0.21 vs 0.92 video, 0.07 vs 0.62 audio).

The two remaining gaps stay tracked in #14316: the `(B, T_v, T_v)` IC-LoRA self-attention mask (not expressible as a plan entry) and the `ulysses_anything` mask path. Fixes #14316.
