### PR TITLE
Fix ModelOpt integration for the >=0.44 list quant_cfg format

### DIFF
--- a/src/diffusers/quantizers/modelopt/modelopt_quantizer.py
+++ b/src/diffusers/quantizers/modelopt/modelopt_quantizer.py
@@ -167,8 +167,13 @@ class NVIDIAModelOptQuantizer(DiffusersQuantizer):
         if self.quantization_config.disable_conv_quantization:
             modules_to_not_convert.extend(self.get_conv_param_names(model))
 
+        # ModelOpt >= 0.44 uses a list-of-entries `quant_cfg`; older versions use a mapping.
+        quant_cfg = self.quantization_config.modelopt_config["quant_cfg"]
         for module in modules_to_not_convert:
-            self.quantization_config.modelopt_config["quant_cfg"]["*" + module + "*"] = {"enable": False}
+            if isinstance(quant_cfg, list):
+                quant_cfg.append({"quantizer_name": "*" + module + "*", "enable": False})
+            else:
+                quant_cfg["*" + module + "*"] = {"enable": False}
         self.quantization_config.modules_to_not_convert = modules_to_not_convert
         mto.apply_mode(model, mode=[("quantize", self.quantization_config.modelopt_config)])
         model.config.quantization_config = self.quantization_config

--- a/src/diffusers/quantizers/quantization_config.py
+++ b/src/diffusers/quantizers/quantization_config.py
@@ -822,7 +822,6 @@ class NVIDIAModelOptConfig(QuantizationConfigMixin):
                 "*k_bmm_quantizer": {},
                 "*v_bmm_quantizer": {},
                 "*softmax_quantizer": {},
-                **mtq.config._default_disabled_quantizer_cfg,
             },
             "algorithm": self.calib_cfg,
         }
@@ -872,6 +871,28 @@ class NVIDIAModelOptConfig(QuantizationConfigMixin):
                     }
                 )
 
+        # Splice in ModelOpt's default-disabled quantizers and emit the `quant_cfg` shape the
+        # installed ModelOpt expects. ModelOpt < 0.44 consumes a `{pattern: cfg}` mapping (and
+        # exposes its default-disabled set as one); >= 0.44 consumes a list of `{"quantizer_name":
+        # ...}` entries (and exposes the default set as a list). Key the choice off that shape. See
+        # https://nvidia.github.io/Model-Optimizer/guides/_quant_cfg.html
+        default_disabled_quantizer_cfg = mtq.config._default_disabled_quantizer_cfg
+        if isinstance(default_disabled_quantizer_cfg, dict):
+            quant_cfg.update(default_disabled_quantizer_cfg)
+            return BASE_CONFIG
+
+        entries = []
+        for k in quant_cfg:
+            entry = {"quantizer_name": k}
+            if "enable" in quant_cfg[k]:
+                entry["enable"] = quant_cfg[k].pop("enable")
+            if quant_cfg[k]:
+                entry["cfg"] = quant_cfg[k]
+            elif "enable" not in entry:
+                entry["enable"] = True
+            entries.append(entry)
+        entries.extend(default_disabled_quantizer_cfg)
+        BASE_CONFIG["quant_cfg"] = entries
         return BASE_CONFIG
 
 

