### PR TITLE
Do not mutate the source transformer config in SD3ControlNetModel.from_transformer

### DIFF
--- a/src/diffusers/models/controlnets/controlnet_sd3.py
+++ b/src/diffusers/models/controlnets/controlnet_sd3.py
@@ -254,8 +254,8 @@ class SD3ControlNetModel(ModelMixin, AttentionMixin, ConfigMixin, PeftAdapterMix
     def from_transformer(
         cls, transformer, num_layers=12, num_extra_conditioning_channels=1, load_weights_from_transformer=True
     ):
-        config = transformer.config
-        config["num_layers"] = num_layers or config.num_layers
+        config = dict(transformer.config)
+        config["num_layers"] = num_layers or transformer.config.num_layers
         config["extra_conditioning_channels"] = num_extra_conditioning_channels
         controlnet = cls.from_config(config)
 

--- a/tests/models/controlnets/test_models_controlnet_sd3.py
+++ b/tests/models/controlnets/test_models_controlnet_sd3.py
@@ -1,0 +1,83 @@
+# Copyright 2026 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from diffusers import SD3ControlNetModel, SD3Transformer2DModel
+
+from ...testing_utils import enable_full_determinism
+
+
+enable_full_determinism()
+
+
+def get_dummy_transformer():
+    torch.manual_seed(0)
+    return SD3Transformer2DModel(
+        sample_size=4,
+        patch_size=1,
+        in_channels=4,
+        out_channels=4,
+        num_layers=3,
+        attention_head_dim=4,
+        num_attention_heads=2,
+        caption_projection_dim=8,
+        joint_attention_dim=8,
+        pooled_projection_dim=8,
+    )
+
+
+class TestSD3ControlNetModelFromTransformer:
+    def test_from_transformer_does_not_mutate_source_config(self):
+        # Regression: `from_transformer` aliased the transformer's live config and wrote
+        # ControlNet-specific values into it, so building a ControlNet silently changed the
+        # source transformer's `num_layers` and added `extra_conditioning_channels`.
+        transformer = get_dummy_transformer()
+        config_before = dict(transformer.config)
+
+        SD3ControlNetModel.from_transformer(
+            transformer,
+            num_layers=1,
+            num_extra_conditioning_channels=2,
+            load_weights_from_transformer=False,
+        )
+
+        assert dict(transformer.config) == config_before, (
+            "`from_transformer` must not modify the source transformer's config."
+        )
+
+    def test_from_transformer_applies_controlnet_config(self):
+        transformer = get_dummy_transformer()
+
+        controlnet = SD3ControlNetModel.from_transformer(
+            transformer,
+            num_layers=1,
+            num_extra_conditioning_channels=2,
+            load_weights_from_transformer=False,
+        )
+
+        assert controlnet.config.num_layers == 1
+        assert controlnet.config.extra_conditioning_channels == 2
+
+    def test_from_transformer_num_layers_falls_back_to_transformer(self):
+        transformer = get_dummy_transformer()
+
+        controlnet = SD3ControlNetModel.from_transformer(
+            transformer,
+            num_layers=None,
+            num_extra_conditioning_channels=1,
+            load_weights_from_transformer=False,
+        )
+
+        assert controlnet.config.num_layers == transformer.config.num_layers


### PR DESCRIPTION
> **Issue link:** this addresses **Issue 4** of #13611.
> I have deliberately not used a `Fixes` keyword: #13611 tracks 6 separate findings, so a closing keyword would close it as soon as this one merges while the others are still open. Happy for the `no-issue-needed` label to be applied, or I can add a closing keyword if you would rather the review issue be closed and reopened.

# What does this PR do?

Fixes Issue 4 of #13611 (`stable_diffusion_3` model/pipeline review).

`SD3ControlNetModel.from_transformer` bound `config = transformer.config`, which aliases the transformer's **live** config, and then wrote ControlNet-specific values into it. Building a ControlNet therefore mutated the transformer it was built from.

Reproduced on `main`:

```
before: num_layers = 3 | has extra_conditioning_channels = False
after : num_layers = 1 | extra_conditioning_channels = 2
```

The source transformer's `num_layers` is overwritten and an unrelated `extra_conditioning_channels` key is injected, which can corrupt later serialization, logging, or any pipeline construction that reuses that transformer.

## Solution

Copy the config before mutating it — which is what the sibling ControlNets already do:

| Model | |
| --- | --- |
| `controlnet_flux.py:135` | `config = dict(transformer.config)` |
| `controlnet_qwenimage.py:113` | `config = dict(transformer.config)` |
| **`controlnet_sd3.py:257`** | **`config = transformer.config`** ← fixed here |

```python
config = dict(transformer.config)
config["num_layers"] = num_layers or transformer.config.num_layers
```

The `num_layers` fallback now reads from `transformer.config` rather than the copied dict, since a plain dict has no attribute access.

I also checked `controlnet_hunyuan.py:177`, which binds the config the same way but only ever reads attributes from it and never writes, so it is not affected and is left alone.

## Testing

New `tests/models/controlnets/test_models_controlnet_sd3.py`:

- `test_from_transformer_does_not_mutate_source_config` — the regression itself
- `test_from_transformer_applies_controlnet_config` — the overrides still reach the ControlNet
- `test_from_transformer_num_layers_falls_back_to_transformer` — covers the `num_layers=None` path, which the rewritten fallback touches

Verified the regression test actually catches the bug: with the fix reverted it fails, with it applied it passes.

```
pytest tests/models/controlnets/test_models_controlnet_sd3.py   -> 3 passed
pytest tests/pipelines/controlnet_sd3/                          -> all passed
ruff check / ruff format --check                                -> clean
git diff --check                                                -> clean
```

Note: `tests/models/controlnets/test_models_controlnet_cosmos.py` has 7 failures, but they reproduce identically on a clean checkout of `main` here, so they are unrelated to this change.

## Before submitting

- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Was this discussed/approved via a GitHub issue? — #13611
- [x] Did you write any new necessary tests?

## Self-review notes

Reviewed against `.ai/references/review-rules.md`, `models.md` and `testing.md`. **No blocking issues.**

**For the reviewer:**

1. `tests/models/controlnets/` previously held only the Cosmos file, and there were no `from_transformer` tests anywhere in the suite. I added a small focused file rather than wiring up the full `BaseModelTesterConfig` mixin suite, which felt like scope creep for a one-line fix — happy to expand it if you'd rather it be a full model tester.
2. Scope kept to Issue 4. #13611 lists six issues; Issue 1 is in #14671, and the rest are untouched.
3. This is behaviour-preserving for the returned ControlNet — only the side effect on the source transformer changes.

## Who can review?

@yiyixuxu @DN6 @hlky
