### PR TITLE
Support dynamic-shifting schedulers in SD3 ControlNet pipelines

### DIFF
--- a/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet.py
+++ b/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet.py
@@ -80,6 +80,20 @@ EXAMPLE_DOC_STRING = """
 """
 
 
+# Copied from diffusers.pipelines.flux.pipeline_flux.calculate_shift
+def calculate_shift(
+    image_seq_len,
+    base_seq_len: int = 256,
+    max_seq_len: int = 4096,
+    base_shift: float = 0.5,
+    max_shift: float = 1.15,
+):
+    m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
+    b = base_shift - m * base_seq_len
+    mu = image_seq_len * m + b
+    return mu
+
+
 # Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.retrieve_timesteps
 def retrieve_timesteps(
     scheduler,
@@ -852,6 +866,7 @@ class StableDiffusion3ControlNetPipeline(
         callback_on_step_end: Callable[[int, int], None] | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
         max_sequence_length: int = 256,
+        mu: float | None = None,
     ):
         r"""
         Function invoked when calling the pipeline for generation.
@@ -963,6 +978,7 @@ class StableDiffusion3ControlNetPipeline(
                 will be passed as `callback_kwargs` argument. You will only be able to include variables listed in the
                 `._callback_tensor_inputs` attribute of your pipeline class.
             max_sequence_length (`int` defaults to 256): Maximum sequence length to use with the `prompt`.
+            mu (`float`, *optional*): `mu` value used for `dynamic_shifting`.
 
         Examples:
 
@@ -1101,18 +1117,7 @@ class StableDiffusion3ControlNetPipeline(
         else:
             assert False
 
-        # 4. Prepare timesteps
-        if XLA_AVAILABLE:
-            timestep_device = "cpu"
-        else:
-            timestep_device = device
-        timesteps, num_inference_steps = retrieve_timesteps(
-            self.scheduler, num_inference_steps, timestep_device, sigmas=sigmas
-        )
-        num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
-        self._num_timesteps = len(timesteps)
-
-        # 5. Prepare latent variables
+        # 4. Prepare latent variables
         num_channels_latents = self.transformer.config.in_channels
         latents = self.prepare_latents(
             batch_size * num_images_per_prompt,
@@ -1124,6 +1129,34 @@ class StableDiffusion3ControlNetPipeline(
             generator,
             latents,
         )
+
+        # 5. Prepare timesteps
+        scheduler_kwargs = {}
+        if self.scheduler.config.get("use_dynamic_shifting", None) and mu is None:
+            _, _, latent_height, latent_width = latents.shape
+            image_seq_len = (latent_height // self.transformer.config.patch_size) * (
+                latent_width // self.transformer.config.patch_size
+            )
+            mu = calculate_shift(
+                image_seq_len,
+                self.scheduler.config.get("base_image_seq_len", 256),
+                self.scheduler.config.get("max_image_seq_len", 4096),
+                self.scheduler.config.get("base_shift", 0.5),
+                self.scheduler.config.get("max_shift", 1.16),
+            )
+            scheduler_kwargs["mu"] = mu
+        elif mu is not None:
+            scheduler_kwargs["mu"] = mu
+
+        if XLA_AVAILABLE:
+            timestep_device = "cpu"
+        else:
+            timestep_device = device
+        timesteps, num_inference_steps = retrieve_timesteps(
+            self.scheduler, num_inference_steps, timestep_device, sigmas=sigmas, **scheduler_kwargs
+        )
+        num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
+        self._num_timesteps = len(timesteps)
 
         # 6. Create tensor stating which controlnets to keep
         controlnet_keep = []

--- a/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet_inpainting.py
+++ b/src/diffusers/pipelines/controlnet_sd3/pipeline_stable_diffusion_3_controlnet_inpainting.py
@@ -103,6 +103,20 @@ EXAMPLE_DOC_STRING = """
 """
 
 
+# Copied from diffusers.pipelines.flux.pipeline_flux.calculate_shift
+def calculate_shift(
+    image_seq_len,
+    base_seq_len: int = 256,
+    max_seq_len: int = 4096,
+    base_shift: float = 0.5,
+    max_shift: float = 1.15,
+):
+    m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
+    b = base_shift - m * base_seq_len
+    mu = image_seq_len * m + b
+    return mu
+
+
 # Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.retrieve_timesteps
 def retrieve_timesteps(
     scheduler,
@@ -1020,6 +1034,7 @@ class StableDiffusion3ControlNetInpaintingPipeline(
         callback_on_step_end: Callable[[int, int], None] | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
         max_sequence_length: int = 256,
+        mu: float | None = None,
     ):
         r"""
         Function invoked when calling the pipeline for generation.
@@ -1135,6 +1150,7 @@ class StableDiffusion3ControlNetInpaintingPipeline(
                 will be passed as `callback_kwargs` argument. You will only be able to include variables listed in the
                 `._callback_tensor_inputs` attribute of your pipeline class.
             max_sequence_length (`int` defaults to 256): Maximum sequence length to use with the `prompt`.
+            mu (`float`, *optional*): `mu` value used for `dynamic_shifting`.
 
         Examples:
 
@@ -1272,18 +1288,7 @@ class StableDiffusion3ControlNetInpaintingPipeline(
         else:
             controlnet_pooled_projections = controlnet_pooled_projections or pooled_prompt_embeds
 
-        # 4. Prepare timesteps
-        if XLA_AVAILABLE:
-            timestep_device = "cpu"
-        else:
-            timestep_device = device
-        timesteps, num_inference_steps = retrieve_timesteps(
-            self.scheduler, num_inference_steps, timestep_device, sigmas=sigmas
-        )
-        num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
-        self._num_timesteps = len(timesteps)
-
-        # 5. Prepare latent variables
+        # 4. Prepare latent variables
         num_channels_latents = self.transformer.config.in_channels
         latents = self.prepare_latents(
             batch_size * num_images_per_prompt,
@@ -1295,6 +1300,34 @@ class StableDiffusion3ControlNetInpaintingPipeline(
             generator,
             latents,
         )
+
+        # 5. Prepare timesteps
+        scheduler_kwargs = {}
+        if self.scheduler.config.get("use_dynamic_shifting", None) and mu is None:
+            _, _, latent_height, latent_width = latents.shape
+            image_seq_len = (latent_height // self.transformer.config.patch_size) * (
+                latent_width // self.transformer.config.patch_size
+            )
+            mu = calculate_shift(
+                image_seq_len,
+                self.scheduler.config.get("base_image_seq_len", 256),
+                self.scheduler.config.get("max_image_seq_len", 4096),
+                self.scheduler.config.get("base_shift", 0.5),
+                self.scheduler.config.get("max_shift", 1.16),
+            )
+            scheduler_kwargs["mu"] = mu
+        elif mu is not None:
+            scheduler_kwargs["mu"] = mu
+
+        if XLA_AVAILABLE:
+            timestep_device = "cpu"
+        else:
+            timestep_device = device
+        timesteps, num_inference_steps = retrieve_timesteps(
+            self.scheduler, num_inference_steps, timestep_device, sigmas=sigmas, **scheduler_kwargs
+        )
+        num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
+        self._num_timesteps = len(timesteps)
 
         # 6. Create tensor stating which controlnets to keep
         controlnet_keep = []

--- a/tests/pipelines/controlnet_sd3/test_controlnet_inpaint_sd3.py
+++ b/tests/pipelines/controlnet_sd3/test_controlnet_inpaint_sd3.py
@@ -195,6 +195,29 @@ class TestStableDiffusion3ControlNetInpaintingPipeline(
 
         assert_tensors_close(image_slice.flatten().cpu(), expected_slice, atol=1e-2)
 
+    def test_dynamic_shifting_scheduler(self):
+        # Regression: this pipeline called `retrieve_timesteps()` without computing `mu`, so any
+        # scheduler with `use_dynamic_shifting=True` (the SD3.5 style configs) raised
+        # "`mu` must be passed when `use_dynamic_shifting` is set to be `True`" before inference.
+        components = self.get_dummy_components()
+        components["scheduler"] = FlowMatchEulerDiscreteScheduler(use_dynamic_shifting=True)
+        pipe = self.get_pipeline(**components).to(torch_device, dtype=torch.float32)
+
+        image = pipe(**self.get_dummy_inputs()).images
+
+        assert image.shape == (1, *self.output_shape)
+
+    def test_dynamic_shifting_scheduler_accepts_explicit_mu(self):
+        components = self.get_dummy_components()
+        components["scheduler"] = FlowMatchEulerDiscreteScheduler(use_dynamic_shifting=True)
+        pipe = self.get_pipeline(**components).to(torch_device, dtype=torch.float32)
+
+        inputs = self.get_dummy_inputs()
+        inputs["mu"] = 0.7
+        image = pipe(**inputs).images
+
+        assert image.shape == (1, *self.output_shape)
+
 
 class TestStableDiffusion3ControlNetInpaintingPipelineMemory(
     StableDiffusion3ControlNetInpaintingPipelineTesterConfig, MemoryTesterMixin

--- a/tests/pipelines/controlnet_sd3/test_controlnet_sd3.py
+++ b/tests/pipelines/controlnet_sd3/test_controlnet_sd3.py
@@ -212,6 +212,29 @@ class TestStableDiffusion3ControlNetPipeline(StableDiffusion3ControlNetPipelineT
         # fmt: on
         self._run_and_check_slice(components, expected_slice)
 
+    def test_dynamic_shifting_scheduler(self):
+        # Regression: this pipeline called `retrieve_timesteps()` without computing `mu`, so any
+        # scheduler with `use_dynamic_shifting=True` (the SD3.5 style configs) raised
+        # "`mu` must be passed when `use_dynamic_shifting` is set to be `True`" before inference.
+        components = self.get_dummy_components()
+        components["scheduler"] = FlowMatchEulerDiscreteScheduler(use_dynamic_shifting=True)
+        pipe = self.get_pipeline(**components).to(torch_device, dtype=torch.float32)
+
+        image = pipe(**self.get_dummy_inputs()).images
+
+        assert image.shape == (1, *self.output_shape)
+
+    def test_dynamic_shifting_scheduler_accepts_explicit_mu(self):
+        components = self.get_dummy_components()
+        components["scheduler"] = FlowMatchEulerDiscreteScheduler(use_dynamic_shifting=True)
+        pipe = self.get_pipeline(**components).to(torch_device, dtype=torch.float32)
+
+        inputs = self.get_dummy_inputs()
+        inputs["mu"] = 0.7
+        image = pipe(**inputs).images
+
+        assert image.shape == (1, *self.output_shape)
+
 
 class TestStableDiffusion3ControlNetPipelineMemory(StableDiffusion3ControlNetPipelineTesterConfig, MemoryTesterMixin):
     """Memory optimization tests (CPU offload, group offload, layerwise casting) for the SD3 ControlNet pipeline."""


### PR DESCRIPTION
> **Issue link:** this addresses **Issue 2** of #13611.
> I have deliberately not used a `Fixes` keyword: #13611 tracks 6 separate findings, so a closing keyword would close it as soon as this one merges while the others are still open. Happy for the `no-issue-needed` label to be applied, or I can add a closing keyword if you would rather the review issue be closed and reopened.

# What does this PR do?

Fixes Issue 2 of #13611.

Both SD3 ControlNet pipelines call `retrieve_timesteps()` with no `mu` handling and expose no `mu` argument, so any scheduler with `use_dynamic_shifting=True` — the SD3.5-style configs — fails before inference:

```python
from diffusers import FlowMatchEulerDiscreteScheduler
from diffusers.pipelines.controlnet_sd3.pipeline_stable_diffusion_3_controlnet import retrieve_timesteps

retrieve_timesteps(FlowMatchEulerDiscreteScheduler(use_dynamic_shifting=True), num_inference_steps=2, device="cpu")
# ValueError: `mu` must be passed when `use_dynamic_shifting` is set to be `True`
```

The base `StableDiffusion3Pipeline` and `StableDiffusion3InpaintPipeline` already compute and pass `mu`, so ControlNet was the odd one out in the SD3 family.

## Solution

Ports the `calculate_shift()` helper, the `mu` argument, and the `scheduler_kwargs["mu"]` handling from the base SD3 pipelines into both ControlNet pipelines.

**One ordering change worth calling out.** `mu` is derived from the latents' shape, but these pipelines prepared timesteps (step 4) *before* latents (step 5) — the reverse of the base SD3 pipelines. So latent preparation now runs first, and the steps are renumbered to match.

That reorder is safe here: `prepare_latents` only draws from the generator and never touches the scheduler, and `retrieve_timesteps` never touches the latents. The strongest evidence is that **every existing expected slice in `tests/pipelines/controlnet_sd3/` still passes unchanged** — I ran the suite after the reorder and before adding any new tests.

The alternative was deriving `image_seq_len` from `height` / `width` to avoid moving anything, but that re-derives what `prepare_latents` already computed and would get the user-supplied-`latents` case wrong.

## Testing

Two tests per pipeline (four total):

- `test_dynamic_shifting_scheduler` — `use_dynamic_shifting=True` now runs, exercising the derived-`mu` path
- `test_dynamic_shifting_scheduler_accepts_explicit_mu` — covers the `elif mu is not None` branch

Verified all four catch the bug: with the fix reverted, all four fail with the `ValueError` above.

```
pytest tests/pipelines/controlnet_sd3/         -> 43 passed, 30 skipped
ruff check / ruff format --check               -> clean
python utils/check_forward_call_docstrings.py  -> all arguments documented
git diff --check                               -> clean
```

## Before submitting

- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Was this discussed/approved via a GitHub issue? — #13611
- [x] Did you write any new necessary tests?

## Self-review notes

Reviewed against `.ai/references/review-rules.md` and `pipelines.md`. **No blocking issues.**

**For the reviewer:**

1. **The step reorder is the part to scrutinise**, and it is the only reason this PR is not a pure addition. Reasoning and evidence above; happy to switch to deriving `image_seq_len` from `height`/`width` instead if you'd rather nothing moved.
2. I used `latent_height` / `latent_width` rather than shadowing `height` / `width` as `pipeline_stable_diffusion_3.py` does, since those names are still live later in these pipelines.
3. I kept the base SD3 pipelines' `max_shift` default of `1.16` for consistency with them, even though `calculate_shift`'s own signature defaults to `1.15`. That discrepancy already exists in `pipeline_stable_diffusion_3.py`; I did not want to silently change it here.
4. Scope kept to Issue 2. Issues 1, 3, 4 and 5 of #13611 are in #14671, #14673, #14672 and #14674.

## Who can review?

@yiyixuxu @asomoza @hlky
