### PR TITLE
Fix double transpose of K/V in templated attention backward

### DIFF
--- a/src/diffusers/models/attention_dispatch.py
+++ b/src/diffusers/models/attention_dispatch.py
@@ -969,9 +969,9 @@ def _cudnn_attention_backward_op(
 ):
     query, key, value, out, lse, cum_seq_q, cum_seq_k, philox_seed, philox_offset = ctx.saved_tensors
 
+    # Only grad_out needs to be transposed here: the saved query/key/value are the tensors the
+    # forward op already transposed to (B, H, S, D) before calling into cuDNN.
     grad_out = grad_out.transpose(1, 2).contiguous()
-    key = key.transpose(1, 2).contiguous()
-    value = value.transpose(1, 2).contiguous()
 
     # Cannot pass first 5 arguments as kwargs because: https://github.com/pytorch/pytorch/blob/d26ca5de058dbcf56ac52bb43e84dd98df2ace97/torch/_dynamo/variables/torch.py#L1341
     grad_query, grad_key, grad_value = torch.ops.aten._scaled_dot_product_cudnn_attention_backward(
@@ -1062,9 +1062,9 @@ def _native_flash_attention_backward_op(
 ):
     query, key, value, out, lse, cum_seq_q, cum_seq_k, philox_seed, philox_offset = ctx.saved_tensors
 
+    # Only grad_out needs to be transposed here: the saved query/key/value are the tensors the
+    # forward op already transposed to (B, H, S, D).
     grad_out = grad_out.transpose(1, 2).contiguous()
-    key = key.transpose(1, 2).contiguous()
-    value = value.transpose(1, 2).contiguous()
 
     grad_query, grad_key, grad_value = torch.ops.aten._scaled_dot_product_flash_attention_backward(
         grad_out,

--- a/tests/models/test_attention_dispatch.py
+++ b/tests/models/test_attention_dispatch.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+# Copyright 2026 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from diffusers.models.attention_dispatch import (
+    _cudnn_attention_backward_op,
+    _cudnn_attention_forward_op,
+    _native_flash_attention_backward_op,
+    _native_flash_attention_forward_op,
+)
+
+from ..testing_utils import assert_tensors_close, is_attention, require_torch_gpu
+
+
+class _TemplatedAttentionOp(torch.autograd.Function):
+    """Minimal driver for a (forward_op, backward_op) pair, mirroring the context parallel wrappers."""
+
+    @staticmethod
+    def forward(ctx, query, key, value, forward_op, backward_op):
+        ctx.backward_op = backward_op
+        # The context parallel wrappers always request the lse.
+        out, _ = forward_op(ctx, query, key, value, return_lse=True)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        grad_query, grad_key, grad_value = ctx.backward_op(ctx, grad_out)
+        return grad_query, grad_key, grad_value, None, None
+
+
+@is_attention
+@require_torch_gpu
+@pytest.mark.parametrize(
+    "forward_op,backward_op",
+    [
+        (_cudnn_attention_forward_op, _cudnn_attention_backward_op),
+        (_native_flash_attention_forward_op, _native_flash_attention_backward_op),
+    ],
+    ids=["cudnn", "native_flash"],
+)
+def test_templated_attention_op_gradients(forward_op, backward_op):
+    """Gradients from the templated forward/backward op pairs must match an eager fp32 reference.
+
+    `num_heads == seq_len` on purpose so that a (B, S, H, D) / (B, H, S, D) layout mix-up cannot be
+    hidden by a shape mismatch. See https://github.com/huggingface/diffusers/issues/14338.
+    """
+    torch.manual_seed(0)
+    batch_size, seq_len, num_heads, head_dim = 2, 16, 16, 64
+    shape = (batch_size, seq_len, num_heads, head_dim)
+    query, key, value, grad_out = (
+        torch.randn(shape, device="cuda", dtype=torch.bfloat16, requires_grad=True) for _ in range(4)
+    )
+
+    ref_query, ref_key, ref_value = (
+        x.detach().float().transpose(1, 2).requires_grad_(True) for x in (query, key, value)
+    )
+    ref_out = torch.nn.functional.scaled_dot_product_attention(ref_query, ref_key, ref_value)
+    ref_out.backward(grad_out.detach().float().transpose(1, 2))
+
+    out = _TemplatedAttentionOp.apply(query, key, value, forward_op, backward_op)
+    out.backward(grad_out)
+
+    assert_tensors_close(out.float(), ref_out.transpose(1, 2), atol=1e-2, rtol=1e-2, msg="forward output")
+    for name, actual, expected in (
+        ("query", query.grad, ref_query.grad),
+        ("key", key.grad, ref_key.grad),
+        ("value", value.grad, ref_value.grad),
+    ):
+        assert_tensors_close(
+            actual.float(), expected.transpose(1, 2), atol=1e-1, rtol=1e-1, msg=f"gradient w.r.t. {name}"
+        )

--- a/tests/models/test_attention_dispatch.py
+++ b/tests/models/test_attention_dispatch.py
@@ -52,14 +52,20 @@ class _TemplatedAttentionOp(torch.autograd.Function):
     ],
     ids=["cudnn", "native_flash"],
 )
