### PR TITLE
[train_text_to_image_lora_sdxl.py] Fix the LR scheduler when num_train_epochs is passed in a distributed training env

### DIFF
--- a/examples/text_to_image/test_text_to_image_lora.py
+++ b/examples/text_to_image/test_text_to_image_lora.py
@@ -220,6 +220,28 @@ class TestTextToImageLoRASDXL(ExamplesTestsAccelerate):
             is_lora = all("lora" in k for k in lora_state_dict.keys())
             assert is_lora
 
+    def test_text_to_image_lora_sdxl_num_train_epochs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_args = f"""
+                examples/text_to_image/train_text_to_image_lora_sdxl.py
+                --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe
+                --dataset_name hf-internal-testing/dummy_image_text_data
+                --resolution 64
+                --train_batch_size 1
+                --gradient_accumulation_steps 1
+                --num_train_epochs 1
+                --learning_rate 5.0e-04
+                --scale_lr
+                --lr_scheduler constant
+                --lr_warmup_steps 0
+                --output_dir {tmpdir}
+                """.split()
+
+            run_command(self._launch_args + test_args)
+            assert os.path.isfile(os.path.join(tmpdir, "pytorch_lora_weights.safetensors"))
+            lora_state_dict = safetensors.torch.load_file(os.path.join(tmpdir, "pytorch_lora_weights.safetensors"))
+            assert all("lora" in k for k in lora_state_dict.keys())
+
     def test_text_to_image_lora_sdxl_with_text_encoder(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             test_args = f"""

--- a/examples/text_to_image/train_text_to_image_lora_sdxl.py
+++ b/examples/text_to_image/train_text_to_image_lora_sdxl.py
@@ -1011,17 +1011,22 @@ def main(args):
     )
 
     # Scheduler and math around the number of training steps.
-    overrode_max_train_steps = False
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    # Check the PR https://github.com/huggingface/diffusers/pull/8312 for detailed explanation.
+    num_warmup_steps_for_scheduler = args.lr_warmup_steps * accelerator.num_processes
     if args.max_train_steps is None:
-        args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
-        overrode_max_train_steps = True
+        len_train_dataloader_after_sharding = math.ceil(len(train_dataloader) / accelerator.num_processes)
+        num_update_steps_per_epoch = math.ceil(len_train_dataloader_after_sharding / args.gradient_accumulation_steps)
+        num_training_steps_for_scheduler = (
+            args.num_train_epochs * num_update_steps_per_epoch * accelerator.num_processes
+        )
+    else:
+        num_training_steps_for_scheduler = args.max_train_steps * accelerator.num_processes
 
     lr_scheduler = get_scheduler(
         args.lr_scheduler,
         optimizer=optimizer,
-        num_warmup_steps=args.lr_warmup_steps * args.gradient_accumulation_steps,
-        num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
+        num_warmup_steps=num_warmup_steps_for_scheduler,
+        num_training_steps=num_training_steps_for_scheduler,
     )
 
     # Prepare everything with our `accelerator`.
@@ -1036,8 +1041,14 @@ def main(args):
 
     # We need to recalculate our total training steps as the size of the training dataloader may have changed.
     num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
-    if overrode_max_train_steps:
+    if args.max_train_steps is None:
         args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
+        if num_training_steps_for_scheduler != args.max_train_steps * accelerator.num_processes:
+            logger.warning(
+                f"The length of the 'train_dataloader' after 'accelerator.prepare' ({len(train_dataloader)}) does not match "
+                f"the expected length ({len_train_dataloader_after_sharding}) when the learning rate scheduler was created. "
+                f"This inconsistency may result in the learning rate scheduler not functioning properly."
+            )
     # Afterwards we recalculate our number of training epochs
     args.num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
 


### PR DESCRIPTION
Fixes #8384

Follow-up to #14527, still one script. This PR only updates `examples/text_to_image/train_text_to_image_lora_sdxl.py`.

**What was wrong**

When `--num_train_epochs` is used, this trainer still built the LR schedule from the unsharded dataloader and ignored `accelerator.num_processes`. The official README already documents `--num_train_epochs=2` for this script, so the broken path is the documented one.

**What changed**

Same #8312 math already in `train_text_to_image_lora.py` and the DreamBooth trainers:

- Warmup and training steps passed to `get_scheduler` are scaled by `accelerator.num_processes`.
- Step counts used to build the schedule assume the dataloader will be sharded.
- After `accelerator.prepare`, we warn if the prepared dataloader length does not match that assumption.
- Added `test_text_to_image_lora_sdxl_num_train_epochs` so the `--num_train_epochs` path is covered.

**Coordination**

Covered by the existing #8384 thread. No new issue comment. @sayakpaul @geniuspatrick

**Minimal training command using `num_train_epochs`**

```bash
export MODEL_NAME="stabilityai/stable-diffusion-xl-base-1.0"
export VAE_NAME="madebyollin/sdxl-vae-fp16-fix"
export DATASET_NAME="lambdalabs/naruto-blip-captions"

accelerate launch train_text_to_image_lora_sdxl.py \
  --pretrained_model_name_or_path=$MODEL_NAME \
  --pretrained_vae_model_name_or_path=$VAE_NAME \
  --dataset_name=$DATASET_NAME --caption_column="text" \
  --resolution=1024 --random_flip \
  --train_batch_size=1 \
  --num_train_epochs=2 --checkpointing_steps=500 \
  --learning_rate=1e-04 --lr_scheduler="constant" --lr_warmup_steps=0 \
  --mixed_precision="fp16" \
  --seed=42 \
  --output_dir="sd-naruto-model-lora-sdxl"
```

**Tests I ran**

```
python3 -m py_compile examples/text_to_image/train_text_to_image_lora_sdxl.py
```

That passed. I did not run the example pytest here because this machine does not have the package or its test extras installed. CI should run the new `test_text_to_image_lora_sdxl_num_train_epochs` plus the existing LoRA SDXL smoke tests.

**Self-review**

- Scope is one official trainer, as requested on the issue.
- The new math is copied from `train_text_to_image_lora.py`, not reinvented.
- No public API change.
- I left the remaining #8384 scripts alone.