### PR TITLE
ci: bound TruffleHog scans on branch pushes

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -17,5 +17,7 @@ jobs:
     - name: Secret Scanning
       uses: trufflesecurity/trufflehog@6bd2d14f7a4bc1e569fa3550efa7ec632a4fa67b  # main
       with:
+        base: ${{ github.event.repository.default_branch }}
+        head: HEAD
         extra_args: --results=verified,unknown
 


### PR DESCRIPTION
## What this changes

Fixes #14376 by passing an explicit `base` and `head` to the TruffleHog action.

On new-branch push events, `github.event.before` is all zeros, so the action falls back to an empty base and scans the repository's full history. This makes new branches fail on legacy findings that are already present on `main`. Bounding the scan against the default branch keeps the current `--results=verified,unknown` behavior while scanning only the branch diff.

## Verification

```bash
$ git diff --check origin/main...HEAD
# no output

$ go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false .github/workflows/trufflehog.yml
# no output

$ gh run watch 31270994941 --repo rathodkunj2005/diffusers --exit-status
✓ fix-trufflehog-new-branch-base-20260808 Secret Leaks · 31270994941
✓ trufflehog in 27s
  ✓ Set up job
  ✓ Checkout code
  ✓ Secret Scanning
  ✓ Post Checkout code
  ✓ Complete job
```

Fork workflow run: https://github.com/rathodkunj2005/diffusers/actions/runs/31270994941
