### PR TITLE
fix(gguf): correct mismatched-shape error message

### DIFF
--- a/src/diffusers/quantizers/gguf/gguf_quantizer.py
+++ b/src/diffusers/quantizers/gguf/gguf_quantizer.py
@@ -84,7 +84,8 @@ class GGUFQuantizer(DiffusersQuantizer):
         inferred_shape = _quant_shape_from_byte_shape(loaded_param_shape, type_size, block_size)
         if inferred_shape != current_param_shape:
             raise ValueError(
-                f"{param_name} has an expected quantized shape of: {inferred_shape}, but received shape: {loaded_param_shape}"
+                f"{param_name} has an expected shape of: {current_param_shape}, but the loaded GGUF weight decodes "
+                f"to shape: {inferred_shape}"
             )
 
         return True


### PR DESCRIPTION
This PR addresses: fix(gguf): correct mismatched-shape error message