### PR TITLE
[docs] Improve navigation

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -34,7 +34,7 @@
       title: Model formats
     - local: using-diffusers/push_to_hub
       title: Sharing pipelines and models
-    title: Use diffusion pipelines
+    title: Using diffusion pipelines
   - isExpanded: false
     sections:
     - local: tutorials/using_peft_for_inference
@@ -67,7 +67,7 @@
       title: Reduce memory usage
     - local: optimization/speed-memory-optims
       title: Compiling and offloading quantized models
-    title: Inference optimization
+    title: Inference
   - isExpanded: false
     sections:
     - local: optimization/pruna
@@ -88,7 +88,7 @@
       title: ParaAttention
     - local: using-diffusers/image_quality
       title: FreeU
-    title: Community optimizations
+    title: Community methods
   - isExpanded: false
     sections:
     - local: quantization/overview

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -12,6 +12,8 @@
   sections:
   - isExpanded: false
     sections:
+    - local: using-diffusers/weighted_prompts
+      title: Prompting
     - local: using-diffusers/loading
       title: DiffusionPipeline
     - local: tutorials/autopipeline
@@ -48,8 +50,6 @@
     - local: using-diffusers/textual_inversion_inference
       title: Textual inversion
     title: Adapters and personalization
-  - local: using-diffusers/weighted_prompts
-    title: Prompting
   title: Inference
 - isExpanded: true
   sections:
@@ -127,14 +127,14 @@
     title: Hardware-specific acceleration
   - isExpanded: false
     sections:
+    - local: using-diffusers/create_a_server
+      title: Create a server
     - local: using-diffusers/batched_inference
       title: Batch inference
     - local: training/distributed_inference
       title: Distributed inference
     - local: hybrid_inference/overview
       title: Remote inference
-    - local: using-diffusers/create_a_server
-      title: Create a server
     title: Serving and scaling
   title: Optimize and scale
 - isExpanded: false
@@ -164,7 +164,7 @@
   - local: modular_diffusers/mellon
     title: Using Custom Blocks with Mellon
   title: Modular Diffusers
-- isExpanded: true
+- isExpanded: false
   sections:
   - local: training/overview
     title: Overview
@@ -211,7 +211,7 @@
   - local: training/nemo_automodel
     title: NeMo Automodel
   title: Train and fine-tune
-- isExpanded: true
+- isExpanded: false
   sections:
   - isExpanded: false
     sections:
@@ -232,6 +232,8 @@
     title: Recipes
   - isExpanded: false
     sections:
+    - local: conceptual/philosophy
+      title: Diffusers philosophy
     - local: using-diffusers/write_own_pipeline
       title: Understanding pipelines, models and schedulers
     - local: using-diffusers/controlling_generation
@@ -246,8 +248,6 @@
     title: How to contribute
   - local: conceptual/ethical_guidelines
     title: Diffusers' Ethical Guidelines
-  - local: conceptual/philosophy
-    title: Diffusers philosophy
   title: Contribute
 - isExpanded: false
   sections:

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -5,93 +5,7 @@
     title: Installation
   - local: quicktour
     title: Quickstart
-  - local: stable_diffusion
-    title: Basic performance
   title: Get started
