### PR TITLE
Use negative crop coordinates when building SDXL negative time ids

### DIFF
--- a/src/diffusers/modular_pipelines/stable_diffusion_xl/before_denoise.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_xl/before_denoise.py
@@ -1154,7 +1154,7 @@ class StableDiffusionXLImg2ImgPrepareAdditionalConditioningStep(ModularPipelineB
             )
         else:
             add_time_ids = list(original_size + crops_coords_top_left + target_size)
-            add_neg_time_ids = list(negative_original_size + crops_coords_top_left + negative_target_size)
+            add_neg_time_ids = list(negative_original_size + negative_crops_coords_top_left + negative_target_size)
 
         passed_add_embed_dim = (
             components.unet.config.addition_time_embed_dim * len(add_time_ids) + text_encoder_projection_dim

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl_img2img.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_sd_xl_img2img.py
@@ -1006,7 +1006,7 @@ class StableDiffusionXLControlNetImg2ImgPipeline(
             )
         else:
             add_time_ids = list(original_size + crops_coords_top_left + target_size)
-            add_neg_time_ids = list(negative_original_size + crops_coords_top_left + negative_target_size)
+            add_neg_time_ids = list(negative_original_size + negative_crops_coords_top_left + negative_target_size)
 
         passed_add_embed_dim = (
             self.unet.config.addition_time_embed_dim * len(add_time_ids) + text_encoder_projection_dim

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_union_sd_xl_img2img.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_union_sd_xl_img2img.py
@@ -996,7 +996,7 @@ class StableDiffusionXLControlNetUnionImg2ImgPipeline(
             )
         else:
             add_time_ids = list(original_size + crops_coords_top_left + target_size)
-            add_neg_time_ids = list(negative_original_size + crops_coords_top_left + negative_target_size)
+            add_neg_time_ids = list(negative_original_size + negative_crops_coords_top_left + negative_target_size)
 
         passed_add_embed_dim = (
             self.unet.config.addition_time_embed_dim * len(add_time_ids) + text_encoder_projection_dim

--- a/src/diffusers/pipelines/pag/pipeline_pag_controlnet_sd_xl_img2img.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_controlnet_sd_xl_img2img.py
@@ -1012,7 +1012,7 @@ class StableDiffusionXLControlNetPAGImg2ImgPipeline(
             )
         else:
             add_time_ids = list(original_size + crops_coords_top_left + target_size)
-            add_neg_time_ids = list(negative_original_size + crops_coords_top_left + negative_target_size)
+            add_neg_time_ids = list(negative_original_size + negative_crops_coords_top_left + negative_target_size)
 
         passed_add_embed_dim = (
             self.unet.config.addition_time_embed_dim * len(add_time_ids) + text_encoder_projection_dim

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_img2img.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_img2img.py
@@ -874,7 +874,7 @@ class StableDiffusionXLPAGImg2ImgPipeline(
             )
         else:
             add_time_ids = list(original_size + crops_coords_top_left + target_size)
-            add_neg_time_ids = list(negative_original_size + crops_coords_top_left + negative_target_size)
+            add_neg_time_ids = list(negative_original_size + negative_crops_coords_top_left + negative_target_size)
 
         passed_add_embed_dim = (
             self.unet.config.addition_time_embed_dim * len(add_time_ids) + text_encoder_projection_dim

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
@@ -965,7 +965,7 @@ class StableDiffusionXLPAGInpaintPipeline(
             )
         else:
             add_time_ids = list(original_size + crops_coords_top_left + target_size)
-            add_neg_time_ids = list(negative_original_size + crops_coords_top_left + negative_target_size)
+            add_neg_time_ids = list(negative_original_size + negative_crops_coords_top_left + negative_target_size)
 
         passed_add_embed_dim = (
             self.unet.config.addition_time_embed_dim * len(add_time_ids) + text_encoder_projection_dim

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -860,7 +860,7 @@ class StableDiffusionXLImg2ImgPipeline(
             )
         else:
             add_time_ids = list(original_size + crops_coords_top_left + target_size)
-            add_neg_time_ids = list(negative_original_size + crops_coords_top_left + negative_target_size)
+            add_neg_time_ids = list(negative_original_size + negative_crops_coords_top_left + negative_target_size)
 
         passed_add_embed_dim = (
             self.unet.config.addition_time_embed_dim * len(add_time_ids) + text_encoder_projection_dim

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -965,7 +965,7 @@ class StableDiffusionXLInpaintPipeline(
             )
         else:
             add_time_ids = list(original_size + crops_coords_top_left + target_size)
-            add_neg_time_ids = list(negative_original_size + crops_coords_top_left + negative_target_size)
+            add_neg_time_ids = list(negative_original_size + negative_crops_coords_top_left + negative_target_size)
 
         passed_add_embed_dim = (
             self.unet.config.addition_time_embed_dim * len(add_time_ids) + text_encoder_projection_dim

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py
@@ -15,6 +15,7 @@
 
 import gc
 import random
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -356,6 +357,40 @@ class TestStableDiffusionXLImg2ImgPipeline(StableDiffusionXLImg2ImgPipelineTeste
         image_slice_with_neg_conditions = image[0, -1, -3:, -3:]
 
         assert (image_slice_with_no_neg_conditions - image_slice_with_neg_conditions).abs().max() > 1e-4
+
+    def test_get_add_time_ids_uses_negative_crops_coords_top_left(self):
+        # Regression: the non-aesthetic-score branch built the negative time ids from
+        # `crops_coords_top_left` rather than `negative_crops_coords_top_left`, so asking for
+        # different positive and negative crop conditioning silently applied the positive
+        # coordinates to both. The aesthetic-score branch above it was already correct.
+        #
+        # Driven through a stand-in rather than the dummy pipeline: this branch emits six time ids
+        # instead of five, which the dummy UNet's `add_embedding` is not sized for.
+        stand_in = SimpleNamespace(
+            config=SimpleNamespace(requires_aesthetics_score=False),
+            unet=SimpleNamespace(
+                config=SimpleNamespace(addition_time_embed_dim=1),
+                add_embedding=SimpleNamespace(linear_1=SimpleNamespace(in_features=7)),
+            ),
+        )
+
+        _, add_neg_time_ids = StableDiffusionXLImg2ImgPipeline._get_add_time_ids(
+            stand_in,
+            original_size=(64, 64),
+            crops_coords_top_left=(1, 2),
+            target_size=(64, 64),
+            aesthetic_score=6.0,
+            negative_aesthetic_score=2.5,
+            negative_original_size=(32, 32),
+            negative_crops_coords_top_left=(9, 10),
+            negative_target_size=(32, 32),
+            dtype=torch.float32,
+            text_encoder_projection_dim=1,
+        )
+
+        assert add_neg_time_ids.flatten().tolist() == [32.0, 32.0, 9.0, 10.0, 32.0, 32.0], (
+            "Negative time ids should use `negative_crops_coords_top_left`."
+        )
 
     def test_pipeline_interrupt(self):
         sd_pipe = self.get_pipeline().to(torch_device)


### PR DESCRIPTION
> **Issue link:** this addresses **Issue 2** of #13610.
> I have deliberately not used a `Fixes` keyword: #13610 tracks 7 separate findings, so a closing keyword would close it as soon as this one merges while the others are still open. Happy for the `no-issue-needed` label to be applied, or I can add a closing keyword if you would rather the review issue be closed and reopened.

# What does this PR do?

Fixes Issue 2 of #13610 (`stable_diffusion_xl` model/pipeline review).

`_get_add_time_ids` accepts `negative_crops_coords_top_left`, and the aesthetic-score branch uses it — but the other branch does not:

```python
if self.config.requires_aesthetics_score:
    add_neg_time_ids = list(negative_original_size + negative_crops_coords_top_left + (negative_aesthetic_score,))
else:
    add_neg_time_ids = list(negative_original_size + crops_coords_top_left + negative_target_size)
    #                                                ^^^^^^^^^^^^^^^^^^^^^ positive coordinates
```

So anyone requesting different positive and negative crop conditioning silently gets the **positive** crop coordinates on both branches, and negative micro-conditioning is wrong.

Reproduced on `main` with the script from the issue:

```
negative time ids: [[32.0, 32.0, 1.0, 2.0, 32.0, 32.0]]   # 1, 2 are the POSITIVE crops
after fix:         [[32.0, 32.0, 9.0, 10.0, 32.0, 32.0]]  # 9, 10 as requested
```

## Solution

Use `negative_crops_coords_top_left`, matching the aesthetic-score branch directly above it and the separate negative `_get_add_time_ids` call the text-to-image pipeline already makes.

The issue names three files. Five more carry this method through `# Copied from`, and `utils/check_copies.py` requires them to match, so all eight are updated together:

| | |
| --- | --- |
| named in the issue | `pipeline_stable_diffusion_xl_img2img.py`, `pipeline_stable_diffusion_xl_inpaint.py`, `modular_pipelines/stable_diffusion_xl/before_denoise.py` |
| `# Copied from` the above | `pipeline_controlnet_sd_xl_img2img.py`, `pipeline_controlnet_union_sd_xl_img2img.py`, `pipeline_pag_controlnet_sd_xl_img2img.py`, `pipeline_pag_sd_xl_img2img.py`, `pipeline_pag_sd_xl_inpaint.py` |

## Testing

`test_get_add_time_ids_uses_negative_crops_coords_top_left` asserts the negative time ids carry the negative crop coordinates.

It drives the method through a lightweight stand-in rather than the dummy pipeline, as the issue's own reproduction does. The reason is concrete: this branch emits six time ids instead of five, and the dummy UNet's `add_embedding.linear_1` is sized for the five-value aesthetic-score layout, so the real dummy pipeline raises on the embedding-dimension check before reaching the logic under test.

Verified it catches the bug: with the fix reverted it fails.

```
pytest tests/pipelines/stable_diffusion_xl/{img2img,inpaint} -k "not ip_adapter"
  -> 74 passed, 43 skipped
ruff check / ruff format --check   -> clean
git diff --check                   -> clean
```

Two sets of pre-existing failures in my environment, both reproducing identically on a clean checkout of `main` and unrelated to this change: the `TestStableDiffusionXL*PipelineIPAdapter` classes (a `ModuleNotFoundError` from an optional dependency I don't have installed), and one `before_denoise.py` `_get_add_time_ids` copy mismatch against `StableDiffusionXLPipeline` — a *different* method from the one changed here.

## Before submitting

- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Was this discussed/approved via a GitHub issue? — #13610
- [x] Did you write any new necessary tests?

## Self-review notes

Reviewed against `.ai/references/review-rules.md` and `pipelines.md`. **No blocking issues.**

**For the reviewer:**

1. **This changes generated output** for anyone who passes `negative_crops_coords_top_left` on a non-aesthetic-score model. That is the point — the old output ignored the argument — but it will move pinned outputs for those callers.
2. **The blast radius is eight files, not the three the issue lists.** That is forced by `# Copied from`; touching only the three would break `check_copies`. Happy to split the copies into a follow-up if you'd rather review them separately.
3. Scope kept to Issue 2. The other six issues in #13610 are untouched.

## Who can review?

@yiyixuxu @asomoza @hlky
