### PR TITLE
Fix three messages that pass extra positional arguments

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -120,8 +120,8 @@ class VaeImageProcessor(ConfigMixin):
         if do_convert_rgb and do_convert_grayscale:
             raise ValueError(
                 "`do_convert_rgb` and `do_convert_grayscale` can not both be set to `True`,"
-                " if you intended to convert the image into RGB format, please set `do_convert_grayscale = False`.",
-                " if you intended to convert the image into grayscale format, please set `do_convert_rgb = False`",
+                " if you intended to convert the image into RGB format, please set `do_convert_grayscale = False`."
+                " if you intended to convert the image into grayscale format, please set `do_convert_rgb = False`"
             )
 
     @staticmethod

--- a/src/diffusers/pipelines/deprecated/spectrogram_diffusion/pipeline_spectrogram_diffusion.py
+++ b/src/diffusers/pipelines/deprecated/spectrogram_diffusion/pipeline_spectrogram_diffusion.py
@@ -249,7 +249,7 @@ class SpectrogramDiffusionPipeline(DiffusionPipeline):
             if callback is not None and i % callback_steps == 0:
                 callback(i, full_pred_mel)
 
-            logger.info("Generated segment", i)
+            logger.info("Generated segment %d", i)
 
         if output_type == "np" and not is_onnx_available():
             raise ValueError(

--- a/src/diffusers/pipelines/wan/image_processor.py
+++ b/src/diffusers/pipelines/wan/image_processor.py
@@ -72,8 +72,8 @@ class WanAnimateImageProcessor(VaeImageProcessor):
         if do_convert_rgb and do_convert_grayscale:
             raise ValueError(
                 "`do_convert_rgb` and `do_convert_grayscale` can not both be set to `True`,"
-                " if you intended to convert the image into RGB format, please set `do_convert_grayscale = False`.",
-                " if you intended to convert the image into grayscale format, please set `do_convert_rgb = False`",
+                " if you intended to convert the image into RGB format, please set `do_convert_grayscale = False`."
+                " if you intended to convert the image into grayscale format, please set `do_convert_rgb = False`"
             )
 
     def _resize_and_fill(

--- a/tests/others/test_image_processor.py
+++ b/tests/others/test_image_processor.py
@@ -308,3 +308,16 @@ class ImageProcessorTest(unittest.TestCase):
         assert out_np.shape == exp_np_shape, (
             f"resized image output shape '{out_np.shape}' didn't match expected shape '{exp_np_shape}'."
         )
+
+    def test_rgb_and_grayscale_conflict_message_is_one_string(self):
+        # The ValueError used to be raised with two arguments, so str(e) rendered the tuple
+        # repr and the second half of the guidance arrived wrapped in quotes and parentheses.
+        with self.assertRaises(ValueError) as ctx:
+            VaeImageProcessor(do_convert_rgb=True, do_convert_grayscale=True)
+
+        assert len(ctx.exception.args) == 1
+        message = str(ctx.exception)
+        assert message.startswith("`do_convert_rgb` and `do_convert_grayscale` can not both be set to `True`,")
+        assert "please set `do_convert_grayscale = False`" in message
+        assert "please set `do_convert_rgb = False`" in message
+        assert not message.startswith("(")


### PR DESCRIPTION
## What does this PR do?

Three messages pass an extra positional argument where a single formatted string was intended.

**1 & 2 — `VaeImageProcessor.__init__` and `WanImageProcessor.__init__`**

```python
raise ValueError(
    "`do_convert_rgb` and `do_convert_grayscale` can not both be set to `True`,"
    " if you intended to convert the image into RGB format, please set `do_convert_grayscale = False`.",
    " if you intended to convert the image into grayscale format, please set `do_convert_rgb = False`",
)
```

The last clause is a second argument, so Python puts each into `args` and `str(e)` renders the tuple repr:

```
('`do_convert_rgb` and `do_convert_grayscale` can not both be set to `True`, if you intended to convert the image into RGB format, please set `do_convert_grayscale = False`.', ' if you intended to convert the image into grayscale format, please set `do_convert_rgb = False`')
```

Half the guidance arrives wrapped in quotes and parentheses. That message is the only thing telling the caller which of the two flags to turn off, so both halves matter.

**3 — `pipeline_spectrogram_diffusion`**

```python
logger.info("Generated segment", i)
```

`logging` treats `i` as a `%`-format argument for a message with no placeholder, formatting raises inside the handler, and `logging` catches it and writes `--- Logging error ---` plus a traceback to stderr. The per-segment progress line never reaches a handler — and this one is inside the denoising loop, so it fires once per segment.

Concatenated the two message halves; added `%d` to the log format.

An AST sweep over `src/diffusers/` for multi-argument string `raise`s and for logging calls with a placeholder-free first argument plus extra positional args reports these three. The fourth hit, `examples/community/llm_grounded_diffusion.py:636`, is in `examples/` — happy to include it if you want examples in scope, left out to keep this to `src/`.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

`test_rgb_and_grayscale_conflict_message_is_one_string` in `tests/others/test_image_processor.py` asserts `len(e.args) == 1`, that both halves of the guidance are present in `str(e)`, and that the message doesn't start with `(`.

Stashing only `image_processor.py` gives `AssertionError: assert 2 == 1`; with the change, `tests/others/test_image_processor.py` is 11 passed. `ruff check` and `ruff format --check` clean on all four files.

## Who can review?

@yiyixuxu @sayakpaul @DN6