-- isExpanded: false
-  sections:
-  - local: using-diffusers/loading
-    title: DiffusionPipeline
-  - local: tutorials/autopipeline
-    title: AutoPipeline
-  - local: using-diffusers/custom_pipeline_overview
-    title: Community pipelines and components
-  - local: using-diffusers/callback
-    title: Pipeline callbacks
-  - local: using-diffusers/reusing_seeds
-    title: Reproducibility
-  - local: using-diffusers/schedulers
-    title: Schedulers
-  - local: using-diffusers/guiders
-    title: Guiders
-  - local: using-diffusers/automodel
-    title: AutoModel
-  - local: using-diffusers/other-formats
-    title: Model formats
-  - local: using-diffusers/push_to_hub
-    title: Sharing pipelines and models
-  title: Pipelines
-- isExpanded: false
-  sections:
-  - local: tutorials/using_peft_for_inference
-    title: LoRA
-  - local: using-diffusers/ip_adapter
-    title: IP-Adapter
-  - local: using-diffusers/controlnet
-    title: ControlNet
-  - local: using-diffusers/t2i_adapter
-    title: T2I-Adapter
-  - local: using-diffusers/dreambooth
-    title: DreamBooth
-  - local: using-diffusers/textual_inversion_inference
-    title: Textual inversion
-  title: Adapters
-- isExpanded: false
-  sections:
-  - local: using-diffusers/weighted_prompts
-    title: Prompting
-  - local: using-diffusers/create_a_server
-    title: Create a server
-  - local: using-diffusers/batched_inference
-    title: Batch inference
-  - local: training/distributed_inference
-    title: Distributed inference
-  - local: hybrid_inference/overview
-    title: Remote inference
-  title: Inference
-- isExpanded: false
-  sections:
-  - local: optimization/fp16
-    title: Accelerate inference
-  - local: optimization/cache
-    title: Caching
-  - local: optimization/attention_backends
-    title: Attention backends
-  - local: optimization/memory
-    title: Reduce memory usage
-  - local: optimization/speed-memory-optims
-    title: Compiling and offloading quantized models
-  - sections:
-    - local: optimization/pruna
-      title: Pruna
-    - local: optimization/xformers
-      title: xFormers
-    - local: optimization/tome
-      title: Token merging
-    - local: optimization/deepcache
-      title: DeepCache
-    - local: optimization/cache_dit
-      title: CacheDiT
-    - local: optimization/tgate
-      title: TGATE
-    - local: optimization/xdit
-      title: xDiT
-    - local: optimization/para_attn
-      title: ParaAttention
-    - local: using-diffusers/image_quality
-      title: FreeU
-    title: Community optimizations
-  title: Inference optimization
 - isExpanded: false
   sections:
   - local: modular_diffusers/overview
@@ -121,6 +35,129 @@
   title: Modular Diffusers
 - isExpanded: false
   sections:
+  - sections:
+    - local: using-diffusers/loading
+      title: DiffusionPipeline
+    - local: tutorials/autopipeline
+      title: AutoPipeline
+    - local: using-diffusers/custom_pipeline_overview
+      title: Community pipelines and components
+    - local: using-diffusers/callback
+      title: Pipeline callbacks
+    - local: using-diffusers/reusing_seeds
+      title: Reproducibility
+    - local: using-diffusers/schedulers
+      title: Schedulers
+    - local: using-diffusers/guiders
+      title: Guiders
+    - local: using-diffusers/automodel
+      title: AutoModel
+    - local: using-diffusers/other-formats
+      title: Model formats
+    - local: using-diffusers/push_to_hub
+      title: Sharing pipelines and models
+    title: Use diffusion pipelines
+  - sections:
+    - local: tutorials/using_peft_for_inference
+      title: LoRA
+    - local: using-diffusers/ip_adapter
+      title: IP-Adapter
+    - local: using-diffusers/controlnet
+      title: ControlNet
+    - local: using-diffusers/t2i_adapter
+      title: T2I-Adapter
+    - local: using-diffusers/dreambooth
+      title: DreamBooth
+    - local: using-diffusers/textual_inversion_inference
+      title: Textual inversion
+    title: Adapters and personalization
+  - local: using-diffusers/weighted_prompts
+    title: Prompting
+  title: Inference
+- isExpanded: false
+  sections:
+  - local: stable_diffusion
+    title: Basic performance
+  - sections:
+    - local: optimization/fp16
+      title: Accelerate inference
+    - local: optimization/cache
+      title: Caching
+    - local: optimization/attention_backends
+      title: Attention backends
+    - local: optimization/memory
+      title: Reduce memory usage
+    - local: optimization/speed-memory-optims
+      title: Compiling and offloading quantized models
+    title: Inference optimization
+  - isExpanded: false
+    sections:
+    - local: optimization/pruna
+      title: Pruna
+    - local: optimization/xformers
+      title: xFormers
+    - local: optimization/tome
+      title: Token merging
+    - local: optimization/deepcache
+      title: DeepCache
+    - local: optimization/cache_dit
+      title: CacheDiT
+    - local: optimization/tgate
+      title: TGATE
+    - local: optimization/xdit
+      title: xDiT
+    - local: optimization/para_attn
+      title: ParaAttention
+    - local: using-diffusers/image_quality
+      title: FreeU
+    title: Community optimizations
+  - sections:
+    - local: quantization/overview
+      title: Getting started
+    - local: quantization/bitsandbytes
+      title: bitsandbytes
+    - local: quantization/gguf
+      title: gguf
+    - local: quantization/nunchaku
+      title: Nunchaku Lite
+    - local: quantization/torchao
+      title: torchao
+    - local: quantization/quanto
+      title: quanto
+    - local: quantization/modelopt
+      title: NVIDIA ModelOpt
+    - local: quantization/autoround
+      title: AutoRound
+    - local: quantization/sdnq
+      title: SDNQ
+    title: Quantization
+  - sections:
+    - local: optimization/onnx
+      title: ONNX
+    - local: optimization/open_vino
+      title: OpenVINO
+    - local: optimization/coreml
+      title: Core ML
+    - local: optimization/mps
+      title: Metal Performance Shaders (MPS)
+    - local: optimization/habana
+      title: Intel Gaudi
+    - local: optimization/neuron
+      title: AWS Neuron
+    title: Hardware-specific acceleration
+  - sections:
+    - local: using-diffusers/batched_inference
+      title: Batch inference
+    - local: training/distributed_inference
+      title: Distributed inference
+    - local: hybrid_inference/overview
+      title: Remote inference
+    - local: using-diffusers/create_a_server
+      title: Create a server
+    title: Serving and scaling
+  title: Optimize and scale
+- isExpanded: false
+  sections:
   - local: training/overview
     title: Overview
   - local: training/create_dataset
