### PR TITLE
Accept tensor ip_adapter_image_embeds in SD3 ControlNet inpainting

### DIFF
--- a/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet_inpainting.py
+++ b/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet_inpainting.py
@@ -777,15 +777,10 @@ class StableDiffusion3ControlNetInpaintingPipeline(
                 "Provide either `ip_adapter_image` or `ip_adapter_image_embeds`. Cannot leave both `ip_adapter_image` and `ip_adapter_image_embeds` defined."
             )
 
-        if ip_adapter_image_embeds is not None:
-            if not isinstance(ip_adapter_image_embeds, list):
-                raise ValueError(
-                    f"`ip_adapter_image_embeds` has to be of type `list` but is {type(ip_adapter_image_embeds)}"
-                )
-            elif ip_adapter_image_embeds[0].ndim not in [3, 4]:
-                raise ValueError(
-                    f"`ip_adapter_image_embeds` has to be a list of 3D or 4D tensors but is {ip_adapter_image_embeds[0].ndim}D"
-                )
+        if ip_adapter_image_embeds is not None and ip_adapter_image_embeds.ndim not in [3, 4]:
+            raise ValueError(
+                f"`ip_adapter_image_embeds` has to be a 3D or 4D tensor but is {ip_adapter_image_embeds.ndim}D"
+            )
 
     # Copied from diffusers.pipelines.stable_diffusion_3.pipeline_stable_diffusion_3.StableDiffusion3Pipeline.prepare_latents
     def prepare_latents(

--- a/tests/pipelines/controlnet_sd3/test_controlnet_inpaint_sd3.py
+++ b/tests/pipelines/controlnet_sd3/test_controlnet_inpaint_sd3.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 from transformers import (
     AutoConfig,
@@ -194,6 +195,35 @@ class TestStableDiffusion3ControlNetInpaintingPipeline(
         # fmt: on
 
         assert_tensors_close(image_slice.flatten().cpu(), expected_slice, atol=1e-2)
+
+    def _check_inputs_with_ip_adapter_embeds(self, pipe, ip_adapter_image_embeds):
+        pipe.check_inputs(
+            height=32,
+            width=32,
+            image=torch.zeros(1, 3, 32, 32),
+            prompt=None,
+            prompt_2=None,
+            prompt_3=None,
+            prompt_embeds=torch.zeros(1, 2, 32),
+            pooled_prompt_embeds=torch.zeros(1, 64),
+            ip_adapter_image_embeds=ip_adapter_image_embeds,
+            control_guidance_start=[0.0],
+            control_guidance_end=[1.0],
+        )
+
+    def test_check_inputs_accepts_ip_adapter_image_embeds_tensor(self):
+        # Regression: `check_inputs` required a `list`, but the `__call__` docstring and
+        # `prepare_ip_adapter_image_embeds` (which calls `.chunk(2)` on it) both document and use a
+        # tensor, so the documented argument could never be passed.
+        pipe = self.get_pipeline()
+
+        self._check_inputs_with_ip_adapter_embeds(pipe, torch.zeros(1, 2, 32))
+
+    def test_check_inputs_rejects_ip_adapter_image_embeds_with_bad_ndim(self):
+        pipe = self.get_pipeline()
+
+        with pytest.raises(ValueError, match="has to be a 3D or 4D tensor"):
+            self._check_inputs_with_ip_adapter_embeds(pipe, torch.zeros(1, 32))
 
 
 class TestStableDiffusion3ControlNetInpaintingPipelineMemory(


### PR DESCRIPTION
> **Issue link:** this addresses **Issue 5** of #13611.
> I have deliberately not used a `Fixes` keyword: #13611 tracks 6 separate findings, so a closing keyword would close it as soon as this one merges while the others are still open. Happy for the `no-issue-needed` label to be applied, or I can add a closing keyword if you would rather the review issue be closed and reopened.

# What does this PR do?

Fixes Issue 5 of #13611.

`StableDiffusion3ControlNetInpaintingPipeline` contradicts itself about the type of `ip_adapter_image_embeds`:

| Location | Contract |
| --- | --- |
| `__call__` docstring (L1111) | *"`torch.Tensor` … a tensor of shape `(batch_size, num_images, emb_dim)`"* |
| `prepare_ip_adapter_image_embeds` (L932) | typed `torch.Tensor \| None`, and calls `.chunk(2)` on it |
| **`check_inputs` (L780)** | **rejects anything that is not a `list`** |

So passing the documented tensor always failed validation, and precomputed IP-Adapter embeddings could not be used at all. Passing a list to satisfy `check_inputs` would then break in `prepare_ip_adapter_image_embeds`, which calls `.chunk(2)`.

The base `StableDiffusion3Pipeline` does not validate this argument in `check_inputs` at all — the list check here appears to be a leftover from the older list-based IP-Adapter API.

## Solution

Validate the tensor's rank instead of its container type:

```python
if ip_adapter_image_embeds is not None and ip_adapter_image_embeds.ndim not in [3, 4]:
    raise ValueError(
        f"`ip_adapter_image_embeds` has to be a 3D or 4D tensor but is {ip_adapter_image_embeds.ndim}D"
    )
```

## Testing

Two tests, driving `check_inputs` directly:

- `test_check_inputs_accepts_ip_adapter_image_embeds_tensor` — the documented 3D tensor now passes
- `test_check_inputs_rejects_ip_adapter_image_embeds_with_bad_ndim` — a 2D tensor still raises, with the new message

Verified both catch the bug: with the fix reverted, both fail.

```
pytest tests/pipelines/controlnet_sd3/   -> 41 passed, 30 skipped
ruff check / ruff format --check         -> clean
git diff --check                         -> clean
```

## Before submitting

- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Was this discussed/approved via a GitHub issue? — #13611
- [x] Did you write any new necessary tests?

## Self-review notes

Reviewed against `.ai/references/review-rules.md` and `pipelines.md`. **No blocking issues.**

**For the reviewer:**

1. **This loosens validation on a public argument.** Anyone currently passing a `list` to work around the old check would now fail later inside `prepare_ip_adapter_image_embeds` rather than early in `check_inputs`. I judged that acceptable because the list path was already broken downstream — there is no working list-based caller to preserve — but flagging it since it is technically a behaviour change.
2. I kept the `ip_adapter_image` / `ip_adapter_image_embeds` mutual-exclusion check above it untouched.
3. Scope kept to Issue 5. Issues 1, 3 and 4 of #13611 are in #14671, #14673 and #14672.

## Who can review?

@yiyixuxu @asomoza @hlky
