### PR TITLE
Key the doc build concurrency group on the pull request number

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
       - "docs/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
# What does this PR do?

`build_pr_documentation.yml` keys its concurrency group on `github.head_ref`, which is the head branch name without the fork owner. Two open PRs from different forks whose branches share a name therefore land in the same group, and a push on one cancels the in-flight doc build on the other.

Shared names are common, because many contributors push to their fork's default branch instead of creating one: 63 of the 591 currently open PRs here share a head branch name with another open PR, 46 of them on `main` and 11 on `patch-1`. A doc build takes around 5 minutes, which is the window in which such a collision cancels a build. I did not find a realized cancellation in the 800 most recent runs, so this is hardening rather than a fix for something currently failing.

`github.event.pull_request.number` is unique per pull request. This workflow only triggers on `pull_request`, so the `github.run_id` fallback is never reached, but keeping it means that a later trigger would fall back to never cancelling rather than to grouping by branch name.

The template this workflow was copied from carries the same expression, and the same one-liner is proposed there in huggingface/doc-builder#829.
