### PR TITLE
fix(image_processor): maintain 3-tuple return contract in InpaintProcessor.preprocess when mask is None

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+from typing import Any
 import warnings
 
 import numpy as np
@@ -885,7 +886,7 @@ class InpaintProcessor(ConfigMixin):
         height: int | None = None,
         width: int | None = None,
         padding_mask_crop: int | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor | None, dict[str, Any]]:
         """
         Preprocess the image and mask.
         """
@@ -894,7 +895,13 @@ class InpaintProcessor(ConfigMixin):
 
         # if mask is None, same behavior as regular image processor
         if mask is None:
-            return self._image_processor.preprocess(image, height=height, width=width)
+            processed_image = self._image_processor.preprocess(image, height=height, width=width)
+            postprocessing_kwargs = {
+                "crops_coords": None,
+                "original_image": None,
+                "original_mask": None,
+            }
+            return processed_image, None, postprocessing_kwargs
 
         if padding_mask_crop is not None:
             crops_coords = self._image_processor.get_crop_region(mask, width, height, pad=padding_mask_crop)

--- a/tests/others/test_image_processor.py
+++ b/tests/others/test_image_processor.py
@@ -17,7 +17,7 @@ import numpy as np
 import PIL.Image
 import torch
 
-from diffusers.image_processor import VaeImageProcessor
+from diffusers.image_processor import InpaintProcessor, VaeImageProcessor
 
 
 class TestImageProcessor:
@@ -306,3 +306,46 @@ class TestImageProcessor:
         assert out_np.shape == exp_np_shape, (
             f"resized image output shape '{out_np.shape}' didn't match expected shape '{exp_np_shape}'."
         )
+
+    def test_inpaint_processor_preprocess_with_mask(self):
+        processor = InpaintProcessor()
+        image = PIL.Image.fromarray(np.zeros((64, 64, 3), dtype=np.uint8))
+        mask = PIL.Image.fromarray(np.zeros((64, 64), dtype=np.uint8))
+
+        out_img, out_mask, postprocessing_kwargs = processor.preprocess(image, mask=mask, height=64, width=64)
+
+        assert isinstance(out_img, torch.Tensor)
+        assert isinstance(out_mask, torch.Tensor)
+        assert isinstance(postprocessing_kwargs, dict)
+        assert postprocessing_kwargs["crops_coords"] is None
+        assert postprocessing_kwargs["original_image"] is None
+        assert postprocessing_kwargs["original_mask"] is None
+
+    def test_inpaint_processor_preprocess_without_mask(self):
+        processor = InpaintProcessor()
+        image = PIL.Image.fromarray(np.zeros((64, 64, 3), dtype=np.uint8))
+
+        out_img, out_mask, postprocessing_kwargs = processor.preprocess(image, height=64, width=64)
+
+        assert isinstance(out_img, torch.Tensor)
+        assert out_mask is None
+        assert isinstance(postprocessing_kwargs, dict)
+        assert postprocessing_kwargs["crops_coords"] is None
+        assert postprocessing_kwargs["original_image"] is None
+        assert postprocessing_kwargs["original_mask"] is None
+
+    def test_inpaint_processor_preprocess_with_padding_mask_crop(self):
+        processor = InpaintProcessor()
+        image = PIL.Image.fromarray(np.zeros((64, 64, 3), dtype=np.uint8))
+        mask = PIL.Image.fromarray(np.ones((64, 64), dtype=np.uint8) * 255)
+
+        out_img, out_mask, postprocessing_kwargs = processor.preprocess(
+            image, mask=mask, height=64, width=64, padding_mask_crop=8
+        )
+
+        assert isinstance(out_img, torch.Tensor)
+        assert isinstance(out_mask, torch.Tensor)
+        assert isinstance(postprocessing_kwargs, dict)
+        assert postprocessing_kwargs["crops_coords"] is not None
+        assert postprocessing_kwargs["original_image"] == image
+        assert postprocessing_kwargs["original_mask"] == mask


### PR DESCRIPTION
# What does this PR do?

Fixes #14470.

`InpaintProcessor.preprocess` returns a 3-tuple `(image, mask, postprocessing_kwargs)` across all masked execution paths, but when `mask is None`, the early return returned only the processed image tensor directly. Callers unpacking the standard 3-value contract (`image, mask, postprocessing_kwargs = processor.preprocess(...)`) would raise `ValueError: not enough values to unpack (expected 3, got 1)`.

### Root Cause
When the 3-value contract and `postprocessing_kwargs` were introduced in commit `f50b18eec` (#12220), the early return for `mask is None` was not updated to return the consistent 3-tuple structure. Additionally, the return type annotation indicated `tuple[torch.Tensor, torch.Tensor]`, which did not reflect the 3-element return value or optional mask.

### Changes
- Updated `InpaintProcessor.preprocess` in `src/diffusers/image_processor.py` when `mask is None` to return `(processed_image, None, postprocessing_kwargs)` where `postprocessing_kwargs` is populated with `{"crops_coords": None, "original_image": None, "original_mask": None}`.
- Updated return type annotation to `tuple[torch.Tensor, torch.Tensor | None, dict[str, Any]]`.
- Added unit tests in `tests/others/test_image_processor.py` covering `preprocess` with mask, without mask (`mask=None`), and with `padding_mask_crop`.

## Before submitting
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Fixes #14470.
- [x] Did you write any new necessary tests?

## Who can review?
@DN6 @yiyixuxu
