### PR TITLE
Fix LDM3D NumPy batch preprocessing

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -989,7 +989,12 @@ class VaeImageProcessorLDM3D(VaeImageProcessor):
         resample: str = "lanczos",
         do_normalize: bool = True,
     ):
-        super().__init__()
+        super().__init__(
+            do_resize=do_resize,
+            vae_scale_factor=vae_scale_factor,
+            resample=resample,
+            do_normalize=do_normalize,
+        )
 
     @staticmethod
     def numpy_to_pil(images: np.ndarray) -> list[PIL.Image.Image]:
@@ -1214,7 +1219,7 @@ class VaeImageProcessorLDM3D(VaeImageProcessor):
             if self.config.do_resize:
                 rgb = self.resize(rgb, height, width)
 
-            depth = np.concatenate(depth, axis=0) if rgb[0].ndim == 4 else np.stack(depth, axis=0)
+            depth = np.concatenate(depth, axis=0) if depth[0].ndim == 4 else np.stack(depth, axis=0)
             depth = self.numpy_to_pt(depth)
             height, width = self.get_default_height_width(depth, height, width)
             if self.config.do_resize:

--- a/tests/others/test_image_processor.py
+++ b/tests/others/test_image_processor.py
@@ -17,7 +17,7 @@ import numpy as np
 import PIL.Image
 import torch
 
-from diffusers.image_processor import VaeImageProcessor
+from diffusers.image_processor import VaeImageProcessor, VaeImageProcessorLDM3D
 
 
 class TestImageProcessor:
@@ -306,3 +306,26 @@ class TestImageProcessor:
         assert out_np.shape == exp_np_shape, (
             f"resized image output shape '{out_np.shape}' didn't match expected shape '{exp_np_shape}'."
         )
+
+    def test_vae_image_processor_ldm3d_config(self):
+        image_processor = VaeImageProcessorLDM3D(
+            do_resize=False,
+            vae_scale_factor=4,
+            resample="nearest",
+            do_normalize=False,
+        )
+
+        assert image_processor.config.do_resize is False
+        assert image_processor.config.vae_scale_factor == 4
+        assert image_processor.config.resample == "nearest"
+        assert image_processor.config.do_normalize is False
+
+    def test_vae_image_processor_ldm3d_np_batch(self):
+        image_processor = VaeImageProcessorLDM3D(do_resize=False, do_normalize=False)
+        rgb = np.zeros((2, 8, 8, 3), dtype=np.float32)
+        depth = np.zeros((2, 8, 8, 1), dtype=np.float32)
+
+        processed_rgb, processed_depth = image_processor.preprocess(rgb, depth)
+
+        assert processed_rgb.shape == (2, 3, 8, 8)
+        assert processed_depth.shape == (2, 1, 8, 8)


### PR DESCRIPTION
# What does this PR do?

Fixes #14428.

`VaeImageProcessorLDM3D.preprocess` supports NumPy RGB/depth batches, but the depth branch was choosing between `concatenate` and `stack` by checking the already-processed RGB tensor instead of the original depth input. That made valid batched depth arrays become 5D and fail in `numpy_to_pt` with `ValueError: axes don't match array`.

This PR:
- forwards the LDM3D image processor init arguments to `VaeImageProcessor.__init__`, matching the documented/configured behavior;
- checks `depth[0].ndim` when batching NumPy depth inputs;
- adds regression coverage for LDM3D config propagation and batched NumPy RGB/depth preprocessing.

Verification:

```text
$ python -m pytest tests/others/test_image_processor.py -k 'ldm3d' -q
..                                                                       [100%]
2 passed, 10 deselected in 0.07s

$ python -m pytest tests/others/test_image_processor.py -q
............                                                             [100%]
12 passed, 2 warnings in 0.01s

$ python -m ruff check src/diffusers/image_processor.py tests/others/test_image_processor.py
All checks passed!
```

AI disclosure / self-review notes:
- I used an AI agent to help identify, implement, and verify this focused fix, and reviewed the final diff before submission.
- Blocking issues found in self-review: none.
- Non-blocking issues found in self-review: none.
- Dead-code advisory: none; the changed branches are exercised by the added tests.

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Not needed; this fixes documented behavior.
- [x] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?
