### PR TITLE
fix: use proper exception objects instead of bare raise/assert strings

### DIFF
--- a/src/diffusers/models/attention_processor.py
+++ b/src/diffusers/models/attention_processor.py
@@ -325,11 +325,11 @@ class Attention(nn.Module):
         """
         if use_xla_flash_attention:
             if not is_torch_xla_available:
-                raise "torch_xla is not available"
+                raise RuntimeError("torch_xla is not available")
             elif is_torch_xla_version("<", "2.3"):
-                raise "flash attention pallas kernel is supported from torch_xla version 2.3"
+                raise RuntimeError("flash attention pallas kernel is supported from torch_xla version 2.3")
             elif is_spmd() and is_torch_xla_version("<", "2.4"):
-                raise "flash attention pallas kernel using SPMD is supported from torch_xla version 2.4"
+                raise RuntimeError("flash attention pallas kernel using SPMD is supported from torch_xla version 2.4")
             else:
                 if is_flux:
                     processor = XLAFluxFlashAttnProcessor2_0(partition_spec)

--- a/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet_inpainting.py
+++ b/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet_inpainting.py
@@ -1262,7 +1262,7 @@ class StableDiffusion3ControlNetInpaintingPipeline(
 
             control_image = control_images
         else:
-            assert ValueError("Controlnet not found. Please check the controlnet model.")
+            raise ValueError("Controlnet not found. Please check the controlnet model.")
 
         if controlnet_pooled_projections is None:
             controlnet_pooled_projections = torch.zeros_like(pooled_prompt_embeds)


### PR DESCRIPTION
This PR addresses: use proper exception objects instead of bare raise/assert strings