### PR TITLE
Clarify that LTX2 prepare_video_coords takes latent grid dims

### DIFF
--- a/src/diffusers/models/transformers/transformer_ltx2.py
+++ b/src/diffusers/models/transformers/transformer_ltx2.py
@@ -880,9 +880,9 @@ class LTX2AudioVideoRotaryPosEmbed(nn.Module):
         fps: float = 24.0,
     ) -> torch.Tensor:
         """
-        Create per-dimension bounds [inclusive start, exclusive end) for each patch with respect to the original pixel
-        space video grid (num_frames, height, width). This will ultimately have shape (batch_size, 3, num_patches, 2)
-        where
+        Create per-dimension bounds [inclusive start, exclusive end) for each patch. `num_frames`, `height` and
+        `width` describe the *latent* grid; the returned bounds are scaled by `self.scale_factors` and are therefore
+        expressed in the original pixel space. This will ultimately have shape (batch_size, 3, num_patches, 2) where
             - axis 1 (size 3) enumerates (frame, height, width) dimensions (e.g. idx 0 corresponds to frames)
             - axis 3 (size 2) stores `[start, end)` indices within each dimension
 


### PR DESCRIPTION
The summary line of `LTX2AudioVideoRotaryPosEmbed.prepare_video_coords` says the bounds are created "with respect to the original pixel space video grid (num_frames, height, width)", which reads as though `num_frames`, `height` and `width` are pixel dimensions.

They are **latent** grid dimensions. `grid_f`/`grid_h`/`grid_w` iterate them directly:

```python
grid_f = torch.arange(start=0, end=num_frames, step=self.patch_size_t, ...)
grid_h = torch.arange(start=0, end=height, step=self.patch_size, ...)
grid_w = torch.arange(start=0, end=width, step=self.patch_size, ...)
```

and `self.scale_factors` is applied only afterwards, in step 3, to convert the latent boundaries into pixel space. So the summary is right about the *output* space but ambiguous about the *inputs*.

The `Args:` entries were already correct ("Number of latent frames in the video latents", "Latent height ...") — this only rewords the summary so the two agree.

Why it matters: passing pixel dims as the summary suggests builds a grid `spatial_compression_ratio ** 2 * temporal_compression_ratio` times too large. For LTX-2.5 (32x spatial, 8x temporal) at 768x1280x121 that is 24M patches instead of 14,400, and the RoPE `freqs` multiply then tries to allocate several hundred GB:

```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 367.14 GiB
  File "src/diffusers/models/transformers/transformer_ltx2.py", line 1038, in forward
    freqs = (grid.unsqueeze(-1) * 2 - 1) * freqs
```

Docstring only; no behaviour change. `ruff check` and `ruff format --check` pass.