### PR TITLE
docs: correct stated defaults in Chroma pipeline docstrings

### DIFF
--- a/src/diffusers/pipelines/chroma/pipeline_chroma.py
+++ b/src/diffusers/pipelines/chroma/pipeline_chroma.py
@@ -628,14 +628,14 @@ class ChromaPipeline(
                 The height in pixels of the generated image. This is set to 1024 by default for the best results.
             width (`int`, *optional*, defaults to self.unet.config.sample_size * self.vae_scale_factor):
                 The width in pixels of the generated image. This is set to 1024 by default for the best results.
-            num_inference_steps (`int`, *optional*, defaults to 50):
+            num_inference_steps (`int`, *optional*, defaults to 35):
                 The number of denoising steps. More denoising steps usually lead to a higher quality image at the
                 expense of slower inference.
             sigmas (`list[float]`, *optional*):
                 Custom sigmas to use for the denoising process with schedulers which support a `sigmas` argument in
                 their `set_timesteps` method. If not defined, the default behavior when `num_inference_steps` is passed
                 will be used.
-            guidance_scale (`float`, *optional*, defaults to 3.5):
+            guidance_scale (`float`, *optional*, defaults to 5.0):
                 Guidance scale as defined in [Classifier-Free Diffusion
                 Guidance](https://huggingface.co/papers/2207.12598). `guidance_scale` is defined as `w` of equation 2.
                 of [Imagen Paper](https://huggingface.co/papers/2205.11487). Guidance scale is enabled by setting

--- a/src/diffusers/pipelines/chroma/pipeline_chroma_img2img.py
+++ b/src/diffusers/pipelines/chroma/pipeline_chroma_img2img.py
@@ -698,7 +698,7 @@ class ChromaImg2ImgPipeline(
                 Custom sigmas to use for the denoising process with schedulers which support a `sigmas` argument in
                 their `set_timesteps` method. If not defined, the default behavior when `num_inference_steps` is passed
                 will be used.
-            guidance_scale (`float`, *optional*, defaults to 3.5):
+            guidance_scale (`float`, *optional*, defaults to 5.0):
                 Guidance scale as defined in [Classifier-Free Diffusion
                 Guidance](https://huggingface.co/papers/2207.12598). `guidance_scale` is defined as `w` of equation 2.
                 of [Imagen Paper](https://huggingface.co/papers/2205.11487). Guidance scale is enabled by setting

--- a/src/diffusers/pipelines/chroma/pipeline_chroma_inpainting.py
+++ b/src/diffusers/pipelines/chroma/pipeline_chroma_inpainting.py
@@ -828,20 +828,20 @@ class ChromaInpaintPipeline(
                 with the same aspect ratio of the image and contains all masked area, and then expand that area based
                 on `padding_mask_crop`. The image and mask_image will then be cropped based on the expanded area before
                 resizing to the original image size for inpainting.
-            num_inference_steps (`int`, *optional*, defaults to 35):
+            num_inference_steps (`int`, *optional*, defaults to 28):
                 The number of denoising steps. More denoising steps usually lead to a higher quality image at the
                 expense of slower inference.
             sigmas (`List[float]`, *optional*):
                 Custom sigmas to use for the denoising process with schedulers which support a `sigmas` argument in
                 their `set_timesteps` method. If not defined, the default behavior when `num_inference_steps` is passed
                 will be used.
-            guidance_scale (`float`, *optional*, defaults to 3.5):
+            guidance_scale (`float`, *optional*, defaults to 7.0):
                 Guidance scale as defined in [Classifier-Free Diffusion
                 Guidance](https://huggingface.co/papers/2207.12598). `guidance_scale` is defined as `w` of equation 2.
                 of [Imagen Paper](https://huggingface.co/papers/2205.11487). Guidance scale is enabled by setting
                 `guidance_scale > 1`. Higher guidance scale encourages to generate images that are closely linked to
                 the text `prompt`, usually at the expense of lower image quality.
-            strength (`float, *optional*, defaults to 0.9):
+            strength (`float, *optional*, defaults to 0.6):
                 Conceptually, indicates how much to transform the reference image. Must be between 0 and 1. image will
                 be used as a starting point, adding more noise to it the larger the strength. The number of denoising
                 steps depends on the amount of noise initially added. When strength is 1, added noise will be maximum
@@ -900,7 +900,7 @@ class ChromaInpaintPipeline(
                 The list of tensor inputs for the `callback_on_step_end` function. The tensors specified in the list
                 will be passed as `callback_kwargs` argument. You will only be able to include variables listed in the
                 `._callback_tensor_inputs` attribute of your pipeline class.
-            max_sequence_length (`int` defaults to 512): Maximum sequence length to use with the `prompt`.
+            max_sequence_length (`int` defaults to 256): Maximum sequence length to use with the `prompt`.
 
         Examples:
 


### PR DESCRIPTION
Fixes #14668

Third docs PR after #14345 and #14541 (both merged).

## What's wrong

The three Chroma pipelines' `__call__` docstrings state `defaults to X` for seven parameters where
the signature uses a different value. Anyone who reads the docstring and passes the documented number
explicitly gets different behavior than omitting the argument — which is the opposite of what a
stated default is for.

Every value below was read from the corresponding `__call__` signature via AST, not inferred:

| File | `__call__` | Parameter | Docstring said | Signature |
|---|---|---|---|---|
| `pipeline_chroma.py` | `:589` | `num_inference_steps` | 50 | **35** |
| `pipeline_chroma.py` | `:589` | `guidance_scale` | 3.5 | **5.0** |
| `pipeline_chroma_img2img.py` | `:648` | `guidance_scale` | 3.5 | **5.0** |
| `pipeline_chroma_inpainting.py` | `:766` | `num_inference_steps` | 35 | **28** |
| `pipeline_chroma_inpainting.py` | `:766` | `guidance_scale` | 3.5 | **7.0** |
| `pipeline_chroma_inpainting.py` | `:766` | `strength` | 0.9 | **0.6** |
| `pipeline_chroma_inpainting.py` | `:766` | `max_sequence_length` | 512 | **256** |

The pattern looks like the docstrings were carried between the three pipelines (and from a Flux-style
ancestor) while the signatures were retuned per pipeline. Note the internal evidence that
`defaults to` really is meant to mirror the literal signature default here: in the same
`pipeline_chroma.py` docstring, `num_images_per_prompt (defaults to 1)` and
`max_sequence_length (defaults to 512)` both match their signature exactly — only these seven drifted.

Docstrings only, no behavior change.

## Correct ones left alone

Not everything the scan surfaced was wrong, and I did not touch what already agrees:
`pipeline_chroma_img2img.py`'s `num_inference_steps` (35) and `strength` (0.9) both match, as does
`max_sequence_length` (512) in `pipeline_chroma.py` and `pipeline_chroma_img2img.py`.

## How I found it, and one thing I got wrong on the way

An AST pass comparing each documented `defaults to <literal>` against the signature's actual literal
default. It reports only when both sides are comparable literals, and deliberately skips two classes
that are *not* defects: a `None` signature default whose docstring names the value resolved in the
body (intentional), and prose defaults like "defaults to the model's current device".

Worth flagging because it nearly produced a wrong entry above: my first pass used a file-wide grep for
`max_sequence_length:` and picked up `encode_prompt`'s signature (`= 512`) instead of `__call__`'s
(`= 256`), which would have made the inpainting row look correct. The table is built from
per-function AST lookups for that reason.

## Validation

```
$ uvx ruff check src/diffusers/pipelines/chroma/
All checks passed!

$ uvx ruff format --check src/diffusers/pipelines/chroma/
5 files already formatted
```

Re-running the scan over `src/diffusers/pipelines/chroma` after the change reports 0 mismatches.

`git diff --stat`: 3 files, +7/-7.

## Self-review (per CONTRIBUTING)

Ran the `.ai/skills/self-review` rubric against `.ai/review-rules.md`:

- **Blocking issues:** none. Docstring text only; no logic, signatures, or defaults changed.
- **`# Copied from`:** all three `__call__` methods checked individually — none carries a
  `# Copied from` header (the markers in these files sit on helpers like `encode_prompt` and
  `_pack_latents`), so editing the three docstrings directly is correct rather than fixing an upstream
  source and running `make fix-copies`. `utils/check_copies.py` is outside my sparse checkout, so this
  is the manual equivalent; CI's consistency check will confirm.
- **Ephemeral context:** none added.
- **Documentation impact:** this *is* the documentation fix; no `docs/` page repeats these numbers
  (checked `docs/source/en/api/pipelines/chroma.md`).
- **Dead code analysis:** not applicable.

## Not claimed

The same scan finds ~190 more `defaults to` mismatches elsewhere in `src/diffusers/`, heavily
clustered in other pipeline families (`num_inference_steps 50 → 28` in 13 files,
`guidance_scale 7.5 → 5.0` in 12, and so on). I kept this PR to one pipeline family rather than
sending a repo-wide sweep. If you'd like the rest, tell me whether you prefer them per-family or as
one batch and I'll follow up — and if you'd rather this were enforced mechanically instead, that scan
could become a `utils/` check.

---

🤖 Written with [Claude Code](https://claude.com/claude-code). All seven signature defaults were read
programmatically and the correct-already entries were verified rather than assumed.

