### PR TITLE
docs: fix 14 typos in docs, comments and docstrings

### DIFF
--- a/docs/source/en/api/pipelines/bria_fibo.md
+++ b/docs/source/en/api/pipelines/bria_fibo.md
@@ -16,7 +16,7 @@ Text-to-image models have mastered imagination - but not control. FIBO changes t
 
 FIBO is trained on structured JSON captions up to 1,000+ words and designed to understand and control different visual parameters such as lighting, composition, color, and camera settings, enabling precise and reproducible outputs.
 
-With only 8 billion parameters, FIBO provides a new level of image quality, prompt adherence and proffesional control.
+With only 8 billion parameters, FIBO provides a new level of image quality, prompt adherence and professional control.
 
 FIBO is trained exclusively on a structured prompt and will not work with freeform text prompts.
 you can use the [FIBO-VLM-prompt-to-JSON](https://huggingface.co/briaai/FIBO-VLM-prompt-to-JSON) model or the [FIBO-gemini-prompt-to-JSON](https://huggingface.co/briaai/FIBO-gemini-prompt-to-JSON)  to convert your freeform text prompt to a structured JSON prompt.

--- a/docs/source/en/api/pipelines/wan.md
+++ b/docs/source/en/api/pipelines/wan.md
@@ -531,7 +531,7 @@ export_to_video(output, "animated_advanced.mp4", fps=30)
 
 - Try lower `shift` values (`2.0` to `5.0`) for lower resolution videos and higher `shift` values (`7.0` to `12.0`) for higher resolution images.
 
-- Wan 2.1 and 2.2 support using [LightX2V LoRAs](https://huggingface.co/Kijai/WanVideo_comfy/tree/main/Lightx2v) to speed up inference. Using them on Wan 2.2 is slightly more involed. Refer to [this code snippet](https://github.com/huggingface/diffusers/pull/12040#issuecomment-3144185272) to learn more.
+- Wan 2.1 and 2.2 support using [LightX2V LoRAs](https://huggingface.co/Kijai/WanVideo_comfy/tree/main/Lightx2v) to speed up inference. Using them on Wan 2.2 is slightly more involved. Refer to [this code snippet](https://github.com/huggingface/diffusers/pull/12040#issuecomment-3144185272) to learn more.
 
 - Wan 2.2 has two denoisers. By default, LoRAs are only loaded into the first denoiser. One can set `load_into_transformer_2=True` to load LoRAs into the second denoiser. Refer to [this](https://github.com/huggingface/diffusers/pull/12074#issue-3292620048) and [this](https://github.com/huggingface/diffusers/pull/12074#issuecomment-3155896144) examples to learn more.
 

--- a/docs/source/en/optimization/memory.md
+++ b/docs/source/en/optimization/memory.md
@@ -156,7 +156,7 @@ pipeline = StableDiffusionXLPipeline.from_pretrained(
 )
 ```
 
-Diffusers uses the maxmium memory of all devices by default, but if they don't fit on the GPUs, then you'll need to use a single GPU and offload to the CPU with the methods below.
+Diffusers uses the maximum memory of all devices by default, but if they don't fit on the GPUs, then you'll need to use a single GPU and offload to the CPU with the methods below.
 
 - [`~DiffusionPipeline.enable_model_cpu_offload`] only works on a single GPU but a very large model may not fit on it
 - [`~DiffusionPipeline.enable_sequential_cpu_offload`] may work but it is extremely slow and also limited to a single GPU
@@ -470,7 +470,7 @@ apply_layerwise_casting(
 
 ## torch.channels_last
 
-[torch.channels_last](https://pytorch.org/tutorials/intermediate/memory_format_tutorial.html) flips how tensors are stored from `(batch size, channels, height, width)` to `(batch size, heigh, width, channels)`. This aligns the tensors with how the hardware sequentially accesses the tensors stored in memory and avoids skipping around in memory to access the pixel values.
+[torch.channels_last](https://pytorch.org/tutorials/intermediate/memory_format_tutorial.html) flips how tensors are stored from `(batch size, channels, height, width)` to `(batch size, height, width, channels)`. This aligns the tensors with how the hardware sequentially accesses the tensors stored in memory and avoids skipping around in memory to access the pixel values.
 
 Not all operators currently support the channels-last format and may result in worst performance, but it is still worth trying.
 

--- a/src/diffusers/guiders/magnitude_aware_guidance.py
+++ b/src/diffusers/guiders/magnitude_aware_guidance.py
@@ -35,7 +35,7 @@ class MagnitudeAwareGuidance(BaseGuidance):
             prompt, while lower values allow for more freedom in generation. Higher values may lead to saturation and
             deterioration of image quality.
         alpha (`float`, defaults to `8.0`):
-            The alpha parameter for the magnitude-aware guidance. Higher values cause more aggressive supression of
+            The alpha parameter for the magnitude-aware guidance. Higher values cause more aggressive suppression of
             guidance scale when the magnitude of the guidance update is large.
         guidance_rescale (`float`, defaults to `0.0`):
             The rescale factor applied to the noise predictions. This is used to improve image quality and fix

--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -1651,7 +1651,7 @@ class FreeNoiseTransformerBlock(nn.Module):
         #
         # The reasoning for the change here is `torch.where` became a bottleneck at some point when golfing memory
         # spikes. It is particularly noticeable when the number of frames is high. My understanding is that this comes
-        # from tensors being copied - which is why we resort to spliting and concatenating here. I've not particularly
+        # from tensors being copied - which is why we resort to splitting and concatenating here. I've not particularly
         # looked into this deeply because other memory optimizations led to more pronounced reductions.
         hidden_states = torch.cat(
             [

--- a/src/diffusers/models/attention_dispatch.py
+++ b/src/diffusers/models/attention_dispatch.py
@@ -2070,7 +2070,7 @@ class SeqAllToAllDim(torch.autograd.Function):
         return (None, grad_input, None, None)
 
 
-# Below are helper functions to handle abritrary head num and abritrary sequence length for Ulysses Anything Attention.
+# Below are helper functions to handle arbitrary head num and arbitrary sequence length for Ulysses Anything Attention.
 def _maybe_pad_qkv_head(x: torch.Tensor, H: int, group: dist.ProcessGroup) -> tuple[torch.Tensor, int]:
     r"""Maybe pad the head dimension to be divisible by world_size.
     x: torch.Tensor, shape (B, S_LOCAL, H, D) H: int, original global head num return: tuple[torch.Tensor, int], padded

--- a/src/diffusers/models/transformers/transformer_ltx2.py
+++ b/src/diffusers/models/transformers/transformer_ltx2.py
@@ -975,7 +975,7 @@ class LTX2AudioVideoRotaryPosEmbed(nn.Module):
             start=shift, end=num_frames + shift, step=self.patch_size_t, dtype=torch.float32, device=device
         )
 
-        # 2. Calculate start timstamps in seconds with respect to the original spectrogram grid
+        # 2. Calculate start timestamps in seconds with respect to the original spectrogram grid
         audio_scale_factor = self.scale_factors[0]
         # Scale back to mel spectrogram space
         grid_start_mel = grid_f * audio_scale_factor
@@ -984,7 +984,7 @@ class LTX2AudioVideoRotaryPosEmbed(nn.Module):
         # Convert mel bins back into seconds
         grid_start_s = grid_start_mel * self.hop_length / self.sampling_rate
 
-        # 3. Calculate start timstamps in seconds with respect to the original spectrogram grid
+        # 3. Calculate start timestamps in seconds with respect to the original spectrogram grid
         grid_end_mel = (grid_f + self.patch_size_t) * audio_scale_factor
         grid_end_mel = (grid_end_mel + self.causal_offset - audio_scale_factor).clip(min=0)
         grid_end_s = grid_end_mel * self.hop_length / self.sampling_rate

--- a/src/diffusers/pipelines/deprecated/unidiffuser/modeling_uvit.py
+++ b/src/diffusers/pipelines/deprecated/unidiffuser/modeling_uvit.py
@@ -1068,7 +1068,7 @@ class UniDiffuserModel(ModelMixin, ConfigMixin):
 
 
         Returns:
-            `tuple`: Returns relevant parts of the model's noise prediction: the first element of the tuple is tbe VAE
+            `tuple`: Returns relevant parts of the model's noise prediction: the first element of the tuple is the VAE
             image embedding, the second element is the CLIP image embedding, and the third element is the CLIP text
             embedding.
         """

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2.py
@@ -271,7 +271,7 @@ class LTX2Pipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraLoaderMixin):
         self.vae_temporal_compression_ratio = (
             self.vae.temporal_compression_ratio if getattr(self, "vae", None) is not None else 8
         )
-        # TODO: check whether the MEL compression ratio logic here is corrct
+        # TODO: check whether the MEL compression ratio logic here is correct
         self.audio_vae_mel_compression_ratio = (
             self.audio_vae.mel_compression_ratio if getattr(self, "audio_vae", None) is not None else 4
         )

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_image2video.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_image2video.py
@@ -274,7 +274,7 @@ class LTX2ImageToVideoPipeline(DiffusionPipeline, FromSingleFileMixin, LTX2LoraL
         self.vae_temporal_compression_ratio = (
             self.vae.temporal_compression_ratio if getattr(self, "vae", None) is not None else 8
         )
-        # TODO: check whether the MEL compression ratio logic here is corrct
+        # TODO: check whether the MEL compression ratio logic here is correct
         self.audio_vae_mel_compression_ratio = (
             self.audio_vae.mel_compression_ratio if getattr(self, "audio_vae", None) is not None else 4
         )

--- a/src/diffusers/pipelines/visualcloze/pipeline_visualcloze_combined.py
+++ b/src/diffusers/pipelines/visualcloze/pipeline_visualcloze_combined.py
@@ -223,7 +223,7 @@ class VisualClozePipeline(
                     f"got {type(task_prompt)} and {type(content_prompt)}"
                 )
             if len(content_prompt) != len(task_prompt):
-                raise ValueError("`task_prompt` and `content_prompt` must have the same length whe they are lists.")
+                raise ValueError("`task_prompt` and `content_prompt` must have the same length when they are lists.")
 
             for sample in image:
                 if not isinstance(sample, list) or not isinstance(sample[0], list):

--- a/src/diffusers/pipelines/visualcloze/pipeline_visualcloze_generation.py
+++ b/src/diffusers/pipelines/visualcloze/pipeline_visualcloze_generation.py
@@ -442,7 +442,7 @@ class VisualClozeGenerationPipeline(
                     f"got {type(task_prompt)} and {type(content_prompt)}"
                 )
             if len(content_prompt) != len(task_prompt):
-                raise ValueError("`task_prompt` and `content_prompt` must have the same length whe they are lists.")
+                raise ValueError("`task_prompt` and `content_prompt` must have the same length when they are lists.")
 
             for sample in image:
                 if not isinstance(sample, list) or not isinstance(sample[0], list):


### PR DESCRIPTION
Follow-up to #14345 (merged), taking up @stevhliu's "feel free to include others here as well!" —
that PR is closed now, so these are in a separate one.

14 spelling fixes across docs, comments, and docstrings. No behavior change except that two of them
are in user-visible `ValueError` text.

## What's fixed

| Where | Fix |
|---|---|
| `docs/.../bria_fibo.md` | `proffesional` → `professional` |
| `docs/.../memory.md` | `maxmium` → `maximum`; `heigh` → `height` (in the `channels_last` tensor-shape explanation, where the wrong word makes the shape wrong) |
| `docs/.../wan.md` | typo in prose |
| `guiders/magnitude_aware_guidance.py` | `supression` → `suppression` (docstring) |
| `models/attention.py` | `spliting` → `splitting` (comment) |
| `models/attention_dispatch.py` | `abritrary` → `arbitrary` ×2 (comment) |
| `models/transformers/transformer_ltx2.py` | `timstamps` → `timestamps` ×2 (comments) |
| `pipelines/deprecated/unidiffuser/modeling_uvit.py` | `tbe` → `the` (docstring `Returns:`) |
| `pipelines/ltx2/pipeline_ltx2*.py` | `corrct` → `correct` ×2 (TODO comments) |
| `pipelines/visualcloze/pipeline_visualcloze_{combined,generation}.py` | `whe they` → `when they` ×2 — **user-visible**, inside `raise ValueError(...)` in `check_inputs` |

## Deliberately excluded

Verified and left alone, so they don't look like oversights:

- **`promt` / `scren` in `pipeline_kandinsky*.py`** — these sit inside `prompt_template` strings that
  are fed verbatim to the text encoder. Fixing the spelling would change generated output, which is a
  behavior change, not a typo fix.
- **`ANE`, `MoT`** — initialisms (Apple Neural Engine, Mixture-of-Transformers).
- **`racoon`** — appears in prompt examples whose reference images were generated with that exact
  (misspelled) prompt, so the example and the image would stop matching.
- **`Shuting Wang`** — a paper author's name.

## Validation

Rebased onto `main` @ `4e0466f3e`; the original commit cherry-picked cleanly, so all 14 sites still
exist upstream.

```
$ uvx ruff check <the 9 changed .py files>
All checks passed!

$ uvx ruff format --check <the 9 changed .py files>
9 files already formatted
```

`git diff --stat`: 12 files, +14/-14.

## Self-review (per CONTRIBUTING)

Ran the `.ai/skills/self-review` rubric against `.ai/review-rules.md`:

- **Blocking issues:** none. The diff is spelling-only; no logic, no signatures, no defaults changed.
- **`# Copied from` (AGENTS.md):** checked explicitly, because the two `visualcloze` files fix the
  *same* error string and that is the shape a copy-link usually takes. Both changed lines are inside
  `check_inputs` (`generation.py:404`, `combined.py:170`), and neither method carries a
  `# Copied from` header — the markers in those files sit on `_get_t5_prompt_embeds`,
  `_get_clip_prompt_embeds`, `_encode_vae_image`, `get_timesteps`, `_pack_latents`. So editing both
  by hand is correct here rather than fixing an upstream source and running `make fix-copies`.
- **Ephemeral context:** none added — no `# per review` style comments.
- **Documentation impact:** none. No public behavior, argument, or default changes, so no `docs/`
  updates are implied beyond the two doc typos already included.
- **Dead code analysis:** not applicable (no new model).

I could not run `python utils/check_copies.py` locally — `utils/` is outside my sparse checkout — so
the copy-link check above is the manual equivalent. CI's `check_repository_consistency` will confirm.

---

🤖 Written with [Claude Code](https://claude.com/claude-code). Every one of the 14 sites was read in
context, and the four excluded classes were each checked rather than assumed.
