### PR TITLE
Do not watermark or postprocess SDXL latent output

### DIFF
--- a/src/diffusers/modular_pipelines/stable_diffusion_xl/decoders.py
+++ b/src/diffusers/modular_pipelines/stable_diffusion_xl/decoders.py
@@ -129,13 +129,14 @@ class StableDiffusionXLDecodeStep(ModularPipelineBlocks):
         else:
             block_state.images = block_state.latents
 
-        # apply watermark if available
-        if hasattr(components, "watermark") and components.watermark is not None:
-            block_state.images = components.watermark.apply_watermark(block_state.images)
+        if not block_state.output_type == "latent":
+            # apply watermark if available
+            if hasattr(components, "watermark") and components.watermark is not None:
+                block_state.images = components.watermark.apply_watermark(block_state.images)
 
-        block_state.images = components.image_processor.postprocess(
-            block_state.images, output_type=block_state.output_type
-        )
+            block_state.images = components.image_processor.postprocess(
+                block_state.images, output_type=block_state.output_type
+            )
 
         self.set_block_state(state, block_state)
 

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_img2img.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_img2img.py
@@ -1521,11 +1521,12 @@ class StableDiffusionXLPAGImg2ImgPipeline(
         else:
             image = latents
 
-        # apply watermark if available
-        if self.watermark is not None:
-            image = self.watermark.apply_watermark(image)
+        if not output_type == "latent":
+            # apply watermark if available
+            if self.watermark is not None:
+                image = self.watermark.apply_watermark(image)
 
-        image = self.image_processor.postprocess(image, output_type=output_type)
+            image = self.image_processor.postprocess(image, output_type=output_type)
 
         # Offload all models
         self.maybe_free_model_hooks()

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py
@@ -1477,11 +1477,12 @@ class StableDiffusionXLImg2ImgPipeline(
         else:
             image = latents
 
-        # apply watermark if available
-        if self.watermark is not None:
-            image = self.watermark.apply_watermark(image)
+        if not output_type == "latent":
+            # apply watermark if available
+            if self.watermark is not None:
+                image = self.watermark.apply_watermark(image)
 
-        image = self.image_processor.postprocess(image, output_type=output_type)
+            image = self.image_processor.postprocess(image, output_type=output_type)
 
         # Offload all models
         self.maybe_free_model_hooks()

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py
@@ -357,6 +357,25 @@ class TestStableDiffusionXLImg2ImgPipeline(StableDiffusionXLImg2ImgPipelineTeste
 
         assert (image_slice_with_no_neg_conditions - image_slice_with_neg_conditions).abs().max() > 1e-4
 
+    def test_latent_output_skips_watermark_and_postprocess(self):
+        # Regression: `output_type="latent"` sets `image = latents`, but this pipeline still ran the
+        # watermarker and `image_processor.postprocess` over it, treating raw latents as decoded RGB.
+        # The text-to-image pipeline already guards both behind `output_type != "latent"`.
+        class SentinelWatermark:
+            def apply_watermark(self, images):
+                raise AssertionError("watermark must not be applied to latent output")
+
+        sd_pipe = self.get_pipeline()
+        sd_pipe.watermark = SentinelWatermark()
+
+        inputs = self.get_dummy_inputs()
+        inputs["output_type"] = "latent"
+        output = sd_pipe(**inputs).images
+
+        assert torch.is_tensor(output)
+        # Raw latents keep the VAE latent channel count; postprocess would have produced 3 channels.
+        assert output.shape[1] == sd_pipe.unet.config.in_channels
+
     def test_pipeline_interrupt(self):
         sd_pipe = self.get_pipeline().to(torch_device)
 


### PR DESCRIPTION
> **Issue link:** this addresses **Issue 4** of #13610.
> I have deliberately not used a `Fixes` keyword: #13610 tracks 7 separate findings, so a closing keyword would close it as soon as this one merges while the others are still open. Happy for the `no-issue-needed` label to be applied, or I can add a closing keyword if you would rather the review issue be closed and reopened.

# What does this PR do?

Fixes Issue 4 of #13610 (`stable_diffusion_xl` model/pipeline review).

With `output_type="latent"` the SDXL img2img pipeline sets `image = latents` and then runs the watermarker and `image_processor.postprocess()` over it, so raw latents are handled as if they were decoded RGB.

The text-to-image pipeline already guards both:

```python
# pipeline_stable_diffusion_xl.py
if not output_type == "latent":
    if self.watermark is not None:
        image = self.watermark.apply_watermark(image)
    image = self.image_processor.postprocess(image, output_type=output_type)
```

With a real watermarker this can corrupt or fail on larger latent tensors; with any custom watermarker it is simply called with the wrong data.

## Solution

Applies the text-to-image guard to the sites that lack it.

The issue names two. I swept the codebase for the same unguarded shape and found one more — `pipeline_pag_sd_xl_img2img.py` — so all three are fixed together:

- `pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_img2img.py`
- `modular_pipelines/stable_diffusion_xl/decoders.py`
- `pipelines/pag/pipeline_pag_sd_xl_img2img.py` *(found by sweep, not listed in the issue)*

The SDXL inpaint pipeline was checked and already guards correctly.

## Testing

`test_latent_output_skips_watermark_and_postprocess` installs a watermarker that raises if called, requests `output_type="latent"`, and asserts the result is still a latent tensor — checking the channel count, since `postprocess` would have collapsed it to 3 channels.

Verified it catches the bug: with the fix reverted it fails.

```
pytest tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_img2img.py -k "not ip_adapter"
  -> 45 passed, 28 skipped
pytest .../test_stable_diffusion_xl_img2img.py .../test_stable_diffusion_xl.py -k "not ip_adapter"
  -> 110 passed, 65 skipped
ruff check / ruff format --check   -> clean
git diff --check                   -> clean
```

The `TestStableDiffusionXL*PipelineIPAdapter` classes are deselected above: they fail on a clean checkout of `main` in my environment with a `ModuleNotFoundError` from an optional dependency I do not have installed, unrelated to this change.

## Before submitting

- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Was this discussed/approved via a GitHub issue? — #13610
- [x] Did you write any new necessary tests?

## Self-review notes

Reviewed against `.ai/references/review-rules.md` and `pipelines.md`. **No blocking issues.**

**For the reviewer:**

1. **This changes what `output_type="latent"` returns** in these pipelines — previously postprocessed, now raw latents. That is the documented and intended behaviour and matches text-to-image, but it is a behaviour change for anyone who was relying on the postprocessed result.
2. **I included one file beyond the issue's list** (`pipeline_pag_sd_xl_img2img.py`), found by sweeping for the identical unguarded pattern. Happy to drop it if you'd rather keep this to the two files named.
3. The modular decoder uses `hasattr(components, "watermark")`; I left that guard as-is and only wrapped it in the `output_type` check.
4. Scope kept to Issue 4. Issue 2 of the same review is in #14676.

## Who can review?

@yiyixuxu @asomoza @hlky
