### PR TITLE
Reject SDE algorithm types on DPMSolverMultistepInverseScheduler

### DIFF
--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep_inverse.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep_inverse.py
@@ -129,9 +129,8 @@ class DPMSolverMultistepInverseScheduler(SchedulerMixin, ConfigMixin):
             Whether to use lower-order solvers in the final steps. Only valid for < 15 inference steps. This can
             stabilize the sampling of DPMSolver for steps < 15, especially for steps <= 10.
         euler_at_final (`bool`, defaults to `False`):
-            Whether to use Euler's method in the final step. It is a trade-off between numerical stability and detail
-            richness. This can stabilize the sampling of the SDE variant of DPMSolver for small number of inference
-            steps, but sometimes may result in blurring.
+            Whether to use Euler's method (first-order) in the final step. It is a trade-off between numerical
+            stability and detail richness for a small number of inference steps, but sometimes may result in blurring.
         use_karras_sigmas (`bool`, *optional*, defaults to `False`):
             Whether to use Karras sigmas for step sizes in the noise schedule during the sampling process. If `True`,
             the sigmas are determined according to a sequence of noise levels {σi}.

--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep_inverse.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep_inverse.py
@@ -118,11 +118,10 @@ class DPMSolverMultistepInverseScheduler(SchedulerMixin, ConfigMixin):
             The threshold value for dynamic thresholding. Valid only when `thresholding=True` and
             `algorithm_type="dpmsolver++"`.
         algorithm_type (`str`, defaults to `dpmsolver++`):
