### PR TITLE
Fix VaeImageProcessorLDM3D silently discarding its own constructor arguments

### DIFF
--- a/src/diffusers/image_processor.py
+++ b/src/diffusers/image_processor.py
@@ -989,7 +989,12 @@ class VaeImageProcessorLDM3D(VaeImageProcessor):
         resample: str = "lanczos",
         do_normalize: bool = True,
     ):
-        super().__init__()
+        super().__init__(
+            do_resize=do_resize,
+            vae_scale_factor=vae_scale_factor,
+            resample=resample,
+            do_normalize=do_normalize,
+        )
 
     @staticmethod
     def numpy_to_pil(images: np.ndarray) -> list[PIL.Image.Image]:

--- a/tests/others/test_image_processor.py
+++ b/tests/others/test_image_processor.py
@@ -17,7 +17,7 @@ import numpy as np
 import PIL.Image
 import torch
 
-from diffusers.image_processor import VaeImageProcessor
+from diffusers.image_processor import VaeImageProcessor, VaeImageProcessorLDM3D
 
 
 class TestImageProcessor:
@@ -306,3 +306,21 @@ class TestImageProcessor:
         assert out_np.shape == exp_np_shape, (
             f"resized image output shape '{out_np.shape}' didn't match expected shape '{exp_np_shape}'."
         )
+
+    def test_vae_image_processor_ldm3d_keeps_its_own_config(self):
+        # LDM3D's __init__ used to call super().__init__() with no arguments, so the base
+        # class's own @register_to_config wrapper re-registered its defaults over whatever
+        # LDM3D had just registered, silently discarding any non-default value passed in.
+        image_processor = VaeImageProcessorLDM3D(
+            do_resize=False, vae_scale_factor=16, resample="bilinear", do_normalize=False
+        )
+        assert image_processor.config.do_resize is False
+        assert image_processor.config.vae_scale_factor == 16
+        assert image_processor.config.resample == "bilinear"
+        assert image_processor.config.do_normalize is False
+
+        default_processor = VaeImageProcessorLDM3D()
+        assert default_processor.config.do_resize is True
+        assert default_processor.config.vae_scale_factor == 8
+        assert default_processor.config.resample == "lanczos"
+        assert default_processor.config.do_normalize is True


### PR DESCRIPTION
Fixes #14429

VaeImageProcessorLDM3D's constructor accepts do_resize, vae_scale_factor, resample, and do_normalize, but the body just calls super().__init__() with nothing. VaeImageProcessor's own __init__ is decorated with @register_to_config too, so that empty call re-runs its wrapper with the base class's own defaults for those exact four names, and register_to_config merges new values over the existing dict rather than skipping keys already set. The net effect: whatever LDM3D registered a line earlier gets clobbered right back to VaeImageProcessor's defaults before the constructor even returns.

```python
p = VaeImageProcessorLDM3D(do_resize=False, vae_scale_factor=16, resample="bilinear", do_normalize=False)
p.config.do_resize          # True, not False
p.config.vae_scale_factor   # 8, not 16
```

Two other VaeImageProcessor subclasses in this same file, IPAdapterMaskProcessor and PixArtImageProcessor, already forward their arguments explicitly to super().__init__(...), so this brings LDM3D in line with that.

Added a test alongside the rest of tests/others/test_image_processor.py that constructs the processor with all four non-default values and checks they survive, plus a defaults case for the other direction. Reverted just the source change locally to confirm the new test fails with the exact clobbering behavior described above, then restored it. Ran the full image processor and config test suites, 22 passed. ruff check and ruff format both clean on the touched files.