### PR TITLE
fix(ci): skip unknown labels in issue labeler instead of failing

### DIFF
--- a/.github/workflows/issue_labeler.yml
+++ b/.github/workflows/issue_labeler.yml
@@ -31,6 +31,11 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           LABELS: ${{ steps.get-labels.outputs.labels }}
         run: |
+          existing=$(gh label list --limit 100 --json name | python -c "import json,sys; print('\n'.join(l['name'] for l in json.load(sys.stdin)))")
           for label in $(echo "$LABELS" | python -c "import json,sys; print('\n'.join(json.load(sys.stdin)))"); do
-            gh issue edit "$ISSUE_NUMBER" --add-label "$label"
+            if echo "$existing" | grep -Fqx "$label"; then
+              gh issue edit "$ISSUE_NUMBER" --add-label "$label"
+            else
+              echo "::warning::Issue labeler produced '$label', which does not exist in this repo; skipping."
+            fi
           done


### PR DESCRIPTION
Fixes #14377.

The labeler LLM is told to pick from a fixed set of labels, but several of those labels do not exist in the repo (`compile`, `attention-backends`, `torchao`, `new-pipeline/model` are still missing today; `needs-env-info` has since been created). `gh issue edit --add-label` fails for any non-existent label, aborting the whole job and leaving most bug reports unlabeled.

**Fix** (`.github/workflows/issue_labeler.yml`): fetch the repo's current label list and only apply labels that exist, skipping the rest with an explicit `::warning` in the run log. The job no longer fails on label drift, and the warning makes missing labels visible so they can be created.

Note: `utils/label_issues.py` still declares the four missing labels as valid — they may be created later; the workflow filter keeps things working either way.