### PR TITLE
fix modular pipeline class resolution for families outside the auto-pipeline mappings

### DIFF
--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -1749,8 +1749,6 @@ class ModularPipeline(ConfigMixin, PushToHubMixin):
             blocks = blocks_class()
 
         if workflow is not None:
-            if blocks is None:
-                raise ValueError(f"`workflow={workflow!r}` requires pipeline blocks, but none could be resolved.")
             blocks = blocks.get_workflow(workflow)
 
         self._blocks = blocks

--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -1930,10 +1930,6 @@ class ModularPipeline(ConfigMixin, PushToHubMixin):
             logger.debug(" try to determine the modular pipeline class from model_index.json")
             standard_pipeline_class = _get_pipeline_class(cls, config=config_dict)
             model_name = _get_model(standard_pipeline_class.__name__)
-            if model_name not in MODULAR_PIPELINE_MAPPING:
-                # Pipelines outside the auto-pipeline task mappings (e.g. video) resolve by their pipeline folder
-                # when it names a modular family, e.g. `diffusers.pipelines.ltx` -> "ltx".
-                model_name = standard_pipeline_class.__module__.split(".")[2]
             map_fn = MODULAR_PIPELINE_MAPPING.get(model_name, _create_default_map_fn("ModularPipeline"))
             pipeline_class_name = map_fn(config_dict)
             diffusers_module = importlib.import_module("diffusers")

--- a/src/diffusers/modular_pipelines/modular_pipeline.py
+++ b/src/diffusers/modular_pipelines/modular_pipeline.py
@@ -1727,6 +1727,7 @@ class ModularPipeline(ConfigMixin, PushToHubMixin):
             )
 
         if blocks is None:
+            blocks_class = None
             if modular_config_dict is not None:
                 blocks_class_name = modular_config_dict.get("_blocks_class_name")
             else:
@@ -1740,10 +1741,12 @@ class ModularPipeline(ConfigMixin, PushToHubMixin):
                     blocks_class_name = self.default_blocks_name
                     blocks_class = getattr(diffusers_module, blocks_class_name)
 
-            if blocks_class is not None:
-                blocks = blocks_class()
-            else:
-                logger.warning(f"`blocks` is `None`, no default blocks class found for {self.__class__.__name__}")
+            if blocks_class is None:
+                raise ValueError(
+                    f"No pipeline blocks could be resolved for {self.__class__.__name__}: pass `blocks`, or use a "
+                    "pipeline class with a `default_blocks_name`."
+                )
+            blocks = blocks_class()
 
         if workflow is not None:
             if blocks is None:
@@ -1927,6 +1930,10 @@ class ModularPipeline(ConfigMixin, PushToHubMixin):
             logger.debug(" try to determine the modular pipeline class from model_index.json")
             standard_pipeline_class = _get_pipeline_class(cls, config=config_dict)
             model_name = _get_model(standard_pipeline_class.__name__)
+            if model_name not in MODULAR_PIPELINE_MAPPING:
+                # Pipelines outside the auto-pipeline task mappings (e.g. video) resolve by their pipeline folder
+                # when it names a modular family, e.g. `diffusers.pipelines.ltx` -> "ltx".
+                model_name = standard_pipeline_class.__module__.split(".")[2]
             map_fn = MODULAR_PIPELINE_MAPPING.get(model_name, _create_default_map_fn("ModularPipeline"))
             pipeline_class_name = map_fn(config_dict)
             diffusers_module = importlib.import_module("diffusers")

--- a/src/diffusers/pipelines/auto_pipeline.py
+++ b/src/diffusers/pipelines/auto_pipeline.py
@@ -81,6 +81,7 @@ from .kandinsky3 import Kandinsky3Img2ImgPipeline, Kandinsky3Pipeline
 from .krea2 import Krea2Pipeline
 from .latent_consistency_models import LatentConsistencyModelImg2ImgPipeline, LatentConsistencyModelPipeline
 from .longcat_audio_dit import LongCatAudioDiTPipeline
+from .ltx import LTXImageToVideoPipeline, LTXPipeline
 from .lumina import LuminaPipeline
 from .lumina2 import Lumina2Pipeline
 from .nucleusmoe_image import NucleusMoEImagePipeline
