### PR TITLE
Guard float64 against fp64-less devices in the Helios schedulers

### DIFF
--- a/src/diffusers/schedulers/scheduling_helios.py
+++ b/src/diffusers/schedulers/scheduling_helios.py
@@ -22,6 +22,7 @@ import torch
 from ..configuration_utils import ConfigMixin, register_to_config
 from ..schedulers.scheduling_utils import SchedulerMixin
 from ..utils import BaseOutput, deprecate
+from ..utils.torch_utils import maybe_adjust_dtype_for_device
 
 
 @dataclass
@@ -235,8 +236,17 @@ class HeliosScheduler(SchedulerMixin, ConfigMixin):
             ratios = np.linspace(stage_sigmas[0].item(), stage_sigmas[-1].item(), num_inference_steps)
             sigmas = torch.from_numpy(ratios)
 
-        self.timesteps = torch.from_numpy(timesteps).to(device=device)
-        self.sigmas = torch.cat([sigmas, torch.zeros(1)]).to(device=device)
+        timesteps = torch.from_numpy(timesteps)
+        sigmas = torch.cat([sigmas, torch.zeros(1)])
+        if device is not None:
+            # In the multi-stage branch both arrays come from np.linspace, so they are
+            # float64, which mps (and npu/neuron) cannot hold. Cast before moving.
+            device = torch.device(device)
+            timesteps = timesteps.to(maybe_adjust_dtype_for_device(timesteps.dtype, device))
+            sigmas = sigmas.to(maybe_adjust_dtype_for_device(sigmas.dtype, device))
+
+        self.timesteps = timesteps.to(device=device)
+        self.sigmas = sigmas.to(device=device)
 
         self._step_index = None
         self.reset_scheduler_history()

--- a/src/diffusers/schedulers/scheduling_helios_dmd.py
+++ b/src/diffusers/schedulers/scheduling_helios_dmd.py
@@ -22,6 +22,7 @@ import torch
 from ..configuration_utils import ConfigMixin, register_to_config
 from ..schedulers.scheduling_utils import SchedulerMixin
 from ..utils import BaseOutput
+from ..utils.torch_utils import maybe_adjust_dtype_for_device
 
 
 @dataclass
@@ -213,8 +214,17 @@ class HeliosDMDScheduler(SchedulerMixin, ConfigMixin):
             ratios = np.linspace(stage_sigmas[0].item(), stage_sigmas[-1].item(), num_inference_steps)
             sigmas = torch.from_numpy(ratios)
 
-        self.timesteps = torch.from_numpy(timesteps).to(device=device)
-        self.sigmas = torch.cat([sigmas, torch.zeros(1)]).to(device=device)
+        timesteps = torch.from_numpy(timesteps)
+        sigmas = torch.cat([sigmas, torch.zeros(1)])
+        if device is not None:
+            # In the multi-stage branch both arrays come from np.linspace, so they are
+            # float64, which mps (and npu/neuron) cannot hold. Cast before moving.
+            device = torch.device(device)
+            timesteps = timesteps.to(maybe_adjust_dtype_for_device(timesteps.dtype, device))
+            sigmas = sigmas.to(maybe_adjust_dtype_for_device(sigmas.dtype, device))
+
+        self.timesteps = timesteps.to(device=device)
+        self.sigmas = sigmas.to(device=device)
 
         self._step_index = None
         self.reset_scheduler_history()
@@ -275,7 +285,11 @@ class HeliosDMDScheduler(SchedulerMixin, ConfigMixin):
         # use higher precision for calculations
         original_dtype = flow_pred.dtype
         device = flow_pred.device
-        flow_pred, xt, sigmas, timesteps = (x.double().to(device) for x in (flow_pred, xt, sigmas, timesteps))
+        # mps (and npu/neuron) cannot hold float64, so fall back to the widest dtype they do
+        dtype = maybe_adjust_dtype_for_device(torch.float64, device)
+        flow_pred, xt, sigmas, timesteps = (
+            x.to(device=device, dtype=dtype) for x in (flow_pred, xt, sigmas, timesteps)
+        )
 
         timestep_id = torch.argmin((timesteps.unsqueeze(0) - timestep.unsqueeze(1)).abs(), dim=1)
         sigma_t = sigmas[timestep_id].reshape(-1, 1, 1, 1, 1)

