### PR TITLE
Fix float truncation in Flux2ImageProcessor._resize_to_target_area

### DIFF
--- a/src/diffusers/pipelines/flux2/image_processor.py
+++ b/src/diffusers/pipelines/flux2/image_processor.py
@@ -109,8 +109,11 @@ class Flux2ImageProcessor(VaeImageProcessor):
         image_width, image_height = image.size
 
         scale = math.sqrt(target_area / (image_width * image_height))
-        width = int(image_width * scale)
-        height = int(image_height * scale)
+        # Use `round` rather than `int`: truncation turns floating-point noise (e.g. 1023.999...) into a lost pixel,
+        # which callers then floor to a smaller multiple of the VAE scale factor. Rounding may exceed `target_area` by
+        # at most one pixel per side, which every caller floors away.
+        width = round(image_width * scale)
+        height = round(image_height * scale)
 
         return image.resize((width, height), PIL.Image.Resampling.LANCZOS)
 


### PR DESCRIPTION
# What does this PR do?

`Flux2ImageProcessor._resize_to_target_area` scales a reference image down to a target area with `int(side * scale)`.

Take a square input, for example 1039x1039. The target area is 1024x1024, so the new side should be exactly 1024. In floating point the computation comes out as `1023.999...` instead. `int` truncates that to 1023.

This is not a rare edge case. I checked every square size from 1025 to 8192. Out of those 7168 sizes, 1152 come out as `1023.999...` instead of 1024. That is about one in six. The smallest ones are 1039, 1040, 1070, 1081 and 1105.

The callers then floor each side to a multiple of 16. 1024 stays 1024, but 1023 becomes 1008. So for these inputs the conditioning image is **1008x1008 instead of 1024x1024**. When `height` and `width` are not passed, the generated image is 1008x1008 as well.

Affected callers (all share the same helper):
- `Flux2Pipeline`, `Flux2KleinPipeline`, `Flux2KleinKVPipeline`
- Flux2 modular blocks (`modular_pipelines/flux2/inputs.py`)
- `ZImageOmniPipeline` (imports `Flux2ImageProcessor`)
- `Flux2ImageProcessor._resize_if_exceeds_area`

**Fix:** use `round` instead of `int`. This may exceed `target_area` by at most one pixel per side, which every caller floors away, so the practical effect is only that exact-scale inputs now land on the intended size. Behavior for other aspect ratios is unchanged apart from the occasional one-tile (16 px) difference where truncation previously crossed a multiple-of-16 boundary.

Repro on `main`:

```python
from PIL import Image
from diffusers.pipelines.flux2.image_processor import Flux2ImageProcessor

Flux2ImageProcessor._resize_to_target_area(Image.new("RGB", (1039, 1039)), 1024 * 1024).size
# main:    (1023, 1023)  -> pipelines floor to 1008x1008
# this PR: (1024, 1024)
```

With this PR, all 7168 square sizes in the sweep above map to 1024x1024.

Verified locally: `tests/others/test_image_processor.py` and `tests/pipelines/flux2/test_pipeline_flux2_klein.py` pass except `TestFlux2KleinPipelineMemory::test_layerwise_casting_inference`, which fails identically on `main` and is unrelated. `make style` / `check_copies.py` are clean.

<details>
<summary>Self-review notes (final round)</summary>

Reviewed the diff against `.ai/references/review-rules.md`, `code_style.md`, `pipelines.md`, and `testing.md`.

- **Blocking issues:** none.
- **Non-blocking issues:** none. The only judgement call is `round` (may exceed `target_area` by ~1 px/side) versus `math.floor(x + eps)` (never exceeds). `round` was chosen because every caller floors to a multiple of 16 immediately afterwards, so the guarantee is not relied upon; happy to switch if maintainers prefer the strict bound.
- **Dead code:** n/a (no new model or code paths).
- **Docs impact:** no user docs reference this helper's sizing; no `# Copied from` blocks reference it.
- **Verdict:** READY.

</details>

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Was this discussed/approved via a GitHub issue or the forum? No, small bug fix.
- [x] Did you make sure to update the documentation with your changes? N/A, no user-facing API change.
- [ ] Did you write any new necessary tests? No, one-line fix to a private helper; the repro above is the check.

## Who can review?

@sayakpaul @yiyixuxu
