### PR TITLE
Fix division-by-zero NaN in shift_terminal with a single denoising step

### DIFF
--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -350,8 +350,10 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         else:
             sigmas = self.shift * sigmas / (1 + (self.shift - 1) * sigmas)
 
-        # 3. If required, stretch the sigmas schedule to terminate at the configured `shift_terminal` value
-        if self.config.shift_terminal:
+        # 3. If required, stretch the sigmas schedule to terminate at the configured `shift_terminal` value. This is
+        #    skipped when there is only a single step, since there is nothing to stretch and the terminal rescaling
+        #    otherwise divides by zero (the single sigma is always 1.0, i.e. `one_minus_z[-1]` is always 0).
+        if self.config.shift_terminal and len(sigmas) > 1:
             sigmas = self.stretch_shift_to_terminal(sigmas)
 
         # 4. If required, convert sigmas to one of karras, exponential, or beta sigma schedules

--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -352,7 +352,8 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
 
         # 3. If required, stretch the sigmas schedule to terminate at the configured `shift_terminal` value. This is
         #    skipped when there is only a single step, since there is nothing to stretch and the terminal rescaling
-        #    otherwise divides by zero (the single sigma is always 1.0, i.e. `one_minus_z[-1]` is always 0).
+        #    otherwise divides by zero (with the default schedule the single sigma is always 1.0, so
+        #    `one_minus_z[-1]` is always 0).
         if self.config.shift_terminal and len(sigmas) > 1:
             sigmas = self.stretch_shift_to_terminal(sigmas)
 

--- a/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
@@ -277,6 +277,10 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         """
         one_minus_z = 1 - t
         scale_factor = one_minus_z[-1] / (1 - self.config.shift_terminal)
+        if scale_factor == 0:
+            # The schedule already ends at 1.0 (e.g. a single-step schedule), so there is nothing to
+            # stretch and dividing by `scale_factor` would produce NaN/Inf.
+            return t
         stretched_t = 1 - (one_minus_z / scale_factor)
         return stretched_t
 
@@ -350,11 +354,8 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
         else:
             sigmas = self.shift * sigmas / (1 + (self.shift - 1) * sigmas)
 
-        # 3. If required, stretch the sigmas schedule to terminate at the configured `shift_terminal` value. This is
-        #    skipped when there is only a single step, since there is nothing to stretch and the terminal rescaling
-        #    otherwise divides by zero (with the default schedule the single sigma is always 1.0, so
-        #    `one_minus_z[-1]` is always 0).
-        if self.config.shift_terminal and len(sigmas) > 1:
+        # 3. If required, stretch the sigmas schedule to terminate at the configured `shift_terminal` value.
+        if self.config.shift_terminal:
             sigmas = self.stretch_shift_to_terminal(sigmas)
 
         # 4. If required, convert sigmas to one of karras, exponential, or beta sigma schedules

--- a/src/diffusers/schedulers/scheduling_flow_match_lcm.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_lcm.py
@@ -359,8 +359,10 @@ class FlowMatchLCMScheduler(SchedulerMixin, ConfigMixin):
         else:
             sigmas = self.shift * sigmas / (1 + (self.shift - 1) * sigmas)  # type: ignore
 
-        # 3. If required, stretch the sigmas schedule to terminate at the configured `shift_terminal` value
-        if self.config.shift_terminal:
+        # 3. If required, stretch the sigmas schedule to terminate at the configured `shift_terminal` value. This is
+        #    skipped when there is only a single step, since there is nothing to stretch and the terminal rescaling
+        #    otherwise divides by zero (the single sigma is always 1.0, i.e. `one_minus_z[-1]` is always 0).
+        if self.config.shift_terminal and len(sigmas) > 1:
             sigmas = self.stretch_shift_to_terminal(sigmas)  # type: ignore
 
         # 4. If required, convert sigmas to one of karras, exponential, or beta sigma schedules

--- a/src/diffusers/schedulers/scheduling_flow_match_lcm.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_lcm.py
@@ -286,6 +286,10 @@ class FlowMatchLCMScheduler(SchedulerMixin, ConfigMixin):
         """
         one_minus_z = 1 - t
         scale_factor = one_minus_z[-1] / (1 - self.config.shift_terminal)
