### PR TITLE
Fix StableDiffusion3Pipeline.skip_guidance_layers raising AttributeError

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
+++ b/src/diffusers/pipelines/stable_diffusion_3/pipeline_stable_diffusion_3.py
@@ -949,6 +949,7 @@ class StableDiffusion3Pipeline(DiffusionPipeline, SD3LoraLoaderMixin, FromSingle
         )
 
         self._guidance_scale = guidance_scale
+        self._skip_guidance_layers = skip_guidance_layers
         self._skip_layer_guidance_scale = skip_layer_guidance_scale
         self._clip_skip = clip_skip
         self._joint_attention_kwargs = joint_attention_kwargs

--- a/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3.py
+++ b/tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3.py
@@ -187,10 +187,12 @@ class TestStableDiffusion3Pipeline(StableDiffusion3PipelineTesterConfig, Pipelin
         inputs = self.get_dummy_inputs()
 
         output_full = pipe(**inputs)[0]
+        assert pipe.skip_guidance_layers is None
 
         inputs_with_skip = inputs.copy()
         inputs_with_skip["skip_guidance_layers"] = [0]
         output_skip = pipe(**inputs_with_skip)[0]
+        assert pipe.skip_guidance_layers == [0]
 
         assert not torch.allclose(output_full, output_skip, atol=1e-5), "Outputs should differ when layers are skipped"
         assert output_full.shape == output_skip.shape, "Outputs should have the same shape"


### PR DESCRIPTION
Fixes #14759.

That issue also covers a second case in `LEditsPPPipelineStableDiffusionXL`, which this PR does not touch: the fix there needs a decision from you about what a guidance scale should mean for LEdits++, so it needs its own follow up.

## What does this PR do?

`StableDiffusion3Pipeline.skip_guidance_layers` raises `AttributeError`, before or after a call:

```python
@property
def skip_guidance_layers(self):
    return self._skip_guidance_layers
```

`__call__` stores the other guidance knobs on `self` so their properties can read them back, but `skip_guidance_layers` was left out of that block:

```python
self._guidance_scale = guidance_scale
self._skip_layer_guidance_scale = skip_layer_guidance_scale
self._clip_skip = clip_skip
self._joint_attention_kwargs = joint_attention_kwargs
self._interrupt = False
```

`grep -rn "_skip_guidance_layers = " src/` returns nothing, so the name is never assigned anywhere in the library. `skip_guidance_layers` stays a local in `__call__` and does reach the transformer, so skip layer guidance itself works. Only the property is broken.

Adding the missing assignment is the whole change. `StableDiffusion3Pipeline.__call__` is not a `# Copied from` source for any other pipeline, so nothing else moves.

## Testing

`tests/pipelines/stable_diffusion_3/test_pipeline_stable_diffusion_3.py::TestStableDiffusion3Pipeline::test_skip_guidance_layers` already runs the feature both ways, so it now also reads the property back. Two assertions, no new fixture.

- That test on `main`: fails with `AttributeError: 'StableDiffusion3Pipeline' object has no attribute 'skip_guidance_layers'`. With this branch: passes. The message names the property rather than the missing underscore attribute, because the getter's `AttributeError` falls through to `nn.Module.__getattr__`, which probably helped this go unnoticed.
- The whole file: 1 failed, 20 passed, 17 skipped on both `main` and this branch. The failure is `test_inference`, which compares against a hardcoded expected slice at `atol=1e-3` and misses on my CPU box on `main` too.
- `ruff check` and `ruff format --check` on both changed files with the 0.9.10 pinned in `setup.py`: clean.
- `make fix-copies` is unaffected, since nothing copies from `__call__`.

Ran on Python 3.13, torch 2.11.0, Linux, CPU.

## Self-review

Against `.ai/references/review-rules.md`:

- Correctness: the added line mirrors the four assignments around it and uses the parameter already in scope. No behaviour outside the property changes, which is why the output comparisons in that test are untouched and still pass.
- Ephemeral context: no comments added, nothing that refers to this PR or its review.
- Copied code: checked that `__call__` is not a `# Copied from` source before editing it.
- Tests: extends the test that already covers this feature rather than adding a second pipeline build, per the dummy-component conventions in `testing.md`.
- Documentation impact: `skip_guidance_layers` is documented as a `__call__` argument in the docstring, which is accurate and unchanged. Nothing under `docs/` mentions the property.
- Suggestion, not blocking: `_skip_layer_guidance_scale` is the mirror image of this, assigned in `__call__` but with no property, while `skip_layer_guidance_start` and `skip_layer_guidance_stop` have neither. If the intent is for every guidance knob to be readable back, those are the remaining gaps. I left them alone since only the missing assignment causes a failure today.