@@ -146,7 +183,7 @@
       title: InstructPix2Pix
     - local: training/cogvideox
       title: CogVideoX
-    title: Models
+    title: Model recipes
   - sections:
     - local: training/text_inversion
       title: Textual Inversion
@@ -160,46 +197,10 @@
       title: Latent Consistency Distillation
     - local: training/ddpo
       title: Reinforcement learning training with DDPO
-    title: Methods
+    title: Training methods
   - local: training/nemo_automodel
     title: NeMo Automodel
-  title: Training
-- isExpanded: false
-  sections:
-  - local: quantization/overview
-    title: Getting started
-  - local: quantization/bitsandbytes
-    title: bitsandbytes
-  - local: quantization/gguf
-    title: gguf
-  - local: quantization/nunchaku
-    title: Nunchaku Lite
-  - local: quantization/torchao
-    title: torchao
-  - local: quantization/quanto
-    title: quanto
-  - local: quantization/modelopt
-    title: NVIDIA ModelOpt
-  - local: quantization/autoround
-    title: AutoRound
-  - local: quantization/sdnq
-    title: SDNQ
-  title: Quantization
-- isExpanded: false
-  sections:
-  - local: optimization/onnx
-    title: ONNX
-  - local: optimization/open_vino
-    title: OpenVINO
-  - local: optimization/coreml
-    title: Core ML
-  - local: optimization/mps
-    title: Metal Performance Shaders (MPS)
-  - local: optimization/habana
-    title: Intel Gaudi
-  - local: optimization/neuron
-    title: AWS Neuron
-  title: Model accelerators and hardware
+  title: Train and fine-tune
 - isExpanded: false
   sections:
   - sections:
@@ -217,22 +218,27 @@
       title: Video generation
     - local: using-diffusers/depth2img
       title: Depth-to-image
-    title: Task recipes
-  - local: using-diffusers/write_own_pipeline
-    title: Understanding pipelines, models and schedulers
+    title: Recipes
+  - sections:
+    - local: using-diffusers/write_own_pipeline
+      title: Understanding pipelines, models and schedulers
+    - local: using-diffusers/controlling_generation
+      title: Controlled generation
+    title: Concepts and background
   - local: using-diffusers/cli
     title: Command line interface
   - local: community_projects
     title: Projects built with Diffusers
-  - local: conceptual/philosophy
-    title: Philosophy
-  - local: using-diffusers/controlling_generation
-    title: Controlled generation
+  title: Resources
+- isExpanded: false
+  sections:
   - local: conceptual/contribution
-    title: How to contribute?
+    title: How to contribute
   - local: conceptual/ethical_guidelines
     title: Diffusers' Ethical Guidelines
-  title: Resources
+  - local: conceptual/philosophy
+    title: Diffusers philosophy
+  title: Contribute
 - isExpanded: false
   sections:
   - sections:

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -5,37 +5,13 @@
     title: Installation
   - local: quicktour
     title: Quickstart
+  - local: using-diffusers/cli
+    title: Command line interface
   title: Get started
-- isExpanded: false
+- isExpanded: true
   sections:
