### PR TITLE
ci: drop stale tokenizers<0.23.0 override

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -20,7 +20,6 @@ env:
   SLACK_API_TOKEN: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
   CONSOLIDATED_REPORT_PATH: consolidated_test_report.md
   # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
-  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
   #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
   #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
   #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
@@ -80,7 +79,7 @@ jobs:
         run: nvidia-smi
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
           uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
@@ -134,7 +133,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
         uv pip install peft@git+https://github.com/huggingface/peft.git
@@ -202,7 +201,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
     - name: Environment
@@ -244,7 +243,7 @@ jobs:
         run: nvidia-smi
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
           uv pip install peft@git+https://github.com/huggingface/peft.git
@@ -295,7 +294,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.6.0\ntorchvision==0.21.0\ntorchaudio==2.6.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.6.0\ntorchvision==0.21.0\ntorchaudio==2.6.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
           uv pip install peft@git+https://github.com/huggingface/peft.git
@@ -371,7 +370,7 @@ jobs:
         run: nvidia-smi
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip install -U ${{ matrix.config.backend }}
           if [ "${{ join(matrix.config.additional_deps, ' ') }}" != "" ]; then
@@ -424,7 +423,7 @@ jobs:
         run: nvidia-smi
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip install -U bitsandbytes optimum_quanto
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git

--- a/.github/workflows/pr_comment_gpu_tests.yml
+++ b/.github/workflows/pr_comment_gpu_tests.yml
@@ -24,7 +24,7 @@ env:
   MKL_NUM_THREADS: 8
   HF_XET_HIGH_PERFORMANCE: 1
   PYTEST_TIMEOUT: 600
-  # Force version overrides across every `uv pip install`: pin tokenizers and the
+  # Force version overrides across every `uv pip install`: pin the
   # torch/torchvision/torchaudio set baked into the image so `-U` installs can't bump
   # torch and break torchvision's C++ ABI. Re-written into the file in the install step.
   UV_OVERRIDE: /tmp/uv-overrides.txt
@@ -136,7 +136,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality,training,test]"
           uv pip install peft@git+https://github.com/huggingface/peft.git
           uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git

--- a/.github/workflows/pr_modular_tests.yml
+++ b/.github/workflows/pr_modular_tests.yml
@@ -35,7 +35,6 @@ env:
   MKL_NUM_THREADS: 4
   PYTEST_TIMEOUT: 60
   # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
-  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
   #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
   #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
   #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
@@ -96,7 +95,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
       - name: Check auto docs
@@ -129,7 +128,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git --no-deps

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -30,7 +30,6 @@ env:
   MKL_NUM_THREADS: 4
   PYTEST_TIMEOUT: 60
   # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
-  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
   #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
   #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
   #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
@@ -123,7 +122,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git --no-deps
@@ -200,7 +199,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
 
@@ -251,7 +250,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         # TODO (sayakpaul, DN6): revisit `--no-deps`
         uv pip install -U peft@git+https://github.com/huggingface/peft.git --no-deps

--- a/.github/workflows/pr_tests_gpu.yml
+++ b/.github/workflows/pr_tests_gpu.yml
@@ -31,7 +31,6 @@ env:
   PYTEST_TIMEOUT: 600
   PIPELINE_USAGE_CUTOFF: 1000000000 # set high cutoff so that only always-test pipelines run
   # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
-  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
   #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
   #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
   #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
@@ -98,7 +97,7 @@ jobs:
           fetch-depth: 2
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
       - name: Environment
         run: |
@@ -140,7 +139,7 @@ jobs:
           nvidia-smi
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
@@ -210,7 +209,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip install peft@git+https://github.com/huggingface/peft.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
@@ -275,7 +274,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
         uv pip install -e ".[quality,training]"
 

--- a/.github/workflows/push_tests.yml
+++ b/.github/workflows/push_tests.yml
@@ -21,7 +21,6 @@ env:
   PYTEST_TIMEOUT: 600
   PIPELINE_USAGE_CUTOFF: 50000
   # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
-  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
   #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
   #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
   #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
@@ -43,7 +42,7 @@ jobs:
           fetch-depth: 2
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
       - name: Environment
         run: |
