### PR TITLE
docs: fix PAG anchor and the StableDiffusionPipelineSafe row in the SD overview

### DIFF
--- a/docs/source/en/api/pipelines/pag.md
+++ b/docs/source/en/api/pipelines/pag.md
@@ -59,7 +59,7 @@ pipeline.enable_model_cpu_offload()
 ```
 
 > [!TIP]
-> The `pag_applied_layers` argument allows you to specify which layers PAG is applied to. Additionally, you can use `set_pag_applied_layers` method to update these layers after the pipeline has been created. Check out the [pag_applied_layers](#pagappliedlayers) section to learn more about applying PAG to other layers.
+> The `pag_applied_layers` argument allows you to specify which layers PAG is applied to. Additionally, you can use `set_pag_applied_layers` method to update these layers after the pipeline has been created. Check out the [pag_applied_layers](#pag_applied_layers) section to learn more about applying PAG to other layers.
 
 If you already have a pipeline created and loaded, you can enable PAG on it using the `from_pipe` API with the `enable_pag` flag. Internally, a PAG pipeline is created based on the pipeline and task you specified. In the example below, since we used `AutoPipelineForText2Image` and passed a `StableDiffusionXLPipeline`, a `StableDiffusionXLPAGPipeline` is created accordingly. Note that this does not require additional memory, and you will have both `StableDiffusionXLPipeline` and  `StableDiffusionXLPAGPipeline` loaded and ready to use. You can read more about the `from_pipe` API and how to reuse pipelines in diffuser [here](https://huggingface.co/docs/diffusers/using-diffusers/loading#reusing-models-in-multiple-pipelines).
 

--- a/docs/source/en/api/pipelines/stable_diffusion/overview.md
+++ b/docs/source/en/api/pipelines/stable_diffusion/overview.md
@@ -85,7 +85,7 @@ The table below summarizes the available Stable Diffusion pipelines, their suppo
         </tr>
         <tr>
             <td class="px-4 py-2 text-gray-700">
-            <a href="./stable_diffusion_safe">StableDiffusionPipelineSafe</a>
+            StableDiffusionPipelineSafe (deprecated; no doc page)
             </td>
             <td class="px-4 py-2 text-gray-700">filtered text-to-image</td>
             <td class="px-4 py-2"><a href="https://huggingface.co/spaces/AIML-TUDA/unsafe-vs-safe-stable-diffusion"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue"/></a>


### PR DESCRIPTION
Description: fixes two dead links in the API docs:

1. `docs/source/en/api/pipelines/pag.md` linked `#pagappliedlayers`; the heading `### pag_applied_layers` keeps its underscores → `#pag_applied_layers`.
2. `docs/source/en/api/pipelines/stable_diffusion/overview.md`: the pipelines table linked `./stable_diffusion_safe`, a doc page that no longer exists anywhere under `docs/source` (verified case-sensitively). The row now names the deprecated pipeline as plain text instead of a dead link.
