### PR TITLE
[train_text_to_image_sdxl.py] Fix the LR scheduler when num_train_epochs is passed in a distributed training env

### DIFF
--- a/examples/text_to_image/test_text_to_image.py
+++ b/examples/text_to_image/test_text_to_image.py
@@ -345,3 +345,26 @@ class TestTextToImageSDXL(ExamplesTestsAccelerate):
             # save_pretrained smoke test
             assert os.path.isfile(os.path.join(tmpdir, "unet", "diffusion_pytorch_model.safetensors"))
             assert os.path.isfile(os.path.join(tmpdir, "scheduler", "scheduler_config.json"))
+
+    def test_text_to_image_sdxl_num_train_epochs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_args = f"""
+                examples/text_to_image/train_text_to_image_sdxl.py
+                --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
+                --dataset_name hf-internal-testing/dummy_image_text_data
+                --resolution 64
+                --center_crop
+                --random_flip
+                --train_batch_size 1
+                --gradient_accumulation_steps 1
+                --num_train_epochs 1
+                --learning_rate 5.0e-04
+                --scale_lr
+                --lr_scheduler constant
+                --lr_warmup_steps 0
+                --output_dir {tmpdir}
+                """.split()
+
+            run_command(self._launch_args + test_args)
+            assert os.path.isfile(os.path.join(tmpdir, "unet", "diffusion_pytorch_model.safetensors"))
+            assert os.path.isfile(os.path.join(tmpdir, "scheduler", "scheduler_config.json"))

--- a/examples/text_to_image/train_text_to_image_sdxl.py
+++ b/examples/text_to_image/train_text_to_image_sdxl.py
@@ -979,17 +979,22 @@ def main(args):
     )
 
     # Scheduler and math around the number of training steps.
-    overrode_max_train_steps = False
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    # Check the PR https://github.com/huggingface/diffusers/pull/8312 for detailed explanation.
+    num_warmup_steps_for_scheduler = args.lr_warmup_steps * accelerator.num_processes
     if args.max_train_steps is None:
-        args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
-        overrode_max_train_steps = True
+        len_train_dataloader_after_sharding = math.ceil(len(train_dataloader) / accelerator.num_processes)
+        num_update_steps_per_epoch = math.ceil(len_train_dataloader_after_sharding / args.gradient_accumulation_steps)
+        num_training_steps_for_scheduler = (
+            args.num_train_epochs * num_update_steps_per_epoch * accelerator.num_processes
+        )
+    else:
+        num_training_steps_for_scheduler = args.max_train_steps * accelerator.num_processes
 
     lr_scheduler = get_scheduler(
         args.lr_scheduler,
         optimizer=optimizer,
-        num_warmup_steps=args.lr_warmup_steps * args.gradient_accumulation_steps,
-        num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
+        num_warmup_steps=num_warmup_steps_for_scheduler,
+        num_training_steps=num_training_steps_for_scheduler,
     )
 
     # Prepare everything with our `accelerator`.
@@ -1002,8 +1007,14 @@ def main(args):
 
     # We need to recalculate our total training steps as the size of the training dataloader may have changed.
     num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
-    if overrode_max_train_steps:
+    if args.max_train_steps is None:
         args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
+        if num_training_steps_for_scheduler != args.max_train_steps * accelerator.num_processes:
+            logger.warning(
+                f"The length of the 'train_dataloader' after 'accelerator.prepare' ({len(train_dataloader)}) does not match "
+                f"the expected length ({len_train_dataloader_after_sharding}) when the learning rate scheduler was created. "
+                f"This inconsistency may result in the learning rate scheduler not functioning properly."
+            )
     # Afterwards we recalculate our number of training epochs
     args.num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
 


### PR DESCRIPTION
Fixes #8384

This PR updates only `examples/text_to_image/train_text_to_image_sdxl.py`, matching the #8312 pattern already applied to `train_text_to_image.py` and the DreamBooth trainers.

**What was wrong**

When `--num_train_epochs` is used (so `max_train_steps` is derived), the SDXL trainer still built the LR schedule from the unsharded dataloader length and ignored `accelerator.num_processes`. In a multi-process run that makes the scheduler finish too early.

**What changed**

- Warmup and training steps passed to `get_scheduler` are scaled by `accelerator.num_processes`.
- Step counts used to build the schedule assume the dataloader will be sharded.
- After `accelerator.prepare`, we warn if the prepared dataloader length does not match that assumption.
- Added a smoke test that runs the script with `--num_train_epochs 1`.

**Coordination**

Claimed on #8384: https://github.com/huggingface/diffusers/issues/8384#issuecomment-5330771888

@sayakpaul @geniuspatrick

**Minimal training command using `num_train_epochs`**

```bash
export MODEL_NAME="stabilityai/stable-diffusion-xl-base-1.0"
export VAE_NAME="madebyollin/sdxl-vae-fp16-fix"
export DATASET_NAME="lambdalabs/naruto-blip-captions"

accelerate launch train_text_to_image_sdxl.py \
  --pretrained_model_name_or_path=$MODEL_NAME \
  --pretrained_vae_model_name_or_path=$VAE_NAME \
  --dataset_name=$DATASET_NAME \
  --resolution=512 --center_crop --random_flip \
  --train_batch_size=1 \
  --gradient_accumulation_steps=4 --gradient_checkpointing \
  --num_train_epochs=1 \
  --learning_rate=1e-06 --lr_scheduler="constant" --lr_warmup_steps=0 \
  --mixed_precision="fp16" \
  --output_dir="sdxl-naruto-model"
```

**Tests I ran**

```
python3 -m py_compile examples/text_to_image/train_text_to_image_sdxl.py
```

That passed. I did not run the example pytest here because this machine does not have the package or its test extras installed. The new `test_text_to_image_sdxl_num_train_epochs` plus the existing `test_text_to_image_sdxl` should cover both `--max_train_steps` and `--num_train_epochs` in CI.

**Self-review**

- Scope is one official trainer, as requested on the issue.
- The new math is copied from `train_text_to_image.py`, not reinvented.
- No public API change.
- I left `train_text_to_image_lora_sdxl.py` and the other remaining scripts alone so this stays one script per PR.