### PR TITLE
[Download] Bump minimum huggingface_hub to 1.30.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ _deps = [
     "ftfy",
     "hf-doc-builder>=0.3.0",
     "httpx<1.0.0",
-    "huggingface-hub>=1.26.0,<2.0",
+    "huggingface-hub>=1.30.0,<2.0",
     "requests-mock==1.10.0",
     "importlib_metadata",
     "invisible-watermark>=0.2.0",

--- a/src/diffusers/dependency_versions_table.py
+++ b/src/diffusers/dependency_versions_table.py
@@ -9,7 +9,7 @@ deps = {
     "ftfy": "ftfy",
     "hf-doc-builder": "hf-doc-builder>=0.3.0",
     "httpx": "httpx<1.0.0",
-    "huggingface-hub": "huggingface-hub>=1.26.0,<2.0",
+    "huggingface-hub": "huggingface-hub>=1.30.0,<2.0",
     "requests-mock": "requests-mock==1.10.0",
     "importlib_metadata": "importlib_metadata",
     "invisible-watermark": "invisible-watermark>=0.2.0",


### PR DESCRIPTION
Follow-up on #14340, which resolves the revision once at the top of the loading entrypoints.

Before `huggingface_hub` v1.30.0, a `ResolvedRevision` did not remember the repo it was resolved for, so passing it along to another repo reused the wrong commit hash (huggingface/huggingface_hub#4767 — same bug as vllm-project/vllm#51260 and huggingface/transformers#47611).

diffusers hits this on the connected-pipeline path: `AutoPipelineFor*.from_pretrained` resolves the revision for the main repo and passes it down to `DiffusionPipeline.from_pretrained`, which forwards it to the connected (`prior`) repo — Kandinsky and Stable Cascade combined pipelines. With `huggingface_hub` < 1.30.0 the prior repo is then fetched at the decoder repo's commit hash and 404s.

huggingface/huggingface_hub#4767 shipped in v1.30.0 and makes `resolve_revision` re-resolve when the repo differs, so bumping the minimum is all that is needed.
