### PR TITLE
Derive DDIM prev_timestep from the inference schedule

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -381,6 +381,42 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
 
         self.timesteps = torch.from_numpy(timesteps).to(device)
 
+    def previous_timestep(self, timestep: int | torch.Tensor) -> int | torch.Tensor:
+        """
+        Return the previous timestep from the schedule produced by [`set_timesteps`].
+
+        The schedule already encodes `timestep_spacing` (`leading`, `trailing`, or `linspace`). Deriving the previous
+        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed
+        `num_train_timesteps // num_inference_steps` step disagrees with the materialised list.
+
+        Args:
+            timestep (`int` or `torch.Tensor`):
+                The current discrete timestep in the diffusion chain (an entry of `self.timesteps`).
+
+        Returns:
+            `int` or `torch.Tensor`:
+                The previous timestep. The final schedule entry returns `-1`, which selects `final_alpha_cumprod`.
+        """
+        if self.num_inference_steps is None:
+            raise ValueError(
+                "Number of inference steps is 'None', you need to run 'set_timesteps' after creating the scheduler"
+            )
+
+        if isinstance(timestep, torch.Tensor) and timestep.ndim > 0:
+            flat = timestep.flatten()
+            prev = torch.stack([self.previous_timestep(t) for t in flat]).reshape(timestep.shape)
+            return prev
+
+        index_candidates = (self.timesteps == timestep).nonzero(as_tuple=True)[0]
+        if len(index_candidates) == 0:
+            # Not an entry of the inference schedule (direct step() calls outside the loop).
+            # Keep the historical unit-stride fallback so off-schedule tooling still works.
+            return timestep - self.config.num_train_timesteps // self.num_inference_steps
+        index = index_candidates[0]
+        if index == self.timesteps.shape[0] - 1:
+            return torch.tensor(-1, device=self.timesteps.device, dtype=self.timesteps.dtype)
+        return self.timesteps[index + 1]
+
     def step(
         self,
         model_output: torch.Tensor,
@@ -441,8 +477,8 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
         # - pred_sample_direction -> "direction pointing to x_t"
         # - pred_prev_sample -> "x_t-1"
 
-        # 1. get previous step value (=t-1)
-        prev_timestep = timestep - self.config.num_train_timesteps // self.num_inference_steps
+        # 1. get previous step value from the materialised schedule (= next entry of self.timesteps)
+        prev_timestep = self.previous_timestep(timestep)
 
         # 2. compute alphas, betas
         alpha_prod_t = self.alphas_cumprod[timestep]

--- a/src/diffusers/schedulers/scheduling_ddim.py
+++ b/src/diffusers/schedulers/scheduling_ddim.py
@@ -386,8 +386,8 @@ class DDIMScheduler(SchedulerMixin, ConfigMixin):
         Return the previous timestep from the schedule produced by [`set_timesteps`].
 
         The schedule already encodes `timestep_spacing` (`leading`, `trailing`, or `linspace`). Deriving the previous
-        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed
-        `num_train_timesteps // num_inference_steps` step disagrees with the materialised list.
+        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed `num_train_timesteps
+        // num_inference_steps` step disagrees with the materialised list.
 
         Args:
             timestep (`int` or `torch.Tensor`):

--- a/src/diffusers/schedulers/scheduling_ddim_cogvideox.py
+++ b/src/diffusers/schedulers/scheduling_ddim_cogvideox.py
@@ -325,6 +325,43 @@ class CogVideoXDDIMScheduler(SchedulerMixin, ConfigMixin):
 
         self.timesteps = torch.from_numpy(timesteps).to(device)
 
+    # Copied from diffusers.schedulers.scheduling_ddim.DDIMScheduler.previous_timestep
+    def previous_timestep(self, timestep: int | torch.Tensor) -> int | torch.Tensor:
+        """
+        Return the previous timestep from the schedule produced by [`set_timesteps`].
+
+        The schedule already encodes `timestep_spacing` (`leading`, `trailing`, or `linspace`). Deriving the previous
+        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed
+        `num_train_timesteps // num_inference_steps` step disagrees with the materialised list.
+
+        Args:
+            timestep (`int` or `torch.Tensor`):
+                The current discrete timestep in the diffusion chain (an entry of `self.timesteps`).
+
+        Returns:
+            `int` or `torch.Tensor`:
+                The previous timestep. The final schedule entry returns `-1`, which selects `final_alpha_cumprod`.
+        """
+        if self.num_inference_steps is None:
+            raise ValueError(
+                "Number of inference steps is 'None', you need to run 'set_timesteps' after creating the scheduler"
+            )
+
+        if isinstance(timestep, torch.Tensor) and timestep.ndim > 0:
+            flat = timestep.flatten()
+            prev = torch.stack([self.previous_timestep(t) for t in flat]).reshape(timestep.shape)
+            return prev
+
+        index_candidates = (self.timesteps == timestep).nonzero(as_tuple=True)[0]
+        if len(index_candidates) == 0:
+            # Not an entry of the inference schedule (direct step() calls outside the loop).
+            # Keep the historical unit-stride fallback so off-schedule tooling still works.
+            return timestep - self.config.num_train_timesteps // self.num_inference_steps
+        index = index_candidates[0]
+        if index == self.timesteps.shape[0] - 1:
+            return torch.tensor(-1, device=self.timesteps.device, dtype=self.timesteps.dtype)
+        return self.timesteps[index + 1]
+
     def step(
         self,
         model_output: torch.Tensor,
@@ -384,8 +421,8 @@ class CogVideoXDDIMScheduler(SchedulerMixin, ConfigMixin):
         # - pred_sample_direction -> "direction pointing to x_t"
         # - pred_prev_sample -> "x_t-1"
 
-        # 1. get previous step value (=t-1)
-        prev_timestep = timestep - self.config.num_train_timesteps // self.num_inference_steps
+        # 1. get previous step value from the materialised schedule (= next entry of self.timesteps)
+        prev_timestep = self.previous_timestep(timestep)
 
         # 2. compute alphas, betas
         alpha_prod_t = self.alphas_cumprod[timestep]

--- a/src/diffusers/schedulers/scheduling_ddim_cogvideox.py
+++ b/src/diffusers/schedulers/scheduling_ddim_cogvideox.py
@@ -331,8 +331,8 @@ class CogVideoXDDIMScheduler(SchedulerMixin, ConfigMixin):
         Return the previous timestep from the schedule produced by [`set_timesteps`].
 
         The schedule already encodes `timestep_spacing` (`leading`, `trailing`, or `linspace`). Deriving the previous
-        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed
-        `num_train_timesteps // num_inference_steps` step disagrees with the materialised list.
+        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed `num_train_timesteps
+        // num_inference_steps` step disagrees with the materialised list.
 
         Args:
             timestep (`int` or `torch.Tensor`):

--- a/src/diffusers/schedulers/scheduling_ddim_parallel.py
+++ b/src/diffusers/schedulers/scheduling_ddim_parallel.py
@@ -391,8 +391,8 @@ class DDIMParallelScheduler(SchedulerMixin, ConfigMixin):
         Return the previous timestep from the schedule produced by [`set_timesteps`].
 
         The schedule already encodes `timestep_spacing` (`leading`, `trailing`, or `linspace`). Deriving the previous
-        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed
-        `num_train_timesteps // num_inference_steps` step disagrees with the materialised list.
+        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed `num_train_timesteps
+        // num_inference_steps` step disagrees with the materialised list.
 
         Args:
             timestep (`int` or `torch.Tensor`):

--- a/src/diffusers/schedulers/scheduling_ddim_parallel.py
+++ b/src/diffusers/schedulers/scheduling_ddim_parallel.py
@@ -268,7 +268,7 @@ class DDIMParallelScheduler(SchedulerMixin, ConfigMixin):
 
     def _get_variance(self, timestep: int, prev_timestep: int | None = None) -> torch.Tensor:
         if prev_timestep is None:
-            prev_timestep = timestep - self.config.num_train_timesteps // self.num_inference_steps
+            prev_timestep = self.previous_timestep(timestep)
 
         alpha_prod_t = self.alphas_cumprod[timestep]
         alpha_prod_t_prev = self.alphas_cumprod[prev_timestep] if prev_timestep >= 0 else self.final_alpha_cumprod
@@ -385,6 +385,43 @@ class DDIMParallelScheduler(SchedulerMixin, ConfigMixin):
 
         self.timesteps = torch.from_numpy(timesteps).to(device)
 
+    # Copied from diffusers.schedulers.scheduling_ddim.DDIMScheduler.previous_timestep
+    def previous_timestep(self, timestep: int | torch.Tensor) -> int | torch.Tensor:
+        """
+        Return the previous timestep from the schedule produced by [`set_timesteps`].
+
+        The schedule already encodes `timestep_spacing` (`leading`, `trailing`, or `linspace`). Deriving the previous
+        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed
+        `num_train_timesteps // num_inference_steps` step disagrees with the materialised list.
+
+        Args:
+            timestep (`int` or `torch.Tensor`):
+                The current discrete timestep in the diffusion chain (an entry of `self.timesteps`).
+
+        Returns:
+            `int` or `torch.Tensor`:
+                The previous timestep. The final schedule entry returns `-1`, which selects `final_alpha_cumprod`.
+        """
+        if self.num_inference_steps is None:
+            raise ValueError(
+                "Number of inference steps is 'None', you need to run 'set_timesteps' after creating the scheduler"
+            )
+
+        if isinstance(timestep, torch.Tensor) and timestep.ndim > 0:
+            flat = timestep.flatten()
+            prev = torch.stack([self.previous_timestep(t) for t in flat]).reshape(timestep.shape)
+            return prev
+
+        index_candidates = (self.timesteps == timestep).nonzero(as_tuple=True)[0]
+        if len(index_candidates) == 0:
+            # Not an entry of the inference schedule (direct step() calls outside the loop).
+            # Keep the historical unit-stride fallback so off-schedule tooling still works.
+            return timestep - self.config.num_train_timesteps // self.num_inference_steps
+        index = index_candidates[0]
+        if index == self.timesteps.shape[0] - 1:
+            return torch.tensor(-1, device=self.timesteps.device, dtype=self.timesteps.dtype)
+        return self.timesteps[index + 1]
+
     def step(
         self,
         model_output: torch.Tensor,
@@ -440,8 +477,8 @@ class DDIMParallelScheduler(SchedulerMixin, ConfigMixin):
         # - pred_sample_direction -> "direction pointing to x_t"
         # - pred_prev_sample -> "x_t-1"
 
-        # 1. get previous step value (=t-1)
-        prev_timestep = timestep - self.config.num_train_timesteps // self.num_inference_steps
+        # 1. get previous step value from the materialised schedule (= next entry of self.timesteps)
+        prev_timestep = self.previous_timestep(timestep)
 
         # 2. compute alphas, betas
         alpha_prod_t = self.alphas_cumprod[timestep]
@@ -565,9 +602,9 @@ class DDIMParallelScheduler(SchedulerMixin, ConfigMixin):
         # - pred_sample_direction -> "direction pointing to x_t"
         # - pred_prev_sample -> "x_t-1"
 
-        # 1. get previous step value (=t-1)
+        # 1. get previous step value from the materialised schedule (= next entry of self.timesteps)
         t = timesteps
-        prev_t = t - self.config.num_train_timesteps // self.num_inference_steps
+        prev_t = self.previous_timestep(t)
 
         t = t.view(-1, *([1] * (model_output.ndim - 1)))
         prev_t = prev_t.view(-1, *([1] * (model_output.ndim - 1)))

--- a/src/diffusers/schedulers/scheduling_dpm_cogvideox.py
+++ b/src/diffusers/schedulers/scheduling_dpm_cogvideox.py
@@ -328,6 +328,43 @@ class CogVideoXDPMScheduler(SchedulerMixin, ConfigMixin):
 
         self.timesteps = torch.from_numpy(timesteps).to(device)
 
+    # Copied from diffusers.schedulers.scheduling_ddim.DDIMScheduler.previous_timestep
+    def previous_timestep(self, timestep: int | torch.Tensor) -> int | torch.Tensor:
+        """
+        Return the previous timestep from the schedule produced by [`set_timesteps`].
+
+        The schedule already encodes `timestep_spacing` (`leading`, `trailing`, or `linspace`). Deriving the previous
+        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed
+        `num_train_timesteps // num_inference_steps` step disagrees with the materialised list.
+
+        Args:
+            timestep (`int` or `torch.Tensor`):
+                The current discrete timestep in the diffusion chain (an entry of `self.timesteps`).
+
+        Returns:
+            `int` or `torch.Tensor`:
+                The previous timestep. The final schedule entry returns `-1`, which selects `final_alpha_cumprod`.
+        """
+        if self.num_inference_steps is None:
+            raise ValueError(
+                "Number of inference steps is 'None', you need to run 'set_timesteps' after creating the scheduler"
+            )
+
+        if isinstance(timestep, torch.Tensor) and timestep.ndim > 0:
+            flat = timestep.flatten()
+            prev = torch.stack([self.previous_timestep(t) for t in flat]).reshape(timestep.shape)
+            return prev
+
+        index_candidates = (self.timesteps == timestep).nonzero(as_tuple=True)[0]
+        if len(index_candidates) == 0:
+            # Not an entry of the inference schedule (direct step() calls outside the loop).
+            # Keep the historical unit-stride fallback so off-schedule tooling still works.
+            return timestep - self.config.num_train_timesteps // self.num_inference_steps
+        index = index_candidates[0]
+        if index == self.timesteps.shape[0] - 1:
+            return torch.tensor(-1, device=self.timesteps.device, dtype=self.timesteps.dtype)
+        return self.timesteps[index + 1]
+
     def get_variables(
         self,
         alpha_prod_t: torch.Tensor,
@@ -463,8 +500,8 @@ class CogVideoXDPMScheduler(SchedulerMixin, ConfigMixin):
         # - pred_sample_direction -> "direction pointing to x_t"
         # - pred_prev_sample -> "x_t-1"
 
-        # 1. get previous step value (=t-1)
-        prev_timestep = timestep - self.config.num_train_timesteps // self.num_inference_steps
+        # 1. get previous step value from the materialised schedule (= next entry of self.timesteps)
+        prev_timestep = self.previous_timestep(timestep)
 
         # 2. compute alphas, betas
         alpha_prod_t = self.alphas_cumprod[timestep]

--- a/src/diffusers/schedulers/scheduling_dpm_cogvideox.py
+++ b/src/diffusers/schedulers/scheduling_dpm_cogvideox.py
@@ -334,8 +334,8 @@ class CogVideoXDPMScheduler(SchedulerMixin, ConfigMixin):
         Return the previous timestep from the schedule produced by [`set_timesteps`].
 
         The schedule already encodes `timestep_spacing` (`leading`, `trailing`, or `linspace`). Deriving the previous
-        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed
-        `num_train_timesteps // num_inference_steps` step disagrees with the materialised list.
+        value from that list is a no-op for uniform strides and corrects `linspace`, where a fixed `num_train_timesteps
+        // num_inference_steps` step disagrees with the materialised list.
 
         Args:
             timestep (`int` or `torch.Tensor`):

--- a/tests/schedulers/test_scheduler_ddim.py
+++ b/tests/schedulers/test_scheduler_ddim.py
@@ -73,6 +73,44 @@ class DDIMSchedulerTest(SchedulerCommonTest):
         for timestep_spacing in ["trailing", "leading"]:
             self.check_over_configs(timestep_spacing=timestep_spacing)
 
+    def test_prev_timestep_matches_schedule(self):
+        # step must use the materialised schedule, not a uniform-stride formula.
+        # The stride formula matches leading and trailing intermediates, but not linspace.
+        for timestep_spacing in ["leading", "trailing", "linspace"]:
+            scheduler = DDIMScheduler(
+                num_train_timesteps=1000,
+                beta_start=0.0001,
+                beta_end=0.02,
+                beta_schedule="linear",
+                clip_sample=False,
+                timestep_spacing=timestep_spacing,
+            )
+            scheduler.set_timesteps(10)
+            timesteps = scheduler.timesteps.tolist()
+            for i, t in enumerate(timesteps):
+                expected = -1 if i == len(timesteps) - 1 else timesteps[i + 1]
+                got = scheduler.previous_timestep(t)
+                got = int(got) if not isinstance(got, int) else got
+                if expected < 0:
+                    self.assertLess(got, 0)
+                else:
+                    self.assertEqual(got, expected)
+
+            # leading / trailing: schedule prev equals the historical stride formula except
+            # at the final step, where both are negative and both select final_alpha_cumprod.
+            if timestep_spacing in ["leading", "trailing"]:
+                stride = scheduler.config.num_train_timesteps // scheduler.num_inference_steps
+                for i, t in enumerate(timesteps[:-1]):
+                    self.assertEqual(timesteps[i + 1], t - stride)
+                hard_last = timesteps[-1] - stride
+                self.assertLess(hard_last, 0)
+
+            # linspace: the historical stride formula disagrees on intermediate steps.
+            if timestep_spacing == "linspace":
+                stride = scheduler.config.num_train_timesteps // scheduler.num_inference_steps
+                mismatches = sum(1 for i, t in enumerate(timesteps[:-1]) if timesteps[i + 1] != t - stride)
+                self.assertGreater(mismatches, 0)
+
     def test_rescale_betas_zero_snr(self):
         for rescale_betas_zero_snr in [True, False]:
             self.check_over_configs(rescale_betas_zero_snr=rescale_betas_zero_snr)


### PR DESCRIPTION
## Summary

`DDIMScheduler.step` formed the previous diffusion index with a uniform stride:

```python
prev_timestep = timestep - self.config.num_train_timesteps // self.num_inference_steps
```

That expression assumes every inference step advances by the same integer. `set_timesteps` with `timestep_spacing="linspace"` does not produce that schedule. For 1000 train steps and 10 inference steps the materialised list strides by 111 while the expression strides by 100, so every step reads `alpha_prod_t_prev` from the wrong index.

`DDIMScheduler` defaults to `timestep_spacing="leading"`. Only callers that explicitly select `linspace` change behaviour. Default sampling outputs do not move.

## Proof that leading and trailing are no-ops

Full deterministic loops (`eta=0`) comparing schedule lookup against the historical stride, same residuals:

| spacing | bit-identical | max abs diff |
| --- | --- | --- |
| `leading` | True | `0.000000e+00` |
| `trailing` | True | `0.000000e+00` |
| `linspace` | False | `2.584383e+02` |

On `leading` and `trailing`, intermediate prev values match the old stride exactly. At the final step the formula can yield a large negative (for example `-100`) while the list yields `-1`; both are `< 0` and both select `final_alpha_cumprod`, so the sample is still bit-identical. On `linspace`, 9 of 10 steps change `alpha_prod_t_prev`. Example prev sequence for 1000/10 linspace: schedule `[888, 777, …, 0, -1]` versus hardcoded `[899, 788, …, 11, -100]`.

## Change

Add `previous_timestep()` that returns the next entry of `self.timesteps` (last entry → `-1`). Use it from `step` (and the parallel batch / variance paths). Same helper is `# Copied from` into the three DDIM-family schedulers below; `make fix-copies` is clean.

## Scope: four changed, two deliberately not

**Changed**

| Scheduler | Why |
| --- | --- |
| `DDIMScheduler` | Source of the bug in #12633 / #11347 |
| `DDIMParallelScheduler` | Same formula in `step`, `_get_variance`, and batch path |
| `CogVideoXDDIMScheduler` | Same formula in `step` |
| `CogVideoXDPMScheduler` | Same formula in `step` |

None of those `step` methods was a `# Copied from` of another; the formula was independently duplicated. The new helper is the shared copy point.

**Not changed**

| Scheduler | Why list lookup is wrong there |
| --- | --- |
| `PNDMScheduler` | `step_prk` uses half-stride intermediates that are not entries of `self.timesteps`. `step_plms` rewrites `prev_timestep` and `timestep` when `counter == 1`. With `skip_prk_steps`, the list contains deliberate duplicates, so a first-match index would pick the wrong row. |
| `RePaintScheduler` | The schedule contains forward jumps. The next list entry is often a *larger* `t`, while the stride formula always means one reverse diffusion step. List lookup would break jump steps. |

## Off-schedule fallback

When `step` is called with a `timestep` that is not an entry of `self.timesteps`, `previous_timestep` falls back to the historical stride. That is not a defensive guess: replacing the fallback with a `ValueError` fails five existing tests that call `step()` outside the inference loop:

- `test_eta`
- `test_inference_steps`
- `test_steps_offset`
- `test_time_indices`
- `test_timestep_spacing`

Pipeline loops always pass schedule entries, so the linspace fix is not diluted by the fallback. Happy to convert the fallback to a raise and update those five tests if maintainers prefer a stricter API.

## Issues

Closes #12633 and #11347. They are one root cause (stride vs `linspace` schedule), not two independent bugs.

## Test plan

- [x] `test_prev_timestep_matches_schedule` fails at pristine base `4b8e466bf` and passes here
- [x] Leading / trailing full-loop bit-identical to the old stride (`max_abs_diff=0`)
- [x] Linspace prev sequence equals the schedule; trajectory changes
- [x] `tests/schedulers/test_scheduler_ddim.py` and `test_scheduler_ddim_parallel.py`: 78 passed
- [x] `make style` exit 0 (ruff + doc-builder + extra checks)
- [x] `make fix-copies` exit 0

Platform: macOS arm64, CPU, CPython 3.12.

---

## Self-review

### Scope

Branch `prev-timestep-schedule-mismatch` against base `4b8e466bf`.

Files:

- `src/diffusers/schedulers/scheduling_ddim.py`
- `src/diffusers/schedulers/scheduling_ddim_parallel.py`
- `src/diffusers/schedulers/scheduling_ddim_cogvideox.py`
- `src/diffusers/schedulers/scheduling_dpm_cogvideox.py`
- `tests/schedulers/test_scheduler_ddim.py`

### Blocking issues

None.

### Non-blocking issues

1. **PNDM and RePaint still use the stride formula**
   - Same line text appears, but list lookup is wrong for PLMS/PRK half-steps and RePaint jumps.
   - Leave for a follow-up if maintainers want a different design there.

2. **Off-schedule `step()` fallback**
   - Load-bearing for the five tests named above. Alternative is raise + update those tests; offered in the PR body.

### Dead code

None introduced.

### Copied-from

| Block | Action |
| --- | --- |
| `DDIMScheduler.previous_timestep` | New source method |
| Parallel / CogVideoX DDIM / CogVideoX DPM `previous_timestep` | `# Copied from` DDIM; `make fix-copies` clean |
| `step` bodies | Not copies; each call site updated to use `previous_timestep` |

### Evidence

- `test_prev_timestep_matches_schedule` fails at base (`AttributeError: previous_timestep`) and passes here.
- Leading / trailing full-loop bit-identical (`max_abs_diff=0`); linspace changes (`max_abs_diff≈2.58e2`).
- DDIM default remains `timestep_spacing="leading"`.
- `make style` and `make fix-copies` exit 0 on this branch (pre-existing tree-wide reformat noise from `ruff format` / doc-builder on unrelated files was not committed).

### Verdict

**READY**.