-  - local: modular_diffusers/overview
-    title: Overview
-  - local: modular_diffusers/quickstart
-    title: Quickstart
-  - local: modular_diffusers/modular_diffusers_states
-    title: States
-  - local: modular_diffusers/pipeline_block
-    title: ModularPipelineBlocks
-  - local: modular_diffusers/sequential_pipeline_blocks
-    title: SequentialPipelineBlocks
-  - local: modular_diffusers/loop_sequential_pipeline_blocks
-    title: LoopSequentialPipelineBlocks
-  - local: modular_diffusers/auto_pipeline_blocks
-    title: AutoPipelineBlocks
-  - local: modular_diffusers/modular_pipeline
-    title: ModularPipeline
-  - local: modular_diffusers/components_manager
-    title: ComponentsManager
-  - local: modular_diffusers/auto_docstring
-    title: Auto docstring and parameter templates
-  - local: modular_diffusers/custom_blocks
-    title: Building Custom Blocks
-  - local: modular_diffusers/mellon
-    title: Using Custom Blocks with Mellon
-  title: Modular Diffusers
-- isExpanded: false
-  sections:
-  - sections:
+  - isExpanded: false
+    sections:
     - local: using-diffusers/loading
       title: DiffusionPipeline
     - local: tutorials/autopipeline
@@ -57,7 +33,8 @@
     - local: using-diffusers/push_to_hub
       title: Sharing pipelines and models
     title: Use diffusion pipelines
-  - sections:
+  - isExpanded: false
+    sections:
     - local: tutorials/using_peft_for_inference
       title: LoRA
     - local: using-diffusers/ip_adapter
@@ -74,11 +51,12 @@
   - local: using-diffusers/weighted_prompts
     title: Prompting
   title: Inference
-- isExpanded: false
+- isExpanded: true
   sections:
   - local: stable_diffusion
     title: Basic performance
-  - sections:
+  - isExpanded: false
+    sections:
     - local: optimization/fp16
       title: Accelerate inference
     - local: optimization/cache
@@ -111,7 +89,8 @@
     - local: using-diffusers/image_quality
       title: FreeU
     title: Community optimizations
-  - sections:
+  - isExpanded: false
+    sections:
     - local: quantization/overview
       title: Getting started
     - local: quantization/bitsandbytes
@@ -131,7 +110,8 @@
     - local: quantization/sdnq
       title: SDNQ
     title: Quantization
-  - sections:
+  - isExpanded: false
+    sections:
     - local: optimization/onnx
       title: ONNX
     - local: optimization/open_vino
@@ -145,7 +125,8 @@
     - local: optimization/neuron
       title: AWS Neuron
     title: Hardware-specific acceleration
-  - sections:
+  - isExpanded: false
+    sections:
     - local: using-diffusers/batched_inference
       title: Batch inference
     - local: training/distributed_inference
@@ -158,6 +139,33 @@
   title: Optimize and scale
 - isExpanded: false
   sections:
+  - local: modular_diffusers/overview
+    title: Overview
+  - local: modular_diffusers/quickstart
+    title: Quickstart
+  - local: modular_diffusers/modular_diffusers_states
+    title: States
+  - local: modular_diffusers/pipeline_block
+    title: ModularPipelineBlocks
+  - local: modular_diffusers/sequential_pipeline_blocks
+    title: SequentialPipelineBlocks
+  - local: modular_diffusers/loop_sequential_pipeline_blocks
+    title: LoopSequentialPipelineBlocks
+  - local: modular_diffusers/auto_pipeline_blocks
+    title: AutoPipelineBlocks
+  - local: modular_diffusers/modular_pipeline
+    title: ModularPipeline
+  - local: modular_diffusers/components_manager
+    title: ComponentsManager
+  - local: modular_diffusers/auto_docstring
+    title: Auto docstring and parameter templates
+  - local: modular_diffusers/custom_blocks
+    title: Building Custom Blocks
+  - local: modular_diffusers/mellon
+    title: Using Custom Blocks with Mellon
+  title: Modular Diffusers
+- isExpanded: true
+  sections:
   - local: training/overview
     title: Overview
   - local: training/create_dataset
@@ -166,7 +174,8 @@
     title: Adapt a model to a new task
   - local: tutorials/basic_training
     title: Train a diffusion model
-  - sections:
+  - isExpanded: false
+    sections:
     - local: training/unconditional_training
       title: Unconditional image generation
     - local: training/text2image
@@ -184,7 +193,8 @@
     - local: training/cogvideox
       title: CogVideoX
     title: Model recipes
-  - sections:
+  - isExpanded: false
+    sections:
     - local: training/text_inversion
       title: Textual Inversion
     - local: training/dreambooth
@@ -201,9 +211,10 @@
   - local: training/nemo_automodel
     title: NeMo Automodel
   title: Train and fine-tune
