### PR TITLE
Fix GGUF `KeyError: None` when offloading rebuilds a parameter

### DIFF
--- a/src/diffusers/quantizers/gguf/utils.py
+++ b/src/diffusers/quantizers/gguf/utils.py
@@ -548,6 +548,16 @@ def dequantize_gguf_tensor(tensor):
 class GGUFParameter(torch.nn.Parameter):
     def __new__(cls, data, requires_grad=False, quant_type=None):
         data = data if data is not None else torch.empty(0)
+        if quant_type is None:
+            # Offloading rebuilds parameters as `param_cls(new_value, requires_grad=...)` without
+            # forwarding `quant_type` (see `accelerate.utils.set_module_tensor_to_device`), so
+            # inherit it from the tensor being wrapped instead of failing with `KeyError: None`.
+            quant_type = getattr(data, "quant_type", None)
+        if quant_type not in GGML_QUANT_SIZES:
+            raise ValueError(
+                f"`GGUFParameter` expects a valid `quant_type`, but got {quant_type}, and it could not "
+                "be inferred from the tensor being wrapped."
+            )
         self = torch.Tensor._make_subclass(cls, data, requires_grad)
         self.quant_type = quant_type
         block_size, type_size = GGML_QUANT_SIZES[quant_type]

--- a/tests/pipelines/testing_utils/quantization.py
+++ b/tests/pipelines/testing_utils/quantization.py
@@ -1380,6 +1380,30 @@ class TestFluxGGUFPipeline(GGUFPipelineTests):
         max_diff = numpy_cosine_similarity_distance(expected_slice, output_slice)
         assert max_diff < 1e-4
 
+    def test_pipeline_inference_sequential_cpu_offload(self):
+        r"""
+        Sequential CPU offload rebuilds every parameter through `param_cls(new_value, ...)`, which
+        used to drop `GGUFParameter.quant_type` and fail with `KeyError: None`. Like the TorchAO
+        equivalent this only checks that inference runs.
+        """
+        quantization_config = GGUFQuantizationConfig(compute_dtype=self.torch_dtype)
+        transformer = self.model_cls.from_single_file(
+            self.ckpt_path, quantization_config=quantization_config, torch_dtype=self.torch_dtype
+        )
+        pipe = FluxPipeline.from_pretrained(
+            "black-forest-labs/FLUX.1-dev", transformer=transformer, torch_dtype=self.torch_dtype
+        )
+        pipe.enable_sequential_cpu_offload()
+
+        output = pipe(
+            prompt="a cat holding a sign that says hello",
+            num_inference_steps=2,
+            generator=torch.Generator("cpu").manual_seed(0),
+            output_type="np",
+        ).images[0]
+
+        assert output.shape == (1024, 1024, 3)
+
 
 class TestSD35LargeGGUFPipeline(GGUFPipelineTests):
     ckpt_path = "https://huggingface.co/city96/stable-diffusion-3.5-large-gguf/blob/main/sd3.5_large-Q4_0.gguf"

--- a/tests/quantization/gguf/test_gguf.py
+++ b/tests/quantization/gguf/test_gguf.py
@@ -83,3 +83,48 @@ class TestGGUFCudaKernels:
             assert torch.allclose(output_native, output_cuda, 1e-2), (
                 f"GGUF CUDA Kernel Output is different from Native Output for {quant_type}"
             )
+
+
+@is_quantization
+@is_gguf
+@require_accelerate
+@require_gguf_version_greater_or_equal("0.10.0")
+class TestGGUFParameterRewrap:
+    """Offloading rebuilds parameters without forwarding `quant_type`."""
+
+    def _make_param(self):
+        from diffusers.quantizers.gguf.utils import GGML_QUANT_SIZES
+
+        quant_type = gguf.GGMLQuantizationType.Q8_0
+        _, type_size = GGML_QUANT_SIZES[quant_type]
+        data = torch.zeros((4, type_size), dtype=torch.uint8)
+
+        return GGUFParameter(data, quant_type=quant_type), quant_type
+
+    def test_rewrap_without_quant_type_inherits_it(self):
+        param, quant_type = self._make_param()
+        rewrapped = GGUFParameter(param, requires_grad=False)
+
+        assert rewrapped.quant_type == quant_type
+        assert rewrapped.quant_shape == param.quant_shape
+
+    def test_set_module_tensor_to_device_preserves_quant_type(self):
+        from accelerate.utils import set_module_tensor_to_device
+
+        from diffusers.quantizers.gguf.utils import GGUFLinear
+
+        param, quant_type = self._make_param()
+        out_features, in_features = param.quant_shape
+        module = GGUFLinear(in_features, out_features, bias=False, compute_dtype=torch.bfloat16)
+        module.weight = param
+
+        # Passing `value` (or moving across devices) is what makes `accelerate` rebuild the
+        # parameter through `param_cls(new_value, requires_grad=...)`. A same-device move with
+        # no value short-circuits before that branch and would not cover the regression.
+        set_module_tensor_to_device(module, "weight", torch.device("cpu"), value=param)
+
+        assert module.weight.quant_type == quant_type
+
+    def test_untyped_construction_raises(self):
+        with pytest.raises(ValueError):
+            GGUFParameter(torch.zeros((4, 32), dtype=torch.uint8))


