### PR TITLE
fix: Fix missing function call in is_torch_xla_version

### DIFF
--- a/src/diffusers/utils/import_utils.py
+++ b/src/diffusers/utils/import_utils.py
@@ -713,7 +713,7 @@ def is_torch_xla_version(operation: str, version: str):
         version (`str`):
             A string version of torch_xla
     """
-    if not is_torch_xla_available:
+    if not _torch_xla_available:
         return False
     return compare_versions(parse(_torch_xla_version), operation, version)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #14641 - `is_torch_xla_version()` in `src/diffusers/utils/import_utils.py` guards with `if not is_torch_xla_available`, but that name refers to the *function* in the same module, which is always truthy. The guard therefore never short-circuits when torch_xla is absent, and `parse(_torch_xla_version)` runs on an invalid version string.

The fix checks the cached boolean `_torch_xla_available` instead.

One-line change, no behavior impact on systems where torch_xla *is* installed.

*Clean rebase of PR 13549 (plus its review follow-up 14510) onto current main.*
