### PR TITLE
fix component library resolution when a transformers model folder shadows a pipeline dir

### DIFF
--- a/src/diffusers/pipelines/pipeline_loading_utils.py
+++ b/src/diffusers/pipelines/pipeline_loading_utils.py
@@ -936,7 +936,11 @@ def _fetch_class_library_tuple(module):
     pipeline_dir = module_path_items[-2] if len(module_path_items) > 2 else None
 
     path = not_compiled_module.__module__.split(".")
-    is_pipeline_module = pipeline_dir in path and hasattr(pipelines, pipeline_dir)
+    # A same-named folder in another library (e.g. `transformers.models.diffusion_gemma` vs
+    # `diffusers.pipelines.diffusion_gemma`) must not count as a pipeline module.
+    is_pipeline_module = (
+        path[0] == diffusers_module.__name__ and pipeline_dir in path and hasattr(pipelines, pipeline_dir)
+    )
 
     # if library is not in LOADABLE_CLASSES, then it is a custom module.
     # Or if it's a pipeline module, then the module is inside the pipeline

--- a/tests/pipelines/test_pipeline_utils.py
+++ b/tests/pipelines/test_pipeline_utils.py
@@ -1111,3 +1111,29 @@ class TestPipelinePushToHub:
 
         # Reset repo
         delete_repo(repo_id, token=TOKEN)
+
+
+class TestFetchClassLibraryTuple:
+    def test_diffusers_model(self):
+        from diffusers import UNet2DConditionModel
+        from diffusers.pipelines.pipeline_loading_utils import _fetch_class_library_tuple
+
+        assert _fetch_class_library_tuple(UNet2DConditionModel) == ("diffusers", "UNet2DConditionModel")
+
+    def test_pipeline_module_class(self):
+        from diffusers.pipelines.deepfloyd_if import IFWatermarker
+        from diffusers.pipelines.pipeline_loading_utils import _fetch_class_library_tuple
+
+        assert _fetch_class_library_tuple(IFWatermarker) == ("deepfloyd_if", "IFWatermarker")
+
+    def test_other_library_class_shadowing_pipeline_dir(self):
+        from diffusers.pipelines.pipeline_loading_utils import _fetch_class_library_tuple
+
+        # A transformers class whose model folder shares its name with a diffusers pipeline folder
+        # (e.g. `transformers.models.diffusion_gemma` vs `diffusers.pipelines.diffusion_gemma`) must
+        # resolve to its own library, not to the pipeline folder.
+        class FakeModel:
+            pass
+
+        FakeModel.__module__ = "transformers.models.diffusion_gemma.modeling_diffusion_gemma"
+        assert _fetch_class_library_tuple(FakeModel) == ("transformers", "FakeModel")


### PR DESCRIPTION
# What does this PR do?

`_fetch_class_library_tuple` treats a component as a pipeline-module class whenever its parent folder name matches a diffusers pipeline folder, without checking the module actually lives in diffusers. A transformers class whose model folder shares a name with a diffusers pipeline folder gets the pipeline folder recorded as its library in `model_index.json`, and `from_pretrained` then fails trying to import it from `diffusers.pipelines.<name>`.

This breaks `DiffusionGemmaPipeline` save/load on main today (`transformers.models.diffusion_gemma` collides with `diffusers.pipelines.diffusion_gemma`):

```py
pipe.save_pretrained(d)  # model_index.json records ["diffusion_gemma", "DiffusionGemmaForBlockDiffusion"]
DiffusionGemmaPipeline.from_pretrained(d)
# AttributeError: module diffusers.pipelines.diffusion_gemma has no attribute DiffusionGemmaForBlockDiffusion
```

The fix requires the module path to start with the diffusers package for the pipeline-module branch. Classes genuinely defined inside a pipeline folder (e.g. `IFWatermarker`) still resolve to their pipeline dir, and unit tests cover all three resolution cases.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)?
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@sayakpaul @DN6
