### PR TITLE
fix: preserve positional __init__ args through from_config round trips

### DIFF
--- a/src/diffusers/configuration_utils.py
+++ b/src/diffusers/configuration_utils.py
@@ -683,8 +683,10 @@ def register_to_config(init):
         parameters = {
             name: p.default for i, (name, p) in enumerate(signature.parameters.items()) if i > 0 and name not in ignore
         }
+        positional_arg_names = set()
         for arg, name in zip(args, parameters.keys()):
             new_kwargs[name] = arg
+            positional_arg_names.add(name)
 
         # Then add all kwargs
         new_kwargs.update(
@@ -695,9 +697,12 @@ def register_to_config(init):
             }
         )
 
-        # Take note of the parameters that were not present in the loaded config
-        if len(set(new_kwargs.keys()) - set(init_kwargs)) > 0:
-            new_kwargs["_use_default_values"] = list(set(new_kwargs.keys()) - set(init_kwargs))
+        # Take note of the parameters that were not present in the loaded config.
+        # Both keyword args (init_kwargs) and positional args must be considered
+        # explicitly provided so they survive from_config round trips.
+        explicitly_provided = set(init_kwargs) | positional_arg_names
+        if len(set(new_kwargs.keys()) - explicitly_provided) > 0:
+            new_kwargs["_use_default_values"] = list(set(new_kwargs.keys()) - explicitly_provided)
 
         new_kwargs = {**config_init_kwargs, **new_kwargs}
         getattr(self, "register_to_config")(**new_kwargs)

--- a/tests/others/test_config.py
+++ b/tests/others/test_config.py
@@ -296,6 +296,21 @@ class TestConfig:
         # Nevertheless "e" should still be correctly loaded to [1, 3] from SampleObject2 instead of defaulting to [1, 5]
         assert new_config_2.config.e == [1, 3]
 
+    def test_positional_args_survive_from_config_round_trip(self, tmp_path):
+        """Non-regression test for https://github.com/huggingface/diffusers/issues/14460"""
+        obj = SampleObject(10, 20)
+        assert obj.config["a"] == 10
+        assert obj.config["b"] == 20
+
+        obj.save_config(tmp_path)
+        loaded = SampleObject.from_config(SampleObject.load_config(tmp_path))
+        assert loaded.config["a"] == 10
+        assert loaded.config["b"] == 20
+
+        # Also verify positional args are not in _use_default_values
+        assert "a" not in obj.config._use_default_values
+        assert "b" not in obj.config._use_default_values
+
     def test_check_path_types(self):
         # Verify that we get a string returned from a WindowsPath or PosixPath (depending on system)
         config = SampleObjectPaths()


### PR DESCRIPTION
# What does this PR do?

The `@register_to_config` decorator computed `_use_default_values` by diffing `new_kwargs` against `init_kwargs`, but `init_kwargs` only captured keyword arguments. Positional args mapped into `new_kwargs` via `zip` were never tracked as explicitly provided, so `from_config` silently reverted them to class defaults.

```python
s = DDIMScheduler(500)
s.config.num_train_timesteps          # 500
DDIMScheduler.from_config(s.config).config.num_train_timesteps  # 1000 (wrong)
```

The fix tracks positional arg names separately and includes them in the set of explicitly provided parameters when computing `_use_default_values`.

Fixes #14460

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Was this discussed/approved via a GitHub issue? #14460
- [x] Did you write any new necessary tests?

## Who can review?

@sayakpaul @yiyixuxu (general functionalities)