### PR TITLE
docs: fix latent -> latents in LTX latent upsampler docstrings

### DIFF
--- a/src/diffusers/pipelines/ltx/pipeline_ltx_latent_upsample.py
+++ b/src/diffusers/pipelines/ltx/pipeline_ltx_latent_upsample.py
@@ -97,7 +97,7 @@ class LTXLatentUpsamplePipeline(DiffusionPipeline):
         tensor.
 
         Args:
-            latent (`torch.Tensor`):
+            latents (`torch.Tensor`):
                 Input latents to normalize
             reference_latents (`torch.Tensor`):
                 The reference latents providing style statistics.

--- a/src/diffusers/pipelines/ltx2/pipeline_ltx2_latent_upsample.py
+++ b/src/diffusers/pipelines/ltx2/pipeline_ltx2_latent_upsample.py
@@ -171,7 +171,7 @@ class LTX2LatentUpsamplePipeline(DiffusionPipeline):
         tensor.
 
         Args:
-            latent (`torch.Tensor`):
+            latents (`torch.Tensor`):
                 Input latents to normalize
             reference_latents (`torch.Tensor`):
                 The reference latents providing style statistics.


### PR DESCRIPTION
`LTXLatentUpsamplerPipeline.__call__` (and the LTX2 variant) takes `latents: torch.Tensor | None = None`, but the docstring documented a `latent` parameter — its own description ('Input latents to normalize') already used the plural. Docstring-only fix in both files.