### PR TITLE
Fix NaN samples from DDPM fixed_large_log variance

### DIFF
--- a/src/diffusers/schedulers/scheduling_ddpm.py
+++ b/src/diffusers/schedulers/scheduling_ddpm.py
@@ -550,7 +550,10 @@ class DDPMScheduler(SchedulerMixin, ConfigMixin):
             )
             if self.variance_type == "fixed_small_log":
                 variance = self._get_variance(t, predicted_variance=predicted_variance) * variance_noise
-            elif self.variance_type == "learned_range":
+            elif self.variance_type in ("learned_range", "fixed_large_log"):
+                # `_get_variance` returns a log-space value for these types. Convert back to a
+                # standard deviation with exp(0.5 * log_var). Taking sqrt() of log(beta) for
+                # `fixed_large_log` is invalid (beta < 1) and produces NaNs.
                 variance = self._get_variance(t, predicted_variance=predicted_variance)
                 variance = torch.exp(0.5 * variance) * variance_noise
             else:

--- a/src/diffusers/schedulers/scheduling_ddpm_parallel.py
+++ b/src/diffusers/schedulers/scheduling_ddpm_parallel.py
@@ -565,7 +565,10 @@ class DDPMParallelScheduler(SchedulerMixin, ConfigMixin):
             )
             if self.variance_type == "fixed_small_log":
                 variance = self._get_variance(t, predicted_variance=predicted_variance) * variance_noise
-            elif self.variance_type == "learned_range":
+            elif self.variance_type in ("learned_range", "fixed_large_log"):
+                # `_get_variance` returns a log-space value for these types. Convert back to a
+                # standard deviation with exp(0.5 * log_var). Taking sqrt() of log(beta) for
+                # `fixed_large_log` is invalid (beta < 1) and produces NaNs.
                 variance = self._get_variance(t, predicted_variance=predicted_variance)
                 variance = torch.exp(0.5 * variance) * variance_noise
             else:

--- a/tests/schedulers/test_scheduler_ddpm.py
+++ b/tests/schedulers/test_scheduler_ddpm.py
@@ -68,6 +68,24 @@ class DDPMSchedulerTest(SchedulerCommonTest):
         assert torch.sum(torch.abs(scheduler._get_variance(487) - 0.00979)) < 1e-5
         assert torch.sum(torch.abs(scheduler._get_variance(999) - 0.02)) < 1e-5
 
+    def test_fixed_large_log_sampling_is_finite_and_matches_fixed_large(self):
+        # `fixed_large_log` stores log(beta). Sampling must use exp(0.5 * log) rather than
+        # sqrt(log(beta)), which is NaN because beta < 1. The intended scale matches `fixed_large`.
+        sample = torch.zeros((1, 2, 2, 2))
+        model_output = torch.zeros_like(sample)
+        log_scheduler = self.scheduler_classes[0](**self.get_scheduler_config(variance_type="fixed_large_log"))
+        large_scheduler = self.scheduler_classes[0](**self.get_scheduler_config(variance_type="fixed_large"))
+
+        log_output = log_scheduler.step(
+            model_output, 500, sample, generator=torch.Generator().manual_seed(0)
+        ).prev_sample
+        large_output = large_scheduler.step(
+            model_output, 500, sample, generator=torch.Generator().manual_seed(0)
+        ).prev_sample
+
+        assert torch.isfinite(log_output).all()
+        assert torch.allclose(log_output, large_output)
+
     def test_rescale_betas_zero_snr(self):
         for rescale_betas_zero_snr in [True, False]:
             self.check_over_configs(rescale_betas_zero_snr=rescale_betas_zero_snr)

--- a/tests/schedulers/test_scheduler_ddpm_parallel.py
+++ b/tests/schedulers/test_scheduler_ddpm_parallel.py
@@ -82,6 +82,24 @@ class DDPMParallelSchedulerTest(SchedulerCommonTest):
         assert torch.sum(torch.abs(scheduler._get_variance(487) - 0.00979)) < 1e-5
         assert torch.sum(torch.abs(scheduler._get_variance(999) - 0.02)) < 1e-5
 
+    def test_fixed_large_log_sampling_is_finite_and_matches_fixed_large(self):
+        # `fixed_large_log` stores log(beta). Sampling must use exp(0.5 * log) rather than
+        # sqrt(log(beta)), which is NaN because beta < 1. The intended scale matches `fixed_large`.
+        sample = torch.zeros((1, 2, 2, 2))
+        model_output = torch.zeros_like(sample)
+        log_scheduler = self.scheduler_classes[0](**self.get_scheduler_config(variance_type="fixed_large_log"))
+        large_scheduler = self.scheduler_classes[0](**self.get_scheduler_config(variance_type="fixed_large"))
+
+        log_output = log_scheduler.step(
+            model_output, 500, sample, generator=torch.Generator().manual_seed(0)
+        ).prev_sample
+        large_output = large_scheduler.step(
+            model_output, 500, sample, generator=torch.Generator().manual_seed(0)
+        ).prev_sample
+
+        assert torch.isfinite(log_output).all()
+        assert torch.allclose(log_output, large_output)
+
     def test_rescale_betas_zero_snr(self):
         for rescale_betas_zero_snr in [True, False]:
             self.check_over_configs(rescale_betas_zero_snr=rescale_betas_zero_snr)


### PR DESCRIPTION
## What this PR does

`DDPMScheduler._get_variance(..., variance_type="fixed_large_log")` (Glide max_log) returns `log(beta)`. `step()` treated that value like a linear variance and took `sqrt()`, which is NaN for `beta < 1`. The same path exists in `DDPMParallelScheduler`.

Sampling now converts log variance with `exp(0.5 * log)`, the same transform already used for `learned_range`. That is equivalent to `sqrt(beta)` / `fixed_large`, so the intended Improved-DDPM / Glide scale is restored and samples stay finite.

Fixes #14569

## Tests

- `tests/schedulers/test_scheduler_ddpm.py::DDPMSchedulerTest::test_fixed_large_log_sampling_is_finite_and_matches_fixed_large`
- `tests/schedulers/test_scheduler_ddpm_parallel.py::DDPMParallelSchedulerTest::test_fixed_large_log_sampling_is_finite_and_matches_fixed_large`

Both assert `fixed_large_log` samples are finite and match `fixed_large` at the same seed.

## Self-review

- Confirmed on current `main` with the issue reproduction: both schedulers produced NaNs at t=500 before the change.
- `_get_variance` still returns log-space values for `fixed_large_log` (Glide max_log). Only the `step()` noise scale is corrected, so callers of `_get_variance` keep the old contract.
- `batch_step_no_noise` does not add variance, so it did not need a change.
- Existing `fixed_small` / `fixed_large` / `fixed_small_log` / `learned_range` branches are unchanged.
