### PR TITLE
[textual_inversion.py] Fix the LR scheduler when num_train_epochs is passed in a distributed training env

### DIFF
--- a/examples/textual_inversion/textual_inversion.py
+++ b/examples/textual_inversion/textual_inversion.py
@@ -771,17 +771,22 @@ def main():
         args.validation_steps = args.validation_epochs * len(train_dataset)
 
     # Scheduler and math around the number of training steps.
-    overrode_max_train_steps = False
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    # Check the PR https://github.com/huggingface/diffusers/pull/8312 for detailed explanation.
+    num_warmup_steps_for_scheduler = args.lr_warmup_steps * accelerator.num_processes
     if args.max_train_steps is None:
-        args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
-        overrode_max_train_steps = True
+        len_train_dataloader_after_sharding = math.ceil(len(train_dataloader) / accelerator.num_processes)
+        num_update_steps_per_epoch = math.ceil(len_train_dataloader_after_sharding / args.gradient_accumulation_steps)
+        num_training_steps_for_scheduler = (
+            args.num_train_epochs * num_update_steps_per_epoch * accelerator.num_processes
+        )
+    else:
+        num_training_steps_for_scheduler = args.max_train_steps * accelerator.num_processes
 
     lr_scheduler = get_scheduler(
         args.lr_scheduler,
         optimizer=optimizer,
-        num_warmup_steps=args.lr_warmup_steps * accelerator.num_processes,
-        num_training_steps=args.max_train_steps * accelerator.num_processes,
+        num_warmup_steps=num_warmup_steps_for_scheduler,
+        num_training_steps=num_training_steps_for_scheduler,
         num_cycles=args.lr_num_cycles,
     )
 
@@ -805,8 +810,14 @@ def main():
 
     # We need to recalculate our total training steps as the size of the training dataloader may have changed.
     num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
-    if overrode_max_train_steps:
+    if args.max_train_steps is None:
         args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
+        if num_training_steps_for_scheduler != args.max_train_steps * accelerator.num_processes:
+            logger.warning(
+                f"The length of the 'train_dataloader' after 'accelerator.prepare' ({len(train_dataloader)}) does not match "
+                f"the expected length ({len_train_dataloader_after_sharding}) when the learning rate scheduler was created. "
+                f"This inconsistency may result in the learning rate scheduler not functioning properly."
+            )
     # Afterwards we recalculate our number of training epochs
     args.num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
 


### PR DESCRIPTION
Fixes #8384

Fixes the LR scheduler step miscalculation in `examples/textual_inversion/textual_inversion.py` when `--num_train_epochs` is used with distributed training.

**What was wrong**
When `--max_train_steps` is None, the script computed `num_update_steps_per_epoch` from the unsharded dataloader length and set `max_train_steps = num_train_epochs * num_update_steps_per_epoch` before `accelerator.prepare`. After sharding, the effective dataloader length is `ceil(len(dataloader)/num_processes)`, so the scheduler was created with `training_steps = max_train_steps * num_processes` while the actual optimization steps were smaller. The mismatch caused the scheduler to step incorrectly and `max_train_steps` to be recomputed without the sharding guard.

**What changed**
Mirrors the fix already applied to `textual_inversion_sdxl.py` in #11557 and the pattern from #8312. Now computes `len_train_dataloader_after_sharding`, derives `num_update_steps_per_epoch` from the sharded length, and sets `num_training_steps_for_scheduler = num_train_epochs * num_update_steps_per_epoch * num_processes` (or `max_train_steps * num_processes` when provided). Introduces `num_warmup_steps_for_scheduler` and defers `max_train_steps` assignment until after `accelerator.prepare` with the warning guard when lengths do not match. One file, one script as requested in #8384.

**Coordination**
Tracks #8384. The issue lists this script as `[ ] textual_inversion.py` and says to target one script per PR and mention @sayakpaul and @geniuspatrick for review. Standing permission for this checklist item, same as the already merged siblings #14527, #14528, #14540.

**Test plan**
- `/home/adi-IL/Desktop/.gh-pr-routine/.venv/bin/python -m py_compile examples/textual_inversion/textual_inversion.py` -> py_compile OK
- `python -c "import ast; ast.parse(open('examples/textual_inversion/textual_inversion.py').read())"` -> ast parse ok
- Manual arithmetic check with dummy lengths (10/100 samples, 2/4 processes, grad_accum 1/2) confirms new `num_training_steps_for_scheduler` equals `max_train_steps * num_processes` after sharding, while the old code produced double or mismatched steps.

**Self-review notes**
Checked against `.ai/references/review-rules.md`: no new dependencies, no model or pipeline changes, preserves existing docstrings and comments, matches the sibling fix in `textual_inversion_sdxl.py:802-853`, no dead code, only the scheduler math block changed. The warning uses the same message as the sibling.

cc @sayakpaul @geniuspatrick