### PR TITLE
Migrate torchao integration off deleted torchao.dtypes and snake_case…

### DIFF
--- a/src/diffusers/quantizers/quantization_config.py
+++ b/src/diffusers/quantizers/quantization_config.py
@@ -624,21 +624,50 @@ class TorchAoConfig(QuantizationConfigMixin):
 
         if is_torchao_available():
             # TODO(aryan): Support sparsify
+            # NOTE: the older snake_case quantization functions (e.g. ``int4_weight_only``,
+            # ``float8_weight_only``) were removed from torchao in favor of ``AOBaseConfig``
+            # subclasses. We build the same string -> config mapping using those config classes.
             from torchao.quantization import (
-                float8_dynamic_activation_float8_weight,
-                float8_static_activation_float8_weight,
-                float8_weight_only,
-                int4_weight_only,
-                int8_dynamic_activation_int4_weight,
-                int8_dynamic_activation_int8_weight,
-                int8_weight_only,
-                uintx_weight_only,
+                Float8DynamicActivationFloat8WeightConfig,
+                Float8StaticActivationFloat8WeightConfig,
+                Float8WeightOnlyConfig,
+                Int4WeightOnlyConfig,
+                Int8DynamicActivationInt8WeightConfig,
+                Int8DynamicActivationIntxWeightConfig,
+                Int8WeightOnlyConfig,
+                IntxWeightOnlyConfig,
             )
 
             if is_torchao_version("<=", "0.14.1"):
                 from torchao.quantization import fpx_weight_only
             # TODO(aryan): Add a note on how to use PerAxis and PerGroup observers
-            from torchao.quantization.observer import PerRow, PerTensor
+            from torchao.quantization import PerGroup, PerRow, PerTensor
+
+            # The ``IntxWeightOnlyConfig`` / ``Int8DynamicActivationIntxWeightConfig`` classes that
+            # replace the old ``uintx_weight_only`` / ``int8_dynamic_activation_int4_weight`` helpers
+            # take a ``granularity`` object rather than the ``group_size`` int the old helpers
+            # accepted. This factory keeps the ``group_size`` kwarg working by translating it to a
+            # ``PerGroup`` granularity, and exposes a ``__signature__`` advertising ``group_size``
+            # plus the config's own kwargs so ``TorchAoConfig``'s kwarg validation still works.
+            def _make_intx_config_adapter(config_cls, granularity_param, **fixed_kwargs):
+                def adapter(group_size=None, **kwargs):
+                    if group_size is not None:
+                        kwargs[granularity_param] = PerGroup(group_size)
+                    return config_cls(**fixed_kwargs, **kwargs)
+
+                params = [inspect.Parameter("group_size", inspect.Parameter.KEYWORD_ONLY, default=None)]
+                for name, param in inspect.signature(config_cls).parameters.items():
+                    if name in fixed_kwargs or name == granularity_param:
+                        continue
+                    params.append(param.replace(kind=inspect.Parameter.KEYWORD_ONLY))
+                adapter.__signature__ = inspect.Signature(params)
+                return adapter
+
+            # int4 weight + int8 activation
+            int8_dynamic_activation_int4_weight = _make_intx_config_adapter(
+                Int8DynamicActivationIntxWeightConfig, "weight_granularity", weight_dtype=torch.int4
+            )
+            intx_weight_only = _make_intx_config_adapter(IntxWeightOnlyConfig, "granularity")
 
             def generate_float8dq_types(dtype: torch.dtype):
                 name = "e5m2" if dtype == torch.float8_e5m2 else "e4m3"
