### PR TITLE
Don't let `_resize_and_fill`/`_resize_and_crop` scale a side down to zero

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -400,8 +400,11 @@ class VaeImageProcessor(ConfigMixin):
         ratio = width / height
         src_ratio = image.width / image.height
 
-        src_w = width if ratio < src_ratio else image.width * height // image.height
-        src_h = height if ratio >= src_ratio else image.height * width // image.width
+        # Floor division collapses the scaled side to 0 for extreme aspect ratios (a 1x2000 image
+        # scaled to fit 512x512 gives `1 * 512 // 2000 == 0`), and `Image.resize` then fails with
+        # "height and width must be > 0", which names neither the input nor the side that vanished.
+        src_w = width if ratio < src_ratio else max(1, image.width * height // image.height)
+        src_h = height if ratio >= src_ratio else max(1, image.height * width // image.width)
 
         resized = image.resize((src_w, src_h), resample=PIL_INTERPOLATION[self.config.resample])
         res = Image.new("RGB", (width, height))
@@ -451,8 +454,8 @@ class VaeImageProcessor(ConfigMixin):
         ratio = width / height
         src_ratio = image.width / image.height
 
-        src_w = width if ratio > src_ratio else image.width * height // image.height
-        src_h = height if ratio <= src_ratio else image.height * width // image.width
+        src_w = width if ratio > src_ratio else max(1, image.width * height // image.height)
+        src_h = height if ratio <= src_ratio else max(1, image.height * width // image.width)
 
         resized = image.resize((src_w, src_h), resample=PIL_INTERPOLATION[self.config.resample])
         res = Image.new("RGB", (width, height))

--- a/tests/others/test_image_processor.py
+++ b/tests/others/test_image_processor.py
@@ -308,3 +308,28 @@ class ImageProcessorTest(unittest.TestCase):
         assert out_np.shape == exp_np_shape, (
             f"resized image output shape '{out_np.shape}' didn't match expected shape '{exp_np_shape}'."
         )
+
+    def test_resize_fill_and_crop_handle_extreme_aspect_ratios(self):
+        """A side must never be scaled down to zero pixels.
+
+        `src_w`/`src_h` are computed with floor division, so scaling a very thin image to fit a
+        square target collapses the short side: `1 * 512 // 2000 == 0`. `PIL.Image.resize` then
+        raises `ValueError: height and width must be > 0`, which names neither the input nor the
+        side that vanished.
+        """
+        image_processor = VaeImageProcessor(vae_scale_factor=1)
+
+        for size in [(1, 2000), (2000, 1), (1, 1)]:
+            image = PIL.Image.new("RGB", size)
+            for resize_mode in ("fill", "crop"):
+                out = image_processor.resize(image, height=512, width=512, resize_mode=resize_mode)
+                assert out.size == (512, 512), f"{size} with resize_mode={resize_mode} gave {out.size}"
+
+    def test_resize_fill_and_crop_unchanged_for_ordinary_images(self):
+        """The clamp must not perturb sizes that were already computed correctly."""
+        image_processor = VaeImageProcessor(vae_scale_factor=1)
+
+        for size in [(64, 64), (900, 3), (3, 900), (1024, 768)]:
+            image = PIL.Image.new("RGB", size)
+            for resize_mode in ("fill", "crop"):
+                assert image_processor.resize(image, height=512, width=512, resize_mode=resize_mode).size == (512, 512)


### PR DESCRIPTION
## What does this PR do?

`_resize_and_fill` and `_resize_and_crop` compute the scaled size with floor division:

```python
src_w = width if ratio < src_ratio else image.width * height // image.height
src_h = height if ratio >= src_ratio else image.height * width // image.width
```

For a very thin image that rounds to zero. Fitting a 1x2000 image into 512x512 gives `1 * 512 // 2000 == 0`, and `Image.resize((0, 512))` fails:

```
1x2000 -> 512x512   fill=ValueError  crop=ok
2000x1 -> 512x512   fill=ValueError  crop=ok
3x900  -> 512x512   fill=ok          crop=ok
900x3  -> 512x512   fill=ok          crop=ok
64x64  -> 512x512   fill=ok          crop=ok
```

```
ValueError: height and width must be > 0
```

which names neither the input image nor the side that collapsed.

`_resize_and_crop` shows `ok` for those two rows only because its comparisons (`ratio > src_ratio` / `ratio <= src_ratio`) send those particular aspect ratios down the branch that returns `width`/`height` directly. The same floor-divided expression is present and collapses the same way for the mirrored inputs, so clamping both keeps the pair consistent rather than fixing one and leaving a latent copy next to it.

Reachable from the public API:

```python
VaeImageProcessor().resize(image, height=512, width=512, resize_mode="fill")
```

## The change

`max(1, ...)` on the four floor-divided expressions. A resize target of zero pixels is never a valid answer, and the clamp only fires where the previous value was 0, so any size that was computed correctly before is untouched.

## Tests

Added to `tests/others/test_image_processor.py`:

- `test_resize_fill_and_crop_handle_extreme_aspect_ratios` — `(1, 2000)`, `(2000, 1)` and `(1, 1)` across both `fill` and `crop`, asserting a `(512, 512)` result
- `test_resize_fill_and_crop_unchanged_for_ordinary_images` — `(64, 64)`, `(900, 3)`, `(3, 900)`, `(1024, 768)`, so the clamp cannot be widened into perturbing sizes that already worked

Reverting only `image_processor.py`:

```
FAILED tests/others/test_image_processor.py::ImageProcessorTest::test_resize_fill_and_crop_handle_extreme_aspect_ratios
1 failed, 1 passed
```

and with the change:

```
$ pytest tests/others/test_image_processor.py
12 passed
```

`make quality` clean on both files.

## Note

I have a second, unrelated PR open against the same file (#14322, empty mask in `get_crop_region`). The hunks do not overlap; both append their tests at the end of `tests/others/test_image_processor.py`, so whichever lands second may want a trivial rebase there.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.
