### PR TITLE
support group offloading under auto offloading

### DIFF
--- a/src/diffusers/modular_pipelines/components_manager.py
+++ b/src/diffusers/modular_pipelines/components_manager.py
@@ -23,6 +23,7 @@ from typing import Any
 import torch
 
 from ..hooks import ModelHook
+from ..hooks.group_offloading import _is_group_offload_enabled
 from ..utils import (
     is_accelerate_available,
     logging,
@@ -76,12 +77,20 @@ class CustomOffloadHook(ModelHook):
         self.other_hooks.append(hook)
 
     def init_hook(self, module):
+        # A group offloaded module holds one group at a time and refuses `.to()`. Moving it here would be a
+        # silent no-op that leaves this hook recording an offload that never happened.
+        if _is_group_offload_enabled(module):
+            return module
         return module.to("cpu")
 
     def pre_forward(self, module, *args, **kwargs):
         if module.device != self.execution_device:
             if self.other_hooks is not None:
-                hooks_to_offload = [hook for hook in self.other_hooks if hook.model.device == self.execution_device]
+                hooks_to_offload = [
+                    hook
+                    for hook in self.other_hooks
+                    if hook.model.device == self.execution_device and not _is_group_offload_enabled(hook.model)
+                ]
                 # offload all other hooks
                 start_time = time.perf_counter()
                 if self.offload_strategy is not None:
@@ -104,7 +113,10 @@ class CustomOffloadHook(ModelHook):
 
                 if hooks_to_offload:
                     clear_device_cache()
-            module.to(self.execution_device)
+            # The strategy still runs above, so a group offloaded model can make room for itself by moving other
+            # models — it just places itself.
+            if not _is_group_offload_enabled(module):
+                module.to(self.execution_device)
         return send_to_device(args, self.execution_device), send_to_device(kwargs, self.execution_device)
 
 
@@ -336,6 +348,7 @@ class ComponentsManager:
         self.collections = OrderedDict()  # collection_name -> set of component_names
         self.model_hooks = None
         self._auto_offload_enabled = False
+        self._offload_strategy = None
 
     def _lookup_ids(
         self,
@@ -692,7 +705,12 @@ class ComponentsManager:
 
         return get_return_dict(matches, return_dict_with_names)
 
-    def enable_auto_cpu_offload(self, device: str | int | torch.device = None, memory_reserve_margin="3GB"):
+    def enable_auto_cpu_offload(
+        self,
+        device: str | int | torch.device = None,
+        memory_reserve_margin="3GB",
+        offload_strategy=None,
+    ):
         """
         Enable automatic CPU offloading for all components.
 
@@ -703,11 +721,19 @@ class ComponentsManager:
         4. The system tries to offload the smallest combination of models that frees enough memory
         5. Models stay on the execution device until another model needs memory and forces them off
 
+        A group offloaded model takes part in this but places itself: it can still make room by moving other models
+        aside, and is never moved to make room for them. Either order works — group offload before or after enabling
+        this. `AutoOffloadStrategy` sizes its decisions from model memory footprints, which do not describe a model
+        holding one group at a time, so pass an `offload_strategy` that decides from the workflow instead.
+
         Args:
             device (str | int | torch.device): The execution device where models are moved for forward passes
             memory_reserve_margin (str): The memory reserve margin to use, default is 3GB. This is the amount of
                                         memory to keep free on the device to avoid running out of memory during model
                                         execution (e.g., for intermediate activations, gradients, etc.)
+            offload_strategy: Any callable with the signature `(hooks, model_id, model, execution_device) -> hooks`,
+                              returning which resident models to offload before the incoming one loads. Defaults to
+                              `AutoOffloadStrategy`, which frees the smallest sufficient combination.
         """
         if not is_accelerate_available():
             raise ImportError("Make sure to install accelerate to use auto_cpu_offload")
@@ -732,7 +758,17 @@ class ComponentsManager:
                 remove_hook_from_module(component, recurse=True)
 
         self.disable_auto_cpu_offload()
-        offload_strategy = AutoOffloadStrategy(memory_reserve_margin=memory_reserve_margin)
+        if offload_strategy is None:
+            offload_strategy = AutoOffloadStrategy(memory_reserve_margin=memory_reserve_margin)
+            if any(
+                isinstance(component, torch.nn.Module) and _is_group_offload_enabled(component)
+                for component in self.components.values()
+            ):
+                logger.warning(
+                    "`AutoOffloadStrategy` decides what to move from model memory footprints, which do not "
+                    "describe a group offloaded model: it holds one group at a time, not its whole weight. Pass "
+                    "an `offload_strategy` that decides from the workflow instead."
+                )
 
         all_hooks = []
         for name, component in self.components.items():
@@ -749,6 +785,23 @@ class ComponentsManager:
         self.model_hooks = all_hooks
         self._auto_offload_enabled = True
         self._auto_offload_device = device
+        self._offload_strategy = offload_strategy
+
+    def set_offload_strategy(self, offload_strategy):
+        """
+        Replace the offload strategy on all managed models. Only valid while auto CPU offloading is enabled.
+
+        Args:
+            offload_strategy:
+                Any callable with the signature `(hooks, model_id, model, execution_device) -> hooks`: it receives the
+                hooks of the models currently on the device and returns the ones to offload before the incoming model
+                loads. The default is `AutoOffloadStrategy`, which frees the smallest sufficient combination.
+        """
+        if not self._auto_offload_enabled:
+            raise ValueError("Auto CPU offloading is not enabled. Call `enable_auto_cpu_offload` first.")
+        for user_hook in self.model_hooks:
+            user_hook.hook.offload_strategy = offload_strategy
+        self._offload_strategy = offload_strategy
 
     def disable_auto_cpu_offload(self):
         """
@@ -765,6 +818,7 @@ class ComponentsManager:
             clear_device_cache()
         self.model_hooks = None
         self._auto_offload_enabled = False
+        self._offload_strategy = None
 
     def get_model_info(
         self,


### PR DESCRIPTION
related to #14346 


with this PR, we now support the use case where a group offloaded model now takes part in auto offloading but places itself:
- it can still make room by moving other models aside (its `pre_forward` consults the strategy as before)
- it is never chosen as the thing to move, since moving it does nothing
- the manager no longer pretends to offload it

Either order works — group offload before or after `enable_auto_cpu_offload`.

Also here, because it is what makes the combination useful:

- added support for custon offload strategy, i.e. `enable_auto_cpu_offload(..., offload_strategy=...)` and `set_offload_strategy(...)`,
- A warning when group offloading meets the default `AutoOffloadStrategy`, it is not meaningful to use AutoOffloadStrategy with group offloading because the default strategy make its decisions from model memory footprints — a number that does not describe a model holding one group at a time.

## Demo


```py
"""Peak memory of Z-Image-Turbo under four placement strategies.

  1. on gpu           everything resident, no offloading
  2. auto             ComponentsManager auto offloading, default strategy
  3. custom           auto offloading, but a strategy that only ever moves the text encoder
  4. custom + group   the same, with the transformer group offloaded

`AutoOffloadStrategy` decides from model memory footprints, which say nothing useful about a group
offloaded model — it holds one group at a time, not its whole weight. A strategy that decides from the
workflow instead ("the text encoder is done, move it") does not have that problem, which is what 3 and
4 show.

  python groupoffload_demo.py
  python groupoffload_demo.py --modes custom+group --steps 8
"""

import argparse
import gc

import torch

from diffusers import ModularPipeline
from diffusers.modular_pipelines import ComponentsManager


REPO = "Tongyi-MAI/Z-Image-Turbo"
GB = 1024**3


class OffloadTextEncoderOnly:
    """Move the text encoder off the device whenever something else needs to load, and nothing else.

    Same signature as `AutoOffloadStrategy`: `(hooks, model_id, model, execution_device) -> hooks`.
    """

    def __call__(self, hooks, model_id, model, execution_device):
        return [hook for hook in hooks if "text_encoder" in hook.model_id]


def run(mode: str, steps: int):
    gc.collect()
    torch.cuda.empty_cache()
    torch.cuda.reset_peak_memory_stats()

    manager = None if mode == "on gpu" else ComponentsManager()
    pipe = ModularPipeline.from_pretrained(REPO, components_manager=manager)
    pipe.load_components(dtype=torch.bfloat16)

    if mode == "on gpu":
        pipe.to("cuda")
    else:
        if mode == "custom+group":
            pipe.transformer.enable_group_offload(
                onload_device=torch.device("cuda"),
                offload_device=torch.device("cpu"),
                offload_type="block_level",
                num_blocks_per_group=1,
                use_stream=True,
            )
        manager.enable_auto_cpu_offload(device="cuda")
        if mode.startswith("custom"):
            manager.set_offload_strategy(OffloadTextEncoderOnly())

    image = pipe(
        prompt="a red fox in a snowy forest",
        num_inference_steps=steps,
        generator=torch.Generator("cpu").manual_seed(0),
        output_type="pt",
        output="images",
    )
    peak = torch.cuda.max_memory_allocated() / GB

    del pipe, manager
    gc.collect()
    torch.cuda.empty_cache()
    return peak, tuple(image.shape)


if __name__ == "__main__":
    p = argparse.ArgumentParser()
    p.add_argument("--steps", type=int, default=4)
    p.add_argument("--modes", default="on gpu,auto,custom,custom+group")
    a = p.parse_args()

    print(f"{REPO}  {torch.cuda.get_device_name(0)}  steps={a.steps}\n")
    for mode in a.modes.split(","):
        peak, shape = run(mode, a.steps)
        print(f"{mode:14s} peak={peak:6.2f}GB  out={shape}", flush=True)

```

`Tongyi-MAI/Z-Image-Turbo` (11.5GB transformer, 3.7GB text encoder in bf16) on one H100, 4 steps:

```
on gpu         peak= 21.68GB
auto           peak= 21.69GB
custom         peak= 14.15GB
custom+group   peak=  7.77GB
```

The whole custom strategy is:

```python
class OffloadTextEncoderOnly:
    def __call__(self, hooks, model_id, model, execution_device):
        return [hook for hook in hooks if "text_encoder" in hook.model_id]
```

`auto` matching `on gpu` is the point: on an 80GB card the default strategy never fires, because
nothing is ever short of memory. Deciding from the workflow ("the text encoder is done") buys 7.5GB,
and group offloading the transformer buys another 6.4GB — 64% off the resident case.


## Not in this PR

- **No tests.**  will add after #14304 
- **Auto group offloading on OOM.** After #14304, the plan is for OOM recovery to apply group
  offloading itself when everything else is already offloaded. The guards here hold for that: when the
  manager group offloads a model it has already hooked, the hook stops moving it from that point on, so no extra bookkeeping is needed.
