### PR TITLE
docs(optimization): document num_cycles, not the nonexistent num_periods

### DIFF
--- a/src/diffusers/optimization.py
+++ b/src/diffusers/optimization.py
@@ -173,7 +173,7 @@ def get_cosine_schedule_with_warmup(
             The number of steps for the warmup phase.
         num_training_steps (`int`):
             The total number of training steps.
-        num_periods (`float`, *optional*, defaults to 0.5):
+        num_cycles (`float`, *optional*, defaults to 0.5):
             The number of periods of the cosine function in a schedule (the default is to just decrease from the max
             value to 0 following a half-cosine).
         last_epoch (`int`, *optional*, defaults to -1):


### PR DESCRIPTION
`get_cosine_schedule_with_warmup`'s docstring documents a `num_periods` parameter. No such parameter exists — the signature and the cosine closure use `num_cycles` (and the hard-restart sibling documents `num_cycles` correctly). One-line docstring fix.