### PR TITLE
Fix duplicated words in runtime error messages

### DIFF
--- a/src/diffusers/modular_pipelines/anima/before_denoise.py
+++ b/src/diffusers/modular_pipelines/anima/before_denoise.py
@@ -108,9 +108,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_images_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_images_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)

--- a/src/diffusers/modular_pipelines/components_manager.py
+++ b/src/diffusers/modular_pipelines/components_manager.py
@@ -172,7 +172,7 @@ class AutoOffloadStrategy:
         try:
             mem_on_device = device_module.mem_get_info(execution_device.index)[0]
         except AttributeError:
-            raise AttributeError(f"Do not know how to obtain obtain memory info for {str(device_module)}.")
+            raise AttributeError(f"Do not know how to obtain memory info for {str(device_module)}.")
 
         mem_on_device = mem_on_device - self.memory_reserve_margin
         if current_module_size < mem_on_device:

--- a/src/diffusers/modular_pipelines/flux/before_denoise.py
+++ b/src/diffusers/modular_pipelines/flux/before_denoise.py
@@ -470,7 +470,7 @@ class FluxImg2ImgPrepareLatentsStep(ModularPipelineBlocks):
     def check_inputs(image_latents, latents):
         if image_latents.shape[0] != latents.shape[0]:
             raise ValueError(
-                f"`image_latents` must have have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
+                f"`image_latents` must have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
             )
 
         if image_latents.ndim != 3:

--- a/src/diffusers/modular_pipelines/helios/before_denoise.py
+++ b/src/diffusers/modular_pipelines/helios/before_denoise.py
@@ -167,9 +167,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_videos_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_videos_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)

--- a/src/diffusers/modular_pipelines/qwenimage/before_denoise.py
+++ b/src/diffusers/modular_pipelines/qwenimage/before_denoise.py
@@ -426,7 +426,7 @@ class QwenImagePrepareLatentsWithStrengthStep(ModularPipelineBlocks):
     def check_inputs(image_latents, latents):
         if image_latents.shape[0] != latents.shape[0]:
             raise ValueError(
-                f"`image_latents` must have have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
+                f"`image_latents` must have same batch size as `latents`, but got {image_latents.shape[0]} and {latents.shape[0]}"
             )
 
         if image_latents.ndim != 3:

--- a/src/diffusers/modular_pipelines/qwenimage/inputs.py
+++ b/src/diffusers/modular_pipelines/qwenimage/inputs.py
@@ -67,9 +67,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_images_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_images_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)

--- a/src/diffusers/modular_pipelines/stable_diffusion_3/inputs.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_3/inputs.py
@@ -70,9 +70,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_images_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_images_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)

--- a/src/diffusers/modular_pipelines/wan/before_denoise.py
+++ b/src/diffusers/modular_pipelines/wan/before_denoise.py
@@ -80,9 +80,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_videos_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_videos_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)

--- a/src/diffusers/modular_pipelines/z_image/before_denoise.py
+++ b/src/diffusers/modular_pipelines/z_image/before_denoise.py
@@ -80,9 +80,7 @@ def repeat_tensor_to_batch_size(
     elif input_tensor.shape[0] == batch_size:
         repeat_by = num_images_per_prompt
     else:
-        raise ValueError(
-            f"`{input_name}` must have have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}"
-        )
+        raise ValueError(f"`{input_name}` must have batch size 1 or {batch_size}, but got {input_tensor.shape[0]}")
 
     # expand the tensor to match the batch_size * num_images_per_prompt
     input_tensor = input_tensor.repeat_interleave(repeat_by, dim=0)


### PR DESCRIPTION
## What does this PR do?

Nine user-facing messages under `src/` repeat a word:

```
`latents` must have have batch size 1 or 2, but got 3
Do not know how to obtain obtain memory info for <module 'torch.cuda'>.
```

Eight are the same `must have have batch size` line in the input-expansion helpers across the modular pipelines — `anima`, `flux`, `helios`, `qwenimage` (×2), `stable_diffusion_3`, `wan`, `z_image` — and the ninth is in `components_manager`'s offload path.

Triggered directly rather than read off the source:

```
before: `latents` must have have batch size 1 or 2, but got 3
after : `latents` must have batch size 1 or 2, but got 3
```

Found with a `\b(\w+) \1\b` sweep over `src/diffusers`, skipping fenced code and markup. Three other hits are deliberate and left alone:

- `"dai dai daie - daie - daie"` — a prompt inside a pix2pix-zero docstring
- `"Guan Guan Ju Jiu"` — a line of Chinese poetry in `longcat_image/system_messages.py`
- `"pip install imageio imageio-ffmpeg"` — two different package names in `import_utils.py`

Dropping the duplicate shortens those lines enough that `ruff` wants the f-string on one line, so the `raise` collapses in seven files. `ruff format --check` reports all nine files as already formatted *before* this change, so I ran `ruff format` on them rather than leave CI red — that's why some hunks are `4 +---` instead of `2 +-`.

#14294 fixes three of the same kind under `docs/`; no file overlap with this.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?

No test: these are message strings with no branch behaviour attached, and I'm not going to pin exact wording in a test that a maintainer would then have to update on every rephrase. `ruff check` and `ruff format --check` clean on all nine.

## Who can review?

@yiyixuxu @sayakpaul @DN6