### PR TITLE
Fix controlnet_pooled_projections tensor handling in SD3 ControlNet pipelines

### DIFF
--- a/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet.py
+++ b/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet.py
@@ -1137,8 +1137,8 @@ class StableDiffusion3ControlNetPipeline(
         if controlnet_config.force_zeros_for_pooled_projection:
             # instantx sd3 controlnet used zero pooled projection
             controlnet_pooled_projections = torch.zeros_like(pooled_prompt_embeds)
-        else:
-            controlnet_pooled_projections = controlnet_pooled_projections or pooled_prompt_embeds
+        elif controlnet_pooled_projections is None:
+            controlnet_pooled_projections = pooled_prompt_embeds
 
         if controlnet_config.joint_attention_dim is not None:
             controlnet_encoder_hidden_states = prompt_embeds

--- a/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet_inpainting.py
+++ b/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet_inpainting.py
@@ -1269,8 +1269,6 @@ class StableDiffusion3ControlNetInpaintingPipeline(
 
         if controlnet_pooled_projections is None:
             controlnet_pooled_projections = torch.zeros_like(pooled_prompt_embeds)
-        else:
-            controlnet_pooled_projections = controlnet_pooled_projections or pooled_prompt_embeds
 
         # 4. Prepare timesteps
         if XLA_AVAILABLE:

--- a/tests/pipelines/controlnet_sd3/test_controlnet_sd3.py
+++ b/tests/pipelines/controlnet_sd3/test_controlnet_sd3.py
@@ -212,6 +212,36 @@ class TestStableDiffusion3ControlNetPipeline(StableDiffusion3ControlNetPipelineT
         # fmt: on
         self._run_and_check_slice(components, expected_slice)
 
+    def test_controlnet_pooled_projections_accepts_tensor(self):
+        # Regression: when the ControlNet does not force zeroed pooled projections, the pipeline
+        # resolved this argument with `controlnet_pooled_projections or pooled_prompt_embeds`.
+        # `or` takes the truthiness of the tensor, which raises "Boolean value of Tensor with more
+        # than one value is ambiguous" for any real pooled projection. See huggingface/diffusers#9686.
+        components = self.get_dummy_components()
+        torch.manual_seed(0)
+        components["controlnet"] = SD3ControlNetModel(
+            sample_size=32,
+            patch_size=1,
+            in_channels=8,
+            num_layers=1,
+            attention_head_dim=8,
+            num_attention_heads=4,
+            joint_attention_dim=32,
+            caption_projection_dim=32,
+            pooled_projection_dim=64,
+            out_channels=8,
+            qk_norm="rms_norm",
+            force_zeros_for_pooled_projection=False,
+        )
+        pipe = self.get_pipeline(**components).to(torch_device, dtype=torch.float32)
+
+        inputs = self.get_dummy_inputs()
+        inputs["controlnet_pooled_projections"] = torch.zeros((1, 64), device=torch_device)
+
+        image = pipe(**inputs).images
+
+        assert image.shape == (1, *self.output_shape)
+
 
 class TestStableDiffusion3ControlNetPipelineMemory(StableDiffusion3ControlNetPipelineTesterConfig, MemoryTesterMixin):
     """Memory optimization tests (CPU offload, group offload, layerwise casting) for the SD3 ControlNet pipeline."""


### PR DESCRIPTION
> **Issue link:** this addresses **Issue 3** of #13611.
> I have deliberately not used a `Fixes` keyword: #13611 tracks 6 separate findings, so a closing keyword would close it as soon as this one merges while the others are still open. Happy for the `no-issue-needed` label to be applied, or I can add a closing keyword if you would rather the review issue be closed and reopened.

# What does this PR do?

Fixes Issue 3 of #13611, which is also reported independently as #9686.

Both SD3 ControlNet pipelines resolve the public `controlnet_pooled_projections` argument with:

```python
controlnet_pooled_projections = controlnet_pooled_projections or pooled_prompt_embeds
```

`or` evaluates the **truthiness** of the left operand, so passing any real pooled projection raises:

```
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```

The documented argument is therefore unusable on that path.

## Solution

**`pipeline_stable_diffusion_3_controlnet.py`** — replace the `or` with an explicit `None` check:

```python
if controlnet_config.force_zeros_for_pooled_projection:
    controlnet_pooled_projections = torch.zeros_like(pooled_prompt_embeds)
elif controlnet_pooled_projections is None:
    controlnet_pooled_projections = pooled_prompt_embeds
```

**`pipeline_stable_diffusion_3_controlnet_inpainting.py`** — here the `else` branch is guarded by `if controlnet_pooled_projections is None`, so it is only reachable when the value is *not* `None`. It could therefore only ever re-assign the value to itself or raise. Removed.

## Testing

`test_controlnet_pooled_projections_accepts_tensor` builds a ControlNet with `force_zeros_for_pooled_projection=False` — the configuration that reaches the broken branch — and passes a tensor.

Verified it catches the bug: with the fix reverted it fails with the `RuntimeError` above; with it applied it passes.

```
pytest tests/pipelines/controlnet_sd3/   -> 40 passed, 30 skipped
ruff check / ruff format --check         -> clean
git diff --check                         -> clean
```

## Before submitting

- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Was this discussed/approved via a GitHub issue? — #13611, #9686
- [x] Did you write any new necessary tests?

## Self-review notes

Reviewed against `.ai/references/review-rules.md` and `pipelines.md`. **No blocking issues.**

**For the reviewer:**

1. **The two pipelines disagree on semantics, and I deliberately did not reconcile that.** The text-to-image pipeline consults `controlnet_config.force_zeros_for_pooled_projection`; the inpainting pipeline instead zeroes whenever the argument is `None` and never consults that flag. The issue's suggested fix would apply the text-to-image logic to both, but that is a behaviour change beyond fixing the crash, so I kept each pipeline's existing semantics. Happy to align them in a follow-up if you want that.
2. Scope kept to Issue 3. Issue 1 is in #14671 and Issue 4 in #14672; the rest of #13611 is untouched.

## Who can review?

@yiyixuxu @asomoza @hlky
