### PR TITLE
Drop the experimental warning from Modular Diffusers

### DIFF
--- a/docs/source/en/modular_diffusers/components_manager.md
+++ b/docs/source/en/modular_diffusers/components_manager.md
@@ -12,6 +12,9 @@ specific language governing permissions and limitations under the License.
 
 # ComponentsManager
 
+> [!WARNING]
+> [`ComponentsManager`] is still under active development and its API may change.
+
 The [`ComponentsManager`] is a model registry and management system for Modular Diffusers. It adds and tracks models, stores useful metadata (model size, device placement, adapters), and supports offloading.
 
 This guide will show you how to use [`ComponentsManager`] to manage components and device memory.

--- a/docs/source/en/modular_diffusers/overview.md
+++ b/docs/source/en/modular_diffusers/overview.md
@@ -12,9 +12,6 @@ specific language governing permissions and limitations under the License.
 
 # Overview
 
-> [!WARNING]
-> Modular Diffusers is under active development and it's API may change.
-
 Modular Diffusers is a unified pipeline system that simplifies your workflow with *pipeline blocks*.
 
 - Blocks are reusable and you only need to create new blocks that are unique to your pipeline.

--- a/src/diffusers/modular_pipelines/__init__.py
+++ b/src/diffusers/modular_pipelines/__init__.py
@@ -7,14 +7,8 @@ from ..utils import (
     get_objects_from_module,
     is_torch_available,
     is_transformers_available,
-    logging,
 )
 
-
-logger = logging.get_logger(__name__)
-logger.warning(
-    "Modular Diffusers is currently an experimental feature under active development. The API is subject to breaking changes in future releases."
-)
 
 # These modules contain pipelines from multiple libraries/frameworks
 _dummy_objects = {}

--- a/src/diffusers/modular_pipelines/anima/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/anima/modular_pipeline.py
@@ -20,7 +20,6 @@ class AnimaModularPipeline(ModularPipeline, AnimaLoraLoaderMixin):
     """
     A ModularPipeline for Anima.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "AnimaAutoBlocks"

--- a/src/diffusers/modular_pipelines/ernie_image/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/ernie_image/modular_pipeline.py
@@ -68,7 +68,6 @@ class ErnieImageModularPipeline(ModularPipeline, ErnieImageLoraLoaderMixin):
     """
     A ModularPipeline for ErnieImage.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "ErnieImageAutoBlocks"

