### PR TITLE
Fix additive attention mask handling in the native NPU attention backend.

### DIFF
--- a/src/diffusers/models/attention_dispatch.py
+++ b/src/diffusers/models/attention_dispatch.py
@@ -1889,6 +1889,9 @@ def _sage_attention_backward_op(
 
 
 def _maybe_modify_attn_mask_npu(query: torch.Tensor, key: torch.Tensor, attn_mask: torch.Tensor | None = None):
+    if attn_mask is not None and attn_mask.dtype != torch.bool:
+        raise ValueError(f"Attention mask must be of type bool, got {attn_mask.dtype}.")
+
     # Skip Attention Mask if all values are 1, `None` mask can speedup the computation
     if attn_mask is not None and torch.all(attn_mask != 0):
         attn_mask = None
@@ -3773,6 +3776,19 @@ def _native_npu_attention(
 ) -> torch.Tensor:
     if return_lse:
         raise ValueError("NPU attention backend does not support setting `return_lse=True`.")
+
+    if attn_mask is not None and attn_mask.is_floating_point():
+        # Preserve additive mask values by letting native SDPA select the appropriate NPU implementation.
+        return _native_attention(
+            query,
+            key,
+            value,
+            attn_mask,
+            dropout_p,
+            scale=scale,
+            _parallel_config=_parallel_config,
+        )
+
     if _parallel_config is None:
         attn_mask = _maybe_modify_attn_mask_npu(query, key, attn_mask)
 


### PR DESCRIPTION
# What does this PR do?

Fixes attention mask handling in the native NPU attention backend.

PyTorch SDPA defines two mask formats:

- Boolean masks are keep masks, where `True` means attend.
- Floating-point masks are additive biases applied directly to attention scores.

Previously, `_native_npu_attention` passed every mask to `_maybe_modify_attn_mask_npu`, which casts the mask to boolean and inverts it for `npu_fusion_attention`. This works for boolean masks but loses the values and semantics of floating-point additive masks.

This PR makes the mask handling explicit:

- Floating-point masks are routed through the existing native SDPA implementation, preserving their additive values.
- Boolean masks continue using `npu_fusion_attention`.
- Other mask dtypes are rejected with a clear error instead of being silently converted to boolean.

No new dependencies are introduced.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

If you used an AI agent, also include your final self-review notes here (or post them as a comment) — the report from the last self-review round, including any findings you intentionally did not fix and why. See https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #14397

### Test results

| Scope | Test | Before the fix | After the fix | Result |
| --- | --- | --- | --- | --- |
| End-to-end | [`dg845/LTX-2.3-Diffusers` with verl-omni NPU training](https://github.com/verl-project/verl-omni/blob/main/examples/flowgrpo_trainer/ltx2/run_ltx2_3_t2av_lora_npu.sh) | `log_prob_diff` was around `1e-3` during the first 5 training steps | `log_prob_diff` decreased to around `1e-5` during the first 5 training steps | ✓ Passed |
| Minimal reproduction | Floating-point additive mask reproduction from this issue | The mask semantics were reversed and the assertion failed | The additive mask is handled correctly and the assertion passes | ✓ Passed |


## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu @dg845
- Pipelines and models: @yiyixuxu @dg845 and @asomoza
- Training examples: @sayakpaul @linoytsaban
- Docs: @stevhliu and @sayakpaul
- MPS: @pcuenca
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
