### PR TITLE
docs: fix typos in Kandinsky 5.0 video docs

### DIFF
--- a/docs/source/en/api/pipelines/kandinsky5_video.md
+++ b/docs/source/en/api/pipelines/kandinsky5_video.md
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 
 Kandinsky 5.0 Lite line-up of lightweight video generation models (2B parameters) that ranks #1 among open-source models in its class. It outperforms larger models and offers the best understanding of Russian concepts in the open-source ecosystem.
 
-Kandinsky 5.0 Pro line-up of large high quality video generation models (19B parameters). It offers high qualty generation in HD and more generation formats like I2V.
+Kandinsky 5.0 Pro line-up of large high quality video generation models (19B parameters). It offers high quality generation in HD and more generation formats like I2V.
 
 The model introduces several key innovations:
 - **Latent diffusion pipeline** with **Flow Matching** for improved training stability
@@ -54,7 +54,7 @@ Kandinsky 5.0 T2V Lite:
 ### Basic Text-to-Video Generation
 
 #### Pro
-**⚠️ Warning!** all Pro models should be infered with pipeline.enable_model_cpu_offload()  
+**⚠️ Warning!** all Pro models should be inferred with pipeline.enable_model_cpu_offload()  
 ```python
 import torch
 from diffusers import Kandinsky5T2VPipeline
@@ -65,7 +65,7 @@ model_id = "kandinskylab/Kandinsky-5.0-T2V-Pro-sft-5s-Diffusers"
 pipe = Kandinsky5T2VPipeline.from_pretrained(model_id, dtype=torch.bfloat16)
 
 pipe = pipe.to("cuda")
-pipeline.transformer.set_attention_backend("flex")                            # <--- Set attention bakend to Flex
+pipeline.transformer.set_attention_backend("flex")                            # <--- Set attention backend to Flex
 pipeline.enable_model_cpu_offload()                                           # <--- Enable cpu offloading for single GPU inference
 pipeline.transformer.compile(mode="max-autotune-no-cudagraphs", dynamic=True) # <--- Compile with max-autotune-no-cudagraphs
 
@@ -126,7 +126,7 @@ pipe = pipe.to("cuda")
 
 pipe.transformer.set_attention_backend(
     "flex"
-)                                       # <--- Set attention bakend to Flex
+)                                       # <--- Set attention backend to Flex
 pipe.transformer.compile(
     mode="max-autotune-no-cudagraphs", 
     dynamic=True
@@ -149,7 +149,7 @@ export_to_video(output, "output.mp4", fps=24, quality=9)
 ```
 
 ### Diffusion Distilled model
-**⚠️ Warning!** all nocfg and diffusion distilled models should be infered wothout CFG (```guidance_scale=1.0```):
+**⚠️ Warning!** all nocfg and diffusion distilled models should be inferred without CFG (```guidance_scale=1.0```):
 
 ```python
 model_id = "kandinskylab/Kandinsky-5.0-T2V-Lite-distilled16steps-5s-Diffusers"
@@ -167,7 +167,7 @@ export_to_video(output, "output.mp4", fps=24, quality=9)
 
 
 ### Basic Image-to-Video Generation
-**⚠️ Warning!** all Pro models should be infered with pipeline.enable_model_cpu_offload()  
+**⚠️ Warning!** all Pro models should be inferred with pipeline.enable_model_cpu_offload()  
 ```python
 import torch
 from diffusers import Kandinsky5T2VPipeline
@@ -178,7 +178,7 @@ model_id = "kandinskylab/Kandinsky-5.0-I2V-Pro-sft-5s-Diffusers"
 pipe = Kandinsky5T2VPipeline.from_pretrained(model_id, dtype=torch.bfloat16)
 
 pipe = pipe.to("cuda")
-pipeline.transformer.set_attention_backend("flex")                            # <--- Set attention bakend to Flex
+pipeline.transformer.set_attention_backend("flex")                            # <--- Set attention backend to Flex
 pipeline.enable_model_cpu_offload()                                           # <--- Enable cpu offloading for single GPU inference
 pipeline.transformer.compile(mode="max-autotune-no-cudagraphs", dynamic=True) # <--- Compile with max-autotune-no-cudagraphs
 


### PR DESCRIPTION
# What does this PR do?

Fixes spelling mistakes in the Kandinsky 5.0 Video docs. Prose and comments only — no code or behavior changes.

| | |
|---|---|
| `qualty` → `quality` | line 16 |
| `infered` → `inferred` | lines 57, 152, 170 |
| `bakend` → `backend` | lines 68, 129, 181 |
| `wothout` → `without` | line 152 |

The `bakend` hits are all in the trailing `# <--- Set attention bakend to Flex` comments; the actual `set_attention_backend(...)` calls were already spelled correctly.

Docs-only: 1 file, +7/-7.

## Verification

No Python source touched (`git diff --name-only` shows only the `.md`), so there is nothing for `make quality` to check. Instead:

- `codespell` on the file is clean after the change (7 hits before, 0 after).
- Line count and triple-backtick fence count are identical to `main` (310 lines, 13 fences — odd because of the inline ```` ```guidance_scale=1.0``` ```` on the distilled-model line), so the markdown structure is untouched.
- All 5 ```` ```python ```` blocks still parse with `ast.parse`.

## Self-review notes

Ran the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill against `.ai/review-rules.md` (plus `AGENTS.md`) on `git diff upstream/main...HEAD`.

**Blocking issues:** none.

**Non-blocking issues:** none.

**Dead code:** N/A — docs-only diff, no code paths added or removed.

**Notes / deliberate calls:**

1. *Kept this PR to spelling only.* While checking the file I noticed the runnable examples have separate problems that are **not** addressed here — happy to open an issue or a follow-up PR if you want them fixed:
   - The Image-to-Video example loads the `...I2V-Pro...` checkpoint with `Kandinsky5T2VPipeline`, calls `load_image(...)` without importing it, and never passes the resulting `image` to `pipe(...)` even though `image` is the first (required) parameter of `Kandinsky5I2VPipeline.__call__`.
   - The Pro T2V and I2V examples assign `pipe = ...` and then call `pipeline.transformer...` / `pipeline.enable_model_cpu_offload()`, which is a `NameError` on copy-paste.

   I left all of it alone to keep this a single-purpose spelling diff rather than mixing a correctness fix into it.
2. *Scoped to this one file.* `codespell` reports ~125 hits across the English docs and `src/`, e.g. `sequencially` ×15 in `modular_pipelines/qwenimage/denoise.py` and `exlucde` in `components_manager.py`. Those want a separate systematic sweep, not a bundle with this one. Let me know if a repo-wide pass would be welcome.
3. *Left the two prose `pipeline.enable_model_cpu_offload()` mentions as-is.* They read as "call this method" rather than as copy-paste code, and renaming them is out of scope for a spelling fix.

**Verdict: READY**

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? — N/A, docs-only.
- [ ] Are you the author (or part of the team) of the model/pipeline? — No.

**AI disclosure:** this PR was prepared with Claude Code. I verified every change myself and checked each spelling against the surrounding text.

## Who can review?

@stevhliu — docs-only spelling fix.
