### PR TITLE
fix: fix: correct attribute error in TangentialCFG and undefined variable in FrequencyDecoupledGuidance

### DIFF
--- a/src/diffusers/guiders/frequency_decoupled_guidance.py
+++ b/src/diffusers/guiders/frequency_decoupled_guidance.py
@@ -275,7 +275,7 @@ class FrequencyDecoupledGuidance(BaseGuidance):
                     pred_guided_pyramid.append(pred)
                 else:
                     # Add the current pred_cond_pyramid level as the "non-FDG" prediction
-                    pred_guided_pyramid.append(pred_cond_freq)
+                    pred_guided_pyramid.append(pred_cond_pyramid[level])
 
             # Convert from frequency space back to data (e.g. pixel) space by applying inverse freq transform
             pred = build_image_from_pyramid(pred_guided_pyramid)

--- a/src/diffusers/guiders/tangential_classifier_free_guidance.py
+++ b/src/diffusers/guiders/tangential_classifier_free_guidance.py
@@ -101,7 +101,7 @@ class TangentialClassifierFreeGuidance(BaseGuidance):
 
     @property
     def is_conditional(self) -> bool:
-        return self._num_outputs_prepared == 1
+        return self._count_prepared == 1
 
     @property
     def num_conditions(self) -> int:


### PR DESCRIPTION
## What does this PR do?

Fixes #14643 - two crash bugs in the guiders:

1. `TangentialCFG.is_conditional` references the nonexistent `self._num_outputs_prepared` (AttributeError) - the attribute is `self._count_prepared`.
2. `FrequencyDecoupledGuidance.forward` uses the undefined name `pred_cond_freq` in the non-FDG branch (NameError) - should be `pred_cond_pyramid[level]`.

+2/-2 across 2 files, no API changes.

*Rebase of #13434. Fixes #14643.*
