### PR TITLE
Fix PriorTransformer Group Offloading Bug

### DIFF
--- a/src/diffusers/models/transformers/prior_transformer.py
+++ b/src/diffusers/models/transformers/prior_transformer.py
@@ -318,5 +318,8 @@ class PriorTransformer(ModelMixin, AttentionMixin, ConfigMixin, UNet2DConditionL
         return PriorTransformerOutput(predicted_image_embedding=predicted_image_embedding)
 
     def post_process_latents(self, prior_latents):
-        prior_latents = (prior_latents * self.clip_std) + self.clip_mean
+        # `clip_std` / `clip_mean` are parameters of this model, not of a submodule, so group offloading onloads
+        # them only for the duration of `forward`. This runs after the denoising loop, hence the explicit move.
+        device = prior_latents.device
+        prior_latents = (prior_latents * self.clip_std.to(device)) + self.clip_mean.to(device)
         return prior_latents

--- a/tests/pipelines/kandinsky/test_kandinsky_prior.py
+++ b/tests/pipelines/kandinsky/test_kandinsky_prior.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import torch
 from torch import nn
 from transformers import (
@@ -36,25 +35,6 @@ from ..testing_utils import (
 
 
 enable_full_determinism()
-
-
-# `PriorTransformer` keeps `positional_embedding`, `prd_embedding`, `clip_mean` and `clip_std` as parameters of the
-# model itself rather than of a submodule, so group offloading never onloads them: the forward pass then mixes
-# onloaded activations with still-offloaded weights. Reproduces at both block and leaf level.
-PIPELINE_GROUP_OFFLOAD_XFAIL_REASON = (
-    "`PriorTransformer` holds parameters directly on the model (`positional_embedding`, `prd_embedding`, "
-    "`clip_mean`, `clip_std`), which group offloading never onloads."
-)
-
-# A second, independent gap: the component-scoped test only offloads the denoiser under the names
-# `transformer`/`unet`/`controlnet`/`adapter`, and only puts `vae`/`vqvae`/`image_encoder` back on the accelerator.
-# A prior pipeline's denoiser is called `prior`, so it matches neither list and is left on CPU while the text
-# encoder is onloaded. Fixing this means widening the mixin's component lists, not changing the pipeline.
-COMPONENT_GROUP_OFFLOAD_XFAIL_REASON = (
-    "The pipeline calls `PriorTransformer.post_process_latents()` after the denoising loop, which reads the "
-    "`clip_mean` / `clip_std` parameters held directly on the model. Group offloading onloads those only for the "
-    "duration of `forward`, so by then they are back on the offload device."
-)
 
 
 class KandinskyPriorPipelineTesterConfig(BasePipelineTesterConfig):
@@ -214,23 +194,3 @@ class TestKandinskyPriorPipeline(KandinskyPriorPipelineTesterConfig, PipelineTes
 
 class TestKandinskyPriorPipelineMemory(KandinskyPriorPipelineTesterConfig, MemoryTesterMixin):
     """Memory optimization tests (CPU offload, group offload, layerwise casting) for the Kandinsky prior pipeline."""
-
-    @pytest.mark.xfail(condition=True, reason=COMPONENT_GROUP_OFFLOAD_XFAIL_REASON, strict=True)
-    @MemoryTesterMixin._USE_STREAM
-    def test_group_offloading_inference_block_level(self, base_pipe_output, use_stream, expected_max_difference=1e-4):
-        super().test_group_offloading_inference_block_level(
-            base_pipe_output, use_stream, expected_max_difference=expected_max_difference
-        )
-
-    @pytest.mark.xfail(condition=True, reason=COMPONENT_GROUP_OFFLOAD_XFAIL_REASON, strict=True)
-    @MemoryTesterMixin._USE_STREAM
-    def test_group_offloading_inference_leaf_level(self, base_pipe_output, use_stream, expected_max_difference=1e-4):
-        super().test_group_offloading_inference_leaf_level(
-            base_pipe_output, use_stream, expected_max_difference=expected_max_difference
-        )
-
-    @pytest.mark.xfail(condition=True, reason=PIPELINE_GROUP_OFFLOAD_XFAIL_REASON, strict=True)
-    def test_pipeline_level_group_offloading_inference(self, base_pipe_output, expected_max_difference=1e-4):
-        super().test_pipeline_level_group_offloading_inference(
-            base_pipe_output, expected_max_difference=expected_max_difference
-        )

--- a/tests/pipelines/kandinsky2_2/test_kandinsky_prior.py
+++ b/tests/pipelines/kandinsky2_2/test_kandinsky_prior.py
@@ -40,25 +40,6 @@ from ..testing_utils import (
 enable_full_determinism()
 
 
-# `PriorTransformer` keeps `positional_embedding`, `prd_embedding`, `clip_mean` and `clip_std` as parameters of the
-# model itself rather than of a submodule, so group offloading never onloads them: the forward pass then mixes
-# onloaded activations with still-offloaded weights. Reproduces at both block and leaf level.
-PIPELINE_GROUP_OFFLOAD_XFAIL_REASON = (
-    "`PriorTransformer` holds parameters directly on the model (`positional_embedding`, `prd_embedding`, "
-    "`clip_mean`, `clip_std`), which group offloading never onloads."
-)
-
-# A second, independent gap: the component-scoped test only offloads the denoiser under the names
-# `transformer`/`unet`/`controlnet`/`adapter`, and only puts `vae`/`vqvae`/`image_encoder` back on the accelerator.
-# A prior pipeline's denoiser is called `prior`, so it matches neither list and is left on CPU while the text
-# encoder is onloaded. Fixing this means widening the mixin's component lists, not changing the pipeline.
-COMPONENT_GROUP_OFFLOAD_XFAIL_REASON = (
-    "The pipeline calls `PriorTransformer.post_process_latents()` after the denoising loop, which reads the "
-    "`clip_mean` / `clip_std` parameters held directly on the model. Group offloading onloads those only for the "
-    "duration of `forward`, so by then they are back on the offload device."
-)
-
-
 class KandinskyV22PriorPipelineTesterConfig(BasePipelineTesterConfig):
     pipeline_class = KandinskyV22PriorPipeline
     required_input_params_in_call_signature = frozenset(["prompt"])
@@ -249,23 +230,3 @@ class TestKandinskyV22PriorPipeline(KandinskyV22PriorPipelineTesterConfig, Pipel
 class TestKandinskyV22PriorPipelineMemory(KandinskyV22PriorPipelineTesterConfig, MemoryTesterMixin):
     """Memory optimization tests (CPU offload, group offload, layerwise casting) for the Kandinsky 2.2 prior
     pipeline."""
-
-    @pytest.mark.xfail(condition=True, reason=COMPONENT_GROUP_OFFLOAD_XFAIL_REASON, strict=True)
-    @MemoryTesterMixin._USE_STREAM
-    def test_group_offloading_inference_block_level(self, base_pipe_output, use_stream, expected_max_difference=1e-4):
-        super().test_group_offloading_inference_block_level(
-            base_pipe_output, use_stream, expected_max_difference=expected_max_difference
-        )
-
-    @pytest.mark.xfail(condition=True, reason=COMPONENT_GROUP_OFFLOAD_XFAIL_REASON, strict=True)
-    @MemoryTesterMixin._USE_STREAM
-    def test_group_offloading_inference_leaf_level(self, base_pipe_output, use_stream, expected_max_difference=1e-4):
-        super().test_group_offloading_inference_leaf_level(
-            base_pipe_output, use_stream, expected_max_difference=expected_max_difference
-        )
-
-    @pytest.mark.xfail(condition=True, reason=PIPELINE_GROUP_OFFLOAD_XFAIL_REASON, strict=True)
-    def test_pipeline_level_group_offloading_inference(self, base_pipe_output, expected_max_difference=1e-4):
-        super().test_pipeline_level_group_offloading_inference(
-            base_pipe_output, expected_max_difference=expected_max_difference
-        )

--- a/tests/pipelines/kandinsky2_2/test_kandinsky_prior_emb2emb.py
+++ b/tests/pipelines/kandinsky2_2/test_kandinsky_prior_emb2emb.py
@@ -16,7 +16,6 @@
 import random
 
 import numpy as np
-import pytest
 import torch
 from PIL import Image
 from torch import nn
@@ -44,25 +43,6 @@ from ..testing_utils import (
 
 
 enable_full_determinism()
-
-
-# `PriorTransformer` keeps `positional_embedding`, `prd_embedding`, `clip_mean` and `clip_std` as parameters of the
-# model itself rather than of a submodule, so group offloading never onloads them: the forward pass then mixes
-# onloaded activations with still-offloaded weights. Reproduces at both block and leaf level.
-PIPELINE_GROUP_OFFLOAD_XFAIL_REASON = (
-    "`PriorTransformer` holds parameters directly on the model (`positional_embedding`, `prd_embedding`, "
-    "`clip_mean`, `clip_std`), which group offloading never onloads."
-)
-
-# A second, independent gap: the component-scoped test only offloads the denoiser under the names
-# `transformer`/`unet`/`controlnet`/`adapter`, and only puts `vae`/`vqvae`/`image_encoder` back on the accelerator.
-# A prior pipeline's denoiser is called `prior`, so it matches neither list and is left on CPU while the text
-# encoder is onloaded. Fixing this means widening the mixin's component lists, not changing the pipeline.
-COMPONENT_GROUP_OFFLOAD_XFAIL_REASON = (
-    "The pipeline calls `PriorTransformer.post_process_latents()` after the denoising loop, which reads the "
-    "`clip_mean` / `clip_std` parameters held directly on the model. Group offloading onloads those only for the "
-    "duration of `forward`, so by then they are back on the offload device."
-)
 
 
 class KandinskyV22PriorEmb2EmbPipelineTesterConfig(BasePipelineTesterConfig):
@@ -233,23 +213,3 @@ class TestKandinskyV22PriorEmb2EmbPipeline(KandinskyV22PriorEmb2EmbPipelineTeste
 class TestKandinskyV22PriorEmb2EmbPipelineMemory(KandinskyV22PriorEmb2EmbPipelineTesterConfig, MemoryTesterMixin):
     """Memory optimization tests (CPU offload, group offload, layerwise casting) for the Kandinsky 2.2 prior
     emb2emb pipeline."""
-
-    @pytest.mark.xfail(condition=True, reason=COMPONENT_GROUP_OFFLOAD_XFAIL_REASON, strict=True)
-    @MemoryTesterMixin._USE_STREAM
-    def test_group_offloading_inference_block_level(self, base_pipe_output, use_stream, expected_max_difference=1e-4):
-        super().test_group_offloading_inference_block_level(
-            base_pipe_output, use_stream, expected_max_difference=expected_max_difference
-        )
-
-    @pytest.mark.xfail(condition=True, reason=COMPONENT_GROUP_OFFLOAD_XFAIL_REASON, strict=True)
-    @MemoryTesterMixin._USE_STREAM
-    def test_group_offloading_inference_leaf_level(self, base_pipe_output, use_stream, expected_max_difference=1e-4):
-        super().test_group_offloading_inference_leaf_level(
-            base_pipe_output, use_stream, expected_max_difference=expected_max_difference
-        )
-
-    @pytest.mark.xfail(condition=True, reason=PIPELINE_GROUP_OFFLOAD_XFAIL_REASON, strict=True)
-    def test_pipeline_level_group_offloading_inference(self, base_pipe_output, expected_max_difference=1e-4):
-        super().test_pipeline_level_group_offloading_inference(
-            base_pipe_output, expected_max_difference=expected_max_difference
-        )


### PR DESCRIPTION
# What does this PR do?

This PR fixes a group offloading bug in pipelines that use a `PriorTransformer` component: because these pipelines call `PriorTransformer.post_process_latents` after `PriorTransformer.forward`, and `post_process_latents` uses the `clip_mean` and `clip_std` parameters directly, if group offloading is active, these parameters will be offloaded (since the offload hook is on `forward` and has fired), which causes a device mismatch error. This affects the following pipelines, whose group offloading tests should now pass:

- **Stable Unclip** (group offloading tests fail on `main` on GPU)
    - `pytest tests/pipelines/stable_unclip/test_stable_unclip.py -k "group_offloading"`
- **Kandinsky prior pipelines** (tests are currently skipped on `main`)
    - `pytest tests/pipelines/kandinsky/test_kandinsky_prior.py -k "group_offloading"`
    - `pytest tests/pipelines/kandinsky2_2/test_kandinsky_prior.py -k "group_offloading"`
    - `pytest tests/pipelines/kandinsky2_2/test_kandinsky_prior_emb2emb.py -k "group_offloading"`

See https://github.com/huggingface/diffusers/pull/14635#issuecomment-5504570397 for more info.


## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@sayakpaul
@DN6

