### PR TITLE
fix: Fix `image_seq_len` in `Lumina2Pipeline` (channel count → patch tokens)

### DIFF
--- a/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
+++ b/src/diffusers/pipelines/lumina2/pipeline_lumina2.py
@@ -696,7 +696,12 @@ class Lumina2Pipeline(DiffusionPipeline, Lumina2LoraLoaderMixin):
 
         # 5. Prepare timesteps
         sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps) if sigmas is None else sigmas
-        image_seq_len = latents.shape[1]
+        # `image_seq_len` is the number of patch tokens the transformer will see, not the
+        # number of latent channels. Lumina2's latents are unpacked `(B, C, H, W)`, so
+        # `latents.shape[1]` gives the channel count (typically 16) instead of the post-patch
+        # sequence length. The transformer patchifies with `config.patch_size` (default 2).
+        patch_size = self.transformer.config.patch_size
+        image_seq_len = (latents.shape[-2] // patch_size) * (latents.shape[-1] // patch_size)
         mu = calculate_shift(
             image_seq_len,
             self.scheduler.config.get("base_image_seq_len", 256),


### PR DESCRIPTION
This PR addresses: Fix `image_seq_len` in `Lumina2Pipeline` (channel count → patch tokens)