### PR TITLE
[hooks] Support Flux2 in MagCache

### DIFF
--- a/docs/source/en/optimization/cache.md
+++ b/docs/source/en/optimization/cache.md
@@ -116,7 +116,7 @@ pipe.transformer.enable_cache(config)
 
 [MagCache](https://github.com/Zehong-Ma/MagCache) accelerates inference by skipping transformer blocks based on the magnitude of the residual update. It observes that the magnitude of updates (Output - Input) decays predictably over the diffusion process. By accumulating an "error budget" based on pre-computed magnitude ratios, it dynamically decides when to skip computation and reuse the previous residual.
 
-MagCache relies on **Magnitude Ratios** (`mag_ratios`), which describe this decay curve. These ratios are specific to the model checkpoint and scheduler.
+MagCache relies on **Magnitude Ratios** (`mag_ratios`), which describe this decay curve. These ratios are specific to the model checkpoint and scheduler. The bundled `FLUX_MAG_RATIOS` were measured on FLUX.1; other models, including Flux2 and Flux2 Klein, need their own calibration run.
 
 To use MagCache, you typically follow a two-step process: **Calibration** and **Inference**.
 

--- a/src/diffusers/hooks/_helpers.py
+++ b/src/diffusers/hooks/_helpers.py
@@ -175,6 +175,7 @@ def _register_transformer_blocks_metadata():
     from ..models.transformers.transformer_bria import BriaTransformerBlock
     from ..models.transformers.transformer_cogview4 import CogView4TransformerBlock
     from ..models.transformers.transformer_flux import FluxSingleTransformerBlock, FluxTransformerBlock
+    from ..models.transformers.transformer_flux2 import Flux2SingleTransformerBlock, Flux2TransformerBlock
     from ..models.transformers.transformer_hunyuan_video import (
         HunyuanVideoSingleTransformerBlock,
         HunyuanVideoTokenReplaceSingleTransformerBlock,
@@ -243,6 +244,22 @@ def _register_transformer_blocks_metadata():
         metadata=TransformerBlockMetadata(
             return_hidden_states_index=1,
             return_encoder_hidden_states_index=0,
+        ),
+    )
+
+    # Flux2
+    TransformerBlockRegistry.register(
+        model_class=Flux2TransformerBlock,
+        metadata=TransformerBlockMetadata(
+            return_hidden_states_index=1,
+            return_encoder_hidden_states_index=0,
+        ),
+    )
+    TransformerBlockRegistry.register(
+        model_class=Flux2SingleTransformerBlock,
+        metadata=TransformerBlockMetadata(
+            return_hidden_states_index=0,
+            return_encoder_hidden_states_index=None,
         ),
     )
 

--- a/src/diffusers/hooks/mag_cache.py
+++ b/src/diffusers/hooks/mag_cache.py
@@ -80,25 +80,6 @@ def nearest_interp(src_array: torch.Tensor, target_length: int) -> torch.Tensor:
     return src_array[mapped_indices]
 
 
-def _align_to_hidden_states(tensor: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
-    """
-    Slice `tensor` down to the trailing `hidden_states.shape[1]` tokens when it is longer along the sequence axis.
-
-    Models such as Flux2 concatenate the text and image streams before their single-stream blocks, so the tail block
-    returns `[text; image]` while the head block only saw the image stream. The image stream sits at the end of the
-    fused sequence in these layouts.
-    """
-    if (
-        tensor.ndim == 3
-        and hidden_states.ndim == 3
-        and tensor.shape[0] == hidden_states.shape[0]
-        and tensor.shape[2] == hidden_states.shape[2]
-        and tensor.shape[1] > hidden_states.shape[1]
-    ):
-        return tensor[:, -hidden_states.shape[1] :]
-    return tensor
-
-
 @dataclass
 class MagCacheConfig:
     r"""
@@ -358,10 +339,16 @@ class MagCacheBlockHook(ModelHook):
             if in_hidden is None:
                 return output
 
-            # Keep the image tokens only, so the residual matches the head input it is added to on skipped steps.
-            out_hidden = _align_to_hidden_states(out_hidden, in_hidden)
+            # Determine residual
             if out_hidden.shape == in_hidden.shape:
                 residual = out_hidden - in_hidden
+            elif out_hidden.ndim == 3 and in_hidden.ndim == 3 and out_hidden.shape[2] == in_hidden.shape[2]:
+                diff = in_hidden.shape[1] - out_hidden.shape[1]
+                if diff == 0:
+                    residual = out_hidden - in_hidden
+                else:
+                    # The tail returned the fused text+image sequence (e.g. Flux2); the image tokens sit at the end.
+                    residual = out_hidden[:, -in_hidden.shape[1] :] - in_hidden
             else:
                 # Fallback for completely mismatched shapes
                 residual = out_hidden

--- a/src/diffusers/hooks/mag_cache.py
+++ b/src/diffusers/hooks/mag_cache.py
@@ -80,6 +80,25 @@ def nearest_interp(src_array: torch.Tensor, target_length: int) -> torch.Tensor:
     return src_array[mapped_indices]
 
 
+def _align_to_hidden_states(tensor: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
+    """
+    Slice `tensor` down to the trailing `hidden_states.shape[1]` tokens when it is longer along the sequence axis.
+
+    Models such as Flux2 concatenate the text and image streams before their single-stream blocks, so the tail block
+    returns `[text; image]` while the head block only saw the image stream. The image stream sits at the end of the
+    fused sequence in these layouts.
+    """
+    if (
+        tensor.ndim == 3
+        and hidden_states.ndim == 3
+        and tensor.shape[0] == hidden_states.shape[0]
+        and tensor.shape[2] == hidden_states.shape[2]
+        and tensor.shape[1] > hidden_states.shape[1]
+    ):
+        return tensor[:, -hidden_states.shape[1] :]
+    return tensor
+
+
 @dataclass
 class MagCacheConfig:
     r"""
@@ -339,15 +358,10 @@ class MagCacheBlockHook(ModelHook):
             if in_hidden is None:
                 return output
 
-            # Determine residual
+            # Keep the image tokens only, so the residual matches the head input it is added to on skipped steps.
+            out_hidden = _align_to_hidden_states(out_hidden, in_hidden)
             if out_hidden.shape == in_hidden.shape:
                 residual = out_hidden - in_hidden
-            elif out_hidden.ndim == 3 and in_hidden.ndim == 3 and out_hidden.shape[2] == in_hidden.shape[2]:
-                diff = in_hidden.shape[1] - out_hidden.shape[1]
-                if diff == 0:
-                    residual = out_hidden - in_hidden
-                else:
-                    residual = out_hidden - in_hidden  # Fallback to matching tail
             else:
                 # Fallback for completely mismatched shapes
                 residual = out_hidden

--- a/tests/models/transformers/test_models_transformer_flux2.py
+++ b/tests/models/transformers/test_models_transformer_flux2.py
@@ -38,6 +38,7 @@ from ..testing_utils import (
     GGUFTesterMixin,
     LoraHotSwappingForModelTesterMixin,
     LoraTesterMixin,
+    MagCacheTesterMixin,
     MemoryTesterMixin,
     ModelTesterMixin,
     SingleFileTesterMixin,
@@ -713,3 +714,7 @@ class TestFlux2Transformer2DSingleFile(Flux2TransformerTesterConfig, SingleFileT
     @property
     def pretrained_model_kwargs(self):
         return {"subfolder": "transformer"}
+
+
+class TestFlux2TransformerMagCache(Flux2TransformerTesterConfig, MagCacheTesterMixin):
+    """MagCache tests for Flux2 Transformer."""

--- a/tests/pipelines/flux2/test_pipeline_flux2.py
+++ b/tests/pipelines/flux2/test_pipeline_flux2.py
@@ -13,6 +13,7 @@ from ..testing_utils import (
     BasePipelineTesterConfig,
     LoraMemoryTesterMixin,
     LoraTesterMixin,
+    MagCacheTesterMixin,
     MemoryTesterMixin,
     PipelineTesterMixin,
     check_qkv_fused_layers_exist,
@@ -204,3 +205,7 @@ class TestFlux2PipelineLoRAMemory(Flux2PipelineTesterConfig, LoraMemoryTesterMix
 
     # See `TestFlux2PipelineLoRA`.
     denoiser_target_modules = {"transformer": ["to_qkv_mlp_proj", "to_k"]}
+
+
+class TestFlux2PipelineMagCache(Flux2PipelineTesterConfig, MagCacheTesterMixin):
+    """MagCache tests for the Flux2 pipeline."""

--- a/tests/pipelines/flux2/test_pipeline_flux2_klein.py
+++ b/tests/pipelines/flux2/test_pipeline_flux2_klein.py
@@ -23,6 +23,7 @@ from ...testing_utils import (
 )
 from ..testing_utils import (
     BasePipelineTesterConfig,
+    MagCacheTesterMixin,
     MemoryTesterMixin,
     PipelineTesterMixin,
     check_qkv_fused_layers_exist,
@@ -283,3 +284,7 @@ class TestFlux2KleinPipelineIntegration:
         assert image.shape == (1, 128, 128, 3)
         assert not np.isnan(image).any(), "Output contains NaN values"
         assert (image >= 0.0).all() and (image <= 1.0).all(), "Output pixel values outside [0, 1]"
+
+
+class TestFlux2KleinPipelineMagCache(Flux2KleinPipelineTesterConfig, MagCacheTesterMixin):
+    """MagCache tests for the Flux2 Klein pipeline."""


### PR DESCRIPTION
MagCache could not be enabled on `Flux2Transformer2DModel` (Flux2 and Flux2 Klein):

1. `Flux2TransformerBlock` and `Flux2SingleTransformerBlock` were not registered in `TransformerBlockRegistry`, so `apply_mag_cache` raised `ValueError: Model class ... not registered`.
2. Once registered, the tail hook raised a shape error. The head hook records the image-only input of `transformer_blocks[0]`, but the Flux2 model concatenates the text and image streams before the single-stream blocks and calls them with `encoder_hidden_states=None`, so the last single block returns the fused `[text; image]` sequence. The residual `tail_output - head_input` could not be formed.

Register the two Flux2 blocks (the single block with `return_encoder_hidden_states_index=None`, matching how the model calls it) and add `_align_to_hidden_states`, which keeps only the trailing image tokens of the fused tensor when computing the residual and when adding it back on skipped steps. The cached residual is therefore image-only, which is what the reference MagCache4FLUX implementation does. This also replaces a dead "fallback" branch in the tail hook that subtracted mismatched shapes anyway.

Tests: hook unit tests with a Flux2-shaped dummy (fused tail, skip and calibration), and `MagCacheTesterMixin` for `Flux2Transformer2DModel`, `Flux2Pipeline` and `Flux2KleinPipeline`.

FirstBlockCache has the same head/tail structure and still fails on Flux2; left for a follow-up.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

If you used an AI agent, also include your final self-review notes here (or post them as a comment) — the report from the last self-review round, including any findings you intentionally did not fix and why. See https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [ ] Did you read the [Coding with AI agents](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution#coding-with-ai-agents) guide?
  - [ ] Did you run the [`self-review`](https://github.com/huggingface/diffusers/blob/main/.ai/skills/self-review/SKILL.md) skill on the diff?
  - [ ] Did you share the final self-review notes in the PR description or a comment?
- [ ] Did you read the [contributor guideline](https://huggingface.co/docs/diffusers/main/en/conceptual/contribution)?
- [ ] Did you read our [philosophy doc](https://huggingface.co/docs/diffusers/main/en/conceptual/philosophy)? (important for complex PRs)
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/c/discussion-related-to-httpsgithubcomhuggingfacediffusers/63)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/diffusers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
- [ ] Are you the author (or part of the team) of the model/pipeline (only applicable for model/pipeline related PRs)?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Core library:

- Schedulers: @yiyixuxu @dg845
- Pipelines and models: @yiyixuxu @dg845 and @asomoza
- Training examples: @sayakpaul @linoytsaban
- Docs: @stevhliu and @sayakpaul
- MPS: @pcuenca
- General functionalities: @sayakpaul @yiyixuxu @DN6

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc
- PEFT: @sayakpaul @BenjaminBossan

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- transformers: [different repo](https://github.com/huggingface/transformers)
- safetensors: [different repo](https://github.com/huggingface/safetensors)

-->
