### PR TITLE
Fix TorchAO group offload CPU cache aliasing

### DIFF
--- a/src/diffusers/hooks/group_offloading.py
+++ b/src/diffusers/hooks/group_offloading.py
@@ -175,8 +175,9 @@ class ModuleGroup:
     @staticmethod
     def _to_cpu(tensor, low_cpu_mem_usage):
         # For TorchAO tensors, `.data` returns an incomplete wrapper without internal attributes
-        # (e.g. `.qdata`, `.scale`), so we must call `.cpu()` on the tensor directly.
-        t = tensor.cpu() if _is_torchao_tensor(tensor) else tensor.data.cpu()
+        # (e.g. `.qdata`, `.scale`), so we must call `.to(..., copy=True)` on the tensor directly. `tensor.cpu()` can
+        # return `tensor` itself when it is already on CPU, which would alias the cached CPU copy with the live parameter.
+        t = tensor.to("cpu", copy=True) if _is_torchao_tensor(tensor) else tensor.data.cpu()
         return t if low_cpu_mem_usage else t.pin_memory()
 
     def _init_cpu_param_dict(self):

--- a/tests/hooks/test_group_offloading.py
+++ b/tests/hooks/test_group_offloading.py
@@ -21,6 +21,7 @@ import torch
 
 from diffusers import AutoencoderKL
 from diffusers.hooks import HookRegistry, ModelHook
+from diffusers.hooks.group_offloading import ModuleGroup, _restore_torchao_tensor, _swap_torchao_tensor
 from diffusers.models import ModelMixin
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from diffusers.utils import logging as diffusers_logging
@@ -371,6 +372,30 @@ class TestGroupOffload:
         pipe.enable_sequential_cpu_offload()
         with pytest.raises(ValueError, match="Cannot apply group offloading"):
             pipe.model.enable_group_offload(torch_device, offload_type="block_level", num_blocks_per_group=3)
+
+    def test_torchao_cpu_cache_does_not_alias_live_parameter(self):
+        try:
+            from torchao.quantization import Int8WeightOnlyConfig, quantize_
+        except ImportError:
+            pytest.skip("test requires torchao")
+
+        linear = torch.nn.Linear(16, 16, bias=False, dtype=torch.bfloat16)
+        quantize_(linear, Int8WeightOnlyConfig(version=2))
+        weight = linear.weight
+
+        cpu_copy = ModuleGroup._to_cpu(weight, low_cpu_mem_usage=True)
+        assert cpu_copy is not weight
+
+        moved = weight.to("meta")
+        _swap_torchao_tensor(weight, moved)
+
+        tensor_data_names = getattr(cpu_copy.__class__, "tensor_data_names")
+        for attr_name in tensor_data_names:
+            assert getattr(cpu_copy, attr_name).device.type == "cpu"
+
+        _restore_torchao_tensor(weight, cpu_copy)
+        for attr_name in tensor_data_names:
+            assert getattr(weight, attr_name).device.type == "cpu"
 
     def test_block_level_stream_with_invocation_order_different_from_initialization_order(self):
         if torch.device(torch_device).type not in ["cuda", "xpu"]:


### PR DESCRIPTION
Fixes #14433.

## What changed

`ModuleGroup._to_cpu()` now creates a real CPU copy for TorchAO tensor subclasses with `to("cpu", copy=True)` instead of `cpu()`. For already-CPU TorchAO tensors, `cpu()` can return the original object, so the group-offload CPU cache aliases the live parameter. When `_swap_torchao_tensor()` later mutates the live parameter's inner tensor attributes during onload, the cached "CPU" copy follows it to the accelerator and the streamed pinning path can fail on accelerator-backed `qdata`.

The regression test covers the aliasing mechanism with a TorchAO int8 v2 parameter and verifies that the cached tensor's internal data stays on CPU after the live parameter is swapped away, then can restore the parameter back to CPU.

## Verification

- `python -m pytest tests/hooks/test_group_offloading.py -q`
  - `36 passed, 4 skipped in 10.45s`
- `ruff check src/diffusers/hooks/group_offloading.py tests/hooks/test_group_offloading.py`
  - `All checks passed!`
- `ruff format --check src/diffusers/hooks/group_offloading.py tests/hooks/test_group_offloading.py`
  - `2 files already formatted`
- `git diff --check`
  - passed

AI-assisted contribution disclosure: I used an AI agent for code navigation and drafting, and verified the diff and commands above locally.