### PR TITLE
Fix latent/caption mismatch in SD3 dreambooth lora trainer with cache_latents + shuffle

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_sd3.py
+++ b/examples/dreambooth/train_dreambooth_lora_sd3.py
@@ -714,6 +714,12 @@ def parse_args(input_args=None):
         if args.class_prompt is not None:
             warnings.warn("You need not use --class_prompt without --with_prior_preservation.")
 
+    if args.cache_latents and args.with_prior_preservation:
+        raise ValueError(
+            "cache_latents + with_prior_preservation: not supported. "
+            "class images have no stable index for cache lookup. "
+        )
+    
     return args
 
 
@@ -861,6 +867,7 @@ class DreamBoothDataset(Dataset):
 
     def __getitem__(self, index):
         example = {}
+        example["index"] = index
         instance_image = self.pixel_values[index % self.num_instance_images]
         example["instance_images"] = instance_image
 
@@ -889,6 +896,7 @@ class DreamBoothDataset(Dataset):
 def collate_fn(examples, with_prior_preservation=False):
     pixel_values = [example["instance_images"] for example in examples]
     prompts = [example["instance_prompt"] for example in examples]
+    indices = [example["index"] for example in examples]
 
     # Concat class and instance examples for prior preservation.
     # We do this to avoid doing two forward passes.
@@ -899,7 +907,7 @@ def collate_fn(examples, with_prior_preservation=False):
     pixel_values = torch.stack(pixel_values)
     pixel_values = pixel_values.to(memory_format=torch.contiguous_format).float()
 
-    batch = {"pixel_values": pixel_values, "prompts": prompts}
+    batch = {"pixel_values": pixel_values, "prompts": prompts, "indices": indices}
     return batch
 
 
@@ -1590,13 +1598,15 @@ def main(args):
     vae_config_shift_factor = vae.config.shift_factor
     vae_config_scaling_factor = vae.config.scaling_factor
     if args.cache_latents:
-        latents_cache = []
+        latents_cache = {}
         for batch in tqdm(train_dataloader, desc="Caching latents"):
             with torch.no_grad():
                 batch["pixel_values"] = batch["pixel_values"].to(
                     accelerator.device, non_blocking=True, dtype=weight_dtype
                 )
-                latents_cache.append(vae.encode(batch["pixel_values"]).latent_dist)
+                sampled = vae.encode(batch["pixel_values"]).latent_dist.sample()
+                for i, idx in enumerate(batch["indices"]):
+                    latents_cache[idx] = sampled[i : i + 1].detach().cpu()
 
         if args.validation_prompt is None:
             del vae
@@ -1767,7 +1777,10 @@ def main(args):
 
                 # Convert images to latent space
                 if args.cache_latents:
-                    model_input = latents_cache[step].sample()
+                    model_input = torch.cat(
+                        [latents_cache[idx].to(accelerator.device, dtype=weight_dtype) for idx in batch["indices"]],
+                        dim=0,
+                    )
                 else:
                     pixel_values = batch["pixel_values"].to(dtype=vae.dtype)
                     model_input = vae.encode(pixel_values).latent_dist.sample()


### PR DESCRIPTION
Fixes #14430

## Root cause

Latents were cached keyed by dataloader step, but the dataloader has `shuffle=True` and is traversed twice: once during caching, once during training. Each traversal produces a different sample order. `latents_cache[step]` returns whatever image happened to land at that step during caching, not the image in the current training batch. No exception is raised, the mismatch is silent.

## Fix

Cache latents keyed by stable dataset index instead of step. Index is generated in `DreamBoothDataset.__getitem__` and passed through `collate_fn`.

Also added a check that rejects `--cache_latents` combined with `--with_prior_preservation`, since class images are not indexed the same way and would hit the same bug through a different path.

## Scope

This PR only covers `train_dreambooth_lora_sd3.py`. It does not touch the Qwen-Image trainer or #12124, which is a separate file with a similar but independent issue.

## Testing

### 1. Isolated repro, no model or GPU required

Dataset index used directly as the tensor value, so any mismatch between cached value and actual batch value is visible by eye. Same dataloader, same seed, two traversals.

Before fix, 4/4 batches mismatched:

step=0: latents_cache[0]=[2.0, 0.0] vs actual pixel_values=[0.0, 3.0] MISMATCH
step=1: latents_cache[1]=[5.0, 3.0] vs actual pixel_values=[7.0, 1.0] MISMATCH
step=2: latents_cache[2]=[1.0, 4.0] vs actual pixel_values=[6.0, 2.0] MISMATCH
step=3: latents_cache[3]=[7.0, 6.0] vs actual pixel_values=[5.0, 4.0] MISMATCH


After fix, 4/4 batches matched:

step=0: indices=[0, 3] cached=[0.0, 3.0] actual=[0.0, 3.0] OK
step=1: indices=[7, 1] cached=[7.0, 1.0] actual=[7.0, 1.0] OK
step=2: indices=[6, 2] cached=[6.0, 2.0] actual=[6.0, 2.0] OK
step=3: indices=[5, 4] cached=[5.0, 4.0] actual=[5.0, 4.0] OK
all_match: True


### 2. Existing test suite

pytest examples/dreambooth/test_dreambooth_lora_sd3.py examples/dreambooth/test_dreambooth_sd3.py -v

11 passed in 344.51s


All existing tests pass, including `test_dreambooth_lora_latent_caching`.