### PR TITLE
fix(ldm3d): return uint16/int32 from rgblike_to_depthmap instead of casting back to uint8

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -1048,28 +1048,16 @@ class VaeImageProcessorLDM3D(VaeImageProcessor):
         #    for return value from a library function.
 
         if isinstance(image, torch.Tensor):
-            # Cast to a safe dtype (e.g., int32 or int64) for the calculation
-            original_dtype = image.dtype
             image_safe = image.to(torch.int32)
-
-            # Calculate the depth map
             depth_map = image_safe[:, :, 1] * 256 + image_safe[:, :, 2]
-
-            # You may want to cast the final result to uint16, but casting to a
-            # larger int type (like int32) is sufficient to fix the overflow.
-            # depth_map = depth_map.to(torch.uint16) # Uncomment if uint16 is strictly required
-            return depth_map.to(original_dtype)
+            # Return int32 — the 16-bit value does not fit back in the uint8 input dtype.
+            return depth_map
 
         elif isinstance(image, np.ndarray):
-            # NumPy equivalent: Cast to a safe dtype (e.g., np.int32)
-            original_dtype = image.dtype
             image_safe = image.astype(np.int32)
-
-            # Calculate the depth map
             depth_map = image_safe[:, :, 1] * 256 + image_safe[:, :, 2]
-
-            # depth_map = depth_map.astype(np.uint16) # Uncomment if uint16 is strictly required
-            return depth_map.astype(original_dtype)
+            # uint16 matches the mode="I;16" consumer in numpy_to_depth.
+            return depth_map.astype(np.uint16)
         else:
             raise TypeError("Input image must be a torch.Tensor or np.ndarray")
 


### PR DESCRIPTION
Fixes #14206

`rgblike_to_depthmap` was combining two 8-bit channels into a 16-bit value (`high * 256 + low`), then casting the result back to the input `uint8` dtype — truncating it. The numpy path fed that into `numpy_to_depth` which uses `mode="I;16"`, causing `ValueError: buffer is not large enough`.

The fix: return the wider type directly. For numpy, `uint16` matches the `mode="I;16"` consumer. For torch, `int32` preserves the full value.

Verified: `rgblike_to_depthmap(high_byte=200, low_byte=100)` now returns `51300` (uint16) instead of truncating to `100`.