-def test_templated_attention_op_gradients(forward_op, backward_op):
+@pytest.mark.parametrize(
+    "batch_size,seq_len,num_heads,head_dim",
+    [(2, 16, 16, 64), (2, 1024, 24, 64)],
+    ids=["heads_eq_seq_len", "dit_like"],
+)
+def test_templated_attention_op_gradients(batch_size, seq_len, num_heads, head_dim, forward_op, backward_op):
     """Gradients from the templated forward/backward op pairs must match an eager fp32 reference.
 
-    `num_heads == seq_len` on purpose so that a (B, S, H, D) / (B, H, S, D) layout mix-up cannot be
-    hidden by a shape mismatch. See https://github.com/huggingface/diffusers/issues/14338.
+    The first shape has `num_heads == seq_len` so that a (B, S, H, D) / (B, H, S, D) layout mix-up
+    cannot be hidden by a shape mismatch; it corrupts the gradients instead. The second has
+    `num_heads != seq_len`, where the same mix-up makes the backend reject the head count outright.
+    See https://github.com/huggingface/diffusers/issues/14338.
     """
     torch.manual_seed(0)
-    batch_size, seq_len, num_heads, head_dim = 2, 16, 16, 64
     shape = (batch_size, seq_len, num_heads, head_dim)
     query, key, value, grad_out = (
         torch.randn(shape, device="cuda", dtype=torch.bfloat16, requires_grad=True) for _ in range(4)


### PR DESCRIPTION
Fixes #14338

`_cudnn_attention_forward_op` saves query/key/value *after* transposing them to `(B, H, S, D)`,
but `_cudnn_attention_backward_op` transposed `key` and `value` a second time, so
`aten::_scaled_dot_product_cudnn_attention_backward` got Q as BHSD and K/V as BSHD. The
`grad_out` transpose is correct and stays, since the forward op returns `out` in BSHD.

`_native_flash_attention_backward_op` has the identical two lines against the identical
forward-op contract, so it is fixed here too. Easy to drop that hunk if you would rather split it.

Four lines deleted, no behaviour change to the forward pass.

## Test

New `tests/models/test_attention_dispatch.py`: drives each forward/backward op pair through a
minimal `autograd.Function` (same contract the `Templated*Attention` wrappers use) and checks
all three gradients against an eager fp32 reference. `num_heads == seq_len` so a layout mix-up
cannot hide behind a shape check. Fails on both backends before the patch, passes after.

## Verified

On 2x A40 (sm_86), torch 2.13.0+cu126, cuDNN 9.10.2, bf16:

- Standalone repro at `B=2 S=16 H=16 D=64` reproduces the reporter's numbers. dQ/dK/dV max abs
  error goes from 7.90 / 7.97 / 3.98 to 0.006 / 0.008 / 0.010, against reference magnitudes of
  1.86 / 2.26 / 2.75.
- End to end: small Flux transformer, `ContextParallelConfig(ulysses_degree=2)`,
  `attention_backend("_native_flash")`, parameter grads all-reduced and compared to a
  single-GPU reference. Before the patch the backward raises `Number of heads in key/value must
  divide number of heads in query`. After, the worst relative grad error is 0.0138, which is
  exactly what the plain `native` backend gives on the same harness.
- `pytest -m "attention or context_parallel"` over `test_attention_dispatch.py`,
  `test_attention_processor.py` and `test_models_transformer_flux.py`: 14 passed, 42 skipped.
  The 10 failures in the full Flux file (LoRA hotswap + AOT compile) are pre-existing and
  reproduce on a clean tree.
- `ruff check`, `ruff format --check`, `utils/check_copies.py` all clean.

## Not verified

- No H100 here, so this is sm_86 only. bf16 only, no dropout, no mask, non-causal.
- `flash_hub` / `_flash_3_hub` / varlen / sage backends skipped, `kernels` is not installed. I
  read their backward ops and none of them have this pattern.
- Ring CP end to end. See below.

## Two things left for follow-ups

1. `_cudnn_attention_forward_op` passes `compute_log_sumexp=return_lse`. The Ulysses wrapper
   forwards the caller's `return_lse`, which is `False` for ordinary model attention, so cuDNN
   never computes the lse and the backward op gets an empty `logsumexp`. On the end-to-end
   harness above, ulysses + `_native_cudnn` still gives a worst relative grad error of 328 after
   this patch, and drops to 0.0138 if I locally force `compute_log_sumexp=True`. So cuDNN CP
   training is still broken, for a different reason than #14338. Torch's own SDPA dispatch
   derives that flag from `query/key/value.requires_grad`. Happy to send it separately.
2. The bool-mask issue @YangXu1990uiuc raised, a `torch.bool` `attn_mask` going into the ATen
   `attn_bias` slot without conversion to an additive `-inf`/`0` bias. Real by inspection, not
   touched here, not tested.

Also worth noting: `test_context_parallel_backward` only asserts that gradients are finite,
never that they are correct, which is why this went unnoticed.

Thanks to @YangXu1990uiuc (NVIDIA cuDNN team) for the precise diagnosis and the repro numbers,
which matched what I measured on A40 to three decimal places.