### PR TITLE
Run cleanup and honor return_dict for SDXL latent output

### DIFF
--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_inpaint_sd_xl.py
@@ -1866,16 +1866,19 @@ class StableDiffusionXLControlNetInpaintPipeline(
         if not output_type == "latent":
             image = self.vae.decode(latents / self.vae.config.scaling_factor, return_dict=False)[0]
         else:
-            return StableDiffusionXLPipelineOutput(images=latents)
+            image = latents
 
-        # apply watermark if available
-        if self.watermark is not None:
-            image = self.watermark.apply_watermark(image)
+        if not output_type == "latent":
+            # apply watermark if available
+            if self.watermark is not None:
+                image = self.watermark.apply_watermark(image)
 
-        image = self.image_processor.postprocess(image, output_type=output_type)
+            image = self.image_processor.postprocess(image, output_type=output_type)
 
-        if padding_mask_crop is not None:
-            image = [self.image_processor.apply_overlay(mask_image, original_image, i, crops_coords) for i in image]
+            if padding_mask_crop is not None:
+                image = [
+                    self.image_processor.apply_overlay(mask_image, original_image, i, crops_coords) for i in image
+                ]
 
         # Offload all models
         self.maybe_free_model_hooks()

--- a/src/diffusers/pipelines/controlnet/pipeline_controlnet_union_inpaint_sd_xl.py
+++ b/src/diffusers/pipelines/controlnet/pipeline_controlnet_union_inpaint_sd_xl.py
@@ -1878,16 +1878,19 @@ class StableDiffusionXLControlNetUnionInpaintPipeline(
         if not output_type == "latent":
             image = self.vae.decode(latents / self.vae.config.scaling_factor, return_dict=False)[0]
         else:
-            return StableDiffusionXLPipelineOutput(images=latents)
+            image = latents
 
-        # apply watermark if available
-        if self.watermark is not None:
-            image = self.watermark.apply_watermark(image)
+        if not output_type == "latent":
+            # apply watermark if available
+            if self.watermark is not None:
+                image = self.watermark.apply_watermark(image)
 
-        image = self.image_processor.postprocess(image, output_type=output_type)
+            image = self.image_processor.postprocess(image, output_type=output_type)
 
-        if padding_mask_crop is not None:
-            image = [self.image_processor.apply_overlay(mask_image, original_image, i, crops_coords) for i in image]
+            if padding_mask_crop is not None:
+                image = [
+                    self.image_processor.apply_overlay(mask_image, original_image, i, crops_coords) for i in image
+                ]
 
         # Offload all models
         self.maybe_free_model_hooks()

--- a/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
+++ b/src/diffusers/pipelines/pag/pipeline_pag_sd_xl_inpaint.py
@@ -1752,16 +1752,19 @@ class StableDiffusionXLPAGInpaintPipeline(
             if needs_upcasting:
                 self.vae.to(dtype=torch.float16)
         else:
-            return StableDiffusionXLPipelineOutput(images=latents)
+            image = latents
 
-        # apply watermark if available
-        if self.watermark is not None:
-            image = self.watermark.apply_watermark(image)
+        if not output_type == "latent":
+            # apply watermark if available
+            if self.watermark is not None:
+                image = self.watermark.apply_watermark(image)
 
-        image = self.image_processor.postprocess(image, output_type=output_type)
+            image = self.image_processor.postprocess(image, output_type=output_type)
 
-        if padding_mask_crop is not None:
-            image = [self.image_processor.apply_overlay(mask_image, original_image, i, crops_coords) for i in image]
+            if padding_mask_crop is not None:
+                image = [
+                    self.image_processor.apply_overlay(mask_image, original_image, i, crops_coords) for i in image
+                ]
 
         # Offload all models
         self.maybe_free_model_hooks()

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_inpaint.py
@@ -1714,16 +1714,19 @@ class StableDiffusionXLInpaintPipeline(
             if needs_upcasting:
                 self.vae.to(dtype=torch.float16)
         else:
-            return StableDiffusionXLPipelineOutput(images=latents)
+            image = latents
 
-        # apply watermark if available
-        if self.watermark is not None:
-            image = self.watermark.apply_watermark(image)
+        if not output_type == "latent":
+            # apply watermark if available
+            if self.watermark is not None:
+                image = self.watermark.apply_watermark(image)
 
-        image = self.image_processor.postprocess(image, output_type=output_type)
+            image = self.image_processor.postprocess(image, output_type=output_type)
 
-        if padding_mask_crop is not None:
-            image = [self.image_processor.apply_overlay(mask_image, original_image, i, crops_coords) for i in image]
+            if padding_mask_crop is not None:
+                image = [
+                    self.image_processor.apply_overlay(mask_image, original_image, i, crops_coords) for i in image
+                ]
 
         # Offload all models
         self.maybe_free_model_hooks()

--- a/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_instruct_pix2pix.py
+++ b/src/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl_instruct_pix2pix.py
@@ -960,13 +960,14 @@ class StableDiffusionXLInstructPix2PixPipeline(
             if needs_upcasting:
                 self.vae.to(dtype=torch.float16)
         else:
-            return StableDiffusionXLPipelineOutput(images=latents)
+            image = latents
 
-        # apply watermark if available
-        if self.watermark is not None:
-            image = self.watermark.apply_watermark(image)
+        if not output_type == "latent":
+            # apply watermark if available
+            if self.watermark is not None:
+                image = self.watermark.apply_watermark(image)
 
-        image = self.image_processor.postprocess(image, output_type=output_type)
+            image = self.image_processor.postprocess(image, output_type=output_type)
 
         # Offload all models
         self.maybe_free_model_hooks()

--- a/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
+++ b/tests/pipelines/stable_diffusion_xl/test_stable_diffusion_xl_inpaint.py
@@ -692,6 +692,25 @@ class TestStableDiffusionXLInpaintPipeline(StableDiffusionXLInpaintPipelineTeste
         image_slice2 = images[1, -1, -3:, -3:]
         assert (image_slice1 - image_slice2).abs().max() > 1e-2
 
+    def test_latent_output_runs_cleanup_and_honors_return_dict(self):
+        # Regression: `output_type="latent"` returned `StableDiffusionXLPipelineOutput(images=latents)`
+        # immediately, which skipped `maybe_free_model_hooks()` and ignored `return_dict=False`.
+        sd_pipe = self.get_pipeline()
+
+        called = {"cleanup": False}
+        sd_pipe.maybe_free_model_hooks = lambda: called.__setitem__("cleanup", True)
+
+        inputs = self.get_dummy_inputs()
+        inputs["output_type"] = "latent"
+        inputs["return_dict"] = False
+        output = sd_pipe(**inputs)
+
+        assert called["cleanup"], "`maybe_free_model_hooks()` should still run for latent output."
+        assert isinstance(output, tuple), "`return_dict=False` should return a tuple."
+        assert torch.is_tensor(output[0])
+        # Raw latents keep the VAE latent channel count; postprocess would have produced 3 channels.
+        assert output[0].shape[1] == sd_pipe.unet.config.in_channels
+
     def test_pipeline_interrupt(self):
         sd_pipe = self.get_pipeline().to(torch_device)
 


### PR DESCRIPTION
> **Issue link:** this addresses **Issue 3** of #13610.
> I have deliberately not used a `Fixes` keyword: #13610 tracks 7 separate findings, so a closing keyword would close it as soon as this one merges while the others are still open. Happy for the `no-issue-needed` label to be applied, or I can add a closing keyword if you would rather the review issue be closed and reopened.

# What does this PR do?

Fixes Issue 3 of #13610 (`stable_diffusion_xl` model/pipeline review).

For `output_type="latent"`, the SDXL inpaint and instruct-pix2pix pipelines return early:

```python
else:
    return StableDiffusionXLPipelineOutput(images=latents)
```

That return jumps over everything after it, so two things break:

- **`maybe_free_model_hooks()` never runs** — model offload cleanup is skipped entirely for latent output
- **`return_dict=False` is ignored** — the caller gets a `StableDiffusionXLPipelineOutput` where a tuple was requested

Reproduced on `main`:

```
StableDiffusionXLPipelineOutput {'cleanup': False}
```

## Solution

Assign `image = latents` rather than returning, and guard watermarking, postprocessing, and the padding-mask overlay behind `output_type != "latent"` — so the shared cleanup and `return_dict` handling at the end of `__call__` runs for every output type. This is the shape the text-to-image pipeline already uses.

The issue names two files. I swept for the same early return and found three more, all fixed together:

| | |
| --- | --- |
| named in the issue | `pipeline_stable_diffusion_xl_inpaint.py`, `pipeline_stable_diffusion_xl_instruct_pix2pix.py` |
| found by sweep | `pipeline_controlnet_inpaint_sd_xl.py`, `pipeline_controlnet_union_inpaint_sd_xl.py`, `pipeline_pag_sd_xl_inpaint.py` |

The inpaint pipelines also apply `padding_mask_crop` overlays, which operate on decoded PIL images, so that call moved inside the same guard.

## Testing

`test_latent_output_runs_cleanup_and_honors_return_dict` stubs `maybe_free_model_hooks` to record whether it fired, requests `output_type="latent"` with `return_dict=False`, and asserts cleanup ran, a tuple came back, and the payload is still a latent tensor (by channel count — `postprocess` would have collapsed it to 3).

Verified it catches the bug: with the fix reverted it fails.

```
pytest tests/pipelines/stable_diffusion_xl/ -k "not ip_adapter"   -> 195 passed, 129 skipped
ruff check / ruff format --check                                  -> clean
git diff --check                                                  -> clean
```

The `TestStableDiffusionXL*PipelineIPAdapter` classes are deselected: they fail on a clean checkout of `main` in my environment with a `ModuleNotFoundError` from an optional dependency I do not have installed, unrelated to this change.

## Before submitting

- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Was this discussed/approved via a GitHub issue? — #13610
- [x] Did you write any new necessary tests?

## Self-review notes

Reviewed against `.ai/references/review-rules.md` and `pipelines.md`. **No blocking issues.**

**For the reviewer:**

1. **`return_dict=False` with `output_type="latent"` now returns a tuple instead of an output object.** That is the fix, but it is a return-type change for anyone who was relying on the old behaviour.
2. **Three files beyond the issue's list**, found by sweeping for the identical early return. Happy to split them out if you'd rather review them separately.
3. **This overlaps in spirit with #14678** (Issue 4, watermarking latents in img2img): both add the `output_type != "latent"` guard, but to disjoint files, so the two do not conflict.
4. The `padding_mask_crop` overlay moving inside the guard is a deliberate part of the fix, not incidental reindentation — it operates on decoded images and would fail on latents.

## Who can review?

@yiyixuxu @asomoza @hlky
