### PR TITLE
Load local ModularPipeline snapshots when modular_model_index.json still names Hub ids

### DIFF
--- a/docs/source/en/modular_diffusers/modular_pipeline.md
+++ b/docs/source/en/modular_diffusers/modular_pipeline.md
@@ -165,7 +165,7 @@ ModularPipeline {
 }
 ```
 
-If you pass a repository to [`~ModularPipelineBlocks.init_pipeline`], it overrides the loading path by matching your block's components against the pipeline config in that repository (`model_index.json` or `modular_model_index.json`).
+If you pass a repository to [`~ModularPipelineBlocks.init_pipeline`], it overrides the loading path by matching your block's components against the pipeline config in that repository (`model_index.json` or `modular_model_index.json`). If that path is a local directory, components whose spec subfolder exists on disk are loaded from that directory even when `modular_model_index.json` still names a Hub id. Components missing from the directory keep the Hub id, so pointer repositories and pruned snapshots can still fetch remotely.
 
 In the example below, the `pretrained_model_name_or_path` will be updated to `"stabilityai/stable-diffusion-xl-base-1.0"`.
 

--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -1702,6 +1702,9 @@ class ModularPipeline(ConfigMixin, PushToHubMixin):
               config values, which will be saved as `modular_model_index.json` during `save_pretrained`
             - The pipeline's config dict is also used to store the pipeline blocks's class name, which will be saved as
               `_blocks_class_name` in the config dict
+            - If `pretrained_model_name_or_path` is a local directory, Hub ids in `modular_model_index.json` are
+              rewritten to that directory for components whose spec subfolder exists locally. Missing subfolders keep
+              the Hub id so pointer repositories and pruned snapshots can still load remotely.
         """
 
         if modular_config_dict is None and config_dict is None and pretrained_model_name_or_path is not None:
@@ -1783,6 +1786,22 @@ class ModularPipeline(ConfigMixin, PushToHubMixin):
                     self._component_specs[name] = component_spec
                 elif name in self._config_specs:
                     self._config_specs[name].default = value
+
+        # `modular_model_index.json` stores Hub ids even in a fully downloaded snapshot. When the caller passed a
+        # local directory, bind each from_pretrained spec to that directory if its subfolder is present. Specs whose
+        # files are missing keep their Hub id so pointer repositories and pruned snapshots still fetch remotely.
+        if pretrained_model_name_or_path is not None and os.path.isdir(pretrained_model_name_or_path):
+            for component_spec in self._component_specs.values():
+                if component_spec.default_creation_method != "from_pretrained":
+                    continue
+                spec_path = component_spec.pretrained_model_name_or_path
+                if not isinstance(spec_path, str) or os.path.isdir(spec_path):
+                    continue
+                subfolder = component_spec.subfolder
+                if not subfolder:
+                    continue
+                if os.path.isdir(os.path.join(pretrained_model_name_or_path, subfolder)):
+                    component_spec.pretrained_model_name_or_path = pretrained_model_name_or_path
 
         if len(kwargs) > 0:
             logger.warning(f"Unexpected input '{kwargs.keys()}' provided. This input will be ignored.")

--- a/tests/modular_pipelines/test_modular_pipeline_loading.py
+++ b/tests/modular_pipelines/test_modular_pipeline_loading.py
@@ -18,8 +18,8 @@ import os
 
 import torch
 
-from diffusers import AutoModel, ControlNetModel, ModularPipeline, UNet2DConditionModel
-from diffusers.modular_pipelines.modular_pipeline_utils import ComponentSpec
+from diffusers import AutoModel, ControlNetModel, DDIMScheduler, ModularPipeline, UNet2DConditionModel
+from diffusers.modular_pipelines import ComponentSpec, ModularPipelineBlocks
 
 
 class TestAutoModelLoadIdTagging:
@@ -239,3 +239,114 @@ class TestModularPipelineInitFallback:
         assert loaded_pipe.__class__.__name__ == pipe.__class__.__name__
         assert loaded_pipe._blocks.__class__.__name__ == pipe._blocks.__class__.__name__
         assert len(loaded_pipe._blocks.sub_blocks) == len(pipe._blocks.sub_blocks)
+
+
+_MISSING_HUB_ID = "org/this-repo-does-not-exist-14640"
+
+
+class _LocalSnapshotBlocks(ModularPipelineBlocks):
+    def __init__(self, component_names=("scheduler",)):
+        self._component_names = component_names
+        super().__init__()
+
+    @property
+    def expected_components(self):
+        type_hints = {"scheduler": DDIMScheduler, "unet": UNet2DConditionModel}
+        return [ComponentSpec(name, type_hints[name]) for name in self._component_names]
+
+
+def _write_modular_index(snapshot_dir, components, repo_ids=None):
+    index = {
+        "_class_name": "ModularPipeline",
+        "_diffusers_version": "0.40.0.dev0",
+        "_blocks_class_name": "ModularPipelineBlocks",
+    }
+    for name, class_name in components.items():
+        repo_id = (repo_ids or {}).get(name, _MISSING_HUB_ID)
+        index[name] = [
+            "diffusers",
+            class_name,
+            {
+                "type_hint": ["diffusers", class_name],
+                "pretrained_model_name_or_path": repo_id,
+                "subfolder": name,
+                "variant": None,
+                "revision": None,
+            },
+        ]
+    with open(os.path.join(snapshot_dir, "modular_model_index.json"), "w") as f:
+        json.dump(index, f)
+
+
+class TestLocalModularSnapshotLoading:
+    def test_init_pipeline_rewrites_hub_ids_when_subfolder_exists(self, tmp_path):
+        snapshot_dir = str(tmp_path / "snapshot")
+        os.makedirs(snapshot_dir)
+        DDIMScheduler().save_pretrained(os.path.join(snapshot_dir, "scheduler"))
+        _write_modular_index(snapshot_dir, {"scheduler": "DDIMScheduler"})
+
+        pipe = _LocalSnapshotBlocks().init_pipeline(snapshot_dir)
+
+        assert pipe._component_specs["scheduler"].pretrained_model_name_or_path == snapshot_dir
+
+        pipe.load_components(names="scheduler", local_files_only=True)
+        assert pipe.scheduler is not None
+        assert isinstance(pipe.scheduler, DDIMScheduler)
+
+    def test_constructor_rewrites_hub_ids_when_subfolder_exists(self, tmp_path):
+        snapshot_dir = str(tmp_path / "snapshot")
+        os.makedirs(snapshot_dir)
+        DDIMScheduler().save_pretrained(os.path.join(snapshot_dir, "scheduler"))
+        _write_modular_index(snapshot_dir, {"scheduler": "DDIMScheduler"})
+
+        pipe = ModularPipeline(
+            blocks=_LocalSnapshotBlocks(),
+            pretrained_model_name_or_path=snapshot_dir,
+            local_files_only=True,
+        )
+
+        assert pipe._component_specs["scheduler"].pretrained_model_name_or_path == snapshot_dir
+        pipe.load_components(names="scheduler", local_files_only=True)
+        assert pipe.scheduler is not None
+
+    def test_missing_local_subfolder_keeps_hub_id(self, tmp_path):
+        snapshot_dir = str(tmp_path / "snapshot")
+        os.makedirs(snapshot_dir)
+        _write_modular_index(snapshot_dir, {"scheduler": "DDIMScheduler"})
+
+        pipe = _LocalSnapshotBlocks().init_pipeline(snapshot_dir)
+
+        assert pipe._component_specs["scheduler"].pretrained_model_name_or_path == _MISSING_HUB_ID
+
+    def test_mixed_snapshot_rewrites_only_present_components(self, tmp_path):
+        snapshot_dir = str(tmp_path / "snapshot")
+        os.makedirs(snapshot_dir)
+        DDIMScheduler().save_pretrained(os.path.join(snapshot_dir, "scheduler"))
+        _write_modular_index(snapshot_dir, {"scheduler": "DDIMScheduler", "unet": "UNet2DConditionModel"})
+
+        pipe = _LocalSnapshotBlocks(component_names=("scheduler", "unet")).init_pipeline(snapshot_dir)
+
+        assert pipe._component_specs["scheduler"].pretrained_model_name_or_path == snapshot_dir
+        assert pipe._component_specs["unet"].pretrained_model_name_or_path == _MISSING_HUB_ID
+
+        pipe.load_components(names="scheduler", local_files_only=True)
+        assert pipe.scheduler is not None
+        assert pipe.unet is None
+
+    def test_existing_local_spec_path_is_not_overwritten(self, tmp_path):
+        other_dir = str(tmp_path / "other")
+        snapshot_dir = str(tmp_path / "snapshot")
+        os.makedirs(snapshot_dir)
+        DDIMScheduler(num_train_timesteps=50).save_pretrained(os.path.join(other_dir, "scheduler"))
+        DDIMScheduler(num_train_timesteps=1000).save_pretrained(os.path.join(snapshot_dir, "scheduler"))
+        _write_modular_index(
+            snapshot_dir,
+            {"scheduler": "DDIMScheduler"},
+            repo_ids={"scheduler": other_dir},
+        )
+
+        pipe = _LocalSnapshotBlocks().init_pipeline(snapshot_dir)
+
+        assert pipe._component_specs["scheduler"].pretrained_model_name_or_path == other_dir
+        pipe.load_components(names="scheduler", local_files_only=True)
+        assert pipe.scheduler.config.num_train_timesteps == 50


### PR DESCRIPTION
# What does this PR do?

Fixes #14640.

### Motivation

`ModularPipeline.from_pretrained(local_dir)` / `blocks.init_pipeline(local_dir)` followed by `load_components()` still resolved components against the Hub id stored in `modular_model_index.json`. A complete local snapshot of MiniMax-H3 therefore re-downloaded ~134 GB (or left components as `None` offline), even though the files were already on disk.

This is the `model_index.json` vs `modular_model_index.json` asymmetry: the standard-repo fallback already binds `repo` to the local path; the modular index is taken verbatim, including published Hub ids.

### Root cause

`ModularPipeline.__init__` copies each from_pretrained spec from `modular_model_index.json` as-is. Published checkpoints such as MiniMax-H3 write `"pretrained_model_name_or_path": "MiniMaxAI/MiniMax-H3"` into every entry. When the caller passed a local directory, those Hub ids still won, so `ComponentSpec.load()` contacted the Hub.

The `model_index.json` fallback already does the right thing:

```python
component_spec_dict = {
    "repo": pretrained_model_name_or_path,  # the local directory
    "subfolder": name,
    ...
}
```

The invariant that was missing: **if the pipeline path is a local directory and `<local_dir>/<subfolder>` exists, load that component from the directory; otherwise keep the Hub id.**

That second clause is required. Modular repos are allowed to be pointer repos (index only, weights elsewhere). Blindly rewriting every spec to the local directory would break those.

### Solution

After specs are applied from either index, if `pretrained_model_name_or_path` is a local directory, rewrite a from_pretrained spec onto that directory only when:

- the spec is not already a local path (explicit local overrides stay put, including stale-path recovery when the recorded path no longer exists)
- the spec has a non-empty `subfolder`
- `<local_dir>/<subfolder>` exists on disk

Missing subfolders keep their Hub id (pointer repos / pruned snapshots). Hub `from_pretrained("org/model")` is unchanged because `os.path.isdir("org/model")` is false.

Not done: wrapping `pin_memory`/`from_pretrained` in try/except, MiniMax-specific branches, or changing how published indexes are written. `save_pretrained(..., overwrite_modular_index=True)` remains the way to persist local references.

### Testing

Synthetic snapshot (no MiniMax weights, no GPU):

```
PYTHONPATH=src python -m pytest tests/modular_pipelines/test_modular_pipeline_loading.py::TestLocalModularSnapshotLoading -q
5 passed in 1.40s
```

Without the `__init__` change the three remapping tests fail; the two "leave Hub id / leave existing local path" tests already passed on main.

```
PYTHONPATH=src python -m pytest tests/modular_pipelines/test_modular_pipeline_loading.py -q
17 passed in 111.45s
```

```
PYTHONPATH=src python -m pytest tests/modular_pipelines/test_modular_pipelines_custom_blocks.py -q -k "not slow and not nightly"
18 passed, 2 skipped in 9.63s
```

```
ruff check src/diffusers/modular_pipelines/modular_pipeline.py tests/modular_pipelines/test_modular_pipeline_loading.py
ruff format --check src/diffusers/modular_pipelines/modular_pipeline.py tests/modular_pipelines/test_modular_pipeline_loading.py
All checks passed; 2 files already formatted
```

New coverage:

- `init_pipeline(local_dir)` with Hub ids in the index and a present `scheduler/` subfolder loads offline
- constructor path, same contract
- missing subfolder keeps the Hub id
- mixed snapshot rewrites only present components
- an existing local spec path is not overwritten by the snapshot directory

### Performance

No extra copies and no extra Hub traffic on the common path. The new branch is an `os.path.isdir` scan of already-loaded specs, only when the pipeline path is a local directory. Hub loads are unchanged. Local snapshots avoid a second download.

### Self-review

- **Blocking:** none.
- **Left for review:** English docs only (`docs/source/en/modular_diffusers/modular_pipeline.md`); the zh page was not updated. Specs remapped at init also flow into `register_components` / saved config — same as passing `pretrained_model_name_or_path` into `load_components()` today. `overwrite_modular_index=True` is still the way to retarget a save.
- **Verdict:** READY.

### Related issue

Fixes #14640

Coordination: https://github.com/huggingface/diffusers/issues/14640 (open, unassigned, no linked PR at the time of this change). Investigation comment: https://github.com/huggingface/diffusers/issues/14640#issuecomment-5458944897

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case. #14640 (investigation comment left; no maintainer ack yet — the issue was unassigned with no linked work)
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

cc @yiyixuxu @apolinario