@@ -648,7 +677,7 @@ class TorchAoConfig(QuantizationConfigMixin):
                     # Note: Activation and Weights cannot have different granularities
                     granularity_name = "tensor" if granularity_cls is PerTensor else "row"
                     types[f"float8dq_{name}_{granularity_name}"] = partial(
-                        float8_dynamic_activation_float8_weight,
+                        Float8DynamicActivationFloat8WeightConfig,
                         activation_dtype=dtype,
                         weight_dtype=dtype,
                         granularity=(granularity_cls(), granularity_cls()),
@@ -675,8 +704,8 @@ class TorchAoConfig(QuantizationConfigMixin):
 
             INT4_QUANTIZATION_TYPES = {
                 # int4 weight + bfloat16/float16 activation
-                "int4wo": int4_weight_only,
-                "int4_weight_only": int4_weight_only,
+                "int4wo": Int4WeightOnlyConfig,
+                "int4_weight_only": Int4WeightOnlyConfig,
                 # int4 weight + int8 activation
                 "int4dq": int8_dynamic_activation_int4_weight,
                 "int8_dynamic_activation_int4_weight": int8_dynamic_activation_int4_weight,
@@ -684,28 +713,28 @@ class TorchAoConfig(QuantizationConfigMixin):
 
             INT8_QUANTIZATION_TYPES = {
                 # int8 weight + bfloat16/float16 activation
-                "int8wo": int8_weight_only,
-                "int8_weight_only": int8_weight_only,
+                "int8wo": Int8WeightOnlyConfig,
+                "int8_weight_only": Int8WeightOnlyConfig,
                 # int8 weight + int8 activation
-                "int8dq": int8_dynamic_activation_int8_weight,
-                "int8_dynamic_activation_int8_weight": int8_dynamic_activation_int8_weight,
+                "int8dq": Int8DynamicActivationInt8WeightConfig,
+                "int8_dynamic_activation_int8_weight": Int8DynamicActivationInt8WeightConfig,
             }
 
             # TODO(aryan): handle torch 2.2/2.3
             FLOATX_QUANTIZATION_TYPES = {
                 # float8_e5m2 weight + bfloat16/float16 activation
-                "float8wo": partial(float8_weight_only, weight_dtype=torch.float8_e5m2),
-                "float8_weight_only": float8_weight_only,
-                "float8wo_e5m2": partial(float8_weight_only, weight_dtype=torch.float8_e5m2),
+                "float8wo": partial(Float8WeightOnlyConfig, weight_dtype=torch.float8_e5m2),
+                "float8_weight_only": Float8WeightOnlyConfig,
+                "float8wo_e5m2": partial(Float8WeightOnlyConfig, weight_dtype=torch.float8_e5m2),
                 # float8_e4m3 weight + bfloat16/float16 activation
-                "float8wo_e4m3": partial(float8_weight_only, weight_dtype=torch.float8_e4m3fn),
+                "float8wo_e4m3": partial(Float8WeightOnlyConfig, weight_dtype=torch.float8_e4m3fn),
                 # float8_e5m2 weight + float8 activation (dynamic)
-                "float8dq": float8_dynamic_activation_float8_weight,
-                "float8_dynamic_activation_float8_weight": float8_dynamic_activation_float8_weight,
+                "float8dq": Float8DynamicActivationFloat8WeightConfig,
+                "float8_dynamic_activation_float8_weight": Float8DynamicActivationFloat8WeightConfig,
                 # ===== Matrix multiplication is not supported in float8_e5m2 so the following errors out.
                 # However, changing activation_dtype=torch.float8_e4m3 might work here =====
                 # "float8dq_e5m2": partial(
-                #     float8_dynamic_activation_float8_weight,
+                #     Float8DynamicActivationFloat8WeightConfig,
                 #     activation_dtype=torch.float8_e5m2,
                 #     weight_dtype=torch.float8_e5m2,
                 # ),
@@ -713,13 +742,13 @@ class TorchAoConfig(QuantizationConfigMixin):
                 # ===== =====
                 # float8_e4m3 weight + float8 activation (dynamic)
                 "float8dq_e4m3": partial(
-                    float8_dynamic_activation_float8_weight,
+                    Float8DynamicActivationFloat8WeightConfig,
                     activation_dtype=torch.float8_e4m3fn,
                     weight_dtype=torch.float8_e4m3fn,
                 ),
                 **generate_float8dq_types(torch.float8_e4m3fn),
                 # float8 weight + float8 activation (static)
-                "float8_static_activation_float8_weight": float8_static_activation_float8_weight,
+                "float8_static_activation_float8_weight": Float8StaticActivationFloat8WeightConfig,
             }
 
             if is_torchao_version("<=", "0.14.1"):
@@ -729,16 +758,19 @@ class TorchAoConfig(QuantizationConfigMixin):
                 FLOATX_QUANTIZATION_TYPES.update(generate_fpx_quantization_types(6))
                 FLOATX_QUANTIZATION_TYPES.update(generate_fpx_quantization_types(7))
 
+            # The old ``uintx_weight_only`` (unsigned) helper is replaced by
+            # ``IntxWeightOnlyConfig``, which expresses low-bit integer weights via the
+            # signed ``torch.intN`` dtypes.
             UINTX_QUANTIZATION_DTYPES = {
-                "uintx_weight_only": uintx_weight_only,
-                "uint1wo": partial(uintx_weight_only, dtype=torch.uint1),
-                "uint2wo": partial(uintx_weight_only, dtype=torch.uint2),
-                "uint3wo": partial(uintx_weight_only, dtype=torch.uint3),
-                "uint4wo": partial(uintx_weight_only, dtype=torch.uint4),
-                "uint5wo": partial(uintx_weight_only, dtype=torch.uint5),
-                "uint6wo": partial(uintx_weight_only, dtype=torch.uint6),
-                "uint7wo": partial(uintx_weight_only, dtype=torch.uint7),
-                # "uint8wo": partial(uintx_weight_only, dtype=torch.uint8),  # uint8 quantization is not supported
+                "uintx_weight_only": intx_weight_only,
+                "uint1wo": partial(intx_weight_only, weight_dtype=torch.int1),
+                "uint2wo": partial(intx_weight_only, weight_dtype=torch.int2),
+                "uint3wo": partial(intx_weight_only, weight_dtype=torch.int3),
+                "uint4wo": partial(intx_weight_only, weight_dtype=torch.int4),
+                "uint5wo": partial(intx_weight_only, weight_dtype=torch.int5),
+                "uint6wo": partial(intx_weight_only, weight_dtype=torch.int6),
+                "uint7wo": partial(intx_weight_only, weight_dtype=torch.int7),
+                # "uint8wo": partial(intx_weight_only, weight_dtype=torch.int8),  # uint8 quantization is not supported
             }
 
             QUANTIZATION_TYPES = {}
@@ -774,31 +806,6 @@ class TorchAoConfig(QuantizationConfigMixin):
         else:
             methods = self._get_torchao_quant_type_to_method()
             quant_type_kwargs = self.quant_type_kwargs.copy()
-            if (
-                not torch.cuda.is_available()
-                and is_torchao_available()
-                and self.quant_type == "int4_weight_only"
-                and version.parse(importlib.metadata.version("torchao")) >= version.parse("0.8.0")
-                and quant_type_kwargs.get("layout", None) is None
-            ):
-                if torch.xpu.is_available():
-                    if version.parse(importlib.metadata.version("torchao")) >= version.parse(
-                        "0.11.0"
-                    ) and version.parse(importlib.metadata.version("torch")) > version.parse("2.7.9"):
-                        from torchao.dtypes import Int4XPULayout
-                        from torchao.quantization.quant_primitives import ZeroPointDomain
-
-                        quant_type_kwargs["layout"] = Int4XPULayout()
-                        quant_type_kwargs["zero_point_domain"] = ZeroPointDomain.INT
-                    else:
-                        raise ValueError(
-                            "TorchAoConfig requires torchao >= 0.11.0 and torch >= 2.8.0 for XPU support. Please upgrade the version or use run on CPU with the cpu version pytorch."
-                        )
-                else:
-                    from torchao.dtypes import Int4CPULayout
-
-                    quant_type_kwargs["layout"] = Int4CPULayout()
-
             return methods[self.quant_type](**quant_type_kwargs)
 
     def __repr__(self):

--- a/src/diffusers/quantizers/torchao/torchao_quantizer.py
+++ b/src/diffusers/quantizers/torchao/torchao_quantizer.py
@@ -84,30 +84,7 @@ def _update_torch_safe_globals():
         (torch.uint6, "torch.uint6"),
         (torch.uint7, "torch.uint7"),
     ]
-    try:
-        from torchao.dtypes import NF4Tensor
-        from torchao.dtypes.uintx.uintx_layout import UintxAQTTensorImpl, UintxTensor
-
-        safe_globals.extend([UintxTensor, UintxAQTTensorImpl, NF4Tensor])
-
-        # note: is_torchao_version(">=", "0.16.0") does not work correctly
-        # with torchao nightly, so using a ">" check which does work correctly
-        if is_torchao_version(">", "0.15.0"):
-            pass
-        else:
-            from torchao.dtypes.floatx.float8_layout import Float8AQTTensorImpl
-            from torchao.dtypes.uintx.uint4_layout import UInt4Tensor
-
-            safe_globals.extend([UInt4Tensor, Float8AQTTensorImpl])
-
-    except (ImportError, ModuleNotFoundError) as e:
-        logger.warning(
-            "Unable to import `torchao` Tensor objects. This may affect loading checkpoints serialized with `torchao`"
-        )
-        logger.debug(e)
-
-    finally:
-        torch.serialization.add_safe_globals(safe_globals=safe_globals)
+    torch.serialization.add_safe_globals(safe_globals=safe_globals)
 
 
 if (
@@ -134,19 +111,10 @@ def fuzzy_match_size(config_name: str) -> Optional[str]:
     return None
 
 
-def _quantization_type(weight):
-    from torchao.dtypes import AffineQuantizedTensor
-    from torchao.quantization.linear_activation_quantized_tensor import LinearActivationQuantizedTensor
-
-    if isinstance(weight, AffineQuantizedTensor):
-        return f"{weight.__class__.__name__}({weight._quantization_type()})"
-
-    if isinstance(weight, LinearActivationQuantizedTensor):
-        return f"{weight.__class__.__name__}(activation={weight.input_quant_func}, weight={_quantization_type(weight.original_weight_tensor)})"
-
-
 def _linear_extra_repr(self):
-    weight = _quantization_type(self.weight)
+    from torchao.utils import TorchAOBaseTensor
+
+    weight = self.weight.__class__.__name__ if isinstance(self.weight, TorchAOBaseTensor) else None
     if weight is None:
         return f"in_features={self.weight.shape[1]}, out_features={self.weight.shape[0]}, weight=None"
     else:
@@ -313,12 +281,12 @@ class TorchAoHfQuantizer(DiffusersQuantizer):
 
         if self.pre_quantized:
             # If we're loading pre-quantized weights, replace the repr of linear layers for pretty printing info
-            # about AffineQuantizedTensor
+            # about the quantized tensor type
             module._parameters[tensor_name] = torch.nn.Parameter(param_value.to(device=target_device))
             if isinstance(module, nn.Linear):
                 module.extra_repr = types.MethodType(_linear_extra_repr, module)
         else:
-            # As we perform quantization here, the repr of linear layers is that of AQT, so we don't have to do it ourselves
+            # As we perform quantization here, the repr of linear layers is set by TorchAO, so we don't have to do it ourselves
             module._parameters[tensor_name] = torch.nn.Parameter(param_value).to(device=target_device)
             quantize_(module, self.quantization_config.get_apply_tensor_subclass())
 

--- a/tests/quantization/torchao/test_torchao.py
+++ b/tests/quantization/torchao/test_torchao.py
@@ -63,10 +63,9 @@ if is_torch_available():
 
 
 if is_torchao_available():
-    from torchao.dtypes import AffineQuantizedTensor
-    from torchao.quantization.linear_activation_quantized_tensor import LinearActivationQuantizedTensor
+    from torchao.quantization import Int4Tensor, Int8Tensor
     from torchao.quantization.quant_primitives import MappingType
-    from torchao.utils import get_model_size_in_bytes
+    from torchao.utils import TorchAOBaseTensor, get_model_size_in_bytes
 
     if version.parse(importlib.metadata.version("torchao")) >= version.Version("0.9.0"):
         from torchao.quantization import Int8WeightOnlyConfig
@@ -316,9 +315,7 @@ class TorchAoTest(unittest.TestCase):
         )
 
         weight = quantized_model.transformer_blocks[0].ff.net[2].weight
-        self.assertTrue(isinstance(weight, AffineQuantizedTensor))
-        self.assertEqual(weight.quant_min, 0)
-        self.assertEqual(weight.quant_max, 15)
+        self.assertTrue(isinstance(weight, Int4Tensor))
 
     def test_device_map(self):
         """
@@ -378,7 +375,7 @@ class TorchAoTest(unittest.TestCase):
                 if "transformer_blocks.0" in device_map:
                     self.assertTrue(isinstance(weight, nn.Parameter))
                 else:
-                    self.assertTrue(isinstance(weight, AffineQuantizedTensor))
+                    self.assertTrue(isinstance(weight, Int4Tensor))
 
                 output = quantized_model(**inputs)[0]
                 output_slice = output.flatten()[-9:].detach().float().cpu().numpy()
@@ -399,7 +396,7 @@ class TorchAoTest(unittest.TestCase):
                 if "transformer_blocks.0" in device_map:
                     self.assertTrue(isinstance(weight, nn.Parameter))
                 else:
-                    self.assertTrue(isinstance(weight, AffineQuantizedTensor))
+                    self.assertTrue(isinstance(weight, Int4Tensor))
 
                 output = quantized_model(**inputs)[0]
                 output_slice = output.flatten()[-9:].detach().float().cpu().numpy()
@@ -416,11 +413,11 @@ class TorchAoTest(unittest.TestCase):
 
         unquantized_layer = quantized_model_with_not_convert.transformer_blocks[0].ff.net[2]
         self.assertTrue(isinstance(unquantized_layer, torch.nn.Linear))
-        self.assertFalse(isinstance(unquantized_layer.weight, AffineQuantizedTensor))
+        self.assertFalse(isinstance(unquantized_layer.weight, Int8Tensor))
         self.assertEqual(unquantized_layer.weight.dtype, torch.bfloat16)
 
         quantized_layer = quantized_model_with_not_convert.proj_out
-        self.assertTrue(isinstance(quantized_layer.weight, AffineQuantizedTensor))
+        self.assertTrue(isinstance(quantized_layer.weight, Int8Tensor))
 
         quantization_config = TorchAoConfig("int8_weight_only")
         quantized_model = FluxTransformer2DModel.from_pretrained(
@@ -500,18 +497,18 @@ class TorchAoTest(unittest.TestCase):
 
             # Will not quantized all the layers by default due to the model weights shapes not being divisible by group_size=64
             for block in transformer_int4wo.transformer_blocks:
-                self.assertTrue(isinstance(block.ff.net[2].weight, AffineQuantizedTensor))
-                self.assertTrue(isinstance(block.ff_context.net[2].weight, AffineQuantizedTensor))
+                self.assertTrue(isinstance(block.ff.net[2].weight, Int4Tensor))
+                self.assertTrue(isinstance(block.ff_context.net[2].weight, Int4Tensor))
 
             # Will quantize all the linear layers except x_embedder
             for name, module in transformer_int4wo_gs32.named_modules():
                 if isinstance(module, nn.Linear) and name not in ["x_embedder"]:
-                    self.assertTrue(isinstance(module.weight, AffineQuantizedTensor))
+                    self.assertTrue(isinstance(module.weight, Int4Tensor))
 
             # Will quantize all the linear layers
             for module in transformer_int8wo.modules():
                 if isinstance(module, nn.Linear):
-                    self.assertTrue(isinstance(module.weight, AffineQuantizedTensor))
+                    self.assertTrue(isinstance(module.weight, Int8Tensor))
 
             total_int4wo = get_model_size_in_bytes(transformer_int4wo)
             total_int4wo_gs32 = get_model_size_in_bytes(transformer_int4wo_gs32)
@@ -638,7 +635,7 @@ class TorchAoSerializationTest(unittest.TestCase):
         output = quantized_model(**inputs)[0]
         output_slice = output.flatten()[-9:].detach().float().cpu().numpy()
         weight = quantized_model.transformer_blocks[0].ff.net[2].weight
-        self.assertTrue(isinstance(weight, (AffineQuantizedTensor, LinearActivationQuantizedTensor)))
+        self.assertTrue(isinstance(weight, TorchAOBaseTensor))
         self.assertTrue(numpy_cosine_similarity_distance(output_slice, expected_slice) < 1e-3)
 
     def _check_serialization_expected_slice(self, quant_method, quant_method_kwargs, expected_slice, device):
@@ -654,11 +651,7 @@ class TorchAoSerializationTest(unittest.TestCase):
         output = loaded_quantized_model(**inputs)[0]
 
         output_slice = output.flatten()[-9:].detach().float().cpu().numpy()
-        self.assertTrue(
-            isinstance(
-                loaded_quantized_model.proj_out.weight, (AffineQuantizedTensor, LinearActivationQuantizedTensor)
-            )
-        )
+        self.assertTrue(isinstance(loaded_quantized_model.proj_out.weight, TorchAOBaseTensor))
         self.assertTrue(numpy_cosine_similarity_distance(output_slice, expected_slice) < 1e-3)
 
     def test_int_a8w8_accelerator(self):
@@ -808,7 +801,7 @@ class SlowTorchAoTests(unittest.TestCase):
         pipe.enable_model_cpu_offload()
 
         weight = pipe.transformer.transformer_blocks[0].ff.net[2].weight
-        self.assertTrue(isinstance(weight, (AffineQuantizedTensor, LinearActivationQuantizedTensor)))
+        self.assertTrue(isinstance(weight, TorchAOBaseTensor))
 
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0].flatten()
@@ -846,7 +839,7 @@ class SlowTorchAoTests(unittest.TestCase):
         pipe.enable_model_cpu_offload()
 
         weight = pipe.transformer.x_embedder.weight
-        self.assertTrue(isinstance(weight, AffineQuantizedTensor))
+        self.assertTrue(isinstance(weight, Int8Tensor))
 
         inputs = self.get_dummy_inputs(torch_device)
         output = pipe(**inputs)[0].flatten()[:128]
@@ -865,7 +858,7 @@ class SlowTorchAoTests(unittest.TestCase):
             pipe.enable_model_cpu_offload()
 
         weight = transformer.x_embedder.weight
-        self.assertTrue(isinstance(weight, AffineQuantizedTensor))
+        self.assertTrue(isinstance(weight, Int8Tensor))
 
         loaded_output = pipe(**inputs)[0].flatten()[:128]
         # Seems to require higher tolerance depending on which machine it is being run.
@@ -953,7 +946,7 @@ class SlowTorchAoPreserializedModelTests(unittest.TestCase):
         # Verify that all linear layer weights are quantized
         for name, module in pipe.transformer.named_modules():
             if isinstance(module, nn.Linear):
-                self.assertTrue(isinstance(module.weight, AffineQuantizedTensor))
+                self.assertTrue(isinstance(module.weight, Int8Tensor))
 
         # Verify outputs match expected slice
         inputs = self.get_dummy_inputs(torch_device)


### PR DESCRIPTION
… configs

Context: follow up on torchao's deletion in https://github.com/pytorch/ao/pull/4696

torchao removed the torchao/dtypes package (AffineQuantizedTensor and the Layout classes) and the snake_case quantization functions (int4_weight_only, float8_weight_only, uintx_weight_only, ...) in favor of AOBaseConfig subclasses. This updates the diffusers torchao integration so it neither crashes on import nor relies on the removed APIs.

Changes:
- quantizers/torchao/torchao_quantizer.py: drop `_quantization_type` and its `from torchao.dtypes import AffineQuantizedTensor` branch; `_linear_extra_repr` now detects quantized weights inline via `isinstance(weight, TorchAOBaseTensor)`. Remove the dead torchao.dtypes safe-globals block in `_update_torch_safe_globals`.
- quantizers/quantization_config.py:
  - `get_apply_tensor_subclass`: drop the Int4XPULayout/Int4CPULayout branch (those layouts were deleted from torchao).
  - `_get_torchao_quant_type_to_method`: build the string -> config mapping from the new Config classes (Int4WeightOnlyConfig, Int8WeightOnlyConfig, Float8WeightOnlyConfig, Float8DynamicActivationFloat8WeightConfig, Float8StaticActivationFloat8WeightConfig, Int8DynamicActivationInt8WeightConfig, Int8DynamicActivationIntxWeightConfig, IntxWeightOnlyConfig). A small adapter preserves the `group_size` kwarg by translating it to a PerGroup granularity and exposes a matching `__signature__` so TorchAoConfig kwarg validation still works. The floatx (fpx) paths remain gated to torchao <= 0.14.1.
- tests/quantization/torchao/test_torchao.py: replace torchao.dtypes / AffineQuantizedTensor references with the new Int4Tensor/Int8Tensor and TorchAOBaseTensor types.

Test plan:
- `python -c "import diffusers.quantizers.quantization_config, diffusers.quantizers.torchao.torchao_quantizer"` imports cleanly.
- `pytest tests/quantization/torchao/test_torchao.py`: 13 passed, 11 skipped; all pure-Python config tests (TorchAoConfigTest, incl. repr / kwarg validation) pass. The 5 remaining failures (test_quantization, test_device_map, test_memory_footprint, test_training, test_sequential_cpu_offload) are torchao new-tensor behavior/numeric drift (output slices, packing/memory sizes, autograd, and float8dq cutlass kernels on the test GPU) pinned to the pre-AOBaseConfig era, not to this change; these tests could not run at all before this fix.

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [ ] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [ ] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu @dg845
- Pipelines and models: @yiyixuxu @dg845 and @asomoza
- Training examples: @sayakpaul @linoytsaban
- Docs: @stevhliu and @sayakpaul
- MPS: @pcuenca
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
