### PR TITLE
Slice lm_head to sampleable rows in MiniMax Music 3 AR decode (9.9x on the head op)

### DIFF
--- a/src/diffusers/modular_pipelines/minimax_music3/encoders.py
+++ b/src/diffusers/modular_pipelines/minimax_music3/encoders.py
@@ -320,14 +320,25 @@ class MiniMaxMusic3AutoregressiveStep(ModularPipelineBlocks):
         past_key_values = output.past_key_values
         last_hidden = output.last_hidden_state[:, -1]
 
-        vocab_mask = torch.ones(language_model.config.vocab_size, dtype=torch.bool, device=text_ids.device)
-        vocab_mask[_AUDIO_CODE_OFFSET : _AUDIO_CODE_OFFSET + _SEMANTIC_VOCAB_SIZE] = False
-        vocab_mask[_AUDIO_END_TOKEN_ID] = False
+        # Only the semantic codes and the end-of-audio token can ever be sampled; every other row is masked to
+        # `-inf` anyway. Slicing `lm_head` to the contiguous row range covering exactly those tokens yields
+        # identical logits for every sampleable token while reading ~10x less weight per frame (the full head
+        # is ~1.4GB in bf16 at this vocabulary size, paid at 25 frames per second of audio).
+        head_start = _AUDIO_END_TOKEN_ID
+        head_end = _AUDIO_CODE_OFFSET + _SEMANTIC_VOCAB_SIZE
+        head_weight = language_model.lm_head.weight[head_start:head_end]
+        head_bias = language_model.lm_head.bias
+        if head_bias is not None:
+            head_bias = head_bias[head_start:head_end]
+
+        vocab_mask = torch.ones(head_end - head_start, dtype=torch.bool, device=text_ids.device)
+        vocab_mask[_AUDIO_CODE_OFFSET - head_start : _AUDIO_CODE_OFFSET - head_start + _SEMANTIC_VOCAB_SIZE] = False
+        vocab_mask[_AUDIO_END_TOKEN_ID - head_start] = False
 
         frame_hiddens = []
         # The first decode step only advances the state past `<|audio_start|>` and is not an emitted frame.
         for frame_index in range(max_frames + 1):
-            logits = language_model.lm_head(last_hidden).float()
+            logits = F.linear(last_hidden, head_weight, head_bias).float()
             logits = logits.masked_fill(vocab_mask, -float("inf"))
             conditional, unconditional = logits[0:1], logits[1:2]
             guided = unconditional + (conditional - unconditional) * _AR_CFG_SCALE
@@ -336,7 +347,7 @@ class MiniMaxMusic3AutoregressiveStep(ModularPipelineBlocks):
             threshold = torch.topk(conditional, _AR_CFG_TOP_K, dim=-1).values[..., -1, None]
             guided = guided.masked_fill(conditional < threshold, -float("inf"))
             guided = guided.masked_fill(vocab_mask.unsqueeze(0), -float("inf"))
-            sampled = _sample_top_k(guided, generator)
+            sampled = _sample_top_k(guided, generator) + head_start
             if int(sampled.item()) == _AUDIO_END_TOKEN_ID:
                 break
 


### PR DESCRIPTION
## What does this PR do?

Requested by @yiyixuxu in #14486: slice `lm_head` to the sampleable rows in
the MiniMax Music 3 autoregressive decode loop.

The loop samples only the 16,384 semantic codes plus the end-of-audio token;
every other vocabulary row was masked to `-inf` *after* a full-vocabulary head
matmul. With a 200k-row head at bf16 that is ~1.64GB of weight read per audio
frame, paid 25 times per second of audio. Slicing the head to the contiguous
sampleable range `[_AUDIO_END_TOKEN_ID, _AUDIO_CODE_OFFSET + _SEMANTIC_VOCAB_SIZE)`
reads ~134MB instead.

**Measured (RTX 4090, bf16, real checkpoint weights):**
- head op: 5.31ms → 0.54ms per frame (9.9x on the op)
- ≈ 2.4s saved per 20s of generated audio; scales linearly with duration

**Numerical characterization** (`labs/verify_slim_head.py` in
[our repo](https://github.com/TheDutchRuler/minimax-music3-studio), 3 seeds ×
200 steps against the real head weights): logits on sampleable rows match the
full-head path to within **one bf16 ulp** (0.03125) — the GEMM tile shape
changes accumulation order. The sampling distribution is unchanged; as with
any kernel-shape change, an individual seed may take a different
(equally valid) trajectory than before.

The masking, CFG, top-k restriction, and sampling ops are byte-for-byte the
reference sequence, only re-indexed into the sliced range (the sampled local
index gets `head_start` added back, so everything downstream is untouched).

## Before submitting
- [x] Read contributor guidelines
- [x] Discussed in #14486 (maintainer-requested)

## Who can review?
@yiyixuxu @asomoza

Developed and verified with Claude (Fable 5 Max).
