### PR TITLE
fix: Fix RecursionError in CosineDPMSolver Brownian tree noise sampler

### DIFF
--- a/src/diffusers/schedulers/scheduling_cosine_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_cosine_dpmsolver_multistep.py
@@ -659,10 +659,15 @@ class CosineDPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
                 seed = (
                     [g.initial_seed() for g in generator] if isinstance(generator, list) else generator.initial_seed()
                 )
+            # Use the actual sigma extrema rather than the config values: the Karras
+            # reconstruction of `sigma_max` in fp32 can drift a few ULPs above the
+            # config value, and `sigma_next == 0` (final_sigmas_type="zero") is
+            # strictly below `config.sigma_min`. Both out-of-range queries drive
+            # torchsde into unbounded interval splitting (#13274).
             self.noise_sampler = BrownianTreeNoiseSampler(
                 model_output,
-                sigma_min=self.config.sigma_min,
-                sigma_max=self.config.sigma_max,
+                sigma_min=self.sigmas.min().item(),
+                sigma_max=self.sigmas.max().item(),
                 seed=seed,
             )
         noise = self.noise_sampler(self.sigmas[self.step_index], self.sigmas[self.step_index + 1]).to(


### PR DESCRIPTION
## What does this PR do?

`CosineDPMSolverMultistepScheduler.step` constructs `BrownianTreeNoiseSampler` with the **config** bounds:

```python
self.noise_sampler = BrownianTreeNoiseSampler(
    model_output,
    sigma_min=self.config.sigma_min,
    sigma_max=self.config.sigma_max,
    seed=seed,
)
noise = self.noise_sampler(self.sigmas[self.step_index], self.sigmas[self.step_index + 1])
```

The queries use the **discretized** schedule `self.sigmas`, which drifts out of those bounds at both ends:

1. The Karras reconstruction of `sigma_max` in fp32 lands a few ULPs above the config value (e.g. `sigma_max=500` → `self.sigmas[0] == 500.00006103515625`). The first query violates torchsde's `tb <= t1` check.
2. With the default `final_sigmas_type=\"zero\"` the last query is `sigma_next == 0`, which is strictly below `config.sigma_min` (e.g. 0.3), violating `ta >= t0`.

torchsde responds to either by recursively splitting the backing interval until Python's recursion limit blows up — this is exactly the `RecursionError: maximum recursion depth exceeded` reported for stable-audio-open-1.0 in #13274:

```
UserWarning: Should have tb<=t1 but got tb=500.00006103515625 and t1=500.0
UserWarning: Should have ta>=t0 but got ta=0.0 and t0=0.3
...
File \".../torchsde/_brownian/brownian_interval.py\", line 328, in _split
    self._left_child._split(midway)
  [Previous line repeated 984 more times]
RuntimeError: maximum recursion depth exceeded
```

This PR switches the Brownian bounds to the actual extrema of `self.sigmas`, matching the pattern already used by `scheduling_dpmsolver_sde.py:690`:

```python
sigma_min=self.sigmas.min().item(),
sigma_max=self.sigmas.max().item(),
```

so the noise sampler is always constructed with an interval that encloses every query issued during sampling.

Fixes #13274

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@yiyixuxu @kashif @sayakpaul

---

*Clean rebase of PR 13515 onto the current main branch. Fixes issue 13274.*
