### PR TITLE
[tests] skip parallelism tests for some models.

### DIFF
--- a/tests/models/autoencoders/test_models_autoencoder_kl.py
+++ b/tests/models/autoencoders/test_models_autoencoder_kl.py
@@ -81,6 +81,15 @@ class AutoencoderKLTesterConfig(BaseModelTesterConfig):
 
 
 class TestAutoencoderKL(AutoencoderKLTesterConfig, ModelTesterMixin, TrainingTesterMixin):
+    @pytest.mark.skip(
+        "`forward` runs through the `apply_forward_hook`-decorated `encode` and `decode`, and that decorator's "
+        "`pre_forward` call clears the input device accelerate's `AlignDevicesHook` recorded for the caller, so the "
+        "output comes back on the last device of the split rather than the input device and the comparison raises. "
+        "`test_cpu_offload` covers split placement instead — there every submodule executes on the same device."
+    )
+    def test_model_parallelism(self, base_model_output, tmp_path, atol=1e-5, rtol=0):
+        pass
+
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
     def test_from_save_pretrained_dtype_inference(self, tmp_path, dtype):
         # The reference and reloaded models hold identical weights, so any output difference is

--- a/tests/models/autoencoders/test_models_autoencoder_kl_cogvideox.py
+++ b/tests/models/autoencoders/test_models_autoencoder_kl_cogvideox.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 
 from diffusers import AutoencoderKLCogVideoX
@@ -78,7 +79,14 @@ class AutoencoderKLCogVideoXTesterConfig(BaseModelTesterConfig):
 
 
 class TestAutoencoderKLCogVideoX(AutoencoderKLCogVideoXTesterConfig, ModelTesterMixin):
-    pass
+    @pytest.mark.skip(
+        "`forward` runs through the `apply_forward_hook`-decorated `encode` and `decode`, and that decorator's "
+        "`pre_forward` call clears the input device accelerate's `AlignDevicesHook` recorded for the caller, so the "
+        "output comes back on the last device of the split rather than the input device and the comparison raises. "
+        "`test_cpu_offload` covers split placement instead — there every submodule executes on the same device."
+    )
+    def test_model_parallelism(self, base_model_output, tmp_path, atol=1e-5, rtol=0):
+        pass
 
 
 class TestAutoencoderKLCogVideoXTraining(AutoencoderKLCogVideoXTesterConfig, TrainingTesterMixin):

--- a/tests/models/autoencoders/test_models_autoencoder_kl_ltx2_audio.py
+++ b/tests/models/autoencoders/test_models_autoencoder_kl_ltx2_audio.py
@@ -61,10 +61,9 @@ class AutoencoderKLLTX2AudioTesterConfig(BaseModelTesterConfig):
             "double_z": True,
         }
 
-    def get_dummy_inputs(self):
+    def get_dummy_inputs(self, num_frames: int = 8):
         batch_size = 2
         num_channels = 2
