### PR TITLE
docs: fix docstring parameter names that do not match signatures

### DIFF
--- a/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
+++ b/src/diffusers/pipelines/flux/pipeline_flux_controlnet.py
@@ -368,9 +368,6 @@ class FluxControlNetPipeline(DiffusionPipeline, FluxLoraLoaderMixin, FromSingleF
             pooled_prompt_embeds (`torch.FloatTensor`, *optional*):
                 Pre-generated pooled text embeddings. Can be used to easily tweak text inputs, *e.g.* prompt weighting.
                 If not provided, pooled text embeddings will be generated from `prompt` input argument.
-            clip_skip (`int`, *optional*):
-                Number of layers to be skipped from CLIP while computing the prompt embeddings. A value of 1 means that
-                the output of the pre-final layer will be used for computing the prompt embeddings.
             lora_scale (`float`, *optional*):
                 A lora scale that will be applied to all LoRA layers of the text encoder if LoRA layers are loaded.
         """

--- a/src/diffusers/pipelines/hunyuan_video1_5/pipeline_hunyuan_video1_5.py
+++ b/src/diffusers/pipelines/hunyuan_video1_5/pipeline_hunyuan_video1_5.py
@@ -352,7 +352,7 @@ class HunyuanVideo15Pipeline(DiffusionPipeline):
                 torch device
             batch_size (`int`):
                 batch size of prompts, defaults to 1
-            num_images_per_prompt (`int`):
+            num_videos_per_prompt (`int`):
                 number of images that should be generated per prompt
             prompt_embeds (`torch.Tensor`, *optional*):
                 Pre-generated text embeddings. If not provided, text embeddings will be generated from `prompt` input

--- a/src/diffusers/pipelines/hunyuan_video1_5/pipeline_hunyuan_video1_5_image2video.py
+++ b/src/diffusers/pipelines/hunyuan_video1_5/pipeline_hunyuan_video1_5_image2video.py
@@ -440,7 +440,7 @@ class HunyuanVideo15ImageToVideoPipeline(DiffusionPipeline):
                 torch device
             batch_size (`int`):
                 batch size of prompts, defaults to 1
-            num_images_per_prompt (`int`):
+            num_videos_per_prompt (`int`):
                 number of images that should be generated per prompt
             prompt_embeds (`torch.Tensor`, *optional*):
                 Pre-generated text embeddings. If not provided, text embeddings will be generated from `prompt` input

--- a/src/diffusers/pipelines/kandinsky5/pipeline_kandinsky.py
+++ b/src/diffusers/pipelines/kandinsky5/pipeline_kandinsky.py
@@ -326,7 +326,6 @@ class Kandinsky5T2VPipeline(DiffusionPipeline, KandinskyLoraLoaderMixin):
         Args:
             prompt (str | list[str]): Input prompt or list of prompts
             device (torch.device): Device to run encoding on
-            num_videos_per_prompt (int): Number of videos to generate per prompt
             max_sequence_length (int): Maximum sequence length for tokenization
             dtype (torch.dtype): Data type for embeddings
 
@@ -395,7 +394,6 @@ class Kandinsky5T2VPipeline(DiffusionPipeline, KandinskyLoraLoaderMixin):
         Args:
             prompt (str | list[str]): Input prompt or list of prompts
             device (torch.device): Device to run encoding on
-            num_videos_per_prompt (int): Number of videos to generate per prompt
             dtype (torch.dtype): Data type for embeddings
 
         Returns:


### PR DESCRIPTION
Docstring-only fixes, each verified against the signature directly above it (found via an AST docstring-Args vs signature sweep over `src/diffusers/pipelines`):

1. `FluxControlNetPipeline.encode_prompt` documented a `clip_skip` parameter — copy-paste from SD-style docs; flux has no CLIP layer-skipping and the parameter does not exist.
2. `HunyuanVideo15Pipeline` / `...Image2VideoPipeline`: the docstring said `num_images_per_prompt (`int`)` while the parameter is `num_videos_per_prompt`.
3. `Kandinsky5` `_encode_prompt_qwen` / `_encode_prompt_clip`: documented `num_videos_per_prompt`, which neither helper accepts; removed the stale entries.

Docstrings only; no code change.