### PR TITLE
Make AttentionModuleMixin.set_attention_slice callable

### DIFF
--- a/src/diffusers/models/attention.py
+++ b/src/diffusers/models/attention.py
@@ -352,13 +352,31 @@ class AttentionModuleMixin:
 
         # Try to get a compatible processor for sliced attention
         if slice_size is not None:
-            processor = self._get_compatible_processor("sliced")
+            processor = self._get_compatible_processor("sliced", slice_size=slice_size)
+            if processor is None:
+                logger.warning(
+                    f"Attention slicing was requested but `{type(self).__name__}` has no sliced attention "
+                    "processor in `_available_processors`. Falling back to the default processor, so attention "
+                    "will not be sliced for this module."
+                )
 
         # If no processor was found or slice_size is None, use default processor
         if processor is None:
-            processor = self.default_processor_cls()
+            processor = self._default_processor_cls()
 
         self.set_processor(processor)
+
+    def _get_compatible_processor(self, processor_type: str, **init_kwargs) -> "AttentionProcessor | None":
+        """
+        Instantiate the first processor in `_available_processors` whose class name contains `processor_type`
+        (case-insensitive), e.g. `"sliced"` for a `SlicedAttnProcessor`-style class. Returns `None` if the module lists
+        no such processor.
+        """
+        processor_type = processor_type.lower()
+        for processor_cls in self._available_processors:
+            if processor_type in processor_cls.__name__.lower():
+                return processor_cls(**init_kwargs)
+        return None
 
     def batch_to_head_dim(self, tensor: torch.Tensor) -> torch.Tensor:
         """

--- a/tests/models/test_attention_processor.py
+++ b/tests/models/test_attention_processor.py
@@ -5,11 +5,14 @@ import numpy as np
 import pytest
 import torch
 from packaging import version
+from torch import nn
 
 from diffusers import DiffusionPipeline
+from diffusers.models.attention import AttentionModuleMixin
 from diffusers.models.attention_processor import Attention, AttnAddedKVProcessor
+from diffusers.utils import logging
 
-from ..testing_utils import torch_device
+from ..testing_utils import CaptureLogger, torch_device
 
 
 class TestAttnAddedKVProcessor:
@@ -132,3 +135,75 @@ class TestDeprecatedAttentionBlock:
 
         assert np.allclose(pre_conversion, conversion, atol=1e-3)
         assert np.allclose(conversion, after_conversion, atol=1e-3)
+
+
+class _MixinTestProcessor:
+    def __call__(self, attn, hidden_states, *args, **kwargs):
+        return hidden_states
+
+
+class _MixinTestSlicedProcessor:
+    def __init__(self, slice_size: int):
+        self.slice_size = slice_size
+
+    def __call__(self, attn, hidden_states, *args, **kwargs):
+        return hidden_states
+
+
+class _MixinAttention(nn.Module, AttentionModuleMixin):
+    _default_processor_cls = _MixinTestProcessor
+    _available_processors = [_MixinTestProcessor]
+    _supports_qkv_fusion = False
+
+    def __init__(self, sliceable_head_dim: int | None = None):
+        super().__init__()
+        if sliceable_head_dim is not None:
+            self.sliceable_head_dim = sliceable_head_dim
+        self.set_processor(self._default_processor_cls())
+
+
+class _MixinAttentionWithSliced(_MixinAttention):
+    _available_processors = [_MixinTestProcessor, _MixinTestSlicedProcessor]
+
+
+class TestAttentionModuleMixinSetAttentionSlice:
+    def test_none_restores_default_processor(self):
+        attn = _MixinAttention()
+        attn.set_processor(_MixinTestSlicedProcessor(2))
+
+        attn.set_attention_slice(None)
+
+        assert isinstance(attn.processor, _MixinTestProcessor)
+
+    def test_uses_sliced_processor_when_available(self):
+        attn = _MixinAttentionWithSliced()
+
+        attn.set_attention_slice(2)
+
+        assert isinstance(attn.processor, _MixinTestSlicedProcessor)
+        assert attn.processor.slice_size == 2
+
+    def test_falls_back_to_default_and_warns_when_no_sliced_processor(self):
+        attn = _MixinAttention()
+        attn_logger = logging.get_logger("diffusers.models.attention")
+        attn_logger.setLevel(logging.WARNING)
+
+        with CaptureLogger(attn_logger) as cap_logger:
+            attn.set_attention_slice(2)
+
+        assert isinstance(attn.processor, _MixinTestProcessor)
+        assert "sliced" in cap_logger.out
+        assert "_MixinAttention" in cap_logger.out
+
+    def test_slice_size_larger_than_sliceable_head_dim_raises(self):
+        attn = _MixinAttentionWithSliced(sliceable_head_dim=4)
+
+        with pytest.raises(ValueError, match="has to be smaller or equal to 4"):
+            attn.set_attention_slice(8)
+
+    def test_get_compatible_processor(self):
+        attn = _MixinAttentionWithSliced()
+        assert isinstance(attn._get_compatible_processor("sliced", slice_size=3), _MixinTestSlicedProcessor)
+
+        attn = _MixinAttention()
+        assert attn._get_compatible_processor("sliced", slice_size=3) is None


### PR DESCRIPTION
# What does this PR do?

`AttentionModuleMixin.set_attention_slice` referred to two names the mixin never defined, so it raised `AttributeError` for every argument:

- `self.default_processor_cls()` — the class attribute is `_default_processor_cls`.
- `self._get_compatible_processor("sliced")` — no such method existed anywhere in `src/`.

Nothing routes into the method today (the models that recurse into submodule `set_attention_slice` all hold `attention_processor.Attention`, which has its own working implementation), so this is latent. It stops being latent as soon as a model built on `AttentionModuleMixin` is wired into `enable_attention_slicing`, which the `TODO` in `modeling_utils.py` points toward.

This PR keeps the shape the method already described in its own comments rather than inventing a new one:

- Fixes the typo so `set_attention_slice(None)` restores `_default_processor_cls`, matching the legacy `Attention.set_attention_slice`.
- Adds `_get_compatible_processor(processor_type, **init_kwargs)` on the mixin. It looks through `_available_processors` for a class whose name contains the requested type (`"sliced"` matches `SlicedAttnProcessor`-style names) and instantiates it with the given kwargs, or returns `None`.
- When slicing is requested but the module lists no sliced processor, it falls back to the default processor as the original comment intended, but now logs a warning naming the module class, so `enable_attention_slicing()` no longer silently becomes a no-op for that model. No `AttentionModuleMixin` subclass in the tree currently ships a sliced processor, so today every mixin-based module takes the warning path; the lookup means one that adds a sliced processor gets picked up without touching the mixin again.

Raising instead of falling back was the other option. I did not take it because `DiffusionPipeline.enable_attention_slicing` calls `set_attention_slice` on every submodule that has the method, so a raise would make that pipeline-level call crash for any pipeline holding a mixin-based model. Happy to switch to a raise if you would rather have the loud failure.

Tests added in `tests/models/test_attention_processor.py` using a tiny in-test `AttentionModuleMixin` subclass (no checkpoints, CPU only): `None` restores the default, an available sliced processor is used with the right `slice_size`, the no-sliced-processor path falls back and warns, the `sliceable_head_dim` guard still raises, and `_get_compatible_processor` returns the instance or `None`.

Fixes #14729

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [x] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment? (below)
- [x] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [x] Was this discussed/approved via a GitHub issue? #14729
- [x] Did you write any new necessary tests?

## Who can review?

@DN6 @yiyixuxu

## Self-review notes

Reviewed the diff against `.ai/references/review-rules.md` and `models.md`/`testing.md`.

- **Blocking:** none found.
- **Non-blocking, left for review:** the fallback-and-warn choice when a module has no sliced processor (versus raising). Deliberate, reasoning in the description above.
- **Non-blocking, left for review:** `_get_compatible_processor` matches on class name substring. This mirrors the existing `"Added" in processor.__class__.__name__` check in `fuse_qkv_projections`, so it is consistent with how the mixin already classifies processors, but a registry attribute would be more explicit if you want that.
- **Dead code:** none added. `_get_compatible_processor` has one caller (`set_attention_slice`) and is exercised directly by `test_get_compatible_processor`.
- **Docs:** no public API surface changed. `set_attention_slice` was already documented; its docstring still describes the behavior.
- Verified: `make quality` clean (ruff, doc-builder style, check_doc_toc, check_ai), `tests/models/test_attention_processor.py` 7 passed on CPU (torch 2.14.0+cpu, Python 3.12), and the reproduction from the issue now prints `AnimaTextConditionerAttnProcessor` for both `None` and `1`, with the warning on the `1` path.
