### PR TITLE
[kandinsky][train_text_to_image_prior.py] Fix LR scheduler when num_train_epochs is passed in a distributed training env

### DIFF
--- a/examples/kandinsky2_2/text_to_image/train_text_to_image_prior.py
+++ b/examples/kandinsky2_2/text_to_image/train_text_to_image_prior.py
@@ -692,17 +692,22 @@ def main():
     )
 
     # Scheduler and math around the number of training steps.
-    overrode_max_train_steps = False
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    # Check the PR https://github.com/huggingface/diffusers/pull/8312 for detailed explanation.
+    num_warmup_steps_for_scheduler = args.lr_warmup_steps * accelerator.num_processes
     if args.max_train_steps is None:
-        args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
-        overrode_max_train_steps = True
+        len_train_dataloader_after_sharding = math.ceil(len(train_dataloader) / accelerator.num_processes)
+        num_update_steps_per_epoch = math.ceil(len_train_dataloader_after_sharding / args.gradient_accumulation_steps)
+        num_training_steps_for_scheduler = (
+            args.num_train_epochs * num_update_steps_per_epoch * accelerator.num_processes
+        )
+    else:
+        num_training_steps_for_scheduler = args.max_train_steps * accelerator.num_processes
 
     lr_scheduler = get_scheduler(
         args.lr_scheduler,
         optimizer=optimizer,
-        num_warmup_steps=args.lr_warmup_steps * args.gradient_accumulation_steps,
-        num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
+        num_warmup_steps=num_warmup_steps_for_scheduler,
+        num_training_steps=num_training_steps_for_scheduler,
     )
 
     clip_mean = prior.clip_mean.clone()
@@ -716,8 +721,14 @@ def main():
     text_encoder.to(accelerator.device, dtype=weight_dtype)
     # We need to recalculate our total training steps as the size of the training dataloader may have changed.
     num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
-    if overrode_max_train_steps:
+    if args.max_train_steps is None:
         args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
+        if num_training_steps_for_scheduler != args.max_train_steps * accelerator.num_processes:
+            logger.warning(
+                f"The length of the 'train_dataloader' after 'accelerator.prepare' ({len(train_dataloader)}) does not match "
+                f"the expected length ({len_train_dataloader_after_sharding}) when the learning rate scheduler was created. "
+                f"This inconsistency may result in the learning rate scheduler not functioning properly."
+            )
     # Afterwards we recalculate our number of training epochs
     args.num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
 


### PR DESCRIPTION
Fixes #8384.

### What was wrong
`examples/kandinsky2_2/text_to_image/train_text_to_image_prior.py` built the LR scheduler with `num_warmup_steps=args.lr_warmup_steps * args.gradient_accumulation_steps` and `num_training_steps=args.max_train_steps * args.gradient_accumulation_steps`, and computed `max_train_steps` as `num_train_epochs * ceil(len(dataloader)/gradient_accumulation)` without sharding. In distributed training (`accelerator.num_processes > 1`) the dataloader length per process is smaller, so the scheduler saw the wrong total steps and warmup.

Same issue fixed for other trainers in #8312 and follow-ups (#8450, #9316, etc.). This file was one of the remaining unchecked items in #8384.

### What changed
Mirrored the fixed pattern from `examples/text_to_image/train_text_to_image.py`:
- `num_warmup_steps_for_scheduler = args.lr_warmup_steps * accelerator.num_processes`
- when `max_train_steps is None`, compute `len_train_dataloader_after_sharding = ceil(len(dataloader)/num_processes)`, then `num_training_steps_for_scheduler = num_epochs * ceil(len_sharded/grad_accum) * num_processes`; else `max_train_steps * num_processes`
- pass those to `get_scheduler`
- after `accelerator.prepare`, recalc `max_train_steps` when it was derived from epochs and warn if the expected sharded length does not match the actual length

Single file, single issue.

### Coordination
- Issue: https://github.com/huggingface/diffusers/issues/8384 (standing community checklist, Good second issue)
- This is the next unchecked item after prior PRs #14546, #14540, #14528, #14527, #14542. No open PR targets this file.

### Tests
- `python -m py_compile examples/kandinsky2_2/text_to_image/train_text_to_image_prior.py` -> OK
- Pattern matches already-merged sibling fixes, so `make style`/`make quality` relevant checks are limited to this single script.

### Self-review
- Chose single-file scope per the guide. Chameleon copy of the sibling fix. No drive-by refactors. No public API change. Warning branch preserves existing behavior for non-sharded case.