### PR TITLE
docs: fix 'allow to' grammar in text-to-image LoRA README

### DIFF
--- a/examples/text_to_image/README.md
+++ b/examples/text_to_image/README.md
@@ -191,7 +191,7 @@ In a nutshell, LoRA allows adapting pretrained models by adding pairs of rank-de
 
 - Previous pretrained weights are kept frozen so that model is not prone to [catastrophic forgetting](https://www.pnas.org/doi/10.1073/pnas.1611835114).
 - Rank-decomposition matrices have significantly fewer parameters than original model, which means that trained LoRA weights are easily portable.
-- LoRA attention layers allow to control to which extent the model is adapted toward new training images via a `scale` parameter.
+- LoRA attention layers allow controlling to which extent the model is adapted toward new training images via a `scale` parameter.
 
 [cloneofsimo](https://github.com/cloneofsimo) was the first to try out LoRA training for Stable Diffusion in the popular [lora](https://github.com/cloneofsimo/lora) GitHub repository.
 


### PR DESCRIPTION
# What does this PR do?

Tiny docs grammar fix in `examples/text_to_image/README.md`: "allow to control" → "allow controlling".

Validated against the surrounding LoRA advantages list.

## Before submitting
- [x] Did you use an AI agent (Claude Code, Codex, Cursor, etc.) to help with this PR? If so:
  - [x] Did you read the Coding with AI agents guide?
  - [x] Did you run a self-review on the diff?
  - [x] Did you share the final self-review notes in the PR description or a comment?
- [x] Did you read the contributor guideline?
- [x] This PR fixes a typo / docs grammar issue.

### Self-review notes
- Single-file docs-only change; confirmed the bullet still matches the LoRA scale-parameter meaning.
- No other `allow to` instances were mixed into this PR from other READMEs.