### PR TITLE
fix: Fix Flux 2 Klein dreambooth default text_encoder_out_layers

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
@@ -358,7 +358,7 @@ def parse_args(input_args=None):
         "--text_encoder_out_layers",
         type=int,
         nargs="+",
-        default=[10, 20, 30],
+        default=[9, 18, 27],
         help="Text encoder hidden layers to compute the final text embeddings.",
     )
     parser.add_argument(


### PR DESCRIPTION
This PR addresses: Fix Flux 2 Klein dreambooth default text_encoder_out_layers