### PR TITLE
fix(schedulers): preserve float32 timesteps for squaredcos_cap_v2 in DPMSolverMultistepScheduler (#12771)

### DIFF
--- a/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
+++ b/src/diffusers/schedulers/scheduling_dpmsolver_multistep.py
@@ -482,7 +482,10 @@ class DPMSolverMultistepScheduler(SchedulerMixin, ConfigMixin):
         sigmas = np.concatenate([sigmas, [sigma_last]]).astype(np.float32)
 
         self.sigmas = torch.from_numpy(sigmas)
-        self.timesteps = torch.from_numpy(timesteps).to(device=device, dtype=torch.int64)
+        if self.config.beta_schedule == "squaredcos_cap_v2":
+            self.timesteps = torch.from_numpy(timesteps.astype(np.float32)).to(device=device)
+        else:
+            self.timesteps = torch.from_numpy(timesteps).to(device=device, dtype=torch.int64)
 
         self.num_inference_steps = len(timesteps)
 

--- a/tests/schedulers/test_scheduler_dpm_multi.py
+++ b/tests/schedulers/test_scheduler_dpm_multi.py
@@ -366,3 +366,27 @@ class DPMSolverMultistepSchedulerTest(SchedulerCommonTest):
 
     def test_exponential_sigmas(self):
         self.check_over_configs(use_exponential_sigmas=True)
+
+    def test_squaredcos_cap_v2(self):
+        scheduler_class = self.scheduler_classes[0]
+        num_inference_steps = 20
+        model = self.dummy_model()
+        sample = self.dummy_sample_deter
+
+        for sigma_key in ["use_karras_sigmas", "use_lu_lambdas", "use_exponential_sigmas", "use_beta_sigmas"]:
+            scheduler_config = self.get_scheduler_config(
+                beta_schedule="squaredcos_cap_v2",
+                **{sigma_key: True},
+            )
+            scheduler = scheduler_class(**scheduler_config)
+            scheduler.set_timesteps(num_inference_steps)
+
+            assert scheduler.timesteps.dtype == torch.float32
+            assert len(scheduler.timesteps.unique()) == num_inference_steps
+
+            prev_sample = sample
+            for t in scheduler.timesteps:
+                residual = model(prev_sample, t)
+                prev_sample = scheduler.step(residual, t, prev_sample).prev_sample
+
+            assert prev_sample is not None


### PR DESCRIPTION
# Fix out-of-bounds error in `DPMSolverMultistepScheduler` when using `beta_schedule="squaredcos_cap_v2"`

Fixes #12771.

### Root Cause
In `DPMSolverMultistepScheduler.set_timesteps()`:
1. When `self.config.use_karras_sigmas=True` (or `use_lu_lambdas=True`), the schedule deliberately skips rounding timesteps to integer when `beta_schedule == "squaredcos_cap_v2"`:
   ```python
   timesteps = np.array([self._sigma_to_t(sigma, log_sigmas) for sigma in sigmas])
   if self.config.beta_schedule != "squaredcos_cap_v2":
       timesteps = timesteps.round()
   ```
   For `squaredcos_cap_v2`, `timesteps` values in early steps are close non-integer floats (e.g., `[999.0, 998.903, 998.802, 998.696, 998.583, ...]`).
2. However, when storing `self.timesteps`, it was hardcoded to `dtype=torch.int64`:
   ```python
   self.timesteps = torch.from_numpy(timesteps).to(device=device, dtype=torch.int64)
   ```
   Casting to `int64` truncates (`floor`) fractional values, collapsing them into consecutive duplicate integers (`tensor([998, 998, 998, 998, 998, 998, 998, 998, 998, 997, ...])`).
3. During inference, on the first step `timestep = 998`, `_init_step_index()` calls `index_for_timestep()`. Because there are duplicate `998` entries, `index_candidates` has multiple matches and takes `index_candidates[1].item()` (index 1 instead of 0).
4. This 1-step index drift carries forward into every subsequent step, causing the last step (step 19 of 20) to have `step_index = 20`. Attempting to read `sigmas[self.step_index + 1]` (index 21 on a tensor of length 21) raises:
   ```
   IndexError: index 21 is out of bounds for dimension 0 with size 21
   ```
   The same failure occurs with `use_exponential_sigmas=True` and `use_beta_sigmas=True`.

### Solution
- Conditionally store `self.timesteps` as `torch.float32` when `self.config.beta_schedule == "squaredcos_cap_v2"` (matching `EulerDiscreteScheduler` and `DPMSolverSDEScheduler`):
  ```python
  if self.config.beta_schedule == "squaredcos_cap_v2":
      self.timesteps = torch.from_numpy(timesteps.astype(np.float32)).to(device=device)
  else:
      self.timesteps = torch.from_numpy(timesteps).to(device=device, dtype=torch.int64)
  ```
- This preserves unique fractional timesteps, eliminating duplicate timestep candidates and preventing index drift.

### Verification
1. **Isolated Reproduction**:
   - Before fix: `DPMSolverMultistepScheduler(beta_schedule="squaredcos_cap_v2", use_karras_sigmas=True)` fails with `IndexError: index 21 is out of bounds for dimension 0 with size 21` at step 19/20.
   - After fix: All 20 steps execute successfully with 100% unique timesteps.
2. **Unit Tests**:
   - Added `test_squaredcos_cap_v2` in `tests/schedulers/test_scheduler_dpm_multi.py`, asserting `dtype == torch.float32`, uniqueness of timesteps, and full denoising loop completion across `use_karras_sigmas`, `use_lu_lambdas`, `use_exponential_sigmas`, and `use_beta_sigmas`.
   - `pytest tests/schedulers/test_scheduler_dpm_multi.py` passes all 42 tests.
3. **End-to-End Pipeline Test**:
   - Ran `StableDiffusionPipeline` generation (`tiny-stable-diffusion-torch`) with `squaredcos_cap_v2` and `use_karras_sigmas=True`, successfully generating images without errors.
4. **Code Quality**:
   - `ruff check` and `ruff format` pass cleanly.