--- a/src/diffusers/modular_pipelines/flux/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/flux/modular_pipeline.py
@@ -25,7 +25,6 @@ class FluxModularPipeline(ModularPipeline, FluxLoraLoaderMixin, TextualInversion
     """
     A ModularPipeline for Flux.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "FluxAutoBlocks"
@@ -61,7 +60,6 @@ class FluxKontextModularPipeline(FluxModularPipeline):
     """
     A ModularPipeline for Flux Kontext.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "FluxKontextAutoBlocks"

--- a/src/diffusers/modular_pipelines/flux2/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/flux2/modular_pipeline.py
@@ -25,7 +25,6 @@ class Flux2ModularPipeline(ModularPipeline, Flux2LoraLoaderMixin):
     """
     A ModularPipeline for Flux2.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "Flux2AutoBlocks"
@@ -61,7 +60,6 @@ class Flux2KleinModularPipeline(Flux2ModularPipeline):
     """
     A ModularPipeline for Flux2-Klein (distilled model).
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "Flux2KleinAutoBlocks"
@@ -82,7 +80,6 @@ class Flux2KleinBaseModularPipeline(Flux2ModularPipeline):
     """
     A ModularPipeline for Flux2-Klein (base model).
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "Flux2KleinBaseAutoBlocks"

--- a/src/diffusers/modular_pipelines/helios/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/helios/modular_pipeline.py
@@ -28,7 +28,6 @@ class HeliosModularPipeline(
     """
     A ModularPipeline for Helios text-to-video generation.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "HeliosAutoBlocks"
@@ -69,7 +68,6 @@ class HeliosPyramidModularPipeline(HeliosModularPipeline):
     """
     A ModularPipeline for Helios pyramid (progressive resolution) video generation.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "HeliosPyramidAutoBlocks"
@@ -81,7 +79,6 @@ class HeliosPyramidDistilledModularPipeline(HeliosModularPipeline):
 
     Uses guidance_scale=1.0 (no CFG) and supports is_amplify_first_chunk for the DMD scheduler.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "HeliosPyramidDistilledAutoBlocks"

--- a/src/diffusers/modular_pipelines/hunyuan_video1_5/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/hunyuan_video1_5/modular_pipeline.py
@@ -27,7 +27,6 @@ class HunyuanVideo15ModularPipeline(
     """
     A ModularPipeline for HunyuanVideo 1.5.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "HunyuanVideo15AutoBlocks"

--- a/src/diffusers/modular_pipelines/ideogram4/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/ideogram4/modular_pipeline.py
@@ -20,7 +20,6 @@ class Ideogram4ModularPipeline(ModularPipeline, Ideogram4LoraLoaderMixin):
     """
     A ModularPipeline for Ideogram4.
 
-    > [!WARNING] > This is an experimental feature!
     """
 
     default_blocks_name = "Ideogram4AutoBlocks"

--- a/src/diffusers/modular_pipelines/krea2/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/krea2/modular_pipeline.py
@@ -20,7 +20,6 @@ class Krea2ModularPipeline(ModularPipeline, Krea2LoraLoaderMixin):
     """
     A ModularPipeline for Krea 2.
 
-    > [!WARNING] > This is an experimental feature!
     """
 
     default_blocks_name = "Krea2AutoBlocks"
@@ -57,7 +56,6 @@ class Krea2TurboModularPipeline(Krea2ModularPipeline):
     A ModularPipeline for the distilled Krea 2 turbo (TDM) checkpoint. It runs without classifier-free guidance, so it
     takes no negative prompt and has no guider.
 
-    > [!WARNING] > This is an experimental feature!
     """
 
     default_blocks_name = "Krea2TurboAutoBlocks"

--- a/src/diffusers/modular_pipelines/ltx/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/ltx/modular_pipeline.py
@@ -71,7 +71,6 @@ class LTXModularPipeline(
     """
     A ModularPipeline for LTX Video.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "LTXAutoBlocks"

--- a/src/diffusers/modular_pipelines/ltx2/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/ltx2/modular_pipeline.py
@@ -30,7 +30,6 @@ class LTX2ModularPipeline(
     """
     A ModularPipeline for LTX-2 (joint video + audio generation).
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "LTX2AutoBlocks"
@@ -130,7 +129,6 @@ class LTX25ModularPipeline(LTX2ModularPipeline):
     Identical to [`LTX2ModularPipeline`] except that its default blocks decode with the diffusion video decoder, which
     is the native default from LTX-2.5 on. A checkpoint routes here through `modular_model_index.json`.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "LTX25AutoBlocks"

--- a/src/diffusers/modular_pipelines/mellon_node_utils.py
+++ b/src/diffusers/modular_pipelines/mellon_node_utils.py
@@ -1,3 +1,9 @@
+"""
+Utilities for exposing modular pipeline blocks as nodes in [Mellon](https://github.com/cubiq/Mellon).
+
+> [!WARNING] > The Mellon integration is still under active development and its API may change.
+"""
+
 import copy
 import json
 import logging
@@ -255,6 +261,8 @@ class MellonParamMeta(type):
 class MellonParam(metaclass=MellonParamMeta):
     """
         Parameter definition for Mellon nodes.
+
+        > [!WARNING] > The Mellon integration is still under active development and its API may change.
 
         Usage:
     ```python
@@ -692,6 +700,8 @@ def node_spec_to_mellon_dict(node_spec: dict[str, Any], node_type: str) -> dict[
 class MellonPipelineConfig:
     """
     Configuration for an entire Mellon pipeline containing multiple nodes.
+
+    > [!WARNING] > The Mellon integration is still under active development and its API may change.
 
     Accepts node specs as dicts with inputs/model_inputs/outputs lists of MellonParam, converts them to Mellon-ready
     format, and handles save/load to Hub.

--- a/src/diffusers/modular_pipelines/minimax_h3/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/minimax_h3/modular_pipeline.py
@@ -179,7 +179,6 @@ class MiniMaxH3ModularPipeline(ModularPipeline, MiniMaxH3LoraLoaderMixin):
     pipe.load_components(dtype=torch.bfloat16)
     ```
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "MiniMaxH3Blocks"

--- a/src/diffusers/modular_pipelines/minimax_music3/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/minimax_music3/modular_pipeline.py
@@ -23,7 +23,6 @@ class MiniMaxMusic3ModularPipeline(ModularPipeline):
     """
     A ModularPipeline for lyrics- and caption-conditioned music generation with MiniMax Music 3.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "MiniMaxMusic3Blocks"

--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -330,7 +330,6 @@ class ModularPipelineBlocks(ConfigMixin, PushToHubMixin):
 
     [`ModularPipelineBlocks`] provides method to load and save the definition of pipeline blocks.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     config_name = "modular_config.json"
@@ -611,8 +610,6 @@ class ConditionalPipelineBlocks(ModularPipelineBlocks):
 
     This class inherits from [`ModularPipelineBlocks`]. Check the superclass documentation for the generic methods the
     library implements for all the pipeline blocks (such as loading or saving etc.)
-
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
 
     Attributes:
         block_classes: List of block classes to be used. Must have the same length as `block_names`.
@@ -972,8 +969,6 @@ class SequentialPipelineBlocks(ModularPipelineBlocks):
 
     This class inherits from [`ModularPipelineBlocks`]. Check the superclass documentation for the generic methods the
     library implements for all the pipeline blocks (such as loading or saving etc.)
-
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
 
     Attributes:
         block_classes: list of block classes to be used
@@ -1335,8 +1330,6 @@ class LoopSequentialPipelineBlocks(ModularPipelineBlocks):
     This class inherits from [`ModularPipelineBlocks`]. Check the superclass documentation for the generic methods the
     library implements for all the pipeline blocks (such as loading or saving etc.)
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
-
     Attributes:
         block_classes: list of block classes to be used
         block_names: list of prefixes for each block
@@ -1628,8 +1621,6 @@ class LoopSequentialPipelineBlocks(ModularPipelineBlocks):
 class ModularPipeline(ConfigMixin, PushToHubMixin):
     """
     Base class for all Modular pipelines.
-
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
 
     Args:
         blocks: ModularPipelineBlocks, the blocks to be used in the pipeline

--- a/src/diffusers/modular_pipelines/qwenimage/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/qwenimage/modular_pipeline.py
@@ -176,7 +176,6 @@ class QwenImageModularPipeline(ModularPipeline, QwenImageLoraLoaderMixin):
     """
     A ModularPipeline for QwenImage.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "QwenImageAutoBlocks"
@@ -228,7 +227,6 @@ class QwenImageEditModularPipeline(ModularPipeline, QwenImageLoraLoaderMixin):
     """
     A ModularPipeline for QwenImage-Edit.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "QwenImageEditAutoBlocks"
@@ -281,7 +279,6 @@ class QwenImageEditPlusModularPipeline(QwenImageEditModularPipeline):
     """
     A ModularPipeline for QwenImage-Edit Plus.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "QwenImageEditPlusAutoBlocks"
@@ -291,7 +288,6 @@ class QwenImageLayeredModularPipeline(QwenImageModularPipeline):
     """
     A ModularPipeline for QwenImage-Layered.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "QwenImageLayeredAutoBlocks"

--- a/src/diffusers/modular_pipelines/stable_diffusion_3/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_3/modular_pipeline.py
@@ -24,7 +24,6 @@ class StableDiffusion3ModularPipeline(ModularPipeline, SD3LoraLoaderMixin, FromS
     """
     A ModularPipeline for Stable Diffusion 3.
 
-    >[!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "StableDiffusion3AutoBlocks"

--- a/src/diffusers/modular_pipelines/stable_diffusion_xl/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_xl/modular_pipeline.py
@@ -45,7 +45,6 @@ class StableDiffusionXLModularPipeline(
     """
     A ModularPipeline for Stable Diffusion XL.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "StableDiffusionXLAutoBlocks"

--- a/src/diffusers/modular_pipelines/wan/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/wan/modular_pipeline.py
@@ -30,7 +30,6 @@ class WanModularPipeline(
     """
     A ModularPipeline for Wan2.1 text2video.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "WanBlocks"
@@ -115,7 +114,6 @@ class WanImage2VideoModularPipeline(WanModularPipeline):
     """
     A ModularPipeline for Wan2.1 image2video (both I2V and FLF2V).
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "WanImage2VideoAutoBlocks"
@@ -125,7 +123,6 @@ class Wan22ModularPipeline(WanModularPipeline):
     """
     A ModularPipeline for Wan2.2 text2video.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "Wan22Blocks"
@@ -135,7 +132,6 @@ class Wan22Image2VideoModularPipeline(Wan22ModularPipeline):
     """
     A ModularPipeline for Wan2.2 image2video.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "Wan22Image2VideoBlocks"

--- a/src/diffusers/modular_pipelines/wan_animate_2/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/wan_animate_2/modular_pipeline.py
@@ -24,7 +24,6 @@ class WanAnimate2ModularPipeline(ModularPipeline, WanLoraLoaderMixin):
     """
     A ModularPipeline for Wan-Animate-2 character animation.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "WanAnimate2Blocks"
@@ -65,7 +64,6 @@ class WanAnimate2DistilledModularPipeline(WanAnimate2ModularPipeline):
     A ModularPipeline for the distilled Wan-Animate-2 model, which samples in few steps without classifier-free
     guidance.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "WanAnimate2DistilledBlocks"

--- a/src/diffusers/modular_pipelines/z_image/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/z_image/modular_pipeline.py
@@ -28,7 +28,6 @@ class ZImageModularPipeline(
     """
     A ModularPipeline for Z-Image.
 
-    > [!WARNING] > This is an experimental feature and is likely to change in the future.
     """
 
     default_blocks_name = "ZImageAutoBlocks"


### PR DESCRIPTION
it's about time. 
we have been and will keep properly deprecate if we are making any API changes 

kept `guider` and `components manager` as experimental 