@@ -84,7 +83,7 @@ jobs:
           nvidia-smi
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
@@ -136,7 +135,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip install peft@git+https://github.com/huggingface/peft.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
@@ -191,7 +190,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
     - name: Environment
@@ -235,7 +234,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
     - name: Environment
       run: |
@@ -276,7 +275,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
 
     - name: Environment

--- a/.github/workflows/push_tests_mps.yml
+++ b/.github/workflows/push_tests_mps.yml
@@ -14,9 +14,6 @@ env:
   HF_XET_HIGH_PERFORMANCE: 1
   PYTEST_TIMEOUT: 600
   RUN_SLOW: no
-  # Force tokenizers<0.23.0 across every `uv pip install` in this workflow,
-  # even when transformers@main declares a higher lower-bound.
-  UV_OVERRIDE: /tmp/uv-overrides.txt
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -46,7 +43,6 @@ jobs:
     - name: Install dependencies
       shell: arch -arch arm64 bash {0}
       run: |
-        echo 'tokenizers<0.23.0' > "$UV_OVERRIDE"
         ${CONDA_RUN} python -m pip install --upgrade pip uv
         ${CONDA_RUN} python -m uv pip install -e ".[quality]"
         ${CONDA_RUN} python -m uv pip install torch torchvision torchaudio

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -43,7 +43,6 @@ jobs:
       - name: Test installing diffusers and importing
         run: |
           pip install -U transformers
-          uv pip uninstall tokenizers && uv pip install "tokenizers<=0.23.0"
           python -c "from diffusers import __version__; print(__version__)"
           python -c "from diffusers import DiffusionPipeline; pipe = DiffusionPipeline.from_pretrained('fusing/unet-ldm-dummy-update'); pipe()"
           python -c "from diffusers import DiffusionPipeline; pipe = DiffusionPipeline.from_pretrained('hf-internal-testing/tiny-stable-diffusion-pipe', safety_checker=None); pipe('ah suh du')"

--- a/.github/workflows/release_tests_fast.yml
+++ b/.github/workflows/release_tests_fast.yml
@@ -20,7 +20,6 @@ env:
   PYTEST_TIMEOUT: 600
   PIPELINE_USAGE_CUTOFF: 50000
   # Force version overrides across every `uv pip install` in this workflow via UV_OVERRIDE:
-  #   - tokenizers<0.23.0, even when transformers@main declares a higher lower-bound.
   #   - torch/torchvision/torchaudio pinned to the image's baked-in set so `-U` installs
   #     (e.g. accelerate@main) can't bump torch and break torchvision's C++ ABI
   #     (torchvision::nms). The pinned set is (re)written into the override file per job below.
@@ -42,7 +41,7 @@ jobs:
           fetch-depth: 2
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
       - name: Environment
@@ -84,7 +83,7 @@ jobs:
           nvidia-smi
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
           uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
@@ -136,7 +135,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality]"
         uv pip install peft@git+https://github.com/huggingface/peft.git
         uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
@@ -188,7 +187,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          printf 'tokenizers<0.23.0\ntorch==2.6.0\ntorchvision==0.21.0\ntorchaudio==2.6.0\n' > "$UV_OVERRIDE"
+          printf 'torch==2.6.0\ntorchvision==0.21.0\ntorchaudio==2.6.0\n' > "$UV_OVERRIDE"
           uv pip install -e ".[quality]"
           uv pip install peft@git+https://github.com/huggingface/peft.git
           uv pip uninstall accelerate && uv pip install -U accelerate@git+https://github.com/huggingface/accelerate.git
@@ -249,7 +248,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
     - name: Environment
@@ -293,7 +292,7 @@ jobs:
         nvidia-smi
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
     - name: Environment
@@ -337,7 +336,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        printf 'tokenizers<0.23.0\ntorch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
+        printf 'torch==2.10.0\ntorchvision==0.25.0\ntorchaudio==2.10.0\n' > "$UV_OVERRIDE"
         uv pip install -e ".[quality,training]"
         uv pip uninstall transformers huggingface_hub && UV_PRERELEASE=allow uv pip install -U transformers@git+https://github.com/huggingface/transformers.git
 


### PR DESCRIPTION
Entire CI is broken. See https://github.com/huggingface/diffusers/actions/runs/32009334120/job/95325596470?pr=13718 as an example.