### PR TITLE
docs(examples): drop duplicated 'with' in sequence-length help strings

### DIFF
--- a/examples/advanced_diffusion_training/train_dreambooth_lora_flux_advanced.py
+++ b/examples/advanced_diffusion_training/train_dreambooth_lora_flux_advanced.py
@@ -421,7 +421,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=512,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--validation_prompt",

--- a/examples/controlnet/train_controlnet_sd3.py
+++ b/examples/controlnet/train_controlnet_sd3.py
@@ -585,7 +585,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=77,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--dataset_preprocess_batch_size", type=int, default=1000, help="Batch size for preprocessing dataset."

--- a/examples/dreambooth/train_dreambooth_flux.py
+++ b/examples/dreambooth/train_dreambooth_flux.py
@@ -329,7 +329,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=77,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--validation_prompt",

--- a/examples/dreambooth/train_dreambooth_lora_flux.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux.py
@@ -349,7 +349,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=512,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--validation_prompt",

--- a/examples/dreambooth/train_dreambooth_lora_flux2.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2.py
@@ -353,7 +353,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=512,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--text_encoder_out_layers",

--- a/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_img2img.py
@@ -354,7 +354,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=512,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--validation_prompt",

--- a/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_klein.py
@@ -353,7 +353,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=512,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--text_encoder_out_layers",

--- a/examples/dreambooth/train_dreambooth_lora_flux2_klein_img2img.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux2_klein_img2img.py
@@ -355,7 +355,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=512,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--validation_prompt",

--- a/examples/dreambooth/train_dreambooth_lora_flux_kontext.py
+++ b/examples/dreambooth/train_dreambooth_lora_flux_kontext.py
@@ -368,7 +368,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=512,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--validation_prompt",

--- a/examples/dreambooth/train_dreambooth_lora_lumina2.py
+++ b/examples/dreambooth/train_dreambooth_lora_lumina2.py
@@ -288,7 +288,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=256,
-        help="Maximum sequence length to use with with the Gemma2 model",
+        help="Maximum sequence length to use with the Gemma2 model",
     )
     parser.add_argument(
         "--system_prompt",

--- a/examples/dreambooth/train_dreambooth_lora_sana.py
+++ b/examples/dreambooth/train_dreambooth_lora_sana.py
@@ -308,7 +308,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=300,
-        help="Maximum sequence length to use with with the Gemma model",
+        help="Maximum sequence length to use with the Gemma model",
     )
     parser.add_argument(
         "--complex_human_instruction",

--- a/examples/dreambooth/train_dreambooth_lora_sd3.py
+++ b/examples/dreambooth/train_dreambooth_lora_sd3.py
@@ -339,7 +339,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=77,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--validation_prompt",

--- a/examples/dreambooth/train_dreambooth_lora_z_image.py
+++ b/examples/dreambooth/train_dreambooth_lora_z_image.py
@@ -353,7 +353,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=512,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
 
     parser.add_argument(

--- a/examples/dreambooth/train_dreambooth_sd3.py
+++ b/examples/dreambooth/train_dreambooth_sd3.py
@@ -315,7 +315,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=77,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--validation_prompt",

--- a/examples/research_projects/sana/train_sana_sprint_diffusers.py
+++ b/examples/research_projects/sana/train_sana_sprint_diffusers.py
@@ -359,7 +359,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=300,
-        help="Maximum sequence length to use with with the Gemma model",
+        help="Maximum sequence length to use with the Gemma model",
     )
     parser.add_argument(
         "--validation_prompt",

--- a/examples/research_projects/sd3_lora_colab/train_dreambooth_lora_sd3_miniature.py
+++ b/examples/research_projects/sd3_lora_colab/train_dreambooth_lora_sd3_miniature.py
@@ -235,7 +235,7 @@ def parse_args(input_args=None):
         "--max_sequence_length",
         type=int,
         default=77,
-        help="Maximum sequence length to use with with the T5 text encoder",
+        help="Maximum sequence length to use with the T5 text encoder",
     )
     parser.add_argument(
         "--validation_prompt",


### PR DESCRIPTION
16 example scripts had `--max_sequence_length` help text reading "Maximum sequence length to use **with with** the T5 text encoder" (one uses the Gemma variant). The duplication surfaces in `--help` output. Mechanical one-word-per-file fix:

```
examples/controlnet/train_controlnet_sd3.py
examples/advanced_diffusion_training/train_dreambooth_lora_flux_advanced.py
examples/dreambooth/train_dreambooth_lora_flux.py (+flux2 variants)
examples/research_projects/sana/train_sana_sprint_diffusers.py
examples/research_projects/sd3_lora_colab/train_dreambooth_lora_sd3_miniature.py
```