### PR TITLE
[train_t2i_adapter_sdxl.py] Fix the LR scheduler when num_train_epochs is passed in a distributed training env

### DIFF
--- a/examples/t2i_adapter/test_t2i_adapter.py
+++ b/examples/t2i_adapter/test_t2i_adapter.py
@@ -49,3 +49,22 @@ class TestT2IAdapter(ExamplesTestsAccelerate):
             run_command(self._launch_args + test_args)
 
             assert os.path.isfile(os.path.join(tmpdir, "diffusion_pytorch_model.safetensors"))
+
+    def test_t2i_adapter_sdxl_num_train_epochs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_args = f"""
+            examples/t2i_adapter/train_t2i_adapter_sdxl.py
+            --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-xl-pipe
+            --adapter_model_name_or_path=hf-internal-testing/tiny-adapter
+            --dataset_name=hf-internal-testing/fill10
+            --output_dir={tmpdir}
+            --resolution=64
+            --train_batch_size=1
+            --gradient_accumulation_steps=1
+            --num_train_epochs=1
+            --checkpointing_steps=2
+            """.split()
+
+            run_command(self._launch_args + test_args)
+
+            assert os.path.isfile(os.path.join(tmpdir, "diffusion_pytorch_model.safetensors"))

--- a/examples/t2i_adapter/train_t2i_adapter_sdxl.py
+++ b/examples/t2i_adapter/train_t2i_adapter_sdxl.py
@@ -1080,17 +1080,22 @@ def main(args):
     )
 
     # Scheduler and math around the number of training steps.
-    overrode_max_train_steps = False
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    # Check the PR https://github.com/huggingface/diffusers/pull/8312 for detailed explanation.
+    num_warmup_steps_for_scheduler = args.lr_warmup_steps * accelerator.num_processes
     if args.max_train_steps is None:
-        args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
-        overrode_max_train_steps = True
+        len_train_dataloader_after_sharding = math.ceil(len(train_dataloader) / accelerator.num_processes)
+        num_update_steps_per_epoch = math.ceil(len_train_dataloader_after_sharding / args.gradient_accumulation_steps)
+        num_training_steps_for_scheduler = (
+            args.num_train_epochs * num_update_steps_per_epoch * accelerator.num_processes
+        )
+    else:
+        num_training_steps_for_scheduler = args.max_train_steps * accelerator.num_processes
 
     lr_scheduler = get_scheduler(
         args.lr_scheduler,
         optimizer=optimizer,
-        num_warmup_steps=args.lr_warmup_steps,
-        num_training_steps=args.max_train_steps,
+        num_warmup_steps=num_warmup_steps_for_scheduler,
+        num_training_steps=num_training_steps_for_scheduler,
         num_cycles=args.lr_num_cycles,
         power=args.lr_power,
     )
@@ -1102,8 +1107,14 @@ def main(args):
 
     # We need to recalculate our total training steps as the size of the training dataloader may have changed.
     num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
-    if overrode_max_train_steps:
+    if args.max_train_steps is None:
         args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
+        if num_training_steps_for_scheduler != args.max_train_steps * accelerator.num_processes:
+            logger.warning(
+                f"The length of the 'train_dataloader' after 'accelerator.prepare' ({len(train_dataloader)}) does not match "
+                f"the expected length ({len_train_dataloader_after_sharding}) when the learning rate scheduler was created. "
+                f"This inconsistency may result in the learning rate scheduler not functioning properly."
+            )
     # Afterwards we recalculate our number of training epochs
     args.num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
 


### PR DESCRIPTION
Fixes #8384

Follow-up to #14527 and #14528, still one script. This PR updates `examples/t2i_adapter/train_t2i_adapter_sdxl.py`.

### What was wrong

When `--num_train_epochs` is used, `train_t2i_adapter_sdxl.py` built the LR schedule from the unsharded dataloader and ignored `accelerator.num_processes`, resulting in mismatched warmup and total training steps across distributed environments.

### What changed

Applies the #8312 pattern already established across the DreamBooth, ControlNet, and Text-to-Image trainers:

- Warmup and training steps passed to `get_scheduler` are scaled by `accelerator.num_processes`.
- Step counts used to build the schedule account for the sharded dataloader length (`math.ceil(len(train_dataloader) / accelerator.num_processes)`).
- After `accelerator.prepare`, a warning is logged if the prepared dataloader length deviates from that expectation.
- Added `test_t2i_adapter_sdxl_num_train_epochs` in `examples/t2i_adapter/test_t2i_adapter.py` to cover the `--num_train_epochs` path.

### Coordination

Covered by the ongoing community tracker #8384. cc @sayakpaul @geniuspatrick

### Minimal training command using `num_train_epochs`

```bash
export MODEL_DIR="stabilityai/stable-diffusion-xl-base-1.0"
export OUTPUT_DIR="sdxl-t2i-adapter-model"

accelerate launch train_t2i_adapter_sdxl.py \
  --pretrained_model_name_or_path=$MODEL_DIR \
  --output_dir=$OUTPUT_DIR \
  --dataset_name=fusing/fill50k \
  --mixed_precision="fp16" \
  --resolution=1024 \
  --learning_rate=1e-5 \
  --num_train_epochs=2 \
  --train_batch_size=1 \
  --gradient_accumulation_steps=4 \
  --seed=42
```

### Tests I ran

```bash
pytest examples/t2i_adapter/test_t2i_adapter.py
python3 -m py_compile examples/t2i_adapter/train_t2i_adapter_sdxl.py examples/t2i_adapter/test_t2i_adapter.py
ruff check examples/t2i_adapter/train_t2i_adapter_sdxl.py examples/t2i_adapter/test_t2i_adapter.py
ruff format --check examples/t2i_adapter/train_t2i_adapter_sdxl.py examples/t2i_adapter/test_t2i_adapter.py
```

All passed (`2 passed in 84.45s`).