### PR TITLE
fix: Fix Flux 2 Klein dreambooth default text_encoder_out_layers

### DIFF
--- a/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
@@ -359,7 +359,7 @@ def parse_args(input_args=None):
         "--text_encoder_out_layers",
         type=int,
         nargs="+",
-        default=[10, 20, 30],
+        default=[9, 18, 27],
         help="Text encoder hidden layers to compute the final text embeddings.",
     )
     parser.add_argument(


### PR DESCRIPTION
## What does this PR do?

Fixes the off-by-one in the \`--text_encoder_out_layers\` CLI default of \`examples/dreambooth/train_dreambooth_lora_flux2_klein.py\`: the script was defaulting to \`[10, 20, 30]\` (the Flux 2 **non-Klein** default, appropriate for its Mistral text encoder), but every Klein pipeline — \`pipeline_flux2_klein.py\`, \`pipeline_flux2_klein_kv.py\`, \`pipeline_flux2_klein_inpaint.py\` — expects \`(9, 18, 27)\` and uses that layer set on every call in the training loop.

The result is a silent mismatch whenever a user trains with the default flag value: Klein's internal \`hidden_states_layers=(9, 18, 27)\` is what the pipeline advertises, but the training script's default CLI flag suggests \`[10, 20, 30]\`, which produces the wrong embeddings if actually passed. The issue reporter lost ~72 GPU hours before catching it.

## Change

One-line fix in \`examples/dreambooth/train_dreambooth_lora_flux2_klein.py\`: change the argparse default for \`--text_encoder_out_layers\` from \`[10, 20, 30]\` → \`[9, 18, 27]\` so it matches the layers Klein's pipelines already use.

The non-Klein Flux 2 training script (\`train_dreambooth_lora_flux2.py\`) stays on \`[10, 20, 30]\`, which is correct for the non-Klein pipeline.

Fixes #13445

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] This PR fixes a bug (linked above).
- [x] Minimal, targeted change — no refactor.

## Who can review?

cc @sayakpaul @yiyixuxu

---

*Clean rebase of PR 13509 onto the current main branch. Fixes issue 13445.*
