### PR TITLE
docs: type three boolean docstring parameters as bool, not str

### DIFF
--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -2609,7 +2609,7 @@ class ModularPipeline(ConfigMixin, PushToHubMixin):
             device (`torch.Device`, *optional*):
                 Returns a pipeline with the specified
                 [`device`](https://pytorch.org/docs/stable/tensor_attributes.html#torch.device)
-            silence_dtype_warnings (`str`, *optional*, defaults to `False`):
+            silence_dtype_warnings (`bool`, *optional*, defaults to `False`):
                 Whether to omit warnings if the target `dtype` is not compatible with the target `device`.
 
         Returns:

--- a/src/diffusers/pipelines/pipeline_utils.py
+++ b/src/diffusers/pipelines/pipeline_utils.py
@@ -420,7 +420,7 @@ class DiffusionPipeline(ConfigMixin, PushToHubMixin):
             device (`torch.Device`, *optional*):
                 Returns a pipeline with the specified
                 [`device`](https://pytorch.org/docs/stable/tensor_attributes.html#torch.device)
-            silence_dtype_warnings (`str`, *optional*, defaults to `False`):
+            silence_dtype_warnings (`bool`, *optional*, defaults to `False`):
                 Whether to omit warnings if the target `dtype` is not compatible with the target `device`.
 
         Returns:

--- a/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -1210,7 +1210,7 @@ def download_from_original_stable_diffusion_ckpt(
             diffusion 2.1.
         device (`str`, *optional*, defaults to `None`):
             The device to use. Pass `None` to determine automatically.
-        from_safetensors (`str`, *optional*, defaults to `False`):
+        from_safetensors (`bool`, *optional*, defaults to `False`):
             If `checkpoint_path` is in `safetensors` format, load checkpoint with safetensors instead of PyTorch.
         load_safety_checker (`bool`, *optional*, defaults to `True`):
             Whether to load the safety checker or not. Defaults to `True`.


### PR DESCRIPTION
Fixes #14723

## What's wrong

Three docstrings annotate a boolean parameter as `` `str` ``. Each line contradicts itself, because it
pairs the `str` type with a boolean default:

| File | Line | Parameter | Was | Now |
|---|---|---|---|---|
| `pipelines/pipeline_utils.py` | 423 | `silence_dtype_warnings` | `` `str` `` | **`bool`** |
| `modular_pipelines/modular_pipeline.py` | 2612 | `silence_dtype_warnings` | `` `str` `` | **`bool`** |
| `pipelines/stable_diffusion/convert_from_ckpt.py` | 1213 | `from_safetensors` | `` `str` `` | **`bool`** |

`str` actively misleads: it implies passing `"False"`, which is truthy.

## Evidence, from the code rather than the parameter names

**`silence_dtype_warnings`** — the same docstring's own signature examples, three lines above the
entry, already write it as a boolean (`pipeline_utils.py:408`, `:410`, `:412`:
`to(dtype, silence_dtype_warnings=False)`). It is read as
`kwargs.pop("silence_dtype_warnings", False)` (`:431`), used as a bare condition (`:588`
`and not silence_dtype_warnings`), and internal callers pass `True` (`:1230`, `:1344`). The prose
directly below it reads "Whether to omit warnings…".

**`from_safetensors`** — annotated `from_safetensors: bool = False` at `:1156`, used as a bare
condition at `:1269`. The *next* docstring entry,
``load_safety_checker (`bool`, *optional*, defaults to `True`)``, is the correct spelling of the same
shape.

## Validation

```
$ uvx ruff check <the 3 changed files>
All checks passed!

$ uvx ruff format --check <the 3 changed files>
3 files already formatted
```

`git diff --stat`: 3 files, +3/-3.

## Self-review (per CONTRIBUTING)

Ran the `.ai/skills/self-review` rubric against `.ai/review-rules.md`:

- **Blocking issues:** none. Docstring text only; no logic, signature, or default changed.
- **`# Copied from`:** checked per function, since two of the three fix the *same* parameter text in
  two files — that is the shape a copy-link usually takes. Both are `def to(self, *args, **kwargs)`
  (`pipeline_utils.py:397`, `modular_pipeline.py:2586`) and neither carries a `# Copied from` header,
  so editing both by hand is correct rather than fixing one source and running `make fix-copies`.
  `utils/check_copies.py` is outside my sparse checkout, so this is the manual equivalent; CI's
  consistency check will confirm.
- **Ephemeral context:** none added.
- **Documentation impact:** this *is* the documentation fix. No `docs/` page restates these types.
- **Dead code analysis:** N/A.

## How this was found, and what it deliberately excludes

An AST pass comparing each documented parameter type against its real annotation. It only reports
unambiguous contradictions between two simple types, and skips everything it cannot settle exactly:
unannotated parameters, containers/unions/generics on either side, prose types, and compatible
spellings like `bool` vs `int`. After this change it reports **0** for `src/diffusers`.

**Related, deliberately left out** — a different problem class that would touch 19 files: 27
docstrings write a boolean default as a *quoted string*, e.g.
``force_zeros_for_empty_prompt (`bool`, *optional*, defaults to `"True"`)`` in
`pipeline_controlnet_sd_xl.py:222` where the signature is `bool = True`. That is a default-value
formatting issue rather than a wrong type, so it does not belong in the same PR. Happy to follow up
per pipeline family or as one batch — tell me which you prefer.

---

🤖 Written with [Claude Code](https://claude.com/claude-code). All three sites were read in context and
each type was confirmed against the code that consumes the value.
