### PR TITLE
[train_instruct_pix2pix_sdxl.py] Fix the LR scheduler when num_train_…

### DIFF
--- a/examples/instruct_pix2pix/test_instruct_pix2pix.py
+++ b/examples/instruct_pix2pix/test_instruct_pix2pix.py
@@ -90,3 +90,23 @@ class TestInstructPix2Pix(ExamplesTestsAccelerate):
 
             # check checkpoint directories exist
             assert {x for x in os.listdir(tmpdir) if "checkpoint" in x} == {"checkpoint-6", "checkpoint-8"}
+
+    def test_instruct_pix2pix_sdxl_num_train_epochs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_args = f"""
+                examples/instruct_pix2pix/train_instruct_pix2pix_sdxl.py
+                --pretrained_model_name_or_path=hf-internal-testing/tiny-stable-diffusion-xl-pipe
+                --dataset_name=hf-internal-testing/instructpix2pix-10-samples
+                --resolution=64
+                --random_flip
+                --train_batch_size=1
+                --num_train_epochs=1
+                --checkpointing_steps=1
+                --output_dir {tmpdir}
+                --seed=0
+                --lr_warmup_steps=0
+                """.split()
+
+            run_command(self._launch_args + test_args)
+
+            assert os.path.isfile(os.path.join(tmpdir, "model_index.json"))

--- a/examples/instruct_pix2pix/train_instruct_pix2pix_sdxl.py
+++ b/examples/instruct_pix2pix/train_instruct_pix2pix_sdxl.py
@@ -951,17 +951,22 @@ def main():
     )
 
     # Scheduler and math around the number of training steps.
-    overrode_max_train_steps = False
-    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    # Check the PR https://github.com/huggingface/diffusers/pull/8312 for detailed explanation.
+    num_warmup_steps_for_scheduler = args.lr_warmup_steps * accelerator.num_processes
     if args.max_train_steps is None:
-        args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
-        overrode_max_train_steps = True
+        len_train_dataloader_after_sharding = math.ceil(len(train_dataloader) / accelerator.num_processes)
+        num_update_steps_per_epoch = math.ceil(len_train_dataloader_after_sharding / args.gradient_accumulation_steps)
+        num_training_steps_for_scheduler = (
+            args.num_train_epochs * num_update_steps_per_epoch * accelerator.num_processes
+        )
+    else:
+        num_training_steps_for_scheduler = args.max_train_steps * accelerator.num_processes
 
     lr_scheduler = get_scheduler(
         args.lr_scheduler,
         optimizer=optimizer,
-        num_warmup_steps=args.lr_warmup_steps * args.gradient_accumulation_steps,
-        num_training_steps=args.max_train_steps * args.gradient_accumulation_steps,
+        num_warmup_steps=num_warmup_steps_for_scheduler,
+        num_training_steps=num_training_steps_for_scheduler,
     )
 
     # Prepare everything with our `accelerator`.
@@ -981,8 +986,14 @@ def main():
 
     # We need to recalculate our total training steps as the size of the training dataloader may have changed.
     num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
-    if overrode_max_train_steps:
+    if args.max_train_steps is None:
         args.max_train_steps = args.num_train_epochs * num_update_steps_per_epoch
+        if num_training_steps_for_scheduler != args.max_train_steps * accelerator.num_processes:
+            logger.warning(
+                f"The length of the 'train_dataloader' after 'accelerator.prepare' ({len(train_dataloader)}) does not match "
+                f"the expected length ({len_train_dataloader_after_sharding}) when the learning rate scheduler was created. "
+                f"This inconsistency may result in the learning rate scheduler not functioning properly."
+            )
     # Afterwards we recalculate our number of training epochs
     args.num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
 


### PR DESCRIPTION
# What does this PR do?

Fixes the learning-rate scheduler setup in `examples/instruct_pix2pix/train_instruct_pix2pix_sdxl.py` when training is launched with `--num_train_epochs` in a distributed environment.

This is one script from the checklist in #8384. The scheduler was previously created from the unsharded dataloader length, so `num_training_steps` did not match the real optimization step count after `accelerator.prepare`. The change matches the #8312 pattern already applied to `train_instruct_pix2pix.py`.

Fixes #8384

Minimal training command using `--num_train_epochs`:

```bash
accelerate launch examples/instruct_pix2pix/train_instruct_pix2pix_sdxl.py \
  --pretrained_model_name_or_path hf-internal-testing/tiny-stable-diffusion-xl-pipe \
  --dataset_name hf-internal-testing/instructpix2pix-10-samples \
  --resolution 64 \
  --random_flip \
  --train_batch_size 1 \
  --num_train_epochs 1 \
  --lr_warmup_steps 0 \
  --output_dir /tmp/instruct-pix2pix-sdxl-epochs \
  --seed 0
```