-- isExpanded: false
+- isExpanded: true
   sections:
-  - sections:
+  - isExpanded: false
+    sections:
     - local: using-diffusers/unconditional_image_generation
       title: Unconditional image generation
     - local: using-diffusers/conditional_image_generation
@@ -219,14 +230,13 @@
     - local: using-diffusers/depth2img
       title: Depth-to-image
     title: Recipes
-  - sections:
+  - isExpanded: false
+    sections:
     - local: using-diffusers/write_own_pipeline
       title: Understanding pipelines, models and schedulers
     - local: using-diffusers/controlling_generation
       title: Controlled generation
     title: Concepts and background
-  - local: using-diffusers/cli
-    title: Command line interface
   - local: community_projects
     title: Projects built with Diffusers
   title: Resources

--- a/docs/source/en/training/dreambooth.md
+++ b/docs/source/en/training/dreambooth.md
@@ -14,6 +14,8 @@ specific language governing permissions and limitations under the License.
 
 [DreamBooth](https://huggingface.co/papers/2208.12242) is a training technique that updates the entire diffusion model by training on just a few images of a subject or style. It works by associating a special word in the prompt with the example images.
 
+To load a trained checkpoint for inference, see [Load a DreamBooth adapter for inference](../using-diffusers/dreambooth).
+
 If you're training on a GPU with limited vRAM, you should try enabling the `gradient_checkpointing` and `mixed_precision` parameters in the training command. You can also reduce your memory footprint by using memory-efficient attention with [xFormers](../optimization/xformers).
 
 This guide will explore the [train_dreambooth.py](https://github.com/huggingface/diffusers/blob/main/examples/dreambooth/train_dreambooth.py) script to help you become more familiar with it, and how you can adapt it for your own use-case.

--- a/docs/source/en/training/text_inversion.md
+++ b/docs/source/en/training/text_inversion.md
@@ -14,6 +14,8 @@ specific language governing permissions and limitations under the License.
 
 [Textual Inversion](https://hf.co/papers/2208.01618) is a training technique for personalizing image generation models with just a few example images of what you want it to learn. This technique works by learning and updating the text embeddings (the new embeddings are tied to a special word you must use in the prompt) to match the example images you provide.
 
+For inference with trained embeddings, see [Textual inversion inference](../using-diffusers/textual_inversion_inference).
+
 If you're training on a GPU with limited vRAM, you should try enabling the `gradient_checkpointing` and `mixed_precision` parameters in the training command. You can also reduce your memory footprint by using memory-efficient attention with [xFormers](../optimization/xformers).
 
 This guide will explore the [textual_inversion.py](https://github.com/huggingface/diffusers/blob/main/examples/textual_inversion/textual_inversion.py) script to help you become more familiar with it, and how you can adapt it for your own use-case.

--- a/docs/source/en/using-diffusers/dreambooth.md
+++ b/docs/source/en/using-diffusers/dreambooth.md
@@ -16,6 +16,8 @@ specific language governing permissions and limitations under the License.
 
 DreamBooth checkpoints are typically a few GBs in size because it contains the full model weights.
 
+To train one, see [Train DreamBooth](../training/dreambooth).
+
 Load the DreamBooth checkpoint with [`~DiffusionPipeline.from_pretrained`] and include the unique identifier in the prompt to activate its generation.
 
 ```py

--- a/docs/source/en/using-diffusers/textual_inversion_inference.md
+++ b/docs/source/en/using-diffusers/textual_inversion_inference.md
@@ -16,6 +16,8 @@ specific language governing permissions and limitations under the License.
 
 Textual Inversion weights are very lightweight and typically only a few KBs because they're only word embeddings. However, this also means the word embeddings need to be loaded after loading a model with [`~DiffusionPipeline.from_pretrained`].
 
+To train embeddings, see [Train textual inversion](../training/text_inversion).
+
 ```py
 import torch
 from diffusers import AutoPipelineForText2Image


### PR DESCRIPTION
Reorganizes the navigation around user intent more, at a high-level:

```md
Get started
Inference
Optimize and scale
Modular Diffusers
Train and fine-tune
Resources
Contribute
API
```

- Group pipeline, adapter, and prompting content together under Inference
- Group performance, optimization, quantization, hardware acceleration, and serving under Optimize and scale
  - Refactor the [Basic performance](https://huggingface.co/docs/diffusers/main/en/stable_diffusion) doc as an overview
- Rename and regroup training subsections into Model recipes and Training methods
- Split Resources from Contribute for better discovery