--- a/tests/quantization/modelopt/test_modelopt.py
+++ b/tests/quantization/modelopt/test_modelopt.py
@@ -1,0 +1,88 @@
+# coding=utf-8
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+from diffusers import NVIDIAModelOptConfig
+from diffusers.utils import is_nvidia_modelopt_available
+
+from ...testing_utils import (
+    is_modelopt,
+    is_quantization,
+    require_modelopt_version_greater_or_equal,
+)
+
+
+if is_nvidia_modelopt_available():
+    import modelopt.torch.quantization as mtq
+
+
+@is_quantization
+@is_modelopt
+@require_modelopt_version_greater_or_equal("0.33.1")
+class TestNVIDIAModelOptConfigQuantCfg:
+    """CPU-only regression tests for `NVIDIAModelOptConfig.get_config_from_quant_type`.
+
+    These only build the config (no model, no accelerator). Diffusers' contract is simply to build a
+    `modelopt_config` the installed ModelOpt accepts; the `quant_cfg` container shape (a mapping vs a
+    list of entries, which changed in ModelOpt 0.44) is ModelOpt's concern, so it is not asserted
+    here. This guards the regression where building the config raised `TypeError: 'list' object is
+    not a mapping` on `NVIDIAModelOptConfig(quant_type=...)`.
+    """
+
+    def _weight_quantizer_num_bits(self, quant_cfg):
+        # `quant_cfg` is a `{pattern: cfg}` mapping or a list of `{"quantizer_name": ...}` entries.
+        if isinstance(quant_cfg, dict):
+            return quant_cfg["*weight_quantizer"].get("num_bits")
+        entry = next(e for e in quant_cfg if e["quantizer_name"] == "*weight_quantizer")
+        return entry.get("cfg", {}).get("num_bits")
+
+    @pytest.mark.parametrize(
+        "init_kwargs, weight_num_bits",
+        [
+            ({"quant_type": "FP8"}, (4, 3)),
+            ({"quant_type": "INT8"}, 8),
+            ({"quant_type": "FP8_FP8"}, (4, 3)),
+            ({"quant_type": "FP8", "weight_only": False}, (4, 3)),
+            (
+                {
+                    "quant_type": "NVFP4",
+                    "block_quantize": 128,
+                    "channel_quantize": -1,
+                    "scale_block_quantize": 8,
+                    "scale_channel_quantize": -1,
+                    "modules_to_not_convert": ["conv"],
+                },
+                (2, 1),
+            ),
+            (
+                {
+                    "quant_type": "INT4",
+                    "block_quantize": 128,
+                    "channel_quantize": -1,
+                    "disable_conv_quantization": True,
+                },
+                4,
+            ),
+        ],
+    )
+    def test_quant_cfg_is_accepted_by_modelopt(self, init_kwargs, weight_num_bits):
+        modelopt_config = NVIDIAModelOptConfig(**init_kwargs).modelopt_config
+        # Diffusers builds the weight quantizer at the requested bit-width ...
+        assert self._weight_quantizer_num_bits(modelopt_config["quant_cfg"]) == weight_num_bits
+        # ... and the whole config must be consumable by the installed ModelOpt (what `mto.apply_mode`
+        # relies on), whatever `quant_cfg` container shape that ModelOpt uses.
+        mtq.config.QuantizeConfig(**modelopt_config)


### PR DESCRIPTION

# What does this PR do?

Fixes https://github.com/NVIDIA/Model-Optimizer/issues/2001

ModelOpt 0.44 changed `quant_cfg` and `mtq.config._default_disabled_quantizer_cfg` from a `{pattern: cfg}` mapping to a list of `{"quantizer_name": ...}` entries. `NVIDIAModelOptConfig.get_config_from_quant_type` spread the default-disabled set into a dict literal, so on ModelOpt >=0.44 building the config raised `TypeError: 'list' object is not a mapping` — hitting the default `NVIDIAModelOptConfig(quant_type=...)` path.

Emit `quant_cfg` in whichever shape the installed ModelOpt expects, keyed off the shape ModelOpt exposes for its default-disabled set: a mapping for <0.44 (unchanged behavior) and the native list of entries for >=0.44 (no deprecation warning). The `modules_to_not_convert` loop in the quantizer appends a list entry or assigns a mapping key accordingly.

Add a CPU-only regression test that builds the config across quant types and checks the installed ModelOpt accepts it — the existing GPU tests are nightly/big-accelerator gated, so this config-construction crash slipped through CI.

# Self-review — Fix ModelOpt integration for the >=0.44 list quant_cfg format

