### PR TITLE
fix: Fix missing function call in is_torch_xla_version

### DIFF
--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -708,7 +708,7 @@ def is_torch_xla_version(operation: str, version: str):
         version (`str`):
             A string version of torch_xla
     """
-    if not is_torch_xla_available:
+    if not _torch_xla_available:
         return False
     return compare_versions(parse(_torch_xla_version), operation, version)
 


### PR DESCRIPTION
This PR addresses: Fix missing function call in is_torch_xla_version