### PR TITLE
Reject an empty mask in `get_crop_region` instead of returning an inverted box

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -305,6 +305,16 @@ class VaeImageProcessor(ConfigMixin):
         mask_image = mask_image.convert("L")
         mask = np.array(mask_image)
 
+        # An all-zero mask has no region to find. The scan below would then run off both ends and
+        # produce an inverted box (x1 > x2, y1 > y2), which surfaces much later as
+        # `ValueError: Coordinate 'right' is less than 'left'` from `PIL.Image.crop`, with nothing
+        # pointing back at the mask.
+        if not mask.any():
+            raise ValueError(
+                "`mask_image` is empty: it contains no non-zero pixels, so there is no region to crop to. "
+                "Either pass a mask with a masked area or set `padding_mask_crop=None`."
+            )
+
         # 1. find a rectangular region that contains all masked ares in an image
         h, w = mask.shape
         crop_left = 0

--- a/tests/others/test_image_processor.py
+++ b/tests/others/test_image_processor.py
@@ -308,3 +308,36 @@ class ImageProcessorTest(unittest.TestCase):
         assert out_np.shape == exp_np_shape, (
             f"resized image output shape '{out_np.shape}' didn't match expected shape '{exp_np_shape}'."
         )
+
+    def test_get_crop_region_normal_mask(self):
+        mask = np.zeros((64, 64), dtype=np.uint8)
+        mask[20:40, 10:30] = 255
+
+        region = VaeImageProcessor.get_crop_region(PIL.Image.fromarray(mask), width=512, height=512)
+
+        assert region == (10, 20, 30, 40)
+
+    def test_get_crop_region_rejects_empty_mask(self):
+        """An all-zero mask has no region to crop to and must say so.
+
+        The column/row scan runs off both ends for an empty mask, so `crop_left` reaches `w` and
+        `crop_right` reaches `w` as well, giving an inverted box such as `(64, 64, 0, 0)`. That
+        travels as far as `PIL.Image.crop`, which fails with `Coordinate 'right' is less than
+        'left'` and no mention of the mask.
+        """
+        empty_mask = PIL.Image.fromarray(np.zeros((64, 64), dtype=np.uint8))
+
+        for pad in (0, 8):
+            with self.assertRaises(ValueError) as ctx:
+                VaeImageProcessor.get_crop_region(empty_mask, width=512, height=512, pad=pad)
+            assert "empty" in str(ctx.exception)
+
+    def test_get_crop_region_single_pixel_and_full_mask_still_work(self):
+        """The two extremes on either side of the empty case keep returning a usable box."""
+        single = np.zeros((64, 64), dtype=np.uint8)
+        single[5, 5] = 255
+        x1, y1, x2, y2 = VaeImageProcessor.get_crop_region(PIL.Image.fromarray(single), width=512, height=512)
+        assert x2 > x1 and y2 > y1
+
+        full = np.full((64, 64), 255, dtype=np.uint8)
+        assert VaeImageProcessor.get_crop_region(PIL.Image.fromarray(full), width=512, height=512) == (0, 0, 64, 64)


### PR DESCRIPTION
## What does this PR do?

`VaeImageProcessor.get_crop_region` scans in from each edge to find the masked area. For an all-zero mask nothing ever breaks those loops, so `crop_left` and `crop_right` both reach `w` (and `crop_top`/`crop_bottom` reach `h`) and the returned box is inverted:

```
normal mask            -> (10, 20, 30, 40)  valid=True   size=20x20
empty mask (all zeros) -> (64, 64,  0,  0)  valid=False  size=-64x-64
empty mask, pad=8      -> (56, 56,  8,  8)  valid=False  size=-48x-48
single pixel           -> ( 5,  5,  6,  6)  valid=True   size=1x1
fully masked           -> ( 0,  0, 64, 64)  valid=True   size=64x64
```

The aspect-ratio expansion below operates on the inverted box without noticing, and the result reaches the caller:

```python
PIL.Image.crop((64, 64, 0, 0))
ValueError: Coordinate 'right' is less than 'left'
```

Nothing in that message points back at the mask.

This is reachable from every inpaint pipeline that takes `padding_mask_crop`:

```
stable_diffusion/pipeline_stable_diffusion_inpaint.py:1163
stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py:1431
stable_diffusion_3/pipeline_stable_diffusion_3_inpaint.py:1195
flux/pipeline_flux_kontext_inpaint.py:1125
flux2/pipeline_flux2_klein_inpaint.py:1010
pag/pipeline_pag_sd_inpaint.py:1145
pag/pipeline_pag_sd_xl_inpaint.py:1424
pag/pipeline_pag_controlnet_sd_inpaint.py:1184
```

An empty mask is a plausible input there: a threshold that removed everything, or a programmatically built mask where no region ended up selected.

## The change

Check `mask.any()` before the scan and raise with a message that names the cause and the two ways out. The empty case already failed; this makes it fail where the reason is known, and it does not change any path that previously worked.

## Tests

Added to `tests/others/test_image_processor.py`:

- `test_get_crop_region_normal_mask` — pins the ordinary result `(10, 20, 30, 40)`
- `test_get_crop_region_rejects_empty_mask` — with `pad=0` and `pad=8`, since padding shifts the inverted box but does not fix it
- `test_get_crop_region_single_pixel_and_full_mask_still_work` — the two cases either side of empty, so the new check cannot be widened into rejecting sparse or full masks

Reverting only `image_processor.py`:

```
FAILED tests/others/test_image_processor.py::ImageProcessorTest::test_get_crop_region_rejects_empty_mask
1 failed, 2 passed
```

and with the change the whole file passes:

```
$ pytest tests/others/test_image_processor.py
13 passed
```

`make quality` (`ruff check` + `ruff format --check`) clean on both files.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.