Scope: `src/diffusers/quantizers/quantization_config.py`, `src/diffusers/quantizers/modelopt/modelopt_quantizer.py`, `tests/quantization/modelopt/{__init__.py,test_modelopt.py}`.

## Blocking issues
**None.** The fix is correct on both supported ModelOpt eras — verified by running the new test against real **0.43.0** (dict branch) and **0.45.0** (list branch), 6/6 each. The `<0.44` dict path is byte-for-byte identical to the pre-fix code (checked against the original method extracted from git).

## Non-blocking issues
1. **One-caller test helper — inline candidate.** `_weight_quantizer_num_bits` (`tests/quantization/modelopt/test_modelopt.py:46`) has a single caller. Per `.ai/AGENTS.md`: *"If a private helper has only one caller, inlining it at the call site is usually the cleaner choice."* It names a real dict-vs-list abstraction, so it's defensible; by the rule it leans toward inlining. Trivial.
2. **CPU validation via a ModelOpt-internal API (advisory for the maintainer).** The test asserts acceptance with `mtq.config.QuantizeConfig(**modelopt_config)` (`test_modelopt.py:88`) rather than a full `mto.apply_mode` on a model — a deliberate CPU-only tradeoff so the regression is caught without a GPU. Worth surfacing to the reviewer, not fixing.

## Rule checks that passed (not issues)
- **No defensive code** (`AGENTS.md`): the `isinstance(default_disabled_quantizer_cfg, dict)` branch and the `elif "enable" not in entry: entry["enable"] = True` fallback are **both reachable and tested** (dict path on 0.43; the `enable:True` case on `FP8 weight_only=False`), so they're not "just in case."
- **Ephemeral context** (`review-rules.md` §Common mistakes): all three comments state the *reason* and stand alone; the doc URL is a stable pointer. None are PR-scoped chatter.
- **Testing conventions** (`testing.md`): backend-tier config unit test mirroring the retained `TestTorchAoConfig` pattern — pytest-style, `@is_quantization`/`@is_modelopt` markers (both registered in `conftest.py`), license header. Pipeline/model tester-mixin rules don't apply. No LoRA/slow/integration added.
- **Copied code**: none of the touched code is under a `# Copied from` header.
- **Style**: `ruff check` + `ruff format --check` clean.

## Dead code (advisory)
Rubric's dead-code pass is scoped to new-model PRs — N/A here.

| path:line | status | reason |
|---|---|---|
| `quantization_config.py:880` (dict branch) | Used | exercised on ModelOpt <0.44 (verified on 0.43.0) |
| `quantization_config.py:894` (`enable:True`) | Used | `FP8 weight_only=False` param in the test |
| `modelopt_quantizer.py:173` (list append) | Used | >=0.44 `modules_to_not_convert` path |

## Documentation impact
No public API changed (behavior-restoring fix). `docs/source/en/quantization/modelopt.md` documents the public `quant_type`/`modules_to_not_convert`/… params — untouched, no staleness introduced. No agent-guide addition warranted (the dict->list gotcha is captured in the code comment + doc link).

## Summary — READY
Minimal, correct on both ModelOpt eras, lint-clean, and covered by a CPU regression test that would have caught the original `TypeError` (which the pre-existing GPU/nightly-gated tests could not).

- **Fix before submitting:** nothing required.
- **Optional polish (your call):** inline `_weight_quantizer_num_bits` (#1).
- **Leave for the actual review:** the `QuantizeConfig`-vs-`apply_mode` CPU-validation tradeoff (#2) — flag it to the maintainer rather than pre-emptively changing it.


## Before submitting
- [ x ] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [ x ] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [ x ] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [ x ] Did you share the final self-review notes in the PR description or a comment?
- [ x ] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ x ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [ x ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ x ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ x ] Did you write any new necessary tests?
- [ x ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu @dg845
- Pipelines and models: @yiyixuxu @dg845 and @asomoza
- Training examples: @sayakpaul @linoytsaban
- Docs: @stevhliu and @sayakpaul
- MPS: @pcuenca
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