-            Algorithm type for the solver; can be `dpmsolver`, `dpmsolver++`, `sde-dpmsolver` or `sde-dpmsolver++`. The
-            `dpmsolver` type implements the algorithms in the [DPMSolver](https://huggingface.co/papers/2206.00927)
-            paper, and the `dpmsolver++` type implements the algorithms in the
-            [DPMSolver++](https://huggingface.co/papers/2211.01095) paper. It is recommended to use `dpmsolver++` or
-            `sde-dpmsolver++` with `solver_order=2` for guided sampling like in Stable Diffusion.
+            Algorithm type for the solver; can be `dpmsolver` or `dpmsolver++`. The `dpmsolver` type implements the
+            algorithms in the [DPMSolver](https://huggingface.co/papers/2206.00927) paper, and the `dpmsolver++` type
+            implements the algorithms in the [DPMSolver++](https://huggingface.co/papers/2211.01095) paper. Stochastic
+            variants (`sde-dpmsolver`, `sde-dpmsolver++`) are not supported: inversion is deterministic.
         solver_type (`str`, defaults to `midpoint`):
             Solver type for the second-order solver; can be `midpoint` or `heun`. The solver type slightly affects the
             sample quality, especially for a small number of steps. It is recommended to use `midpoint` solvers.
@@ -174,7 +173,7 @@ class DPMSolverMultistepInverseScheduler(SchedulerMixin, ConfigMixin):
         thresholding: bool = False,
         dynamic_thresholding_ratio: float = 0.995,
         sample_max_value: float = 1.0,
-        algorithm_type: Literal["dpmsolver", "dpmsolver++", "sde-dpmsolver", "sde-dpmsolver++"] = "dpmsolver++",
+        algorithm_type: Literal["dpmsolver", "dpmsolver++"] = "dpmsolver++",
         solver_type: Literal["midpoint", "heun"] = "midpoint",
         lower_order_final: bool = True,
         euler_at_final: bool = False,
@@ -188,6 +187,11 @@ class DPMSolverMultistepInverseScheduler(SchedulerMixin, ConfigMixin):
         timestep_spacing: Literal["linspace", "leading", "trailing"] = "linspace",
         steps_offset: int = 0,
     ):
+        if algorithm_type in ["sde-dpmsolver", "sde-dpmsolver++"]:
+            raise ValueError(
+                f"DPMSolverMultistepInverseScheduler does not support algorithm_type='{algorithm_type}' because "
+                "inversion is deterministic; use 'dpmsolver++' or 'dpmsolver' instead."
+            )
         if self.config.use_beta_sigmas and not is_scipy_available():
             raise ImportError("Make sure to install scipy if you want to use beta sigmas.")
         if (
@@ -203,8 +207,11 @@ class DPMSolverMultistepInverseScheduler(SchedulerMixin, ConfigMixin):
             raise ValueError(
                 "Only one of `config.use_beta_sigmas`, `config.use_exponential_sigmas`, `config.use_karras_sigmas` can be used."
             )
-        if algorithm_type in ["dpmsolver", "sde-dpmsolver"]:
-            deprecation_message = f"algorithm_type {algorithm_type} is deprecated and will be removed in a future version. Choose from `dpmsolver++` or `sde-dpmsolver++` instead"
+        if algorithm_type == "dpmsolver":
+            deprecation_message = (
+                "algorithm_type dpmsolver is deprecated and will be removed in a future version. "
+                "Choose `dpmsolver++` instead."
+            )
             deprecate(
                 "algorithm_types dpmsolver and sde-dpmsolver",
                 "1.0.0",
@@ -244,12 +251,7 @@ class DPMSolverMultistepInverseScheduler(SchedulerMixin, ConfigMixin):
         self.init_noise_sigma = 1.0
 
         # settings for DPM-Solver
-        if algorithm_type not in [
-            "dpmsolver",
-            "dpmsolver++",
-            "sde-dpmsolver",
-            "sde-dpmsolver++",
-        ]:
+        if algorithm_type not in ["dpmsolver", "dpmsolver++"]:
             if algorithm_type == "deis":
                 self.register_to_config(algorithm_type="dpmsolver++")
             else:

--- a/tests/schedulers/test_scheduler_dpm_multi_inverse.py
+++ b/tests/schedulers/test_scheduler_dpm_multi_inverse.py
@@ -271,3 +271,27 @@ class DPMSolverMultistepSchedulerTest(SchedulerCommonTest):
 
     def test_exponential_sigmas(self):
         self.check_over_configs(use_exponential_sigmas=True)
+
+    def test_rejects_stochastic_algorithm_types(self):
+        # Inversion uses increasing sigmas, so h = lambda_t - lambda_s is negative.
+        # The SDE variance terms are only real for h > 0 and produce NaN under inversion.
+        for algorithm_type in ["sde-dpmsolver", "sde-dpmsolver++"]:
+            with self.assertRaises(ValueError) as ctx:
+                DPMSolverMultistepInverseScheduler(algorithm_type=algorithm_type)
+            message = str(ctx.exception)
+            self.assertIn("DPMSolverMultistepInverseScheduler", message)
+            self.assertIn(algorithm_type, message)
+            self.assertIn("deterministic", message)
+
+        for algorithm_type in ["dpmsolver", "dpmsolver++"]:
+            scheduler = DPMSolverMultistepInverseScheduler(
+                num_train_timesteps=1000,
+                beta_start=0.00085,
+                beta_end=0.012,
+                algorithm_type=algorithm_type,
+            )
+            scheduler.set_timesteps(10)
+            sample = torch.randn(1, 4, 8, 8)
+            model_output = torch.randn(1, 4, 8, 8)
+            prev = scheduler.step(model_output, scheduler.timesteps[0], sample).prev_sample
+            self.assertFalse(torch.isnan(prev).any())


### PR DESCRIPTION
## Summary

Under inversion the noise schedule runs from clean to noisy, so sigmas increase with step index. Since `lambda = log(alpha) - log(sigma)`, an increasing sigma makes lambda decrease, and `h = lambda_t - lambda_s` is therefore negative by construction. On the reported configuration (`sde-dpmsolver++`, Karras, 25 steps) the first step measures `lambda_s=3.534699`, `lambda_t=3.075704`, `h=-0.458995`, and `1 - exp(-2h) = -1.504252`.

Both stochastic update branches then take the square root of a negative number:

| `algorithm_type` | variance term | for `h < 0` |
| --- | --- | --- |
| `sde-dpmsolver++` | `sqrt(1 - exp(-2h))` | negative, because `exp(-2h) > 1` |
| `sde-dpmsolver` | `sqrt(exp(2h) - 1)` | negative, because `exp(2h) < 1` |

The deterministic branches (`dpmsolver`, `dpmsolver++`) contain no square root and step without NaN. The same first-step NaN appears with `use_karras_sigmas=False`, so the defect is not specific to Karras.

No published method defines stochastic DPM-Solver inversion. Inventing a sign-corrected variance term (for example `sqrt(exp(-2h) - 1)`) would define an unvalidated sampler and turn a loud all-NaN failure into a quiet wrong latent. Inversion is deterministic by purpose: recovering the noise that produces a given sample. This PR therefore rejects the unsupported types at construction with a concise error, and corrects the class docstring so it only advertises the deterministic algorithms.

## Why the SDE code paths stay

Four of the SDE arms sit inside methods marked `# Copied from` `DPMSolverMultistepScheduler`, where those algorithm types remain valid. Deleting them would mean removing the copy headers and unlinking those methods from the forward scheduler for no behavioural change; `make fix-copies` exits clean with the arms left in place. The two uncopied SDE arms in `step` still consume `variance_noise`; removing them would leave a parameter that is accepted and ignored, which is the defect already reported in #14353.

## Backwards compatibility

A saved config with `algorithm_type="sde-dpmsolver++"` (or `sde-dpmsolver`) will now raise `ValueError` at load or construction instead of producing all-NaN samples at the first step. That config already could not invert correctly, so the change replaces a silent wrong answer with an immediate error. Happy to convert the raise into a deprecation warning with a transition window if maintainers prefer that.

## Test plan

- [x] `test_rejects_stochastic_algorithm_types` fails at pristine base `4b8e466bf` (`ValueError not raised`) and passes on this branch
- [x] Construction with `sde-dpmsolver` and `sde-dpmsolver++` raises; message names the scheduler, the type, and that inversion is deterministic
- [x] Construction and first step with `dpmsolver` and `dpmsolver++` remain finite (no NaN)
- [x] Full `tests/schedulers/test_scheduler_dpm_multi_inverse.py`: 39 passed
- [x] `make style` and `make fix-copies` exit 0

Platform: macOS arm64, CPU, CPython 3.12.

Fixes #10748

---

## Self-review

### Scope

Commit range on `scheduler-correctness` against base `4b8e466bf`.

Files:

- `src/diffusers/schedulers/scheduling_dpmsolver_multistep_inverse.py`
- `tests/schedulers/test_scheduler_dpm_multi_inverse.py`

### Blocking issues

None.

### Non-blocking issues

1. **Deprecation key still names `sde-dpmsolver`**
   - `deprecate("algorithm_types dpmsolver and sde-dpmsolver", ...)` keeps the historical key so existing warning filters stay stable. The user-facing message only deprecates `dpmsolver`.
   - Intentional: renaming the key would re-fire warnings for no benefit.

### Dead code (advisory): left on purpose

| Method | `# Copied from` | SDE branches |
| --- | --- | --- |
| `convert_model_output` | yes (forward multistep) | kept for copy sync |
| `dpm_solver_first_order_update` | yes | kept for copy sync |
| `multistep_dpm_solver_second_order_update` | yes | kept for copy sync |
| `multistep_dpm_solver_third_order_update` | yes | kept for copy sync |
| `step` | no | still uses `variance_noise` |

### Documentation impact

- Class Args for `algorithm_type` and `euler_at_final` updated so the docstring only describes supported behaviour.
- No separate `docs/source` page for this scheduler was changed.

### Copied-from blast radius

| Block | Action | Why |
| --- | --- | --- |
| `__init__` | Edited | Not a `# Copied from` block |
| update methods with SDE arms | Untouched | Synchronised with the forward scheduler |
| No inverse consumers of `# Copied from` this class | N/A | Grep shows no copies of the inverse scheduler |

### Verdict

**READY**. Fix before submitting: nothing. Leave for review: whether the construction-time raise should be a deprecation window instead.