@@ -269,6 +270,7 @@ AUTO_INPAINT_PIPELINES_MAPPING = OrderedDict(
 AUTO_TEXT2VIDEO_PIPELINES_MAPPING = OrderedDict(
     [
         ("anyflow", AnyFlowPipeline),
+        ("ltx", LTXPipeline),
         ("wan", WanPipeline),
     ]
 )
@@ -282,6 +284,7 @@ AUTO_CONDITION2VIDEO_PIPELINES_MAPPING = OrderedDict(
 AUTO_IMAGE2VIDEO_PIPELINES_MAPPING = OrderedDict(
     [
         ("anyflow-far", AnyFlowFARPipeline),
+        ("ltx", LTXImageToVideoPipeline),
         ("wan-i2v", WanImageToVideoPipeline),
     ]
 )

--- a/tests/modular_pipelines/test_modular_pipeline_loading.py
+++ b/tests/modular_pipelines/test_modular_pipeline_loading.py
@@ -275,7 +275,7 @@ class TestModularPipelineInitFallback:
             ModularPipeline()
 
     def test_from_pretrained_resolves_family_outside_auto_pipeline_mappings(self, tmp_path):
-        # LTX is not in the auto-pipeline task mappings, so the modular class resolves from the pipeline folder.
+        # A standard model_index.json resolves to the modular class through the auto-pipeline video mappings.
         with open(tmp_path / "model_index.json", "w") as f:
             json.dump({"_class_name": "LTXPipeline", "_diffusers_version": "0.0.0"}, f)
 

--- a/tests/modular_pipelines/test_modular_pipeline_loading.py
+++ b/tests/modular_pipelines/test_modular_pipeline_loading.py
@@ -268,3 +268,18 @@ class TestModularPipelineInitFallback:
         assert loaded_pipe.__class__.__name__ == pipe.__class__.__name__
         assert loaded_pipe._blocks.__class__.__name__ == pipe._blocks.__class__.__name__
         assert len(loaded_pipe._blocks.sub_blocks) == len(pipe._blocks.sub_blocks)
+
+    def test_init_raises_without_resolvable_blocks(self):
+        # The base class has no `default_blocks_name`, so with no `blocks` there is nothing to build from.
+        with pytest.raises(ValueError, match="No pipeline blocks could be resolved"):
+            ModularPipeline()
+
+    def test_from_pretrained_resolves_family_outside_auto_pipeline_mappings(self, tmp_path):
+        # LTX is not in the auto-pipeline task mappings, so the modular class resolves from the pipeline folder.
+        with open(tmp_path / "model_index.json", "w") as f:
+            json.dump({"_class_name": "LTXPipeline", "_diffusers_version": "0.0.0"}, f)
+
+        pipe = ModularPipeline.from_pretrained(str(tmp_path))
+
+        assert pipe.__class__.__name__ == "LTXModularPipeline"
+        assert pipe.blocks.__class__.__name__ == "LTXAutoBlocks"

--- a/tests/modular_pipelines/test_modular_pipeline_loading.py
+++ b/tests/modular_pipelines/test_modular_pipeline_loading.py
@@ -274,7 +274,7 @@ class TestModularPipelineInitFallback:
         with pytest.raises(ValueError, match="No pipeline blocks could be resolved"):
             ModularPipeline()
 
-    def test_from_pretrained_resolves_family_outside_auto_pipeline_mappings(self, tmp_path):
+    def test_from_pretrained_resolves_video_pipeline_from_model_index(self, tmp_path):
         # A standard model_index.json resolves to the modular class through the auto-pipeline video mappings.
         with open(tmp_path / "model_index.json", "w") as f:
             json.dump({"_class_name": "LTXPipeline", "_diffusers_version": "0.0.0"}, f)


### PR DESCRIPTION
# What does this PR do?

`ModularPipeline.from_pretrained` on a standard repo finds the modular class through the auto-pipeline mappings. LTX isn't in them, so it fell back to the base `ModularPipeline`, which has no default blocks, and `__init__` crashed on an unbound variable:

```py
ModularPipeline.from_pretrained("Lightricks/LTX-Video")
# UnboundLocalError: cannot access local variable 'blocks_class' where it is not associated with a value
```

Bare `ModularPipeline()` crashed the same way. This adds `LTXPipeline` and `LTXImageToVideoPipeline` to the text2video and image2video auto mappings, so LTX-Video loads as `LTXModularPipeline` with `LTXAutoBlocks`, and raises a clear `ValueError` when no blocks class can be resolved (the old warning branch was unreachable, and the next line dereferences `self._blocks` anyway).

Found while verifying #14730 on real checkpoints.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)?
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@yiyixuxu