+        if scale_factor == 0:
+            # The schedule already ends at 1.0 (e.g. a single-step schedule), so there is nothing to
+            # stretch and dividing by `scale_factor` would produce NaN/Inf.
+            return t
         stretched_t = 1 - (one_minus_z / scale_factor)
         return stretched_t
 
@@ -359,11 +363,8 @@ class FlowMatchLCMScheduler(SchedulerMixin, ConfigMixin):
         else:
             sigmas = self.shift * sigmas / (1 + (self.shift - 1) * sigmas)  # type: ignore
 
-        # 3. If required, stretch the sigmas schedule to terminate at the configured `shift_terminal` value. This is
-        #    skipped when there is only a single step, since there is nothing to stretch and the terminal rescaling
-        #    otherwise divides by zero (with the default schedule the single sigma is always 1.0, so
-        #    `one_minus_z[-1]` is always 0).
-        if self.config.shift_terminal and len(sigmas) > 1:
+        # 3. If required, stretch the sigmas schedule to terminate at the configured `shift_terminal` value.
+        if self.config.shift_terminal:
             sigmas = self.stretch_shift_to_terminal(sigmas)  # type: ignore
 
         # 4. If required, convert sigmas to one of karras, exponential, or beta sigma schedules

--- a/src/diffusers/schedulers/scheduling_flow_match_lcm.py
+++ b/src/diffusers/schedulers/scheduling_flow_match_lcm.py
@@ -361,7 +361,8 @@ class FlowMatchLCMScheduler(SchedulerMixin, ConfigMixin):
 
         # 3. If required, stretch the sigmas schedule to terminate at the configured `shift_terminal` value. This is
         #    skipped when there is only a single step, since there is nothing to stretch and the terminal rescaling
-        #    otherwise divides by zero (the single sigma is always 1.0, i.e. `one_minus_z[-1]` is always 0).
+        #    otherwise divides by zero (with the default schedule the single sigma is always 1.0, so
+        #    `one_minus_z[-1]` is always 0).
         if self.config.shift_terminal and len(sigmas) > 1:
             sigmas = self.stretch_shift_to_terminal(sigmas)  # type: ignore
 

--- a/src/diffusers/schedulers/scheduling_unipc_multistep.py
+++ b/src/diffusers/schedulers/scheduling_unipc_multistep.py
@@ -432,7 +432,7 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
                 sigmas = self.time_shift(mu, 1.0, sigmas)
             else:
                 sigmas = self.config.flow_shift * sigmas / (1 + (self.config.flow_shift - 1) * sigmas)
-            if self.config.shift_terminal:
+            if self.config.shift_terminal and len(sigmas) > 1:
                 sigmas = self.stretch_shift_to_terminal(sigmas)
             eps = 1e-6
             if np.fabs(sigmas[0] - 1) < eps:

--- a/src/diffusers/schedulers/scheduling_unipc_multistep.py
+++ b/src/diffusers/schedulers/scheduling_unipc_multistep.py
@@ -432,7 +432,7 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
                 sigmas = self.time_shift(mu, 1.0, sigmas)
             else:
                 sigmas = self.config.flow_shift * sigmas / (1 + (self.config.flow_shift - 1) * sigmas)
-            if self.config.shift_terminal and len(sigmas) > 1:
+            if self.config.shift_terminal:
                 sigmas = self.stretch_shift_to_terminal(sigmas)
             eps = 1e-6
             if np.fabs(sigmas[0] - 1) < eps:
@@ -521,6 +521,10 @@ class UniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
         """
         one_minus_z = 1 - t
         scale_factor = one_minus_z[-1] / (1 - self.config.shift_terminal)
+        if scale_factor == 0:
+            # The schedule already ends at 1.0 (e.g. a single-step schedule), so there is nothing to
+            # stretch and dividing by `scale_factor` would produce NaN/Inf.
+            return t
         stretched_t = 1 - (one_minus_z / scale_factor)
         return stretched_t
 

--- a/tests/schedulers/test_scheduler_shift_terminal_single_step.py
+++ b/tests/schedulers/test_scheduler_shift_terminal_single_step.py
@@ -43,3 +43,11 @@ class ShiftTerminalSingleStepTest(unittest.TestCase):
         scheduler = UniPCMultistepScheduler(use_flow_sigmas=True, shift_terminal=0.1)
         scheduler.set_timesteps(num_inference_steps=1)
         self.assertFalse(torch.isnan(scheduler.sigmas).any())
+
+    def test_flow_match_euler_discrete_custom_schedule_ending_at_one_no_nan(self):
+        # A multi-step custom schedule whose last sigma is already 1.0 hits the same
+        # `one_minus_z[-1] == 0` division-by-zero case as the single-step schedule.
+        scheduler = FlowMatchEulerDiscreteScheduler(shift_terminal=0.1)
+        scheduler.set_timesteps(sigmas=[0.9, 1.0])
+        self.assertFalse(torch.isnan(scheduler.sigmas).any())
+        self.assertFalse(torch.isinf(scheduler.sigmas).any())

--- a/tests/schedulers/test_scheduler_shift_terminal_single_step.py
+++ b/tests/schedulers/test_scheduler_shift_terminal_single_step.py
@@ -1,0 +1,45 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+
+from diffusers import FlowMatchEulerDiscreteScheduler, FlowMatchLCMScheduler, UniPCMultistepScheduler
+
+
+class ShiftTerminalSingleStepTest(unittest.TestCase):
+    """
+    Regression test for https://github.com/huggingface/diffusers/issues/14411.
+
+    `stretch_shift_to_terminal()` rescales sigmas by `one_minus_z[-1] / (1 - shift_terminal)`. With
+    `num_inference_steps=1` the only sigma is 1.0, so `one_minus_z[-1]` is 0 and the rescale divides by
+    zero, producing a NaN sigma. Schedulers that support `shift_terminal` must skip the stretch when
+    there is only a single step instead of stretching into NaN.
+    """
+
+    def test_flow_match_euler_discrete_single_step_no_nan(self):
+        scheduler = FlowMatchEulerDiscreteScheduler(shift_terminal=0.1)
+        scheduler.set_timesteps(num_inference_steps=1)
+        self.assertFalse(torch.isnan(scheduler.sigmas).any())
+
+    def test_flow_match_lcm_single_step_no_nan(self):
+        scheduler = FlowMatchLCMScheduler(shift_terminal=0.1)
+        scheduler.set_timesteps(num_inference_steps=1)
+        self.assertFalse(torch.isnan(scheduler.sigmas).any())
+
+    def test_unipc_flow_sigmas_single_step_no_nan(self):
+        scheduler = UniPCMultistepScheduler(use_flow_sigmas=True, shift_terminal=0.1)
+        scheduler.set_timesteps(num_inference_steps=1)
+        self.assertFalse(torch.isnan(scheduler.sigmas).any())


### PR DESCRIPTION
Fixes #14411

## Root cause
`stretch_shift_to_terminal()` rescales the sigma schedule so it terminates at `config.shift_terminal`, computing `scale_factor = one_minus_z[-1] / (1 - shift_terminal)`. When `num_inference_steps=1`, the single sigma is always `1.0`, so `one_minus_z[-1] == 0`, making `scale_factor == 0` and the division produce `NaN`. That `NaN` sigma then crashes `index_for_timestep()` with an `IndexError` inside `scheduler.step()`.

## Fix
There is nothing to stretch with only one step, so skip the call to `stretch_shift_to_terminal()` when `len(sigmas) <= 1`. The same `if self.config.shift_terminal:` pattern (guarding a call to `stretch_shift_to_terminal`) exists in three schedulers that support `shift_terminal`, so the guard is applied consistently to all three:

- `FlowMatchEulerDiscreteScheduler`
- `FlowMatchLCMScheduler`
- `UniPCMultistepScheduler` (flow-sigmas path)

None of the touched lines are inside `# Copied from` blocks, so no `make fix-copies` follow-up is needed.

## Verification
- Reproduced the exact NaN via the original (unguarded) logic.
- Ran `FlowMatchEulerDiscreteScheduler.set_timesteps(num_inference_steps=1, ...)` with `shift_terminal=0.1` against the patched code: sigmas are `[1., 0.]`, no NaN.
- Confirmed `num_inference_steps=4` is unaffected and still correctly terminates at `shift_terminal=0.1` (`[1.0, 0.7, 0.4, 0.1, 0.0]`).