### PR TITLE
Add First Block Cache support for Flux 2

### DIFF
--- a/src/diffusers/hooks/_helpers.py
+++ b/src/diffusers/hooks/_helpers.py
@@ -175,6 +175,7 @@ def _register_transformer_blocks_metadata():
     from ..models.transformers.transformer_bria import BriaTransformerBlock
     from ..models.transformers.transformer_cogview4 import CogView4TransformerBlock
     from ..models.transformers.transformer_flux import FluxSingleTransformerBlock, FluxTransformerBlock
+    from ..models.transformers.transformer_flux2 import Flux2SingleTransformerBlock, Flux2TransformerBlock
     from ..models.transformers.transformer_hunyuan_video import (
         HunyuanVideoSingleTransformerBlock,
         HunyuanVideoTokenReplaceSingleTransformerBlock,
@@ -240,6 +241,22 @@ def _register_transformer_blocks_metadata():
     )
     TransformerBlockRegistry.register(
         model_class=FluxSingleTransformerBlock,
+        metadata=TransformerBlockMetadata(
+            return_hidden_states_index=1,
+            return_encoder_hidden_states_index=0,
+        ),
+    )
+
+    # Flux2
+    TransformerBlockRegistry.register(
+        model_class=Flux2TransformerBlock,
+        metadata=TransformerBlockMetadata(
+            return_hidden_states_index=1,
+            return_encoder_hidden_states_index=0,
+        ),
+    )
+    TransformerBlockRegistry.register(
+        model_class=Flux2SingleTransformerBlock,
         metadata=TransformerBlockMetadata(
             return_hidden_states_index=1,
             return_encoder_hidden_states_index=0,

--- a/src/diffusers/models/transformers/transformer_flux2.py
+++ b/src/diffusers/models/transformers/transformer_flux2.py
@@ -837,18 +837,13 @@ class Flux2SingleTransformerBlock(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        encoder_hidden_states: torch.Tensor | None,
+        encoder_hidden_states: torch.Tensor,
         temb_mod: torch.Tensor,
         image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
         joint_attention_kwargs: dict[str, Any] | None = None,
-        split_hidden_states: bool = False,
-        text_seq_len: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        # If encoder_hidden_states is None, hidden_states is assumed to have encoder_hidden_states already
-        # concatenated
-        if encoder_hidden_states is not None:
-            text_seq_len = encoder_hidden_states.shape[1]
-            hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
+        text_seq_len = encoder_hidden_states.shape[1]
+        hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
 
         mod_shift, mod_scale, mod_gate = Flux2Modulation.split(temb_mod, 1)[0]
 
@@ -866,11 +861,8 @@ class Flux2SingleTransformerBlock(nn.Module):
         if hidden_states.dtype == torch.float16:
             hidden_states = hidden_states.clip(-65504, 65504)
 
-        if split_hidden_states:
-            encoder_hidden_states, hidden_states = hidden_states[:, :text_seq_len], hidden_states[:, text_seq_len:]
-            return encoder_hidden_states, hidden_states
-        else:
-            return hidden_states
+        encoder_hidden_states, hidden_states = hidden_states[:, :text_seq_len], hidden_states[:, text_seq_len:]
+        return encoder_hidden_states, hidden_states
 
 
 class Flux2TransformerBlock(nn.Module):
@@ -1374,12 +1366,9 @@ class Flux2Transformer2DModel(
                     joint_attention_kwargs=kv_attn_kwargs,
                 )
 
-        # Concatenate text and image streams for single-block inference
-        hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
-
         # Blend single block modulation for extract mode: [txt_mod, ref_mod, img_mod]
         if kv_cache_mode == "extract" and num_ref_tokens > 0:
-            total_single_len = hidden_states.shape[1]
+            total_single_len = num_txt_tokens + hidden_states.shape[1]
             single_stream_mod = _blend_single_block_mods(
                 single_stream_mod, ref_single_mod, num_txt_tokens, num_ref_tokens, total_single_len
             )
@@ -1396,28 +1385,26 @@ class Flux2Transformer2DModel(
                 kv_attn_kwargs_single["kv_cache"] = kv_cache.get_single(index_block)
 
             if torch.is_grad_enabled() and self.gradient_checkpointing:
-                hidden_states = self._gradient_checkpointing_func(
+                encoder_hidden_states, hidden_states = self._gradient_checkpointing_func(
                     block,
                     hidden_states,
-                    None,
+                    encoder_hidden_states,
                     single_stream_mod,
                     concat_rotary_emb,
                     kv_attn_kwargs_single,
                 )
             else:
-                hidden_states = block(
+                encoder_hidden_states, hidden_states = block(
                     hidden_states=hidden_states,
-                    encoder_hidden_states=None,
+                    encoder_hidden_states=encoder_hidden_states,
                     temb_mod=single_stream_mod,
                     image_rotary_emb=concat_rotary_emb,
                     joint_attention_kwargs=kv_attn_kwargs_single,
                 )
 
-        # Remove text tokens (and ref tokens in extract mode) from concatenated stream
+        # Remove ref tokens (extract mode only) from the image stream
         if kv_cache_mode == "extract" and num_ref_tokens > 0:
-            hidden_states = hidden_states[:, num_txt_tokens + num_ref_tokens :, ...]
-        else:
-            hidden_states = hidden_states[:, num_txt_tokens:, ...]
+            hidden_states = hidden_states[:, num_ref_tokens:, ...]
 
         # 7. Output layers
         hidden_states = self.norm_out(hidden_states, temb)

--- a/tests/models/transformers/test_models_transformer_flux2.py
+++ b/tests/models/transformers/test_models_transformer_flux2.py
@@ -34,6 +34,7 @@ from ..testing_utils import (
     BaseModelTesterConfig,
     BitsAndBytesTesterMixin,
     ContextParallelTesterMixin,
+    FirstBlockCacheTesterMixin,
     GGUFCompileTesterMixin,
     GGUFTesterMixin,
     LoraHotSwappingForModelTesterMixin,
@@ -196,6 +197,10 @@ class TestFlux2TransformerTensorParallelNeuron:
             f"Neuron tensor-parallel worker failed (exit {result.returncode}).\n"
             f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
         )
+
+
+class TestFlux2TransformerFBCCache(Flux2TransformerTesterConfig, FirstBlockCacheTesterMixin):
+    """FirstBlockCache tests for Flux2 Transformer."""
 
 
 class TestFlux2TransformerLoRA(Flux2TransformerTesterConfig, LoraTesterMixin):

--- a/tests/pipelines/flux2/test_pipeline_flux2_klein.py
+++ b/tests/pipelines/flux2/test_pipeline_flux2_klein.py
@@ -23,6 +23,7 @@ from ...testing_utils import (
 )
 from ..testing_utils import (
     BasePipelineTesterConfig,
+    FirstBlockCacheTesterMixin,
     MemoryTesterMixin,
     PipelineTesterMixin,
     check_qkv_fused_layers_exist,
@@ -196,6 +197,10 @@ class TestFlux2KleinPipeline(Flux2KleinPipelineTesterConfig, PipelineTesterMixin
 
 class TestFlux2KleinPipelineMemory(Flux2KleinPipelineTesterConfig, MemoryTesterMixin):
     """Memory optimization tests (CPU offload, group offload, layerwise casting) for the Flux2 Klein pipeline."""
+
+
+class TestFlux2KleinPipelineFirstBlockCache(Flux2KleinPipelineTesterConfig, FirstBlockCacheTesterMixin):
+    """First Block Cache tests for the Flux2 Klein pipeline."""
 
 
 @require_torch_neuron


### PR DESCRIPTION
Fixes #14280

`Flux2TransformerBlock` and `Flux2SingleTransformerBlock` were never registered in
`TransformerBlockRegistry`, so `enable_cache(FirstBlockCacheConfig(...))` raised
`ValueError: Model class ... not registered`. Registering them is not enough on its own: the model
forward did the txt/img `cat` once between the two block loops, so the FBCache head block (double,
2-tuple of separate streams) and tail block (single, bare concatenated tensor) had incompatible
outputs and the residual bridge failed with `TypeError: unsupported operand type(s) for -: 'Tensor'
and 'list'`.

Changes:

- Register both Flux 2 block classes with the same indices as Flux v1
  (`return_hidden_states_index=1`, `return_encoder_hidden_states_index=0`).
- Move the `cat`/`split` into `Flux2SingleTransformerBlock.forward`, matching
  `FluxSingleTransformerBlock`. Every Flux 2 block now takes `(hidden_states,
  encoder_hidden_states)` and returns `(encoder_hidden_states, hidden_states)`. The block already
  carried `split_hidden_states` / `text_seq_len` parameters for this; nothing ever passed them, so
  they are removed.
- Add `TestFlux2TransformerFBCCache` and `FirstBlockCacheTesterMixin` on
  `Flux2KleinPipelineFastTests`.

This is direction (A) from the issue. Direction (B) would put one model's double/single boundary
into the generic `apply_first_block_cache`.

Verified on 8x A40 (sm_86), torch 2.13.0+cu126, bf16, with dummy models:

- The 7 new tests fail before the patch and pass after.
- With only the registration half applied, the failure moves to the `Tensor - list` bridge error, so
  the model change is load-bearing.
- The model refactor is bit-for-bit identical on all three forward paths: plain, `kv_cache_mode="extract"`,
  `kv_cache_mode="cached"`. The Klein KV-cache path including ref-token modulation blending is
  unchanged.
- Cost of the extra per-block `cat`: 288.0 / 288.7 ms per forward with the patch vs 287.6 / 287.7 ms
  without, on an idle A40 at 8 double + 48 single blocks, dim 3072, 1024 image + 512 text tokens.
  Noise floor.
- `tests/models/transformers/test_models_transformer_flux2.py` has an identical failure set before
  and after (10 `torch.compile` tests that die in the inductor C++ backend on this box, unrelated).
  `tests/hooks/` and the Flux v1 cache tests pass.

Not verified: no pretrained FLUX.2 checkpoint was loaded, so there is no image-quality check, and no
FBCache speedup numbers. All `torch.compile` tests fail on this machine for an unrelated toolchain
reason, before and after, so the compiled path is untested. `Flux2Pipeline` (non-Klein) still does
not open a `cache_context`, so FBCache raises `No context is set` there; that is a separate gap and
I left it alone.

Reported by @sqhuang, whose issue also worked out the root cause and both candidate directions.