### PR TITLE
Validate DDPM generator list length against batch size

### DIFF
--- a/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
+++ b/src/diffusers/pipelines/ddpm/pipeline_ddpm.py
@@ -109,6 +109,12 @@ class DDPMPipeline(DiffusionPipeline):
         else:
             image_shape = (batch_size, self.unet.config.in_channels, *self.unet.config.sample_size)
 
+        if isinstance(generator, list) and len(generator) != batch_size:
+            raise ValueError(
+                f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
+                f" size of {batch_size}. Make sure the batch size matches the length of the generators."
+            )
+
         device = self._execution_device
         if device.type == "mps":
             # randn does not work reproducibly on mps

--- a/tests/pipelines/ddpm/test_ddpm.py
+++ b/tests/pipelines/ddpm/test_ddpm.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import numpy as np
+import pytest
 import torch
 
 from diffusers import DDPMPipeline, DDPMScheduler, UNet2DModel
@@ -99,6 +100,15 @@ class TestDDPMPipeline(DDPMPipelineTesterConfig, PipelineTesterMixin):
         assert output_sample.shape == output_epsilon.shape
         assert not torch.isnan(output_sample).any()
         assert not torch.allclose(output_sample, output_epsilon, atol=1e-3)
+
+    def test_generator_list_batch_size_mismatch_raises(self):
+        pipe = self.get_pipeline()
+        inputs = self.get_dummy_inputs()
+        inputs["batch_size"] = 2
+        inputs["generator"] = [self.get_generator(0)]
+
+        with pytest.raises(ValueError, match="list of generators of length 1.*effective batch size of 2"):
+            pipe(**inputs)
 
 
 class TestDDPMPipelineMemory(DDPMPipelineTesterConfig, MemoryTesterMixin):


### PR DESCRIPTION
# What does this PR do?
This PR adds validation in DDPMPipeline to ensure that when a list of torch.Generators is provided, its length matches the requested batch_size. Before, DDPMPipeline could accept mismatched generator lists (they would silently succeed or fail later with an error depending on the list length). The new validation follows the existing behavior in the sibling DDIMPipeline and raises a clear ValueError before noise generation. A focused regression test was added to cover this case. It addresses Issue 2 in #13649.

Tests:
.venv/bin/pytest tests/pipelines/ddpm/test_ddpm.py::TestDDPMPipeline::test_generator_list_batch_size_mismatch_raises -q
# 1 passed
.venv/bin/pytest tests/pipelines/ddpm/test_ddpm.py -q
# 15 passed, 23 skipped

Formatting/style check:
PATH=.venv/bin:$PATH make modified_only_fixup
# All checks passed; 2 files left unchanged

Help from AI:
Codex was used to assist with investigating the issue, implementing the change, and reviewing the final diff.

Final self-review findings:
- The DDPM validation matches the existing DDIM validation in wording and structure
- The validation is placed before the initial randn_tensor(...) call
- No shared helper or unrelated refactor is needed
- The regression test reuses the existing DDPM test helpers and covers the reported mismatch
- No unrelated changes or outstanding self-review findings remain

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case : https://github.com/huggingface/diffusers/issues/13649#issue-4352114857
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?


## Who can review?
cc @yiyixuxu @dg845 

