### PR TITLE
FIX LoRA tests warning about unexpected keys

### DIFF
--- a/src/diffusers/utils/peft_utils.py
+++ b/src/diffusers/utils/peft_utils.py
@@ -391,13 +391,13 @@ def _create_lora_config(
         raise TypeError("`LoraConfig` class could not be instantiated.") from e
 
 
-def _maybe_warn_for_unhandled_keys(incompatible_keys, adapter_name):
+def _maybe_warn_for_unhandled_keys(incompatible_keys, adapter_name: str) -> None:
     warn_msg = ""
     if incompatible_keys is not None:
         # Check only for unexpected keys.
         unexpected_keys = getattr(incompatible_keys, "unexpected_keys", None)
         if unexpected_keys:
-            lora_unexpected_keys = [k for k in unexpected_keys if "lora_" in k and adapter_name in k]
+            lora_unexpected_keys = [k for k in unexpected_keys if ".lora_" in k]
             if lora_unexpected_keys:
                 warn_msg = (
                     f"Loading adapter weights from state_dict led to unexpected keys found in the model:"
@@ -407,7 +407,7 @@ def _maybe_warn_for_unhandled_keys(incompatible_keys, adapter_name):
         # Filter missing keys specific to the current adapter.
         missing_keys = getattr(incompatible_keys, "missing_keys", None)
         if missing_keys:
-            lora_missing_keys = [k for k in missing_keys if "lora_" in k and adapter_name in k]
+            lora_missing_keys = [k for k in missing_keys if ".lora_" in k and adapter_name in k]
             if lora_missing_keys:
                 warn_msg += (
                     f"Loading adapter weights from state_dict led to missing keys in the model:"


### PR DESCRIPTION
# What does this PR do?

The issue appeared after merging https://github.com/huggingface/peft/pull/3490 in PEFT. As part of a side effect of that refactor, the adapter name is not part of the state dict keys in the reported mismatches. The warning logic did, however, check for the adapter name, resulting in the warning not being emitted.

The fix simply drops the adapter name from the check for unexpected keys. This should be safe, because we only load one adapter at a time, so unexpected keys should not report on other adapters anyway.

While working on this function, I also changed the `"lora_" in k` check to `".lora_" in k`. This should be strictly more precise, but it's not related to the fix. I also added some type annotations for good measure.

The tests now pass with both PEFT from source and the latest PEFT release (i.e. before the refactor merge).

<!-- Remove if not applicable -->

Fixes https://github.com/huggingface/peft/issues/3548.


## Before submitting
- [ ] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [ ] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [ ] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [ ] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?