--- a/tests/schedulers/test_scheduler_helios.py
+++ b/tests/schedulers/test_scheduler_helios.py
@@ -1,0 +1,56 @@
+import unittest
+
+import torch
+
+from diffusers import HeliosDMDScheduler, HeliosScheduler
+from diffusers.utils.torch_utils import maybe_adjust_dtype_for_device
+
+from ..testing_utils import torch_device
+
+
+class HeliosSchedulerDeviceDtypeTest(unittest.TestCase):
+    """Regression tests for #14367.
+
+    Both Helios schedulers built `float64` tensors and moved them straight to the target
+    device. `np.linspace` in the multi-stage branch yields `float64`, so on a device that
+    cannot hold it — mps, and per `_FP64_UNSUPPORTED_DEVICES` also npu and neuron —
+    `set_timesteps` raised `TypeError` before any model ran.
+
+    These assertions are written against `torch_device`, so on a CPU or CUDA runner they
+    check that the dtype is left alone, and on an fp64-less device they check the
+    downcast actually happens.
+    """
+
+    scheduler_classes = (HeliosScheduler, HeliosDMDScheduler)
+    num_inference_steps = 4
+
+    def test_set_timesteps_dtype_is_supported_by_device(self):
+        expected = maybe_adjust_dtype_for_device(torch.float64, torch.device(torch_device))
+        for scheduler_class in self.scheduler_classes:
+            scheduler = scheduler_class()
+            scheduler.set_timesteps(self.num_inference_steps, device=torch_device, stage_index=0)
+
+            for name, tensor in (("timesteps", scheduler.timesteps), ("sigmas", scheduler.sigmas)):
+                assert tensor.device.type == torch.device(torch_device).type, (
+                    f"{scheduler_class.__name__}.{name} was not moved to {torch_device}"
+                )
+                assert tensor.dtype == expected, (
+                    f"{scheduler_class.__name__}.{name} has dtype {tensor.dtype} on {torch_device}, "
+                    f"expected {expected}"
+                )
+
+    def test_convert_flow_pred_to_x0_runs_on_device(self):
+        scheduler = HeliosDMDScheduler()
+        scheduler.set_timesteps(self.num_inference_steps, device=torch_device, stage_index=0)
+
+        shape = (1, 4, 2, 8, 8)
+        flow_pred = torch.randn(shape, generator=torch.Generator().manual_seed(0)).to(torch_device)
+        xt = torch.randn(shape, generator=torch.Generator().manual_seed(1)).to(torch_device)
+
+        x0_pred = scheduler.convert_flow_pred_to_x0(
+            flow_pred, xt, scheduler.timesteps[:1], scheduler.sigmas, scheduler.timesteps
+        )
+
+        assert x0_pred.shape == flow_pred.shape
+        assert x0_pred.dtype == flow_pred.dtype
+        assert torch.isfinite(x0_pred).all()


### PR DESCRIPTION
## What this fixes

Fixes #14367.

Both Helios schedulers build `float64` tensors and move them straight to the target device. In the multi-stage branch, `timesteps` and `sigmas` both come from `np.linspace`, which is `float64`, so on a device that cannot hold it the move raises:

```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64.
```

`HeliosPyramidPipeline` calls `set_timesteps(..., device=device)`, so on Apple Silicon this fails at the first scheduler call (`pipeline_helios_pyramid.py:941`) — after `encode_prompt` (:710) and `prepare_latents` (:887) have run, but before the transformer.

Three sites, all reproducible on `main` (0.40.0.dev0):

| Site | Scheduler |
|---|---|
| `scheduling_helios.py` `set_timesteps` | `HeliosScheduler` |
| `scheduling_helios_dmd.py` `set_timesteps` | `HeliosDMDScheduler` |
| `scheduling_helios_dmd.py` `convert_flow_pred_to_x0` — `.double()` on four on-device tensors | `HeliosDMDScheduler` |

## The change

All three route the dtype through `maybe_adjust_dtype_for_device`, which this codebase already uses for exactly this (53 call sites). It downcasts `float64` only on devices in `_FP64_UNSUPPORTED_DEVICES` — `mps`, `npu`, `neuron` — and is a no-op elsewhere, so CPU and CUDA keep full `float64` precision.

In `set_timesteps` the cast happens before the move rather than after, since the failing operation *is* the move.

## Verification

| | before | after |
|---|---|---|
| `HeliosScheduler.set_timesteps(device="mps")` | `TypeError` | ok, `float32` |
| `HeliosDMDScheduler.set_timesteps(device="mps")` | `TypeError` | ok, `float32` |
| `HeliosDMDScheduler.convert_flow_pred_to_x0` on mps | `TypeError` | ok, finite |
| the same three on CPU | ok, `float64` | **bit-identical**, `float64` |

Full `tests/schedulers/`: 6 failed / 979 passed with this change, versus 8 failed / 977 passed without it — the same six pre-existing local MPS failures either way, plus the two new tests.

## Tests

`tests/schedulers/test_scheduler_helios.py` is new; these schedulers had no test coverage. Both tests fail on `main` and pass with this change.

They assert against `torch_device`, comparing the resulting dtype to `maybe_adjust_dtype_for_device(torch.float64, torch_device)`. On a CPU or CUDA runner that asserts `float64` is left alone; on an fp64-less device it asserts the downcast happened. So the tests are meaningful on CI without requiring Apple hardware, though only an mps/npu/neuron runner exercises the actual regression.

## Overlap with #14071

@Shreyas-jk opened #14071 in June, which fixes the third site (`convert_flow_pred_to_x0`). I did not spot it when I filed #14367 — apologies for the duplication, that was my miss.

The two differences, so you can pick rather than guess:

- **Coverage.** #14071 fixes the `convert_flow_pred_to_x0` upcast only. The two `set_timesteps` sites are untouched by it, and those are the ones that break `HeliosPyramidPipeline` first — `set_timesteps(..., device=device)` at :941 runs before the transformer, so on Apple Silicon the failure happens there, not in `convert_flow_pred_to_x0`.
- **Mechanism.** #14071 uses `torch.float32 if device.type == "mps" else torch.float64`. Routing through `maybe_adjust_dtype_for_device` instead picks up `npu` and `neuron` from `_FP64_UNSUPPORTED_DEVICES` as well, and keeps this file consistent with the other 53 call sites.

I am happy to drop my third hunk and rebase on top of #14071 if you would rather merge that one first — its author got there before me and the credit for that site is theirs either way. Just say which you prefer.

