### PR TITLE
[CI] Fix authentication on forked PRs

### DIFF
--- a/.github/workflows/push_tests_fast.yml
+++ b/.github/workflows/push_tests_fast.yml
@@ -55,6 +55,9 @@ jobs:
       run:
         shell: bash
 
+    env:
+      HF_TOKEN: ${{ secrets.DIFFUSERS_HF_HUB_READ_TOKEN }}
+
     steps:
     - name: Checkout diffusers
       uses: actions/checkout@v6

--- a/tests/models/testing_utils/single_file.py
+++ b/tests/models/testing_utils/single_file.py
@@ -28,6 +28,7 @@ from ...testing_utils import (
     backend_empty_cache,
     is_single_file,
     nightly,
+    require_hf_token,
     torch_device,
 )
 from .common import check_device_map_is_respected
@@ -52,6 +53,10 @@ def fetch_checkpoint_metadata(ckpt_path):
     return HfApi().parse_safetensors_file_metadata(pretrained_model_name_or_path, weight_name)
 
 
+# The checkpoints these tests resolve against include gated repos, so they only run where an
+# authenticated token is available. In CI that is everywhere except fork PRs, whose
+# `pull_request` runs resolve the token secret to an empty value.
+@require_hf_token
 @is_single_file
 class SingleFileTesterMixin:
     """

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -850,6 +850,16 @@ def require_bitsandbytes_version_greater(bnb_version):
     return decorator
 
 
+def require_hf_token(test_case):
+    """
+    Decorator marking a test that requires a Hugging Face auth token (e.g. to access gated repos). The test is
+    skipped when no token is available.
+    """
+    from huggingface_hub import get_token
+
+    return pytest.mark.skipif(get_token() is None, reason="test requires a Hugging Face auth token")(test_case)
+
+
 def require_hf_hub_version_greater(hf_hub_version):
     def decorator(test_case):
         correct_hf_hub_version = version.parse(


### PR DESCRIPTION
# What does this PR do?
Introduced `HF_TOKEN` so that we could run fast single file tests on PRs. These fail for forked PRs because secrets are not injected into those runs. 

This PR:
- adds a `require_hf_token` decorator on the SF tests that skips these tests when no HF token is set. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

If you used an AI agent, also include your final self-review notes here (or post them as a comment) — the report from the last self-review round, including any findings you intentionally did not fix and why. See https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [ ] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [ ] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [ ] Did you share the final self-review notes in the PR description or a comment?
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu @dg845
- Pipelines and models: @yiyixuxu @dg845 and @asomoza
- Training examples: @sayakpaul @linoytsaban
- Docs: @stevhliu and @sayakpaul
- MPS: @pcuenca
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
