### PR TITLE
Convert bool attn_mask to additive bias in cuDNN forward op

### DIFF
--- a/src/diffusers/models/attention_dispatch.py
+++ b/src/diffusers/models/attention_dispatch.py
@@ -920,6 +920,11 @@ def _cudnn_attention_forward_op(
     if enable_gqa:
         raise ValueError("`enable_gqa` is not yet supported for cuDNN attention.")
 
+    # The aten op takes an additive bias, so a boolean mask has to be converted the same way
+    # `F.scaled_dot_product_attention` does before dispatching to it.
+    if attn_mask is not None and attn_mask.dtype == torch.bool:
+        attn_mask = torch.zeros_like(attn_mask, dtype=query.dtype).masked_fill_(attn_mask.logical_not(), float("-inf"))
+
     tensors_to_save = ()
 
     # Contiguous is a must here! Calling cuDNN backend with aten ops produces incorrect results

--- a/tests/models/test_attention_dispatch.py
+++ b/tests/models/test_attention_dispatch.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+# Copyright 2026 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from diffusers.models.attention_dispatch import _cudnn_attention_forward_op
+
+from ..testing_utils import assert_tensors_close, is_attention, require_torch_gpu, torch_device
+
+
+@is_attention
+@require_torch_gpu
+class TestCudnnAttentionForwardOp:
+    @pytest.mark.parametrize("mask_type", ["partial", "fully_masked_row"])
+    def test_boolean_attn_mask_matches_sdpa(self, mask_type):
+        batch_size, num_heads, seq_len, head_dim = 1, 2, 16, 64
+        torch.manual_seed(0)
+
+        # the forward op takes `(batch_size, seq_len, num_heads, head_dim)`
+        query, key, value = (
+            torch.randn(batch_size, seq_len, num_heads, head_dim, device=torch_device, dtype=torch.bfloat16)
+            for _ in range(3)
+        )
+        attn_mask = torch.ones(batch_size, num_heads, seq_len, seq_len, device=torch_device, dtype=torch.bool)
+        if mask_type == "partial":
+            attn_mask[..., 3, 5:] = False
+        else:
+            attn_mask[..., 7, :] = False
+
+        out = _cudnn_attention_forward_op(None, query, key, value, attn_mask=attn_mask, _save_ctx=False)
+        expected = torch.nn.functional.scaled_dot_product_attention(
+            query.transpose(1, 2), key.transpose(1, 2), value.transpose(1, 2), attn_mask=attn_mask
+        ).transpose(1, 2)
+
+        assert_tensors_close(out, expected, atol=1e-2, rtol=1e-2, msg=f"cuDNN forward op with {mask_type} mask")


### PR DESCRIPTION
Fixes #14342

`_cudnn_attention_forward_op` passes `attn_mask` into
`torch.ops.aten._scaled_dot_product_cudnn_attention` as `attn_bias`. That slot is an additive bias
in the query dtype, and unlike `F.scaled_dot_product_attention` the raw ATen op does not convert a
`torch.bool` mask first, so a boolean mask is consumed as non-float data and the masked positions
are not suppressed. This patch converts a boolean mask to a `-inf`/`0` bias before the call, which
is what `F.scaled_dot_product_attention` does. It sits before `ctx.attn_mask = attn_mask`, so the
backward op gets the converted bias too.

`-inf` rather than `torch.finfo(dtype).min`: they are not interchangeable on a fully masked row
(zeros vs `mean(V)`), and `-inf` is the value that matches boolean-mask semantics on every backend,
which is what this wrapper is emulating.

New `tests/models/test_attention_dispatch.py` drives the forward op with a bool mask, once with a
partially masked row and once with a fully masked row, and compares against
`F.scaled_dot_product_attention` given the same mask. Both cases fail before the patch and pass
after.

## Verified

1x A40 (sm_86), torch 2.9.0+cu126, cuDNN 9.10.2, bf16, `B=1 H=2 S=16 D=64`:

- Standalone repro, max abs error against `F.scaled_dot_product_attention` goes from 2.12 (partial)
  and 1.15 (fully masked row) to exactly 0.0 on both, against a reference magnitude of ~1.8.
- Pre-fix, the bool-mask output is bit identical to the *no mask* output for one head and garbage
  for the other, i.e. on this stack the mask is dropped rather than applied as an additive 0/1. Same
  numbers under torch 2.13.0+cu126 driving the ATen op directly.
- `pytest -m "attention or context_parallel"` over `test_attention_dispatch.py`,
  `test_attention_processor.py` and `test_models_transformer_flux.py`: 7 passed, 41 skipped. The 8
  failures are `*_hub` backends failing to fetch a kernel build for this system and reproduce on a
  clean tree.
- `ruff check`, `ruff format --check`, `utils/check_copies.py` all clean.

## Not verified

- Multi-GPU ulysses/ring end to end with a boolean mask. The fix is tested at the forward op, which
  is the layer the bug is at.
- Gradients. The conversion lands in `ctx.attn_mask`, which is what the ATen backward wants, but the
  backward through this path has separate open problems (double K/V transpose, and
  `compute_log_sumexp=return_lse` leaving the backward with an empty lse), so a grad check here
  would not be meaningful yet.
- bf16 on sm_86 only. No fp16, no sm_89+, no H100.
- `_native_flash_attention_forward_op` does not have this bug, since
  `aten::_scaled_dot_product_flash_attention` has no bias argument. It accepts `attn_mask` and
  silently drops it, which is a separate problem and is left alone here.

Reported by @YangXu1990uiuc, who also identified the fix and the `-inf` vs `finfo.min` distinction.