### PR DESCRIPTION
Fixes #14691.

## What was broken

`GGUFParameter.__new__` defaults `quant_type` to `None` and then looks it up in `GGML_QUANT_SIZES` without a guard. Offloading rebuilds parameters as `param_cls(new_value, requires_grad=old_value.requires_grad)` — `accelerate.utils.set_module_tensor_to_device` — without forwarding `quant_type`, so every rebuild raised `KeyError: None`.

The effect: `enable_sequential_cpu_offload()` was unusable with any GGUF-quantised transformer. Since `enable_model_cpu_offload()` moves the whole transformer onto the accelerator at once, **no GGUF checkpoint larger than available VRAM could be run at all** — precisely the case GGUF quantisation exists to serve. On an 8 GB card that ruled out FLUX.1-schnell Q8_0 (12.7 GB) and Chroma1-HD Q8_0 (9.7 GB).

The error was also misleading: `KeyError: None` surfacing from inside accelerate reads as a corrupt or unsupported model file. I wrote off three different models as broken quants before running a known-good file under sequential offload and finding it failed identically.

## The fix

Inherit `quant_type` from the tensor being wrapped when it isn't passed, and raise an explicit error where there is nothing to inherit. That second path already raised (`GGML_QUANT_SIZES[None]`), so nothing that works today starts failing — it only stops the failure from surfacing as a bare `KeyError: None`.

The original suggestion in the issue was to leave `quant_shape = None` instead of raising. **@TANGBUDU correctly pointed out that this is wrong**: `FluxLoraLoaderMixin._calculate_module_shape()` does read `weight.quant_shape` for a `GGUFParameter`, and `dequantize_gguf_tensor()` only checks that `quant_type` exists, not that it's valid — so a `None`-typed parameter would have relocated the failure rather than removed it. Credit to them for the catch; this PR takes the inheritance-only route because of it.

## Tests

Two backend-level regression tests plus one pipeline-level test:

| test | on `main` | with this PR |
|---|---|---|
| `test_rewrap_without_quant_type_inherits_it` | fails, `KeyError: None` | passes |
| `test_set_module_tensor_to_device_preserves_quant_type` | fails, `KeyError: None` | passes |
| `test_untyped_construction_raises` | fails (raises `KeyError`) | passes |

Verified in both directions locally (`pytest tests/quantization/gguf/test_gguf.py -k Rewrap`), reverting the `utils.py` change to confirm each one actually fails without it.

One trap worth flagging for review: a naive `set_module_tensor_to_device` test **passes on `main`**, because a same-device move with no `value` short-circuits before the rebuild branch. It only reproduces on an actual device change or an explicit `value=`.

`test_pipeline_inference_sequential_cpu_offload` closes the coverage gap @TANGBUDU identified — `test_sequential_cpu_offload` currently exists only on `TestTorchAo`, and all four GGUF pipeline tests use `enable_model_cpu_offload()`. It follows the TorchAO precedent of asserting only that inference runs. **It is nightly + big-accelerator, so I could not run it on an 8 GB card — CI will be its first real execution.**

## On group offloading

@DN6 asked whether the issue persists under leaf-level group offloading. It does not, and the reason is mechanical: group offloading moves tensors **in place** (`param.data = param.data.to(...)` in `hooks/group_offloading.py`), so `GGUFParameter.__new__` is never re-entered. Only paths that *reconstruct* the parameter are affected.

Measured on FLUX.1-schnell Q4_K_S, 512×512, 1 step, RTX 5070 Laptop 8 GB (text encoders nulled so only the transformer offload path is exercised):

| offload mode | result | peak VRAM | time |
|---|---|---|---|
| `enable_sequential_cpu_offload()`, `main` | **`KeyError: None`** | — | — |
| group offload `leaf_level` | works | 0.77 GiB | 8.3–11.5 s |
| group offload `leaf_level`, `use_stream=True` | works | 0.77 GiB | 3.0–3.7 s |
| `enable_sequential_cpu_offload()`, this PR | works | 0.61 GiB | 5.4–6.5 s |

So group offloading is a real workaround today. `enable_sequential_cpu_offload()` is still the API the low-VRAM docs point at first, though, and it is broken for every GGUF checkpoint.

## Env

diffusers `main`, torch 2.11.0+cu128, accelerate 1.14.0, gguf 0.19.0, Python 3.12, Linux (WSL2), RTX 5070 Laptop 8 GB (sm_120).

cc @DN6 @TANGBUDU — review very welcome, this is my first contribution here.