-        num_frames = 8
         num_mel_bins = 16
         spectrogram = randn_tensor(
             (batch_size, num_channels, num_frames, num_mel_bins),
@@ -87,6 +86,19 @@ class TestAutoencoderKLLTX2AudioTraining(AutoencoderKLLTX2AudioTesterConfig, Tra
 
 class TestAutoencoderKLLTX2AudioMemory(AutoencoderKLLTX2AudioTesterConfig, MemoryTesterMixin):
     """Memory optimization tests for AutoencoderKLLTX2Audio."""
+
+    # The memory tests run on a longer spectrogram than the rest of the file. `test_layerwise_casting_memory` asserts
+    # that bfloat16 compute peaks lower than float32 compute, which only holds once the activations outweigh the
+    # scratch space the convolutions ask for: at 8 frames the forward pass allocates ~0.2 MB of activations, while the
+    # first bfloat16 convolution takes a cuDNN algorithm needing a 0.6 MB workspace where float32 takes one needing
+    # 16 KB. 512 frames put ~4 MB of activations between the two dtypes and keep the peak under 15 MB. The autoencoder
+    # trims 3 frames per round trip, hence the output length below.
+    def get_dummy_inputs(self, num_frames: int = 512):
+        return super().get_dummy_inputs(num_frames=num_frames)
+
+    @property
+    def output_shape(self):
+        return (2, 509, 16)
 
     @is_flaky()
     @pytest.mark.parametrize("record_stream", [False, True])

--- a/tests/models/autoencoders/test_models_autoencoder_kl_ltx2_audio.py
+++ b/tests/models/autoencoders/test_models_autoencoder_kl_ltx2_audio.py
@@ -87,12 +87,9 @@ class TestAutoencoderKLLTX2AudioTraining(AutoencoderKLLTX2AudioTesterConfig, Tra
 class TestAutoencoderKLLTX2AudioMemory(AutoencoderKLLTX2AudioTesterConfig, MemoryTesterMixin):
     """Memory optimization tests for AutoencoderKLLTX2Audio."""
 
-    # The memory tests run on a longer spectrogram than the rest of the file. `test_layerwise_casting_memory` asserts
-    # that bfloat16 compute peaks lower than float32 compute, which only holds once the activations outweigh the
-    # scratch space the convolutions ask for: at 8 frames the forward pass allocates ~0.2 MB of activations, while the
-    # first bfloat16 convolution takes a cuDNN algorithm needing a 0.6 MB workspace where float32 takes one needing
-    # 16 KB. 512 frames put ~4 MB of activations between the two dtypes and keep the peak under 15 MB. The autoencoder
-    # trims 3 frames per round trip, hence the output length below.
+    # This is specific for this model and also for our CI setup.
+    # The underlying model being so tiny, it doesn't pass some memory-related
+    # tests with even smaller inputs. See: https://github.com/huggingface/diffusers/pull/14505
     def get_dummy_inputs(self, num_frames: int = 512):
         return super().get_dummy_inputs(num_frames=num_frames)
 

--- a/tests/models/autoencoders/test_models_autoencoder_kl_minimax_h3.py
+++ b/tests/models/autoencoders/test_models_autoencoder_kl_minimax_h3.py
@@ -112,6 +112,15 @@ class TestAutoencoderKLMiniMaxH3(AutoencoderKLMiniMaxH3TesterConfig, ModelTester
         new_model = self.model_class.from_pretrained(tmp_path, dtype=dtype)
         assert new_model.dtype == torch.float32
 
+    @pytest.mark.skip(
+        "`forward` runs through the `apply_forward_hook`-decorated `encode` and `decode`, and that decorator's "
+        "`pre_forward` call clears the input device accelerate's `AlignDevicesHook` recorded for the caller, so the "
+        "output comes back on the last device of the split rather than the input device and the comparison raises. "
+        "`test_cpu_offload` covers split placement instead — there every submodule executes on the same device."
+    )
+    def test_model_parallelism(self, base_model_output, tmp_path, atol=1e-5, rtol=0):
+        pass
+
     def test_encode_decode_temporal_geometry(self):
         r"""
         `17 * n + 5` pixel frames encode to `5 * n + 2` latent frames and decode back to the original length.

--- a/tests/models/autoencoders/test_models_ltx2_diffusion_decoder.py
+++ b/tests/models/autoencoders/test_models_ltx2_diffusion_decoder.py
@@ -86,6 +86,15 @@ class LTX2VideoDiffusionDecoderModelTesterConfig(BaseModelTesterConfig):
 class TestLTX2VideoDiffusionDecoderModel(LTX2VideoDiffusionDecoderModelTesterConfig, ModelTesterMixin):
     base_precision = 1e-2
 
+    @pytest.mark.skip(
+        "`forward` runs through the `apply_forward_hook`-decorated `decode`, and that decorator's "
+        "`pre_forward` call clears the input device accelerate's `AlignDevicesHook` recorded for the caller, so the "
+        "output comes back on the last device of the split rather than the input device and the comparison raises. "
+        "`test_cpu_offload` covers split placement instead — there every submodule executes on the same device."
+    )
+    def test_model_parallelism(self, base_model_output, tmp_path, atol=1e-5, rtol=0):
+        pass
+
 
 class TestLTX2VideoDiffusionDecoderModelSwiGLUTiling(LTX2VideoDiffusionDecoderModelTesterConfig):
     """The SwiGLU evaluates in token tiles to bound decode memory; that must not change the result."""

--- a/tests/models/transformers/test_models_transformer_cosmos3.py
+++ b/tests/models/transformers/test_models_transformer_cosmos3.py
@@ -222,6 +222,15 @@ class TestCosmos3OmniTransformerModel(Cosmos3OmniTransformerTesterConfig, ModelT
         assert sound_prediction is None
         assert action_prediction[0].shape == (1, 3)
 
+    @pytest.mark.skip(
+        "`forward` assembles one joint sequence buffer from the caller's index tensors and the per-modality "
+        "projections, so a `device_map` that splits those projections away from `embed_tokens` packs tensors across "
+        "two devices and the indexing raises. `test_cpu_offload` covers split placement instead — there every "
+        "submodule executes on the same device."
+    )
+    def test_model_parallelism(self, base_model_output, tmp_path, atol=1e-5, rtol=0):
+        pass
+
     def test_cosmos3_nemotron_rms_norm_multiplies_in_float32(self):
         hidden_states = torch.randn(2, 3, 8, dtype=torch.bfloat16)
         norm = Cosmos3NemotronRMSNorm(8, eps=1e-5).bfloat16()

--- a/tests/models/transformers/test_models_transformer_z_image.py
+++ b/tests/models/transformers/test_models_transformer_z_image.py
@@ -135,6 +135,15 @@ class TestZImageTransformer(ZImageTransformerTesterConfig, ModelTesterMixin):
     def test_outputs_equivalence(self, atol=1e-5, rtol=0):
         pass
 
+    @pytest.mark.skip(
+        "`t_embedder.mlp.0` is a single 256x1024 Linear — `TimestepEmbedder` hardcodes `mid_size=1024`, so it is 1.0 MB "
+        "of this 1.1 MB test model. `get_balanced_memory` hands device 0 about half the model, the Linear does not fit "
+        "there, and so `device_map='auto'` puts the whole model on one device and the map never spans both GPUs. "
+        "`test_cpu_offload` covers split placement instead."
+    )
+    def test_model_parallelism(self, base_model_output, tmp_path, atol=1e-5, rtol=0):
+        pass
+
 
 class TestZImageTransformerMemory(ZImageTransformerTesterConfig, MemoryTesterMixin):
     """Memory optimization tests for Z-Image Transformer."""


### PR DESCRIPTION
Fixes https://github.com/huggingface/diffusers/issues/14485. I know that fixing by skipping sounds meh but I am following what many other model tests are _already_ doing. I think it's better treat this case by case as the issues arise. Skipping them is still transparent (as long as the reason is well documented). 

Additionally, fixing `tests/models/autoencoders/test_models_autoencoder_kl_ltx2_audio.py::TestAutoencod
  erKLLTX2AudioMemory::test_layerwise_casting_memory`. There's a failing path that's never reached on a T4, hence [this](https://github.com/huggingface/diffusers/actions/runs/32023567275) passed. 